### PR TITLE
Fix PR review findings for the local SQLite dashboard

### DIFF
--- a/claude-plugin/scripts/publish-zip.sh
+++ b/claude-plugin/scripts/publish-zip.sh
@@ -35,11 +35,32 @@ node "$PLUGIN_DIR/scripts/build.mjs"
 # never consults .gitignore, so a complete dist on disk IS a complete dist in the
 # archive — but an incomplete BUILD would silently ship a plugin whose missing
 # git-hook/worker scripts block the installing user's commits (see build.mjs
-# header). Kept in lockstep with build.mjs entryPoints AND _publish-lib.sh's
-# PUBLISH_REQUIRED_DIST.
-REQUIRED_DIST="Cli.js PluginBootstrapHook.js StopHook.js SessionStartHook.js PostCommitHook.js PostMergeHook.js PostRewriteHook.js PrepareMsgHook.js PrePushHook.js QueueWorker.js PrePushWorker.js DashboardServerEntry.js dashboard-assets/index.html"
+# header).
+#
+# SOURCED from _publish-lib.sh rather than restated. This file used to carry its
+# own copy, and the copy drifted the moment the dashboard arrived: it checked
+# `dashboard-assets/index.html` alone while the server's own door check
+# (resolveDashboardAssetsDir) requires the stylesheet and all eight scripts — so
+# the zip path could still ship the exact partial asset tree the shared list was
+# expanded file-by-file to prevent.
+# shellcheck source=./_publish-lib.sh
+. "$SCRIPT_DIR/_publish-lib.sh"
+
+# The lib re-defines PLUGIN_DIR from ITS own location, so this source silently
+# repoints a variable this script already set — and the source sits between the
+# two uses of it: `node "$PLUGIN_DIR/scripts/build.mjs"` above ran against the
+# original, while the completeness check and the packing below use the lib's.
+# They resolve to the same directory today only because both files live in
+# scripts/. Moving either one would build one plugin and ship another, with
+# nothing on screen to say so — so assert the agreement rather than rely on it.
+if [ "$(cd "$PLUGIN_DIR" && pwd)" != "$(cd "$SCRIPT_DIR/../plugins/jolli" && pwd)" ]; then
+	echo "error: _publish-lib.sh re-pointed PLUGIN_DIR to $PLUGIN_DIR" >&2
+	echo "       (expected $SCRIPT_DIR/../plugins/jolli — the build above used that one)" >&2
+	exit 1
+fi
+
 missing=""
-for f in $REQUIRED_DIST; do
+for f in "${PUBLISH_REQUIRED_DIST[@]}"; do
 	[ -s "$PLUGIN_DIR/dist/$f" ] || missing="$missing $f"
 done
 if [ -n "$missing" ]; then

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -218,8 +218,9 @@ export interface TranscriptReadResult {
 	 *  usage; the summed segments equal {@link usageBreakdown}. */
 	readonly usageByModel?: ReadonlyArray<ModelTokenUsage>;
 	/** Tool calls over the slice, one bucket per distinct tool. ABSENT means the
-	 *  source's transcripts carry no tool records at all (only Claude's do
-	 *  today); an EMPTY array means the slice genuinely called no tools. Consumers
+	 *  source's transcripts carry no tool records this runtime can read — see
+	 *  `TOOL_RECORDING_SOURCES` for which sources those are and why the list is
+	 *  evidence-gated; an EMPTY array means the slice genuinely called no tools. Consumers
 	 *  must keep the two apart — reporting an uncovered agent as "used no tools"
 	 *  is the failure mode this distinction exists to prevent. */
 	readonly toolUse?: ReadonlyArray<ToolCallCount>;
@@ -651,6 +652,36 @@ export interface CommitSummary {
 	readonly jolliDocUrl?: string;
 	/** Server-side article ID for direct update on subsequent pushes (set after first push) */
 	readonly jolliDocId?: number;
+	/**
+	 * Full URL / id of the pushed SKILL-USAGE article (docType `skill`) — the commit's
+	 * whole skill aggregate, one document per commit.
+	 *
+	 * **On the summary, not on a `SkillCommitRef`, and that is the point.** The article
+	 * covers the commit, exactly like the Memory Bank's `skills--<hash8>.md` and the
+	 * single "Skills used" Context row; there is no one skill it belongs to. Holding the
+	 * id on a representative ref instead — as this briefly did — put a commit-level
+	 * identity inside `mergeSkillRef`'s per-ref inheritance rules, which fold refs by
+	 * `<source>:<skill>`: a squash whose root and child had each been pushed left TWO
+	 * refs carrying an id from two different aggregate articles, the push reused
+	 * whichever sorted first (silently retitling another commit's article) and the other
+	 * became an orphan no cleanup path could see, because `supersededDocIds` only fires
+	 * when both sides of ONE fold carry an id.
+	 *
+	 * Squash/rebase treat it exactly like `jolliDocId`: 1:1 migration copies it (same
+	 * refs, same article), and a many-to-one merge adopts the NEWEST child's id and
+	 * routes the rest into `orphanedDocIds` for deletion. The merged root's skill table
+	 * is the fold of every child's, so no child's article is still the same document —
+	 * but updating one in place beats minting a new one, because `cleanupOrphanedDocs`
+	 * is best-effort and a failed delete then strands N stale articles instead of N-1
+	 * (see `collectChildSkillsDocMeta`, which is where the rule lives).
+	 *
+	 * The name is NOT the registry's uniform `jolliDocId` default: on a `CommitSummary`
+	 * that name is already taken by the memory article itself, so the `skill` kind
+	 * overrides both field names (see `core/push/ContextKindDefinition.ts`).
+	 */
+	readonly jolliSkillsDocUrl?: string;
+	/** See {@link CommitSummary.jolliSkillsDocUrl}. */
+	readonly jolliSkillsDocId?: number;
 	/**
 	 * Memory summary article IDs (NOT plan article IDs) superseded during squash/rebase merge.
 	 * Deleted from Jolli Space after a successful push. Accumulated across re-squashes.

--- a/cli/src/commands/DashboardCommand.test.ts
+++ b/cli/src/commands/DashboardCommand.test.ts
@@ -17,6 +17,13 @@ vi.mock("../dashboard/Backfill.js", () => ({
 vi.mock("../dashboard/Backup.js", () => ({
 	opportunisticSnapshot: vi.fn().mockResolvedValue({ status: "skipped", reason: "test" }),
 }));
+// The launcher ends with an auto-cutover attempt. Unmocked it would run against
+// the REAL repo this suite executes in (several tests pass no `cwd`, so it falls
+// back to `process.cwd()`): reading its profile, stamping an attempt into it, and
+// possibly running a cutover CAS against a throwaway test database.
+vi.mock("../dashboard/AutoCutover.js", () => ({
+	maybeAutoCutover: vi.fn().mockResolvedValue("skipped"),
+}));
 vi.mock("../dashboard/RepoRegistry.js", () => ({
 	registerRepo: vi.fn(
 		async (): Promise<RegisteredRepo> => ({
@@ -33,6 +40,7 @@ vi.mock("../dashboard/DashboardDb.js", async (importOriginal) => {
 	return { ...original, canUseDashboardDb: vi.fn(() => true) };
 });
 
+import { maybeAutoCutover } from "../dashboard/AutoCutover.js";
 import { backfillRepos } from "../dashboard/Backfill.js";
 import { opportunisticSnapshot } from "../dashboard/Backup.js";
 import { canUseDashboardDb } from "../dashboard/DashboardDb.js";
@@ -303,6 +311,26 @@ describe("executeDashboard", () => {
 		expect(backfillRepos).toHaveBeenCalledTimes(1);
 	});
 
+	it("attempts a THROTTLED auto-cutover after the import", async () => {
+		// The import is what makes the compare likely to pass, so the attempt belongs
+		// after it — but this is a reopen command, so it must not pay the compare on
+		// every launch the way the one-shot import entry point does.
+		const d = deps();
+		await executeDashboard("stats", { cwd: "/w" }, d);
+		expect(maybeAutoCutover).toHaveBeenCalledWith("/w", expect.objectContaining({ throttle: true }));
+		expect(vi.mocked(backfillRepos).mock.invocationCallOrder[0]).toBeLessThan(
+			vi.mocked(maybeAutoCutover).mock.invocationCallOrder[0] as number,
+		);
+	});
+
+	it("a launch that never got a server does not attempt a cutover", async () => {
+		// Everything past `ensureServerRunning` is skipped on the failure return, so
+		// a repo whose dashboard cannot start is not silently fenced either.
+		const d = deps({ fetchHealth: async () => ({ ok: false }) });
+		await expect(executeDashboard("stats", {}, d)).resolves.toBe(false);
+		expect(maybeAutoCutover).not.toHaveBeenCalled();
+	});
+
 	it("takes the daily snapshot here, not in the read-only server process", async () => {
 		// The trigger used to live in `startDashboardServer`, where it opened a
 		// WRITABLE handle (and so could run schema migrations) from the one
@@ -495,7 +523,10 @@ describe("createProgressPrinter", () => {
 		// motionless minute is the worse problem.
 		const lines: string[] = [];
 		const printer = createProgressPrinter({ log: (line) => lines.push(line) });
-		printer.onProgress(event({ kind: "commits", done: 0, total: undefined }));
+		// `firstRun` — only a bootstrap can take minutes. A sweep triggered by a
+		// moved branch tip skips `--numstat` for stored commits and finishes in under
+		// a second, so the patience note must not ride along with it.
+		printer.onProgress(event({ kind: "commits", done: 0, total: undefined, firstRun: true }));
 		for (let done = 200; done <= 4_000; done += 200)
 			printer.onProgress(event({ kind: "commits", done, total: 4_000 }));
 		printer.onProgress(event({ kind: "summaries", done: 0, total: undefined }));
@@ -538,7 +569,15 @@ describe("createProgressPrinter", () => {
 			["jolliai", 2],
 		] as const) {
 			printer.onProgress(
-				event({ repoName, repoIndex, repoTotal: 2, kind: "commits", done: 0, total: undefined }),
+				event({
+					repoName,
+					repoIndex,
+					repoTotal: 2,
+					kind: "commits",
+					done: 0,
+					total: undefined,
+					firstRun: true,
+				}),
 			);
 			printer.onProgress(
 				event({ repoName, repoIndex, repoTotal: 2, kind: "sessions", done: 0, total: undefined }),

--- a/cli/src/commands/DashboardCommand.ts
+++ b/cli/src/commands/DashboardCommand.ts
@@ -27,6 +27,7 @@ import { fileURLToPath } from "node:url";
 import type { Command } from "commander";
 import { getProjectRootDir } from "../core/GitOps.js";
 import { getGlobalConfigDir } from "../core/SessionTracker.js";
+import { maybeAutoCutover } from "../dashboard/AutoCutover.js";
 import { type BackfillProgress, backfillRepos } from "../dashboard/Backfill.js";
 import { opportunisticSnapshot } from "../dashboard/Backup.js";
 import { canUseDashboardDb, DASHBOARD_SQLITE_MIN_VERSION, ensureDashboardDbExists } from "../dashboard/DashboardDb.js";
@@ -377,6 +378,16 @@ async function stopServer(deps: DashboardDeps): Promise<void> {
  *
  * Never throws: a failed import is a warning, not a failed enable.
  */
+/**
+ * Block headers, chosen by whichever tier reveals the block.
+ *
+ * Separate strings because they describe different work: `commits` re-sweeps git
+ * whenever any branch tip moves, while `memories` is cursor-gated on the orphan
+ * tip and normally does nothing at all.
+ */
+const MIGRATION_HEADER = "\n  Migrating your memories to the Jolli Memory database…";
+const HISTORY_HEADER = "\n  Indexing your git history…";
+
 async function runHistoryImport(deps: DashboardDeps): Promise<void> {
 	try {
 		const repos = await listActiveRepos(deps.configDir);
@@ -387,14 +398,14 @@ async function runHistoryImport(deps: DashboardDeps): Promise<void> {
 		// doing.
 		const quiet = repos.length === 0;
 		// Held, not printed: on a steady-state pass the whole block is noise. The
-		// import itself is now cursor-gated (see Backfill's `sot-import`), so a
-		// converged run does no memory work at all — but the phase markers still
-		// fire for the tiers that DO run every time (sessions), and a header
-		// announcing a migration that will not happen is exactly what made this
-		// look like it re-migrated on every launch. The closing ✓ line is the
+		// import itself is cursor-gated (see Backfill's `sot-import`), so a converged
+		// run does no memory work at all — but the phase markers still fire for the
+		// tiers that DO run every time (sessions), and a header announcing a
+		// migration that will not happen is exactly what made this look like it
+		// re-migrated on every launch. The header is therefore chosen at reveal time
+		// by the tier that had work, not written up front. The closing ✓ line is the
 		// honest report and prints either way.
 		const out = createDeferredWriter();
-		if (!quiet) out.write("\n  Migrating your memories to the Jolli Memory database…");
 		const printer = createProgressPrinter({ log: out.write });
 		const results = await backfillRepos(repos, {
 			...(deps.dbPath ? { dbPath: deps.dbPath } : {}),
@@ -413,13 +424,18 @@ async function runHistoryImport(deps: DashboardDeps): Promise<void> {
 			// now fires only inside its own gate, so it cannot reach here ungated
 			// anyway.
 			onProgress: (progress) => {
-				if (progress.kind === "commits" || progress.kind === "memories") out.reveal();
+				// The header names the tier that actually has work. Scanning git history
+				// is NOT migrating memories, and titling it that way is what made a
+				// routine commit sweep read as "it re-migrates everything on every
+				// launch" — the memory tier had converged and said so on the next line.
+				if (progress.kind === "commits") out.reveal(HISTORY_HEADER);
+				else if (progress.kind === "memories") out.reveal(MIGRATION_HEADER);
 				printer.onProgress(progress);
 			},
 		});
 		if (quiet) return;
 		// A failure has to be shown in context — which repo, under which header.
-		if (results.some((r) => r.mode === "skipped")) out.reveal();
+		if (results.some((r) => r.mode === "skipped")) out.reveal(MIGRATION_HEADER);
 		// A repo that threw used to reach `log.error` and nothing else, so on
 		// screen it was indistinguishable from a repo with nothing to do.
 		for (const failed of results.filter((r) => r.mode === "skipped")) {
@@ -440,7 +456,7 @@ async function runHistoryImport(deps: DashboardDeps): Promise<void> {
 		if (bootstrapped > 0 || newMemories > 0) {
 			// Something landed, so the progress that produced it belongs on screen —
 			// including the runs too fast to have tripped the elapsed-time reveal.
-			out.reveal();
+			out.reveal(MIGRATION_HEADER);
 			console.log(`  ✓ Migrated ${migrated} ${migrated === 1 ? "memory" : "memories"}${across}.\n`);
 		} else {
 			// Previously this branch printed NOTHING, which is the bug that started
@@ -475,8 +491,15 @@ async function runHistoryImport(deps: DashboardDeps): Promise<void> {
 export function createDeferredWriter(): {
 	/** Print if revealed, otherwise hold. */
 	readonly write: (line: string) => void;
-	/** Flush everything held and print directly from here on. Idempotent. */
-	readonly reveal: () => void;
+	/**
+	 * Flush everything held and print directly from here on. Idempotent.
+	 *
+	 * `header` is printed once, ahead of the held lines — which is why it is a
+	 * reveal argument rather than a line written up front: WHICH tier turned out
+	 * to have work is discovered inside the run, and the header names it. The
+	 * first reveal wins; later ones cannot retitle a block already on screen.
+	 */
+	readonly reveal: (header?: string) => void;
 } {
 	const held: string[] = [];
 	let revealed = false;
@@ -485,9 +508,10 @@ export function createDeferredWriter(): {
 			if (revealed) console.log(line);
 			else held.push(line);
 		},
-		reveal: (): void => {
+		reveal: (header?: string): void => {
 			if (revealed) return;
 			revealed = true;
+			if (header) console.log(header);
 			for (const line of held) console.log(line);
 			held.length = 0;
 		},
@@ -543,7 +567,13 @@ export function createProgressPrinter(deps: { readonly log?: (line: string) => v
 					// printing "the first run can take a few minutes" up front was
 					// wrong on exactly the runs where it was most visible. Emitting it
 					// with the first git scan makes it true whenever it appears.
-					if (progress.kind === "commits" && !warnedSlow) {
+					//
+					// `firstRun` narrows it further, and has to: a sweep triggered by a
+					// moved branch tip re-reads the commit list but skips `--numstat`
+					// for everything already stored, so it finishes in well under a
+					// second on a 2.5k-commit history. Only a real bootstrap can take
+					// minutes, and only a bootstrap sets the flag.
+					if (progress.kind === "commits" && progress.firstRun && !warnedSlow) {
 						warnedSlow = true;
 						write("  Scanning your whole history — this can take a few minutes.");
 						write("  Interrupting is safe: progress is saved and the next run resumes.");
@@ -623,6 +653,15 @@ const PHASE_LABELS: Record<"commits" | "summaries" | "sessions", string> = {
  * runtime without flag-free `node:sqlite` there is no database to import into,
  * and staying silent is better than an error at the end of a successful setup.
  * Never throws and never touches `process.exitCode`.
+ *
+ * Ends by attempting the cutover, for the same reason the import runs here at
+ * all: this is the moment the database has just been filled from the orphan
+ * branch, so it is the moment the containment compare is most likely to pass.
+ * Without a caller here the engine was only ever reachable by typing `jolli
+ * cutover`, and every repo stayed `uncutover` — reads served from the folder
+ * layer, `SqliteStorage` never on the path. `maybeAutoCutover` reports nothing
+ * and cannot throw, so it cannot turn a successful setup into a failure; the
+ * two states short of `cutover` are both workable and converge later.
  */
 export async function importDashboardHistory(cwd: string, deps: DashboardDeps = {}): Promise<void> {
 	if (!canUseDashboardDb()) return;
@@ -632,6 +671,8 @@ export async function importDashboardHistory(cwd: string, deps: DashboardDeps = 
 		log.info("not registering a repo from %s: %s", cwd, errMsg(err));
 	}
 	await runHistoryImport(deps);
+	// No throttle: a fresh import is the one attempt worth making unconditionally.
+	await maybeAutoCutover(cwd, deps.dbPath ? { dbPath: deps.dbPath } : {});
 }
 
 /**
@@ -720,6 +761,20 @@ export async function executeDashboard(
 	// Write side last: the page is already up and polling, so history fills in
 	// as this lands. Runs in this command process — the server never writes.
 	await runHistoryImport(deps);
+	// Attempted for the same reason {@link importDashboardHistory} does it: the
+	// import above has just filled the database from the orphan branch, so this is
+	// when the containment compare is most likely to pass. Without a call here the
+	// guided front door — which wakes the dashboard through this function rather
+	// than the import-only entry point — would be the one setup path that never
+	// converges past `uncutover`.
+	//
+	// THROTTLED, unlike that caller, and the difference is the invocation
+	// frequency rather than the moment: `jolli dashboard` is a reopen command a
+	// user can type many times a day, the import is cursor-gated so a steady-state
+	// reopen fills nothing in, and the engine's compare reads every file the
+	// frozen tip lists. Unthrottled, a repo that keeps answering `not-ready` would
+	// pay that sweep on every launch. Reports nothing and cannot throw.
+	await maybeAutoCutover(cwd, { throttle: true, ...(deps.dbPath ? { dbPath: deps.dbPath } : {}) });
 	// The "dashboard start" half of the no-daemon backup schedule (the other is
 	// the post-commit QueueWorker). It belongs here, not in the server: taking a
 	// snapshot needs a WRITABLE handle, which runs schema migrations, and the

--- a/cli/src/commands/GuidedFrontDoor.test.ts
+++ b/cli/src/commands/GuidedFrontDoor.test.ts
@@ -25,7 +25,7 @@ const h = vi.hoisted(() => ({
 	saveUserProfile: vi.fn(),
 	isInsideGitWorkTree: vi.fn(),
 	isLocalAgentUsable: vi.fn(),
-	importDashboardHistory: vi.fn(),
+	executeDashboard: vi.fn(),
 	canUseDashboardDb: vi.fn(),
 }));
 
@@ -54,7 +54,7 @@ vi.mock("../dashboard/DashboardDb.js", () => ({ canUseDashboardDb: h.canUseDashb
 vi.mock("../hooks/PushCompensation.js", () => ({ triggerPendingPushRetry: h.triggerPendingPushRetry }));
 vi.mock("../install/GitHookInstaller.js", () => ({ isGitHookInstalled: h.isGitHookInstalled }));
 vi.mock("../install/Installer.js", () => ({ install: h.install }));
-vi.mock("./DashboardCommand.js", () => ({ importDashboardHistory: h.importDashboardHistory }));
+vi.mock("./DashboardCommand.js", () => ({ executeDashboard: h.executeDashboard }));
 vi.mock("./EnableCommand.js", () => ({ promptSetup: h.promptSetup }));
 vi.mock("./SpaceSyncStep.js", () => ({ runSpaceSyncStep: h.runSpaceSyncStep }));
 vi.mock("./BackfillFrontDoorStep.js", () => ({ runBackfillFrontDoorStep: h.runBackfillFrontDoorStep }));
@@ -125,7 +125,7 @@ describe("GuidedFrontDoor", () => {
 		h.isInsideGitWorkTree.mockReturnValue(true);
 		h.isLocalAgentUsable.mockResolvedValue(true);
 		h.canUseDashboardDb.mockReturnValue(true);
-		h.importDashboardHistory.mockResolvedValue(undefined);
+		h.executeDashboard.mockResolvedValue(true);
 	});
 
 	afterEach(() => {
@@ -790,19 +790,19 @@ describe("GuidedFrontDoor", () => {
 		expect(out()).not.toContain("Next steps");
 	});
 
-	// ── Importing history into the dashboard database. Triggered by the back-fill
-	// STEP COMPLETING (not by it having built anything), because that step reports
-	// nothing back, and because this import is the only thing that moves freshly
-	// built memories into the dashboard database. No web service is started. ──
+	// ── Waking the local web service. Triggered by the back-fill STEP COMPLETING
+	// (not by it having built anything), because that step reports nothing back,
+	// and because this call is the only thing that moves freshly built memories
+	// into the dashboard database AND puts them on screen. ──
 
-	describe("dashboard history import", () => {
-		it("imports after the back-fill step, before Next steps", async () => {
+	describe("local dashboard wake-up", () => {
+		it("wakes the dashboard after the back-fill step, before Next steps", async () => {
 			await runGuidedFrontDoor();
 
-			expect(h.importDashboardHistory).toHaveBeenCalledWith("/repo");
-			// Order matters: the import is what picks up whatever the back-fill just wrote.
+			expect(h.executeDashboard).toHaveBeenCalledWith("stats", { cwd: "/repo" });
+			// Order matters: the import half is what picks up whatever the back-fill just wrote.
 			expect(h.runBackfillFrontDoorStep.mock.invocationCallOrder[0]).toBeLessThan(
-				h.importDashboardHistory.mock.invocationCallOrder[0] as number,
+				h.executeDashboard.mock.invocationCallOrder[0] as number,
 			);
 			// And it lands before the closing orientation.
 			expect(logs.findIndex((l) => l.includes("Jolli is listening"))).toBeLessThan(
@@ -810,35 +810,51 @@ describe("GuidedFrontDoor", () => {
 			);
 		});
 
-		it("imports even when the back-fill offer was declined or never appeared", async () => {
-			// The step is a no-op in both cases and returns void either way — the import
+		it("wakes even when the back-fill offer was declined or never appeared", async () => {
+			// The step is a no-op in both cases and returns void either way — the wake-up
 			// is deliberately not conditional on it having built anything.
 			h.runBackfillFrontDoorStep.mockResolvedValue(undefined);
 			await runGuidedFrontDoor();
-			expect(h.importDashboardHistory).toHaveBeenCalledTimes(1);
+			expect(h.executeDashboard).toHaveBeenCalledTimes(1);
+		});
+
+		it("a dashboard that refuses or throws prints a retry hint and finishes cleanly", async () => {
+			// `executeDashboard` reports failure as `false` (it prints its own reason);
+			// the front door's exit code stays reserved for hard blockers either way.
+			h.executeDashboard.mockResolvedValue(false);
+			await runGuidedFrontDoor();
+			expect(out()).toContain("run 'jolli dashboard' to retry");
+			expect(out()).toContain("Next steps");
+			expect(process.exitCode).toBeUndefined();
+
+			logs.length = 0;
+			h.executeDashboard.mockRejectedValue(new Error("port in use"));
+			await runGuidedFrontDoor();
+			expect(out()).toContain("run 'jolli dashboard' to retry");
+			expect(process.exitCode).toBeUndefined();
 		});
 
 		it("runtime without flag-free node:sqlite → skipped silently", async () => {
 			h.canUseDashboardDb.mockReturnValue(false);
 			await runGuidedFrontDoor();
-			expect(h.importDashboardHistory).not.toHaveBeenCalled();
+			expect(h.executeDashboard).not.toHaveBeenCalled();
 			expect(out()).not.toContain("Dashboard");
 			expect(out()).toContain("Next steps");
 			expect(process.exitCode).toBeUndefined();
 		});
 
-		it("generation not configured → no back-fill step and no import", async () => {
+		it("generation not configured → no back-fill step and no wake-up", async () => {
 			h.loadAuthToken.mockResolvedValue(undefined);
 			h.loadConfig.mockResolvedValue({});
 			await runGuidedFrontDoor();
 			expect(h.runBackfillFrontDoorStep).not.toHaveBeenCalled();
-			expect(h.importDashboardHistory).not.toHaveBeenCalled();
+			expect(h.executeDashboard).not.toHaveBeenCalled();
 		});
 
-		it("dead ends (not a repo / enable declined) never import", async () => {
+		it("dead ends (not a repo / enable declined) never wake the dashboard", async () => {
 			h.isInsideGitWorkTree.mockReturnValue(false);
 			await runGuidedFrontDoor();
-			expect(h.importDashboardHistory).not.toHaveBeenCalled();
+			expect(h.executeDashboard).not.toHaveBeenCalled();
 
 			vi.clearAllMocks();
 			h.isInsideGitWorkTree.mockReturnValue(true);
@@ -851,7 +867,7 @@ describe("GuidedFrontDoor", () => {
 			h.createStorage.mockResolvedValue({});
 			h.getSummaryCount.mockResolvedValue(0);
 			await runGuidedFrontDoor();
-			expect(h.importDashboardHistory).not.toHaveBeenCalled();
+			expect(h.executeDashboard).not.toHaveBeenCalled();
 		});
 	});
 

--- a/cli/src/commands/GuidedFrontDoor.ts
+++ b/cli/src/commands/GuidedFrontDoor.ts
@@ -12,7 +12,7 @@
  * its state still needs):
  *   git repo? → onboarding (fresh only) → repair broken provider → Sign in? →
  *   Enable? → status line → cloud side-effects → backfill → listening →
- *   import dashboard history → Next steps
+ *   wake the local dashboard (import history, serve, open) → Next steps
  *
  * `Sign in?` deliberately precedes `Enable?`. The opening status line moved to
  * AFTER `Enable?` so `✓ enabled` is always truthful. Non-git directories are a
@@ -33,14 +33,16 @@ import { canUseDashboardDb } from "../dashboard/DashboardDb.js";
 import { triggerPendingPushRetry } from "../hooks/PushCompensation.js";
 import { isGitHookInstalled } from "../install/GitHookInstaller.js";
 import { install } from "../install/Installer.js";
-import { setLogDir } from "../Logger.js";
+import { createLogger, errMsg, setLogDir } from "../Logger.js";
 import { runBackfillFrontDoorStep } from "./BackfillFrontDoorStep.js";
 import { isAffirmative, isInsideGitWorkTree, promptText, resolveProjectDir } from "./CliUtils.js";
-import { importDashboardHistory } from "./DashboardCommand.js";
+import { executeDashboard } from "./DashboardCommand.js";
 import { promptSetup } from "./EnableCommand.js";
 import { canGenerateNow, promptGenerationFix } from "./GenerationFix.js";
 import { offerOptionalJolliLogin } from "./OptionalLogin.js";
 import { runSpaceSyncStep } from "./SpaceSyncStep.js";
+
+const log = createLogger("GuidedFrontDoor");
 
 /** Lightweight front-door status. Deliberately avoids the heavy `getStatus()`. */
 export interface GuidedFrontDoorStatus {
@@ -249,8 +251,9 @@ export async function runGuidedFrontDoor(): Promise<void> {
 		console.log(`\n  ${listening}`);
 		// Whatever the back-fill offer did (built memories, was declined, or never
 		// appeared), the memories it may have just written reach the dashboard
-		// database only through this import — so run one here. See below.
-		await importLocalDashboardHistory(cwd);
+		// database only through this import — and the guided front door is the one
+		// entry point that finishes by SHOWING them. See below.
+		await wakeLocalDashboard(cwd);
 	}
 
 	// Next steps orientation — printed on EVERY path that reaches here, for new
@@ -265,36 +268,49 @@ export async function runGuidedFrontDoor(): Promise<void> {
 }
 
 /**
- * Registers this repo and imports its memory into the dashboard database — the
- * same `importDashboardHistory` call `jolli enable` makes, so the two entry
- * points leave the machine in the same state.
+ * Wakes the local web service: registers this repo, imports its memory into the
+ * dashboard database, brings up (or reuses) the read-only server and opens the
+ * browser on it — one `executeDashboard` call, which is exactly what `jolli
+ * dashboard` runs.
  *
- * Placed AFTER the back-fill step on purpose. `backfillRepos` (which this
- * wraps) is the ONLY production caller of the source-of-truth import: memories
- * the back-fill just wrote would otherwise sit outside the dashboard database
- * until the user happened to run `jolli dashboard` by hand. Running it here
- * means the page is already populated whenever they do open it. Registration
- * alone is not the point — the hooks self-register from the write path on the
- * next commit (see ProducerHooks) — the import is.
+ * Placed AFTER the back-fill step on purpose. `backfillRepos` (which the import
+ * half wraps) is the ONLY production caller of the source-of-truth import:
+ * memories the back-fill just wrote would otherwise sit outside the dashboard
+ * database until the user happened to run `jolli dashboard` by hand.
+ * Registration alone is not the point — the hooks self-register from the write
+ * path on the next commit (see ProducerHooks) — the import is.
  *
- * It stops there: no port is bound, no server spawned, no browser opened. The
- * front door installs hooks and builds memories; deciding to run a local web
- * service is a separate, explicit `jolli dashboard`.
+ * Opening the browser is the point of doing it HERE rather than reusing
+ * `importDashboardHistory`. This is the guided setup, the one path a new user
+ * walks to completion, and the memories it just spent LLM budget building have
+ * no surface until something shows them. `ensureServerRunning` probes `/health`
+ * first, so a second `jolli` run reuses the live server instead of spawning a
+ * second one. `jolli enable` deliberately stays import-only — there the server
+ * is a side effect of a narrower request.
  *
  * Deliberately triggered by the STEP COMPLETING, not by it having built
  * anything: `runBackfillFrontDoorStep` returns `void` by contract (it reports
- * nothing to the front door), and `jolli enable` imports unconditionally too.
+ * nothing to the front door).
  *
- * Never fails the front door: `importDashboardHistory` never throws, and
- * `process.exitCode` must stay untouched here — the front door's exit code is
- * non-zero only for a hard blocker (not a repo, install failure).
+ * Never fails the front door: `executeDashboard` reports success as a boolean
+ * precisely so soft callers can shrug a failure off, and `process.exitCode` must
+ * stay untouched here — the front door's exit code is non-zero only for a hard
+ * blocker (not a repo, install failure). A browser that will not open is already
+ * non-fatal inside the launcher, which prints the URL either way.
  */
-async function importLocalDashboardHistory(cwd: string): Promise<void> {
-	// No flag-free `node:sqlite` → nothing to import into. `importDashboardHistory`
-	// self-gates on the same check; kept here so the intent is readable at the
-	// call site. Same gate as `jolli enable`.
+async function wakeLocalDashboard(cwd: string): Promise<void> {
+	// No flag-free `node:sqlite` → no database to import into and nothing to
+	// serve. Gated here rather than left to `executeDashboard`, which reports that
+	// runtime as an ERROR — correct when the user typed `jolli dashboard`, wrong
+	// as the closing line of a successful setup. Same gate as `jolli enable`.
 	if (!canUseDashboardDb()) return;
-	await importDashboardHistory(cwd);
+	try {
+		const opened = await executeDashboard("stats", { cwd });
+		if (!opened) console.log("  (Dashboard did not open — run 'jolli dashboard' to retry.)\n");
+	} catch (err) {
+		log.warn("dashboard wake failed (non-fatal): %s", errMsg(err));
+		console.log("  (Dashboard did not open — run 'jolli dashboard' to retry.)\n");
+	}
 }
 
 /** Prints the closing orientation shown on every non-dead-end front-door run. */

--- a/cli/src/core/AntigravityTranscriptReader.test.ts
+++ b/cli/src/core/AntigravityTranscriptReader.test.ts
@@ -134,3 +134,65 @@ describe("unwrapUserRequest", () => {
 		expect(unwrapUserRequest("  plain user text  ")).toBe("plain user text");
 	});
 });
+
+describe("readAntigravityTranscript toolUse", () => {
+	it("counts the PLANNER_RESPONSE tool_calls it also summarizes into the text", async () => {
+		const path = writeTranscript(REAL_TRANSCRIPT_FULL);
+		const result = await readAntigravityTranscript(path);
+		expect(result.toolUse).toEqual([{ name: "run_command", kind: "builtin", calls: 1 }]);
+	});
+
+	it("sums repeated calls to the same tool across steps", async () => {
+		const path = writeTranscript([
+			{
+				step_index: 0,
+				type: "PLANNER_RESPONSE",
+				created_at: "2026-07-19T09:46:50Z",
+				tool_calls: [
+					{ name: "run_command", args: {} },
+					{ name: "view_file", args: {} },
+				],
+			},
+			{
+				step_index: 1,
+				type: "PLANNER_RESPONSE",
+				created_at: "2026-07-19T09:46:51Z",
+				tool_calls: [{ name: "run_command", args: {} }],
+			},
+		]);
+		const result = await readAntigravityTranscript(path);
+		expect(result.toolUse).toEqual([
+			{ name: "run_command", kind: "builtin", calls: 2 },
+			{ name: "view_file", kind: "builtin", calls: 1 },
+		]);
+	});
+
+	it("reports an empty array — not undefined — for a tool-free slice", async () => {
+		const path = writeTranscript([
+			{ step_index: 0, type: "USER_INPUT", created_at: "2026-07-19T09:46:50Z", content: "hi" },
+		]);
+		const result = await readAntigravityTranscript(path);
+		expect(result.toolUse).toEqual([]);
+	});
+
+	it("counts only the calls inside the consumed slice", async () => {
+		const path = writeTranscript([
+			{
+				step_index: 0,
+				type: "PLANNER_RESPONSE",
+				created_at: "2026-07-19T09:46:50Z",
+				tool_calls: [{ name: "run_command", args: {} }],
+			},
+			{
+				step_index: 1,
+				type: "PLANNER_RESPONSE",
+				created_at: "2026-07-19T10:00:00Z",
+				tool_calls: [{ name: "view_file", args: {} }],
+			},
+		]);
+		const first = await readAntigravityTranscript(path, undefined, "2026-07-19T09:50:00Z");
+		expect(first.toolUse).toEqual([{ name: "run_command", kind: "builtin", calls: 1 }]);
+		const second = await readAntigravityTranscript(path, first.newCursor);
+		expect(second.toolUse).toEqual([{ name: "view_file", kind: "builtin", calls: 1 }]);
+	});
+});

--- a/cli/src/core/AntigravityTranscriptReader.ts
+++ b/cli/src/core/AntigravityTranscriptReader.ts
@@ -21,6 +21,7 @@
 
 import { readFile } from "node:fs/promises";
 import type { TranscriptCursor, TranscriptEntry, TranscriptReadResult } from "../Types.js";
+import { builtinTool, ToolUseTally } from "./ToolNameClassify.js";
 import { mergeConsecutiveEntries } from "./TranscriptReader.js";
 
 const USER_REQUEST_RE = /<USER_REQUEST>\s*([\s\S]*?)\s*<\/USER_REQUEST>/;
@@ -72,6 +73,7 @@ export async function readAntigravityTranscript(
 	const entries: TranscriptEntry[] = [];
 	let lastTs = cursor?.updatedAt ?? new Date().toISOString();
 	let lineNumber = startLine;
+	const tally = new ToolUseTally();
 
 	for (let i = startLine; i < lines.length; i++) {
 		lineNumber = i + 1;
@@ -100,6 +102,16 @@ export async function readAntigravityTranscript(
 			const tcs = Array.isArray(obj.tool_calls)
 				? (obj.tool_calls as { name?: string; args?: Record<string, unknown> }[])
 				: [];
+			// Same array the summary line is built from — the calls were already
+			// parsed here and only ever folded into prose; this counts them too.
+			// Entries carry `{name, args}` and no id, prefix or server field, so
+			// every call is a builtin and none can be de-duplicated. A repeated
+			// PLANNER_RESPONSE line is not a shape this transcript produces (it is
+			// append-only and each step_index appears once), so counting every
+			// occurrence is correct rather than merely tolerable.
+			for (const tc of tcs) {
+				if (typeof tc?.name === "string" && tc.name.length > 0) tally.add(builtinTool(tc.name));
+			}
 			const parts = [content, ...tcs.map(toolCallSummary)].filter((p) => p.length > 0);
 			if (parts.length) entries.push({ role: "assistant", content: parts.join("\n"), timestamp: ts });
 		} else if (type === "RUN_COMMAND") {
@@ -114,5 +126,7 @@ export async function readAntigravityTranscript(
 		// Lines actually consumed this pass (matches the other readers' convention);
 		// on an early `beforeTimestamp` break `lineNumber` is the unconsumed cutoff line.
 		totalLinesRead: lineNumber - startLine,
+		// Always present, even when empty — see TOOL_RECORDING_SOURCES.
+		toolUse: tally.values(),
 	};
 }

--- a/cli/src/core/AtomicJsonFile.ts
+++ b/cli/src/core/AtomicJsonFile.ts
@@ -1,0 +1,38 @@
+/**
+ * AtomicJsonFile — the one temp-then-rename writer for small JSON state files.
+ *
+ * Every file this is for has the same failure mode: it is read back with a
+ * fail-open parser, so a torn or truncated write does not surface as an error,
+ * it surfaces as "the file says nothing" — a dropped opt-out (`profile.json`)
+ * or, worse, a registry whose next read-modify-write cements the loss
+ * (`dashboard-repos.json`, the file the `repos` table is a projection of).
+ * `writeFile` truncates and then writes, so a crash, a kill, or ENOSPC in that
+ * window produces exactly that state.
+ *
+ * The temp name carries the PID so two writers that ever race WITHOUT the lock
+ * cannot land in each other's partial file — the rename is what is atomic, not
+ * the copy into the temp.
+ */
+
+import { mkdir, rename, unlink, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+/** Writes `contents` to `path` via a PID-scoped temp + rename. */
+export async function writeFileAtomic(
+	path: string,
+	contents: string,
+	opts: { readonly mode?: number } = {},
+): Promise<void> {
+	await mkdir(dirname(path), { recursive: true });
+	const tmpPath = `${path}.${process.pid}.tmp`;
+	// The mode goes on the temp: rename preserves it, and creating the temp
+	// world-readable first would leak the very contents the mode is protecting.
+	await writeFile(tmpPath, contents, opts.mode !== undefined ? { encoding: "utf-8", mode: opts.mode } : "utf-8");
+	try {
+		// Atomic on the same volume; replaces the target on Windows too.
+		await rename(tmpPath, path);
+	} catch (err) {
+		await unlink(tmpPath).catch(() => {});
+		throw err;
+	}
+}

--- a/cli/src/core/ClineCliTranscriptReader.test.ts
+++ b/cli/src/core/ClineCliTranscriptReader.test.ts
@@ -111,3 +111,79 @@ describe("readClineCliTranscript", () => {
 		expect(r.totalLinesRead).toBe(0);
 	});
 });
+
+describe("readClineCliTranscript toolUse", () => {
+	let dir: string;
+	let path: string;
+	beforeEach(async () => {
+		dir = await mkdtemp(join(tmpdir(), "cline-cli-tools-"));
+		path = join(dir, "m.messages.json");
+	});
+	afterEach(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	it("counts the fixture's tool_use block without counting its tool_result", async () => {
+		await writeFile(path, JSON.stringify(FIXTURE), "utf8");
+		const r = await readClineCliTranscript(path);
+		// m3 makes one `run_commands` call; m4 is that call's result, echoed back
+		// as a `tool_result` block carrying the same `name`.
+		expect(r.toolUse).toEqual([{ name: "run_commands", kind: "builtin", calls: 1 }]);
+	});
+
+	it("classifies an MCP call by its mcp__ prefix", async () => {
+		await writeFile(
+			path,
+			JSON.stringify({
+				messages: [
+					{
+						id: "m1",
+						role: "assistant",
+						content: [{ type: "tool_use", id: "c1", name: "mcp__jollimemory__recall", input: {} }],
+						ts: 1000,
+					},
+				],
+			}),
+			"utf8",
+		);
+		const r = await readClineCliTranscript(path);
+		expect(r.toolUse).toEqual([{ name: "jollimemory.recall", kind: "mcp", server: "jollimemory", calls: 1 }]);
+	});
+
+	it("reports an empty array — not undefined — for a tool-free slice", async () => {
+		await writeFile(
+			path,
+			JSON.stringify({ messages: [{ id: "m1", role: "user", content: [{ type: "text", text: "hi" }], ts: 1 }] }),
+			"utf8",
+		);
+		const r = await readClineCliTranscript(path);
+		expect(r.toolUse).toEqual([]);
+	});
+
+	it("counts only the calls inside the consumed slice", async () => {
+		await writeFile(
+			path,
+			JSON.stringify({
+				messages: [
+					{
+						id: "m1",
+						role: "assistant",
+						content: [{ type: "tool_use", id: "c1", name: "read_file", input: {} }],
+						ts: 1000,
+					},
+					{
+						id: "m2",
+						role: "assistant",
+						content: [{ type: "tool_use", id: "c2", name: "run_commands", input: {} }],
+						ts: 9000,
+					},
+				],
+			}),
+			"utf8",
+		);
+		const first = await readClineCliTranscript(path, null, new Date(5000).toISOString());
+		expect(first.toolUse).toEqual([{ name: "read_file", kind: "builtin", calls: 1 }]);
+		const second = await readClineCliTranscript(path, first.newCursor);
+		expect(second.toolUse).toEqual([{ name: "run_commands", kind: "builtin", calls: 1 }]);
+	});
+});

--- a/cli/src/core/ClineCliTranscriptReader.ts
+++ b/cli/src/core/ClineCliTranscriptReader.ts
@@ -1,18 +1,22 @@
 import { readFile } from "node:fs/promises";
 import { createLogger } from "../Logger.js";
-import type { TranscriptCursor, TranscriptReadResult } from "../Types.js";
+import type { ToolCallCount, TranscriptCursor, TranscriptReadResult } from "../Types.js";
 import {
 	buildClineReadResult,
 	emptyClineReadResult,
 	mapClineRole,
 	type NormalizedMessage,
 } from "./ClineTranscriptShared.js";
+import { classifyToolName, ToolUseTally } from "./ToolNameClassify.js";
 
 const log = createLogger("ClineCliReader");
 
 interface ClineCliBlock {
 	readonly type: string;
 	readonly text?: string;
+	/** Anthropic-block `tool_use` fields — present only on `type:"tool_use"` blocks. */
+	readonly id?: string;
+	readonly name?: string;
 }
 interface ClineCliMessage {
 	readonly role?: string;
@@ -38,6 +42,24 @@ function extractText(msg: ClineCliMessage): string {
 	return parts.join("\n").trim();
 }
 
+/**
+ * The message's `tool_use` blocks, classified.
+ *
+ * The Cline CLI stores `messages[].content` as Anthropic content blocks (the
+ * same array `extractText` walks for `type:"text"`), so a tool call is a
+ * `type:"tool_use"` block carrying `name` and a `toolu_…` `id`, and MCP tools
+ * are named `mcp__<server>__<tool>`. Deduped on the block id within the message
+ * — `tool_result` blocks are the same call's answer and are not counted.
+ */
+function extractTools(msg: ClineCliMessage): ToolCallCount[] {
+	const tally = new ToolUseTally();
+	for (const block of msg.content ?? []) {
+		if (block.type !== "tool_use" || typeof block.name !== "string" || block.name.length === 0) continue;
+		tally.addOnce(typeof block.id === "string" ? block.id : undefined, classifyToolName(block.name));
+	}
+	return tally.values();
+}
+
 export async function readClineCliTranscript(
 	transcriptPath: string,
 	cursor?: TranscriptCursor | null,
@@ -53,7 +75,12 @@ export async function readClineCliTranscript(
 	const messages: NormalizedMessage[] = (Array.isArray(parsed.messages) ? parsed.messages : []).map((msg) => {
 		const role = mapClineRole(msg.role);
 		const raw = extractText(msg);
-		return { role, content: role === "human" ? unwrapUserInput(raw) : raw, ts: msg.ts };
+		return {
+			role,
+			content: role === "human" ? unwrapUserInput(raw) : raw,
+			ts: msg.ts,
+			tools: extractTools(msg),
+		};
 	});
-	return buildClineReadResult(transcriptPath, messages, cursor, beforeTimestamp);
+	return buildClineReadResult(transcriptPath, messages, cursor, beforeTimestamp, { recordsTools: true });
 }

--- a/cli/src/core/ClineTranscriptReader.test.ts
+++ b/cli/src/core/ClineTranscriptReader.test.ts
@@ -173,3 +173,37 @@ describe("readClineTranscript", () => {
 		expect(r.newCursor.lineNumber).toBe(0);
 	});
 });
+
+describe("readClineTranscript toolUse", () => {
+	let dir: string;
+	let path: string;
+	beforeEach(async () => {
+		dir = await mkdtemp(join(tmpdir(), "cline-tools-"));
+		path = join(dir, "api_conversation_history.json");
+	});
+	afterEach(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	it("omits toolUse entirely — the extension's tool records are prose, not structure", async () => {
+		// Cline (VS Code) replays tool results as `[execute_command …] Result:` text
+		// inside role:"user" turns. That is a heuristic signal, so this source stays
+		// out of TOOL_RECORDING_SOURCES and must report ABSENT rather than `[]` —
+		// `[]` would be read downstream as "this agent called no tools".
+		await writeFile(path, JSON.stringify(FIXTURE), "utf8");
+		const r = await readClineTranscript(path);
+		expect(r.toolUse).toBeUndefined();
+	});
+
+	it("still omits toolUse when the file does happen to carry tool_use blocks", async () => {
+		await writeFile(
+			path,
+			JSON.stringify([
+				{ role: "assistant", content: [{ type: "tool_use", id: "c1", name: "read_file", input: {} }], ts: 1 },
+			]),
+			"utf8",
+		);
+		const r = await readClineTranscript(path);
+		expect(r.toolUse).toBeUndefined();
+	});
+});

--- a/cli/src/core/ClineTranscriptShared.ts
+++ b/cli/src/core/ClineTranscriptShared.ts
@@ -1,4 +1,5 @@
-import type { TranscriptCursor, TranscriptEntry, TranscriptReadResult } from "../Types.js";
+import type { ToolCallCount, TranscriptCursor, TranscriptEntry, TranscriptReadResult } from "../Types.js";
+import { ToolUseTally } from "./ToolNameClassify.js";
 import { mergeConsecutiveEntries } from "./TranscriptReader.js";
 
 /** Structured scan error shared by the Cline CLI + extension sources (non-SQLite). */
@@ -12,6 +13,30 @@ export interface NormalizedMessage {
 	readonly role: "human" | "assistant" | undefined;
 	readonly content: string;
 	readonly ts?: number;
+	/**
+	 * Tool calls this message made, already classified by the caller — the shape
+	 * of a tool record is per-source, so extraction stays in the reader that
+	 * knows the file format. Aggregated over the CONSUMED slice only, which is
+	 * why it rides on the message rather than being returned separately.
+	 */
+	readonly tools?: ReadonlyArray<ToolCallCount>;
+}
+
+/** Per-source knobs for {@link buildClineReadResult}. */
+export interface ClineReadOptions {
+	/**
+	 * Whether this source's transcripts can express tool calls at all.
+	 *
+	 * Opt-in rather than inferred from `messages`, because the two Cline sources
+	 * genuinely differ and the difference is invisible in the data: the CLI
+	 * writes Anthropic `tool_use` blocks, while the VS Code extension replays
+	 * tool results as PROSE inside `role:"user"` text (`[execute_command …]
+	 * Result:` — the `TOOL_RESULT_RE` the extension reader strips). Prose is a
+	 * heuristic signal, so the extension reports nothing and is deliberately
+	 * absent from `TOOL_RECORDING_SOURCES`. Inferring capability from "no tools
+	 * found" would turn that into the false claim "called no tools".
+	 */
+	readonly recordsTools?: boolean;
 }
 
 /** Map a raw Cline role string to a TranscriptEntry role (unknown → undefined → dropped). */
@@ -33,16 +58,21 @@ export function buildClineReadResult(
 	messages: ReadonlyArray<NormalizedMessage>,
 	cursor: TranscriptCursor | null | undefined,
 	beforeTimestamp: string | undefined,
+	options?: ClineReadOptions,
 ): TranscriptReadResult {
 	const startIndex = cursor?.lineNumber ?? 0;
 	const beforeMs = beforeTimestamp ? Date.parse(beforeTimestamp) : undefined;
 
 	const rawEntries: TranscriptEntry[] = [];
+	const tally = new ToolUseTally();
 	let lastConsumedIndex = startIndex;
 	for (let i = startIndex; i < messages.length; i++) {
 		const msg = messages[i];
 		if (beforeMs !== undefined && typeof msg.ts === "number" && msg.ts > beforeMs) break;
 		lastConsumedIndex = i + 1;
+		// Before the role/content skip: a message that is nothing but tool calls
+		// produces no entry, and its calls would be lost below.
+		for (const tool of msg.tools ?? []) tally.add(tool, tool.calls);
 		if (msg.role === undefined || msg.content.length === 0) continue;
 		const timestamp = typeof msg.ts === "number" ? new Date(msg.ts).toISOString() : undefined;
 		rawEntries.push(
@@ -56,7 +86,12 @@ export function buildClineReadResult(
 		lineNumber: beforeTimestamp ? lastConsumedIndex : messages.length,
 		updatedAt: new Date().toISOString(),
 	};
-	return { entries, newCursor, totalLinesRead: lastConsumedIndex - startIndex };
+	return {
+		entries,
+		newCursor,
+		totalLinesRead: lastConsumedIndex - startIndex,
+		...(options?.recordsTools ? { toolUse: tally.values() } : {}),
+	};
 }
 
 /** Empty result preserving the caller's cursor index (used on unreadable file). */

--- a/cli/src/core/CursorCliTranscriptReader.test.ts
+++ b/cli/src/core/CursorCliTranscriptReader.test.ts
@@ -298,3 +298,72 @@ describe("readCursorCliTranscript", () => {
 		expect(r2.entries).toEqual([{ role: "assistant", content: "second" }]);
 	});
 });
+
+describe("readCursorCliTranscript toolUse", () => {
+	let dir: string;
+	beforeEach(async () => {
+		dir = await mkdtemp(join(tmpdir(), "cursor-cli-tools-"));
+	});
+	afterEach(async () => {
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	// cursor-agent speaks the Anthropic block format, so a tool call is a
+	// `type:"tool_use"` part with a `toolu_…` id — the same parts the reader
+	// deliberately drops from the conversation text.
+	const withTools = [
+		JSON.stringify({
+			role: "assistant",
+			message: {
+				content: [
+					{ type: "text", text: "Checking." },
+					{ type: "tool_use", id: "toolu_1", name: "read_file", input: {} },
+					{ type: "tool_use", id: "toolu_2", name: "mcp__jollimemory__search", input: {} },
+				],
+			},
+		}),
+		JSON.stringify({
+			role: "assistant",
+			message: { content: [{ type: "tool_use", id: "toolu_3", name: "read_file", input: {} }] },
+		}),
+		"",
+	].join("\n");
+
+	it("counts tool_use parts, classifying MCP names by their mcp__ prefix", async () => {
+		const p = join(dir, "t.jsonl");
+		await writeFile(p, withTools);
+		const result = await readCursorCliTranscript(p);
+		expect(result.toolUse).toEqual([
+			{ name: "read_file", kind: "builtin", calls: 2 },
+			{ name: "jollimemory.search", kind: "mcp", server: "jollimemory", calls: 1 },
+		]);
+	});
+
+	it("counts a turn that is nothing but tool calls, which produces no entry", async () => {
+		const p = join(dir, "t.jsonl");
+		await writeFile(
+			p,
+			`${JSON.stringify({
+				role: "assistant",
+				message: { content: [{ type: "tool_use", id: "toolu_1", name: "read_file", input: {} }] },
+			})}\n`,
+		);
+		const result = await readCursorCliTranscript(p);
+		expect(result.entries).toEqual([]);
+		expect(result.toolUse).toEqual([{ name: "read_file", kind: "builtin", calls: 1 }]);
+	});
+
+	it("reports an empty array — not undefined — for a tool-free slice", async () => {
+		const p = join(dir, "t.jsonl");
+		await writeFile(p, REAL_JSONL);
+		const result = await readCursorCliTranscript(p);
+		expect(result.toolUse).toEqual([]);
+	});
+
+	it("counts only the calls inside the consumed slice", async () => {
+		const p = join(dir, "t.jsonl");
+		await writeFile(p, withTools);
+		const first = await readCursorCliTranscript(p, { transcriptPath: p, lineNumber: 1, updatedAt: "" });
+		expect(first.toolUse).toEqual([{ name: "read_file", kind: "builtin", calls: 1 }]);
+	});
+});

--- a/cli/src/core/CursorCliTranscriptReader.ts
+++ b/cli/src/core/CursorCliTranscriptReader.ts
@@ -27,6 +27,7 @@
 import { readFile } from "node:fs/promises";
 import { createLogger } from "../Logger.js";
 import type { TranscriptCursor, TranscriptEntry, TranscriptReadResult } from "../Types.js";
+import { classifyToolName, ToolUseTally } from "./ToolNameClassify.js";
 import { mergeConsecutiveEntries } from "./TranscriptReader.js";
 
 const log = createLogger("CursorCliReader");
@@ -34,6 +35,9 @@ const log = createLogger("CursorCliReader");
 interface CursorCliPart {
 	readonly type?: string;
 	readonly text?: unknown;
+	/** Anthropic-block `tool_use` fields — present only on `type:"tool_use"` parts. */
+	readonly id?: unknown;
+	readonly name?: unknown;
 }
 interface CursorCliLine {
 	readonly role?: string;
@@ -138,6 +142,7 @@ export async function readCursorCliTranscript(
 	const cutoffMs = beforeTimestamp ? Date.parse(beforeTimestamp) : Number.NaN;
 	const hasCutoff = !Number.isNaN(cutoffMs);
 	const rawEntries: TranscriptEntry[] = [];
+	const tally = new ToolUseTally();
 	// Advances only across lines we actually consumed — so the cursor never moves
 	// past a deferred (post-cutoff) turn or a trailing partial line (see below).
 	let lastConsumed = Math.min(startLine, lines.length);
@@ -166,6 +171,14 @@ export async function readCursorCliTranscript(
 			const content = role === "human" ? unwrapUser(text) : text;
 			if (content.length > 0) rawEntries.push({ role, content });
 		}
+		// The `tool_use` parts this reader drops from the CONTENT are still counted
+		// here — a pure tool-call turn yields no entry but is real agent activity.
+		// cursor-agent speaks the Anthropic block format, so blocks carry a
+		// `toolu_…` id (dedupe key) and MCP tools are named `mcp__<server>__<tool>`.
+		for (const p of parsed.message?.content ?? []) {
+			if (p.type !== "tool_use" || typeof p.name !== "string" || p.name.length === 0) continue;
+			tally.addOnce(typeof p.id === "string" ? p.id : undefined, classifyToolName(p.name));
+		}
 		lastConsumed = i + 1;
 	}
 
@@ -175,5 +188,6 @@ export async function readCursorCliTranscript(
 		lineNumber: lastConsumed,
 		updatedAt: new Date().toISOString(),
 	};
-	return { entries, newCursor, totalLinesRead: lastConsumed - startLine };
+	// Always present, even when empty — see TOOL_RECORDING_SOURCES.
+	return { entries, newCursor, totalLinesRead: lastConsumed - startLine, toolUse: tally.values() };
 }

--- a/cli/src/core/DevinTranscriptReader.test.ts
+++ b/cli/src/core/DevinTranscriptReader.test.ts
@@ -587,3 +587,100 @@ describe("readDevinTranscript", () => {
 		await expect(readDevinTranscript("/no/hash/here")).rejects.toThrow();
 	});
 });
+
+describe("readDevinTranscript toolUse", () => {
+	/** Builds a one-chain Devin DB from raw chat_message objects. */
+	async function seed(messages: ReadonlyArray<Record<string, unknown>>): Promise<{ path: string; dir: string }> {
+		const dir = await mkdtemp(join(tmpdir(), "devin-tools-"));
+		const p = join(dir, "s.db");
+		const db = new DatabaseSync(p);
+		db.exec(
+			"CREATE TABLE sessions(id TEXT, main_chain_id INTEGER); CREATE TABLE message_nodes(session_id TEXT, node_id INTEGER, parent_node_id INTEGER, chat_message TEXT);",
+		);
+		db.prepare("INSERT INTO sessions VALUES('s', ?)").run(messages.length);
+		const insert = db.prepare("INSERT INTO message_nodes VALUES('s',?,?,?)");
+		for (let i = 0; i < messages.length; i++) {
+			insert.run(i + 1, i === 0 ? null : i, JSON.stringify(messages[i]));
+		}
+		db.close();
+		return { path: `${p}#s`, dir };
+	}
+
+	// Devin's chat_message is an OpenAI chat-completions message: its live rows
+	// carry `tool_calls` next to `tool_call_id`, so an entry is
+	// {id, type:"function", function:{name, arguments}}.
+	it("counts tool_calls on an assistant turn whose content is empty", async () => {
+		const { path, dir } = await seed([
+			{
+				role: "assistant",
+				content: "",
+				metadata: { created_at: "2026-07-18T00:00:00Z" },
+				tool_calls: [
+					{ id: "call_1", type: "function", function: { name: "exec", arguments: "{}" } },
+					{ id: "call_2", type: "function", function: { name: "exec", arguments: "{}" } },
+					{ id: "call_3", type: "function", function: { name: "str_replace", arguments: "{}" } },
+				],
+			},
+		]);
+		const result = await readDevinTranscript(path);
+		// The turn itself is dropped (empty content) — the calls are the only
+		// surviving record of it.
+		expect(result.entries).toEqual([]);
+		expect(result.toolUse).toEqual([
+			{ name: "exec", kind: "builtin", calls: 2 },
+			{ name: "str_replace", kind: "builtin", calls: 1 },
+		]);
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	it("accepts a flattened entry and de-duplicates on the call id", async () => {
+		const { path, dir } = await seed([
+			{
+				role: "assistant",
+				content: "x",
+				metadata: { created_at: "2026-07-18T00:00:00Z" },
+				tool_calls: [
+					{ id: "call_1", name: "exec" },
+					{ id: "call_1", name: "exec" },
+					{ name: "exec" },
+					null,
+					{ id: "call_9", function: {} },
+				],
+			},
+		]);
+		const result = await readDevinTranscript(path);
+		expect(result.toolUse).toEqual([{ name: "exec", kind: "builtin", calls: 2 }]);
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	it("reports an empty array — not undefined — for a tool-free slice", async () => {
+		const { path, dir } = await seed([
+			{ role: "user", content: "hi", metadata: { created_at: "2026-07-18T00:00:00Z" } },
+		]);
+		const result = await readDevinTranscript(path);
+		expect(result.toolUse).toEqual([]);
+		await rm(dir, { recursive: true, force: true });
+	});
+
+	it("counts only the calls inside the consumed slice", async () => {
+		const { path, dir } = await seed([
+			{
+				role: "assistant",
+				content: "a",
+				metadata: { created_at: "2026-07-18T00:00:00Z" },
+				tool_calls: [{ id: "call_1", function: { name: "exec" } }],
+			},
+			{
+				role: "assistant",
+				content: "b",
+				metadata: { created_at: "2026-07-19T00:00:00Z" },
+				tool_calls: [{ id: "call_2", function: { name: "str_replace" } }],
+			},
+		]);
+		const first = await readDevinTranscript(path, null, "2026-07-18T12:00:00Z");
+		expect(first.toolUse).toEqual([{ name: "exec", kind: "builtin", calls: 1 }]);
+		const second = await readDevinTranscript(path, first.newCursor);
+		expect(second.toolUse).toEqual([{ name: "str_replace", kind: "builtin", calls: 1 }]);
+		await rm(dir, { recursive: true, force: true });
+	});
+});

--- a/cli/src/core/DevinTranscriptReader.ts
+++ b/cli/src/core/DevinTranscriptReader.ts
@@ -14,15 +14,18 @@
  * Envelope verified against a live `~/.local/share/devin/cli/sessions.db`
  * install: `content` is always a plain string (assistant turns that are pure
  * tool calls carry `content: ""`, which the empty-content skip already
- * handles), and `metadata.created_at` is an ISO 8601 string. Other fields the
- * live rows carry (`tool_calls`, `thinking`, `tool_call_id`, `telemetry`,
- * `extensions`, …) are ignored — only `role`/`content`/`metadata.created_at`
- * are read here.
+ * handles), and `metadata.created_at` is an ISO 8601 string. Beyond
+ * `role`/`content`/`metadata.created_at`, one more live field is read:
+ * `tool_calls`, counted into `TranscriptReadResult.toolUse` (see
+ * {@link tallyDevinToolCalls}) — which is the only record left of a pure
+ * tool-call turn, since the empty-content skip drops the turn itself. The rest
+ * (`thinking`, `tool_call_id`, `telemetry`, `extensions`, …) are ignored.
  */
 
 import { createLogger } from "../Logger.js";
 import type { TranscriptCursor, TranscriptEntry, TranscriptReadResult } from "../Types.js";
 import { withSqliteDb } from "./SqliteHelpers.js";
+import { builtinTool, ToolUseTally } from "./ToolNameClassify.js";
 import { mergeConsecutiveEntries } from "./TranscriptReader.js";
 
 const log = createLogger("DevinReader");
@@ -37,6 +40,35 @@ interface ChatMessage {
 	readonly role?: string;
 	readonly content?: unknown;
 	readonly metadata?: { readonly created_at?: unknown } | null;
+	readonly tool_calls?: unknown;
+}
+
+/**
+ * Counts one node's `tool_calls` into `tally`.
+ *
+ * Devin's `chat_message` is an OpenAI chat-completions message — the live rows
+ * carry `tool_calls` alongside `tool_call_id`, which is that API's pairing field
+ * and is what fixes the envelope: an entry is
+ * `{id, type:"function", function:{name, arguments}}`. A bare `{name}` is
+ * accepted too so a schema that flattens the wrapper still counts rather than
+ * silently reporting zero.
+ *
+ * Names are bare (`exec` and friends) with no prefix or server field, so every
+ * call is a builtin; nothing here guesses at an MCP shape Devin has not been
+ * observed writing. De-duplication is on the entry's own `id` — an assistant
+ * turn that is pure tool calls carries `content: ""` and is dropped from the
+ * conversation by the empty-content skip, so these counts are the only place
+ * that activity survives.
+ */
+function tallyDevinToolCalls(tally: ToolUseTally, msg: ChatMessage): void {
+	if (!Array.isArray(msg.tool_calls)) return;
+	for (const raw of msg.tool_calls) {
+		if (raw === null || typeof raw !== "object") continue;
+		const tc = raw as { id?: unknown; name?: unknown; function?: { name?: unknown } };
+		const name = typeof tc.function?.name === "string" ? tc.function.name : tc.name;
+		if (typeof name !== "string" || name.length === 0) continue;
+		tally.addOnce(typeof tc.id === "string" ? tc.id : undefined, builtinTool(name));
+	}
 }
 
 const ROLE_MAP: Readonly<Record<string, "human" | "assistant">> = {
@@ -155,6 +187,7 @@ export async function readDevinTranscript(
 ): Promise<TranscriptReadResult> {
 	const { dbPath, sessionId } = parseSyntheticPath(transcriptPath);
 	const cutoffTime = beforeTimestamp ? Date.parse(beforeTimestamp) : undefined;
+	const tally = new ToolUseTally();
 
 	try {
 		const { rawEntries, totalNodes, startIndex, lastConsumedIndex, anchorId } = await withSqliteDb(dbPath, (db) => {
@@ -212,6 +245,7 @@ export async function readDevinTranscript(
 				if (role !== undefined && content.length > 0) {
 					rawEntries.push({ role, content, timestamp });
 				}
+				tallyDevinToolCalls(tally, msg);
 				lastConsumedIndex = startIndex + i + 1;
 			}
 
@@ -239,7 +273,8 @@ export async function readDevinTranscript(
 			startIndex,
 			newCursor.lineNumber,
 		);
-		return { entries, newCursor, totalLinesRead };
+		// Always present, even when empty — see TOOL_RECORDING_SOURCES.
+		return { entries, newCursor, totalLinesRead, toolUse: tally.values() };
 	} catch (error: unknown) {
 		log.error("Failed to read Devin session %s: %s", sessionId, (error as Error).message);
 		// Preserve an ENOENT code so callers (e.g. TranscriptLoader) can treat a

--- a/cli/src/core/GeminiTranscriptReader.test.ts
+++ b/cli/src/core/GeminiTranscriptReader.test.ts
@@ -274,3 +274,91 @@ describe("readGeminiTranscript", () => {
 		expect(result.newCursor.lineNumber).toBe(2);
 	});
 });
+
+describe("readGeminiTranscript toolUse", () => {
+	// Shape read off real ~/.gemini/tmp/<project>/chats/session-*.json files: the
+	// array hangs off the `gemini` message and its entries are bare-named.
+	it("counts a gemini message's toolCalls as builtins", async () => {
+		const filePath = await createSession([
+			{ id: "1", type: "user", timestamp: "2026-03-20T10:00:00.000Z", content: "list the folder" },
+			{
+				id: "2",
+				type: "gemini",
+				timestamp: "2026-03-20T10:00:05.000Z",
+				content: "Done.",
+				toolCalls: [
+					{ id: "ww9tmu6j", name: "list_directory", status: "success" },
+					{ id: "s5tfezrm", name: "read_file", status: "success" },
+				],
+			} as never,
+		]);
+		const result = await readGeminiTranscript(filePath);
+		expect(result.toolUse).toEqual([
+			{ name: "list_directory", kind: "builtin", calls: 1 },
+			{ name: "read_file", kind: "builtin", calls: 1 },
+		]);
+	});
+
+	it("counts a cancelled call — the agent still made it", async () => {
+		const filePath = await createSession([
+			{
+				id: "1",
+				type: "gemini",
+				timestamp: "2026-03-20T10:00:05.000Z",
+				content: "",
+				toolCalls: [{ id: "47ff01hw", name: "run_shell_command", status: "cancelled" }],
+			} as never,
+		]);
+		const result = await readGeminiTranscript(filePath);
+		expect(result.toolUse).toEqual([{ name: "run_shell_command", kind: "builtin", calls: 1 }]);
+	});
+
+	it("counts a repeated call id once and distinct ids separately", async () => {
+		const filePath = await createSession([
+			{
+				id: "1",
+				type: "gemini",
+				timestamp: "2026-03-20T10:00:05.000Z",
+				content: "a",
+				toolCalls: [
+					{ id: "a", name: "run_shell_command" },
+					{ id: "a", name: "run_shell_command" },
+					{ id: "b", name: "run_shell_command" },
+				],
+			} as never,
+		]);
+		const result = await readGeminiTranscript(filePath);
+		expect(result.toolUse).toEqual([{ name: "run_shell_command", kind: "builtin", calls: 2 }]);
+	});
+
+	it("reports an empty array — not undefined — for a tool-free slice", async () => {
+		const filePath = await createSession([
+			{ id: "1", type: "user", timestamp: "2026-03-20T10:00:00.000Z", content: "hi" },
+		]);
+		const result = await readGeminiTranscript(filePath);
+		expect(result.toolUse).toEqual([]);
+	});
+
+	it("counts only the calls inside the consumed slice", async () => {
+		const filePath = await createSession([
+			{
+				id: "1",
+				type: "gemini",
+				timestamp: "2026-03-20T10:00:00.000Z",
+				content: "a",
+				toolCalls: [{ id: "a", name: "read_file" }],
+			} as never,
+			{
+				id: "2",
+				type: "gemini",
+				timestamp: "2026-03-20T12:00:00.000Z",
+				content: "b",
+				toolCalls: [{ id: "b", name: "grep_search" }],
+			} as never,
+		]);
+		const first = await readGeminiTranscript(filePath, null, "2026-03-20T11:00:00.000Z");
+		expect(first.toolUse).toEqual([{ name: "read_file", kind: "builtin", calls: 1 }]);
+		const second = await readGeminiTranscript(filePath, first.newCursor);
+		expect(second.toolUse).toEqual([{ name: "grep_search", kind: "builtin", calls: 1 }]);
+	});
+});

--- a/cli/src/core/GeminiTranscriptReader.ts
+++ b/cli/src/core/GeminiTranscriptReader.ts
@@ -19,9 +19,33 @@
 import { readFile } from "node:fs/promises";
 import { createLogger } from "../Logger.js";
 import type { TranscriptCursor, TranscriptEntry, TranscriptReadResult } from "../Types.js";
+import { builtinTool, ToolUseTally } from "./ToolNameClassify.js";
 import { mergeConsecutiveEntries } from "./TranscriptReader.js";
 
 const log = createLogger("GeminiTranscriptReader");
+
+/**
+ * One entry of a `gemini` message's `toolCalls` array.
+ *
+ * Read off real `~/.gemini/tmp/<project>/chats/session-*.json` files: the array
+ * hangs off the ASSISTANT message that made the calls (alongside `model`,
+ * `thoughts` and `tokens`), and each entry carries
+ * `{id, name, args, result, status, timestamp, resultDisplay, displayName,
+ * description}`. Only `id` (dedupe) and `name` (identity) are read here.
+ *
+ * Names in that corpus are bare and undecorated — `run_shell_command`,
+ * `read_file`, `list_directory`, `grep_search` — with no prefix, namespace or
+ * server field anywhere on the entry, so every call is classified as a builtin.
+ * Nothing here guesses at an MCP shape Gemini has not been observed writing.
+ *
+ * `status` is NOT filtered on. A `cancelled` call (present in the corpus) was
+ * still a call the agent decided to make, which is the question this counter
+ * answers; filtering would silently under-report the agent's activity.
+ */
+interface GeminiToolCall {
+	readonly id?: unknown;
+	readonly name?: unknown;
+}
 
 /** Gemini message record structure (subset of fields we care about) */
 interface GeminiMessageRecord {
@@ -29,6 +53,7 @@ interface GeminiMessageRecord {
 	readonly type: string;
 	readonly timestamp: string;
 	readonly content: GeminiContent;
+	readonly toolCalls?: ReadonlyArray<GeminiToolCall>;
 }
 
 /** Gemini content can be a string, an array of parts, or absent */
@@ -84,6 +109,7 @@ export async function readGeminiTranscript(
 	const rawEntries: TranscriptEntry[] = [];
 	const cutoffTime = beforeTimestamp ? new Date(beforeTimestamp).getTime() : undefined;
 	let lastConsumedIndex = startIndex;
+	const tally = new ToolUseTally();
 
 	for (let i = 0; i < newMessages.length; i++) {
 		const msg = newMessages[i];
@@ -99,6 +125,13 @@ export async function readGeminiTranscript(
 		const entry = parseGeminiMessage(msg);
 		if (entry) {
 			rawEntries.push(entry);
+		}
+		// Counted independently of `entry`: a message whose text was empty (or
+		// whose type is not conversational) can still carry tool calls, and those
+		// are real agent activity. Gating on the entry would drop them.
+		for (const tc of msg.toolCalls ?? []) {
+			if (typeof tc?.name !== "string" || tc.name.length === 0) continue;
+			tally.addOnce(typeof tc.id === "string" ? tc.id : undefined, builtinTool(tc.name));
 		}
 		lastConsumedIndex = startIndex + i + 1;
 	}
@@ -123,7 +156,11 @@ export async function readGeminiTranscript(
 		newCursor.lineNumber,
 	);
 
-	return { entries, newCursor, totalLinesRead };
+	// Always present (never conditional): Gemini's transcripts CAN express tool
+	// calls, so an empty array is the positive claim "this slice called none".
+	// Dropping the field would make the source look incapable — see
+	// TOOL_RECORDING_SOURCES.
+	return { entries, newCursor, totalLinesRead, toolUse: tally.values() };
 }
 
 /** Returns null for non-conversational message types (info, error, warning). */

--- a/cli/src/core/InlineScript.test.ts
+++ b/cli/src/core/InlineScript.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { escapeForInlineScript } from "./InlineScript.js";
+
+const LS = String.fromCharCode(0x2028);
+const PS = String.fromCharCode(0x2029);
+
+/** What the browser would see for `<script>window.X = <json>;</script>`. */
+const inlined = (json: string) => `<script>window.X = ${escapeForInlineScript(json)};</script>`;
+
+describe("escapeForInlineScript", () => {
+	it("escapes </script so the element cannot be closed from inside the data", () => {
+		const out = escapeForInlineScript(JSON.stringify({ title: "</script><img onerror=x>" }));
+		expect(out).not.toContain("</script");
+		expect(out).toContain("\\u003c/script");
+	});
+
+	// The regression this module exists for: the previous sequence-based escape
+	// neutralized `</script` only, so `<!--` still moved the tokenizer into
+	// script-data-escaped state and swallowed every later inlined script.
+	it("escapes <!-- so a comment opener cannot enter script-data-escaped state", () => {
+		const out = inlined(JSON.stringify({ title: "<!--<script>" }));
+		expect(out).not.toContain("<!--");
+		// Exactly one `<script` and one `</script` remain: the wrapper's own.
+		expect(out.match(/<script/g)).toHaveLength(1);
+		expect(out.match(/<\/script/g)).toHaveLength(1);
+	});
+
+	it("leaves no raw < for any breakout sequence, whatever its case", () => {
+		for (const payload of ["</SCRIPT >", "<!--", "<script", "<!-- --><script>alert(1)</script>"]) {
+			expect(escapeForInlineScript(JSON.stringify({ t: payload }))).not.toContain("<");
+		}
+	});
+
+	it("escapes the raw U+2028/U+2029 line terminators JSON leaves unescaped", () => {
+		const out = escapeForInlineScript(`{"x":"${LS}${PS}"}`);
+		expect(out).not.toContain(LS);
+		expect(out).not.toContain(PS);
+		expect(out).toContain("\\u2028");
+		expect(out).toContain("\\u2029");
+	});
+
+	it("round-trips through JSON.parse unchanged — the escape is transparent to the parser", () => {
+		const value = { title: "<!--<script>a</script>", nested: [`${LS}x`, "a < b", "&amp;"] };
+		expect(JSON.parse(escapeForInlineScript(JSON.stringify(value)))).toEqual(value);
+	});
+
+	it("leaves > and & alone — neither can leave script-data state", () => {
+		const out = escapeForInlineScript(JSON.stringify({ t: "a > b & c" }));
+		expect(out).toContain(">");
+		expect(out).toContain("&");
+	});
+
+	it("is a no-op for JSON with nothing to escape", () => {
+		const json = JSON.stringify({ a: 1, b: "plain text" });
+		expect(escapeForInlineScript(json)).toBe(json);
+	});
+});

--- a/cli/src/core/InlineScript.ts
+++ b/cli/src/core/InlineScript.ts
@@ -1,0 +1,41 @@
+/**
+ * InlineScript — the one hardening applied to JSON embedded in an inline
+ * `<script>` block. Kept dependency-free on purpose: three surfaces inline
+ * model JSON into a page (the dashboard server, the standalone graph export,
+ * and the VS Code webview panel), and each used to carry its own copy of this
+ * function. Three copies of a security primitive is three chances to fix one
+ * and miss two — which is exactly what happened: all three neutralized
+ * `</script` and missed `<!--`.
+ */
+
+/**
+ * Escapes every `<` in already-serialized JSON as `<`, plus the two raw JS
+ * line terminators U+2028/U+2029 that `JSON.stringify` leaves unescaped.
+ *
+ * Escaping the character rather than the `</script` sequence is what makes this
+ * complete. The HTML tokenizer has THREE ways out of a script block, and the
+ * sequence-based version only closed one of them:
+ *
+ *   - `</script`  — closes the element.
+ *   - `<!--`      — enters script-data-escaped state, after which the block's
+ *                   own `</script>` no longer closes it. A commit message
+ *                   containing `<!--<script>` therefore swallowed every script
+ *                   inlined after the data block (blank page), and with a
+ *                   matching `-->` it was an injection primitive.
+ *   - `<script`   — inside the escaped state, escalates one level further.
+ *
+ * All three start with `<`, and `<` is the same string to a JSON parser,
+ * so one substitution covers the whole class with no per-sequence reasoning.
+ * `>` and `&` are deliberately NOT escaped: neither can move the tokenizer out
+ * of script-data state, so escaping them would only inflate the payload.
+ *
+ * Input MUST be the output of `JSON.stringify` (or equivalent). This is safe
+ * for a JSON document precisely because every `<` in one is inside a string
+ * literal; applied to arbitrary JS it would corrupt a `a < b` comparison.
+ */
+export function escapeForInlineScript(json: string): string {
+	return json
+		.replace(/</g, "\\u003c")
+		.replace(/\u2028/g, "\\u2028")
+		.replace(/\u2029/g, "\\u2029");
+}

--- a/cli/src/core/JolliMemoryPushOrchestrator.test.ts
+++ b/cli/src/core/JolliMemoryPushOrchestrator.test.ts
@@ -191,6 +191,20 @@ describe("serializeSummaryJson", () => {
 		expect(json.commitHash).toBe("a");
 	});
 
+	it("strips the skill-article publish state too (the skill push runs first and weaves it on)", () => {
+		const s = {
+			commitHash: "a",
+			jolliSkillsDocId: 42,
+			jolliSkillsDocUrl: "https://acme.jolli.ai/articles?doc=42",
+			skills: [{ source: "claude", skill: "jolli-recall", uses: 2 }],
+		} as unknown as CommitSummary;
+		const json = JSON.parse(serializeSummaryJson(s) ?? "{}");
+		expect(json.jolliSkillsDocId).toBeUndefined();
+		expect(json.jolliSkillsDocUrl).toBeUndefined();
+		// The skill rows themselves are commit content and stay.
+		expect(json.skills).toHaveLength(1);
+	});
+
 	it("keeps nested plan/note/reference docId/url (needed for rendering the article links)", () => {
 		const s = {
 			commitHash: "a",
@@ -2068,36 +2082,69 @@ describe("skill attachments", () => {
 		vi.mocked(readSkillFromBranch).mockReset().mockResolvedValue(null);
 	});
 
-	it("pushes a skill article and writes the id back onto the UNIFORM fields", async () => {
+	it("pushes ONE skill article and writes its id back onto the COMMIT", async () => {
 		const client = fakeClient({
 			push: async (payload) => (payload.docType === "skill" ? fakePushResult({ docId: 77 }) : fakePushResult()),
 		});
-		const summary = leaf({ skills: [skillRef] });
+		const second = { ...skillRef, archivedKey: "claude:other-a1b2c3d4", skill: "other" };
+		const summary = leaf({ skills: [skillRef, second] });
 
-		await pushSummary(summary, baseCtx(client), new Map([["skill", [skillRef]]]));
+		await pushSummary(summary, baseCtx(client), new Map([["skill", [skillRef, second]]]));
 
-		expect(client.push).toHaveBeenCalledWith(
-			expect.objectContaining({ docType: "skill", commitHash: summary.commitHash }),
-		);
+		// Two skills, one article — the commit's skills are ONE artifact everywhere else
+		// (the Memory Bank writes a single `skills--<hash8>.md`), and the push now matches.
+		const skillPushes = vi.mocked(client.push).mock.calls.filter(([p]) => p.docType === "skill");
+		expect(skillPushes).toHaveLength(1);
+		expect(skillPushes[0][0]).toMatchObject({ commitHash: summary.commitHash });
 		const stored = vi.mocked(storeSummary).mock.calls[0][0];
-		// A new kind takes the registry defaults, so the published id lands on
-		// `jolliDocId` / `jolliDocUrl` rather than a `jolliSkillDoc*` pair.
-		expect(stored.skills?.[0]).toMatchObject({ jolliDocId: 77, jolliDocUrl: `${BASE}/articles?doc=77` });
+		// On the SUMMARY, because the article covers the commit. Parking it on a
+		// representative ref put a commit-level id inside `mergeSkillRef`'s per-ref fold.
+		expect(stored).toMatchObject({ jolliSkillsDocId: 77, jolliSkillsDocUrl: `${BASE}/articles?doc=77` });
+		expect(stored.skills?.[0]).not.toHaveProperty("jolliDocId");
 	});
 
-	it("reuses a stored skill docId as an update target when the env matches", async () => {
+	it("reuses the commit's stored skill docId as an update target when the env matches", async () => {
 		const client = fakeClient();
-		const withDoc = { ...skillRef, jolliDocId: 66, jolliDocUrl: `${BASE}/articles?doc=66` };
-		await pushSummary(leaf({ skills: [withDoc] }), baseCtx(client), new Map([["skill", [withDoc]]]));
+		const summary = {
+			...leaf({ skills: [skillRef] }),
+			jolliSkillsDocId: 66,
+			jolliSkillsDocUrl: `${BASE}/articles?doc=66`,
+		};
+		await pushSummary(summary, baseCtx(client), new Map([["skill", [skillRef]]]));
 		expect(client.push).toHaveBeenCalledWith(expect.objectContaining({ docType: "skill", docId: 66 }));
 	});
 
 	it("drops a stored skill docId minted against another backend", async () => {
 		const client = fakeClient();
-		const foreign = { ...skillRef, jolliDocId: 66, jolliDocUrl: "https://other.jolli.ai/articles?doc=66" };
-		await pushSummary(leaf({ skills: [foreign] }), baseCtx(client), new Map([["skill", [foreign]]]));
+		const summary = {
+			...leaf({ skills: [skillRef] }),
+			jolliSkillsDocId: 66,
+			jolliSkillsDocUrl: "https://other.jolli.ai/articles?doc=66",
+		};
+		await pushSummary(summary, baseCtx(client), new Map([["skill", [skillRef]]]));
 		const skillPayload = vi.mocked(client.push).mock.calls.find(([p]) => p.docType === "skill")?.[0];
 		expect(skillPayload?.docId).toBeUndefined();
+	});
+
+	it("migrates a legacy per-skill article id onto the commit and orphans the others", async () => {
+		// A shipped version published one article per (skill, commit). Ignoring those ids
+		// would leak every one of them — `cleanupOrphanedDocs` only ever sees
+		// `orphanedDocIds` — so the newest is adopted as the commit's aggregate and the
+		// rest are queued for deletion. N articles converge to 1 in a single push.
+		const client = fakeClient();
+		const older = { ...skillRef, jolliDocId: 61, jolliDocUrl: `${BASE}/articles?doc=61` };
+		const newer = {
+			...skillRef,
+			archivedKey: "claude:other-a1b2c3d4",
+			skill: "other",
+			lastUsedAt: "2026-08-09T10:00:00.000Z",
+			jolliDocId: 62,
+			jolliDocUrl: `${BASE}/articles?doc=62`,
+		};
+		await pushSummary(leaf({ skills: [older, newer] }), baseCtx(client), new Map([["skill", [older, newer]]]));
+		expect(client.push).toHaveBeenCalledWith(expect.objectContaining({ docType: "skill", docId: 62 }));
+		const stored = vi.mocked(storeSummary).mock.calls[0][0];
+		expect(stored.orphanedDocIds).toContain(61);
 	});
 
 	it("logs and continues past a failed skill push — the summary still publishes", async () => {

--- a/cli/src/core/JolliMemoryPushOrchestrator.ts
+++ b/cli/src/core/JolliMemoryPushOrchestrator.ts
@@ -39,6 +39,7 @@ import {
 } from "./push/ContextPush.js";
 import { canReuseDocId } from "./push/DocIdReuse.js";
 import { referenceBaseKey } from "./push/kinds/index.js";
+import { adoptLegacySkillDocIds } from "./push/LegacySkillDocIds.js";
 import { latestPlanPerName, planBaseKey } from "./push/PlanGrouping.js";
 import { clearSpaceBindingCache, saveSpaceBindingCache } from "./SpaceBindingCache.js";
 import { buildPushTitle, collectSortedTopics } from "./SummaryFormat.js";
@@ -77,7 +78,8 @@ const MAX_SUMMARY_JSON_BYTES = 1_572_864;
 /**
  * Serializes a summary for the `summaryJson` push field: the enriched
  * `summaryForMarkdown` copy (plan/note URLs woven in) minus the client push-state
- * fields — `jolliDocId`/`jolliDocUrl` churn per push, while `orphanedDocIds`
+ * fields — `jolliDocId`/`jolliDocUrl` and their skill-article siblings
+ * `jolliSkillsDocId`/`jolliSkillsDocUrl` churn per push, while `orphanedDocIds`
  * and `unresolvedOrphanHashes` are cleanup bookkeeping. None of them are
  * commit content the share page should see
  * (stripping them also keeps the top-level fields of a re-push byte-identical for
@@ -89,6 +91,13 @@ export function serializeSummaryJson(summary: CommitSummary): string | undefined
 	const {
 		jolliDocId: _docId,
 		jolliDocUrl: _docUrl,
+		// The skill aggregate is pushed BEFORE the summary in the same run, so
+		// `applyPublishedUrls` has already woven the freshly minted id/URL onto the
+		// summary by the time we serialize — leaving them in would put this push's
+		// own publish state into the sidecar (and make the same commit's JSON differ
+		// per environment, since the ids are per-backend).
+		jolliSkillsDocId: _skillsDocId,
+		jolliSkillsDocUrl: _skillsDocUrl,
 		orphanedDocIds: _orphaned,
 		unresolvedOrphanHashes: _unresolved,
 		...content
@@ -376,11 +385,15 @@ export interface PushSummaryOptions {
  * injected chooser).
  */
 export async function pushSummary(
-	summary: CommitSummary,
+	original: CommitSummary,
 	ctx: PushContext,
 	attachments?: AttachmentSelection | ContextSelection,
 	opts?: PushSummaryOptions,
 ): Promise<PushSummaryResult> {
+	// Convert any per-skill article ids published by an older version into the
+	// commit-level one before anything reads them — see `adoptLegacySkillDocIds`.
+	// Persisted by this function's own write-back, like every other field it updates.
+	const summary = adoptLegacySkillDocIds(original);
 	const displayBase = ctx.baseUrl.replace(/\/+$/, "");
 	// Env key of the tenant this push targets — every docId minted below is tagged
 	// with it, and an existing docId is reused as an update target only when its

--- a/cli/src/core/OpenCodeTranscriptReader.test.ts
+++ b/cli/src/core/OpenCodeTranscriptReader.test.ts
@@ -434,3 +434,126 @@ describe("OpenCodeTranscriptReader", () => {
 		expect(second.entries[1].content).toBe("Reply 2");
 	});
 });
+
+describe("OpenCodeTranscriptReader toolUse", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "opencode-tools-"));
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	// A `part` row with `data.type === "tool"` IS a call and `data.tool` is its
+	// name — the same evidence OpenCodeSkillScanner is built on.
+	it("counts tool parts as builtins, including on a message with no text", async () => {
+		const now = Date.now();
+		const transcriptPath = await createTestDb(tempDir, "sess-t1", [
+			{
+				id: "m1",
+				role: "assistant",
+				parts: [
+					{ type: "text", text: "Looking." },
+					{ type: "tool", tool: "bash", callID: "c1" },
+					{ type: "tool", tool: "read", callID: "c2" },
+				],
+				time_created: now,
+			},
+			{
+				id: "m2",
+				role: "assistant",
+				parts: [{ type: "tool", tool: "bash", callID: "c3" }],
+				time_created: now + 1,
+			},
+		]);
+
+		const result = await readOpenCodeTranscript(transcriptPath);
+
+		expect(result.toolUse).toEqual([
+			{ name: "bash", kind: "builtin", calls: 2 },
+			{ name: "read", kind: "builtin", calls: 1 },
+		]);
+	});
+
+	it("re-attributes the first-class skill tool to the skill it loaded", async () => {
+		const now = Date.now();
+		const transcriptPath = await createTestDb(tempDir, "sess-t2", [
+			{
+				id: "m1",
+				role: "assistant",
+				parts: [
+					{
+						type: "tool",
+						tool: "skill",
+						callID: "c1",
+						state: { status: "completed", metadata: { name: "brainstorming" } },
+					},
+				],
+				time_created: now,
+			},
+		]);
+
+		const result = await readOpenCodeTranscript(transcriptPath);
+
+		expect(result.toolUse).toEqual([{ name: "brainstorming", kind: "skill", calls: 1 }]);
+	});
+
+	it("falls back to the requested skill name when metadata carries none", async () => {
+		const now = Date.now();
+		const transcriptPath = await createTestDb(tempDir, "sess-t3", [
+			{
+				id: "m1",
+				role: "assistant",
+				parts: [{ type: "tool", tool: "skill", callID: "c1", state: { input: { name: "code-review" } } }],
+				time_created: now,
+			},
+		]);
+
+		const result = await readOpenCodeTranscript(transcriptPath);
+
+		expect(result.toolUse).toEqual([{ name: "code-review", kind: "skill", calls: 1 }]);
+	});
+
+	it("keeps a nameless skill call as a builtin rather than dropping it", async () => {
+		const now = Date.now();
+		const transcriptPath = await createTestDb(tempDir, "sess-t4", [
+			{ id: "m1", role: "assistant", parts: [{ type: "tool", tool: "skill", callID: "c1" }], time_created: now },
+		]);
+
+		const result = await readOpenCodeTranscript(transcriptPath);
+
+		expect(result.toolUse).toEqual([{ name: "skill", kind: "builtin", calls: 1 }]);
+	});
+
+	it("reports an empty array — not undefined — for a tool-free slice", async () => {
+		const now = Date.now();
+		const transcriptPath = await createTestDb(tempDir, "sess-t5", [
+			{ id: "m1", role: "user", parts: [{ type: "text", text: "hi" }], time_created: now },
+		]);
+
+		const result = await readOpenCodeTranscript(transcriptPath);
+
+		expect(result.toolUse).toEqual([]);
+	});
+
+	it("counts only the calls inside the consumed slice", async () => {
+		const now = Date.now();
+		const transcriptPath = await createTestDb(tempDir, "sess-t6", [
+			{ id: "m1", role: "assistant", parts: [{ type: "tool", tool: "bash", callID: "c1" }], time_created: now },
+			{
+				id: "m2",
+				role: "assistant",
+				parts: [{ type: "tool", tool: "read", callID: "c2" }],
+				time_created: now + 600_000,
+			},
+		]);
+
+		const first = await readOpenCodeTranscript(transcriptPath, null, new Date(now + 1000).toISOString());
+		expect(first.toolUse).toEqual([{ name: "bash", kind: "builtin", calls: 1 }]);
+
+		const second = await readOpenCodeTranscript(transcriptPath, first.newCursor);
+		expect(second.toolUse).toEqual([{ name: "read", kind: "builtin", calls: 1 }]);
+	});
+});

--- a/cli/src/core/OpenCodeTranscriptReader.ts
+++ b/cli/src/core/OpenCodeTranscriptReader.ts
@@ -17,11 +17,15 @@
  */
 
 import { createLogger } from "../Logger.js";
-import type { TranscriptCursor, TranscriptEntry, TranscriptReadResult } from "../Types.js";
+import type { ToolCallCount, TranscriptCursor, TranscriptEntry, TranscriptReadResult } from "../Types.js";
 import { withSqliteDb } from "./SqliteHelpers.js";
+import { builtinTool, skillTool, ToolUseTally } from "./ToolNameClassify.js";
 import { mergeConsecutiveEntries } from "./TranscriptReader.js";
 
 const log = createLogger("OpenCodeTranscriptReader");
+
+/** OpenCode's tool name for loading a skill (see `OpenCodeSkillScanner`). */
+const SKILL_TOOL = "skill";
 
 /** A single part row's parsed data from the `part` table */
 interface OpenCodePartData {
@@ -49,6 +53,7 @@ export async function readOpenCodeTranscript(
 	const { dbPath, sessionId } = parseSyntheticPath(transcriptPath);
 	const startIndex = cursor?.lineNumber ?? 0;
 	const cutoffTime = beforeTimestamp ? new Date(beforeTimestamp).getTime() : undefined;
+	const tally = new ToolUseTally();
 
 	try {
 		const { rawEntries, totalMessages, lastConsumedIndex } = await withSqliteDb(dbPath, (db) => {
@@ -105,6 +110,9 @@ export async function readOpenCodeTranscript(
 				if (entry) {
 					rawEntries.push(entry);
 				}
+				// Independent of `entry`: an assistant message whose only parts are
+				// tool calls yields no text entry but is real agent activity.
+				tallyOpenCodeToolParts(tally, msg.parts);
 				lastConsumedIndex = startIndex + i + 1;
 			}
 
@@ -131,11 +139,60 @@ export async function readOpenCodeTranscript(
 			newCursor.lineNumber,
 		);
 
-		return { entries, newCursor, totalLinesRead };
+		// Always present, even when empty — see TOOL_RECORDING_SOURCES for why an
+		// empty array and an absent field mean opposite things.
+		return { entries, newCursor, totalLinesRead, toolUse: tally.values() };
 	} catch (error: unknown) {
 		log.error("Failed to read OpenCode session %s: %s", sessionId.substring(0, 8), (error as Error).message);
 		throw new Error(`Cannot read OpenCode session: ${sessionId}`);
 	}
+}
+
+/**
+ * Counts one message's tool `part` rows into `tally`.
+ *
+ * A `part` row with `data.type === "tool"` IS a tool call and `data.tool` is its
+ * name — nothing heuristic, read off a real `~/.local/share/opencode/opencode.db`
+ * (the same evidence `OpenCodeSkillScanner` is built on). Names are bare, with no
+ * prefix or server field anywhere on the row, so every call is a builtin except
+ * the first-class `skill` tool, which is re-attributed to the skill it loaded.
+ *
+ * The skill name resolves the way the scanner resolves it: `state.metadata.name`
+ * is authoritative and `state.input.name` is the request. A `skill` call with
+ * neither stays a builtin named `skill` rather than being dropped — the call
+ * happened, only its subject is unknown.
+ *
+ * De-duplication is on `data.callID` when present. The join already yields one
+ * row per part, so this only guards against a part row repeated across the
+ * message grouping; a row without a call id is counted unconditionally.
+ */
+function tallyOpenCodeToolParts(tally: ToolUseTally, partDataJsons: ReadonlyArray<string>): void {
+	for (const json of partDataJsons) {
+		let data: Record<string, unknown>;
+		try {
+			data = JSON.parse(json) as Record<string, unknown>;
+		} catch {
+			continue;
+		}
+		if (data.type !== "tool" || typeof data.tool !== "string" || data.tool.length === 0) continue;
+		const callId = typeof data.callID === "string" ? data.callID : undefined;
+		tally.addOnce(callId, openCodeToolCall(data));
+	}
+}
+
+/** One OpenCode tool part's identity: the `skill` tool names its skill, everything else is a builtin. */
+function openCodeToolCall(data: Record<string, unknown>): ToolCallCount {
+	const tool = data.tool as string;
+	if (tool !== SKILL_TOOL) return builtinTool(tool);
+	const state = isRecord(data.state) ? data.state : undefined;
+	const metadata = isRecord(state?.metadata) ? state.metadata : undefined;
+	const input = isRecord(state?.input) ? state.input : undefined;
+	const name = typeof metadata?.name === "string" ? metadata.name : input?.name;
+	return typeof name === "string" && name.length > 0 ? skillTool(name) : builtinTool(tool);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 /**

--- a/cli/src/core/ProcessedSourceStore.ts
+++ b/cli/src/core/ProcessedSourceStore.ts
@@ -22,6 +22,20 @@ export function emptyProcessedSet(): ProcessedSet {
 
 /** Reads `topics/processed.json`; missing or unparseable → empty set (never throws). */
 export async function readProcessedSet(cwd?: string, storage?: StorageProvider): Promise<ProcessedSet> {
+	return (await readProcessedSetOrNull(cwd, storage)) ?? emptyProcessedSet();
+}
+
+/**
+ * The same read, but `null` when the file EXISTS and could not be parsed.
+ *
+ * `readProcessedSet` collapses "nothing processed yet" and "could not read it"
+ * into the same empty set, which is right for an ingest decision (re-processing
+ * a source is idempotent) and wrong for anything that RECONCILES against the
+ * value: taking an unreadable file as an empty live-set deletes every row it
+ * was supposed to describe. Callers that prune must use this one and skip the
+ * prune on `null` — the same distinction the alias index already draws.
+ */
+export async function readProcessedSetOrNull(cwd?: string, storage?: StorageProvider): Promise<ProcessedSet | null> {
 	const resolved = await resolveStorage(storage, cwd);
 	const raw = await resolved.readFile(PROCESSED_PATH);
 	if (!raw) return emptyProcessedSet();
@@ -38,8 +52,8 @@ export async function readProcessedSet(cwd?: string, storage?: StorageProvider):
 			},
 		};
 	} catch {
-		log.warn("Failed to parse %s — treating as empty", PROCESSED_PATH);
-		return emptyProcessedSet();
+		log.warn("Failed to parse %s — treating as unreadable", PROCESSED_PATH);
+		return null;
 	}
 }
 

--- a/cli/src/core/RepoProfile.ts
+++ b/cli/src/core/RepoProfile.ts
@@ -19,10 +19,11 @@
  */
 
 import { readFileSync, statSync } from "node:fs";
-import { mkdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { readFile, stat, unlink } from "node:fs/promises";
 import { dirname, isAbsolute, join } from "node:path";
 import { getJolliMemoryDir } from "../Logger.js";
 import { execFileSyncHidden } from "../util/Subprocess.js";
+import { writeFileAtomic } from "./AtomicJsonFile.js";
 import { execGit, listWorktrees } from "./GitOps.js";
 import { withStrictProfileLock } from "./Locks.js";
 
@@ -71,6 +72,18 @@ export interface RepoProfile {
 	 * there is no legitimate "unfreeze" — old clients must never write the
 	 * frozen branch again.
 	 */
+	/**
+	 * When the automatic cutover attempt last RAN for this clone (epoch ms).
+	 *
+	 * Only a throttle, never evidence of state: the two witnesses that decide
+	 * routing are {@link cutoverFence} and the database's `repo_state.cutover`
+	 * row, and this field is deliberately not consulted by either. It exists
+	 * because the attempt's step 3 reads every file the frozen tip lists, which
+	 * is far too expensive to repeat on every commit for a repo that keeps
+	 * answering `not-ready`. Absent means "never attempted", which is what every
+	 * repo enabled before auto-cutover shipped reads back.
+	 */
+	cutoverAttemptedAtMs?: number;
 	cutoverFence?: {
 		readonly reason: string;
 		readonly at: string;
@@ -148,19 +161,11 @@ async function fileExists(path: string): Promise<boolean> {
 }
 
 async function writeProfile(profilePath: string, profile: RepoProfile): Promise<void> {
-	await mkdir(dirname(profilePath), { recursive: true });
 	// Atomic write: a torn/partial file reads back as `{}` (corrupt JSON), which
-	// would silently drop a durable opt-out. Write a PID-scoped temp then rename
-	// (atomic on the same volume; replaces the target on Windows). The PID suffix
-	// avoids a temp-file collision if two writers ever race without the lock.
-	const tmpPath = `${profilePath}.${process.pid}.tmp`;
-	await writeFile(tmpPath, `${JSON.stringify(profile, null, "\t")}\n`);
-	try {
-		await rename(tmpPath, profilePath);
-	} catch (err) {
-		await unlink(tmpPath).catch(() => {});
-		throw err;
-	}
+	// would silently drop a durable opt-out. `writeFileAtomic` is the shared
+	// temp-then-rename writer -- see its header for why every fail-open JSON
+	// state file in this codebase goes through it.
+	await writeFileAtomic(profilePath, `${JSON.stringify(profile, null, "\t")}\n`);
 }
 
 /**

--- a/cli/src/core/SkillsAggregateMarkdown.ts
+++ b/cli/src/core/SkillsAggregateMarkdown.ts
@@ -9,9 +9,20 @@
 
 import type { CommitSummary, SkillCommitRef, SkillUsage } from "../Types.js";
 
+/**
+ * `skills--<hash8>` — the per-commit skill aggregate's identity.
+ *
+ * Shared by the Memory Bank file name below and the pushed article's `entryKey`
+ * (see the `skill` context kind), so the same aggregate is not named two ways: one
+ * commit's skills are ONE artifact locally and ONE article remotely.
+ */
+export function skillsAggregateKey(hash8: string): string {
+	return `skills--${hash8}`;
+}
+
 /** `skills--<hash8>.md` — the visible aggregate's file name for one commit. */
 export function skillsAggregateFileName(hash8: string): string {
-	return `skills--${hash8}.md`;
+	return `${skillsAggregateKey(hash8)}.md`;
 }
 
 /**

--- a/cli/src/core/SqliteStorage.test.ts
+++ b/cli/src/core/SqliteStorage.test.ts
@@ -296,7 +296,13 @@ describe("SqliteStorage reads", () => {
 
 	it("reads a child leaf directly and keeps its own empty children array", async () => {
 		const text = await storage.readFile(`summaries/${"c".repeat(40)}.json`);
-		expect(JSON.parse(text as string).children).toEqual([]);
+		const parsed = JSON.parse(text as string) as { commitHash: string; children: unknown[] };
+		expect(parsed.children).toEqual([]);
+		// A non-root is assembled from its SUBTREE, not from its root's whole
+		// family: the sibling `b…` shares a root_hash with it and must not leak
+		// in. That is also why the two shapes exist — see assembleMemoryTree.
+		expect(parsed.commitHash).toBe("c".repeat(40));
+		expect(text).not.toContain("b".repeat(40));
 	});
 
 	it("keeps siblings in child_pos order — the array order the parent file had", async () => {

--- a/cli/src/core/SqliteStorage.ts
+++ b/cli/src/core/SqliteStorage.ts
@@ -49,7 +49,6 @@ import { isManuallyDisabled } from "../Logger.js";
 import type { CommitSummary, FileWrite } from "../Types.js";
 import type { StorageKind, StorageProvider } from "./StorageProvider.js";
 import { toCatalogEntry } from "./SummaryStore.js";
-import { countTopics } from "./SummaryTree.js";
 
 /** One memories row, as the assembly needs it. */
 interface MemoryRow {
@@ -131,16 +130,45 @@ export function assembleMemoryTree(
 	repoId: number,
 	hash: string,
 ): Record<string, unknown> | undefined {
-	const root = db.prepare("SELECT root_hash FROM memories WHERE repo_id = ? AND commit_hash = ?").get(repoId, hash) as
-		| { root_hash: string }
-		| undefined;
-	if (!root) return undefined;
-	const tree = db
-		.prepare(
-			`SELECT commit_hash, parent_hash, child_pos, tree_hash, summary_json
-			   FROM memories WHERE repo_id = ? AND root_hash = ?`,
-		)
-		.all(repoId, root.root_hash) as MemoryRow[];
+	const row = db
+		.prepare("SELECT root_hash, parent_hash FROM memories WHERE repo_id = ? AND commit_hash = ?")
+		.get(repoId, hash) as { root_hash: string; parent_hash: string | null } | undefined;
+	if (!row) return undefined;
+	// Two shapes, because measurement says one query cannot serve both.
+	//
+	// `assembleSummary` only ever walks DOWNWARD, so for a non-root the whole
+	// `root_hash` family is mostly ancestors and siblings whose bodies are read
+	// for nothing — and the bodies are the cost (the largest tree here is 68 rows
+	// / 2 MB of JSON). Walking the edges instead takes reading one leaf of that
+	// tree from 7.45 ms to 0.35 ms.
+	//
+	// For a ROOT the subtree IS the tree, so the recursion buys nothing and its
+	// per-row join costs: the same read measured 12.04 ms by `root_hash` against
+	// 18.79 ms by CTE. Roots are also the common case — every sidebar entry — so
+	// applying the CTE to both made the aggregate over all 835 stored summaries
+	// SLOWER (4.81 → 5.54 ms/read) while looking like an optimisation.
+	//
+	// The recursive step is indexed either way: `UNIQUE (repo_id, parent_hash,
+	// child_pos)` covers the `parent_hash` join.
+	const tree = (
+		row.parent_hash === null
+			? db.prepare(
+					`SELECT commit_hash, parent_hash, child_pos, tree_hash, summary_json
+					   FROM memories WHERE repo_id = ? AND root_hash = ?`,
+				)
+			: db.prepare(
+					`WITH RECURSIVE subtree(commit_hash) AS (
+					     SELECT commit_hash FROM memories WHERE repo_id = ?1 AND commit_hash = ?2
+					     UNION ALL
+					     SELECT m.commit_hash FROM memories m
+					       JOIN subtree s ON m.parent_hash = s.commit_hash
+					      WHERE m.repo_id = ?1
+					   )
+					   SELECT m.commit_hash, m.parent_hash, m.child_pos, m.tree_hash, m.summary_json
+					     FROM memories m JOIN subtree ON subtree.commit_hash = m.commit_hash
+					    WHERE m.repo_id = ?1`,
+				)
+	).all(repoId, row.parent_hash === null ? row.root_hash : hash) as MemoryRow[];
 	const self = tree.find((r) => r.commit_hash === hash);
 	return self ? assembleSummary(childrenOf(tree), self) : undefined;
 }
@@ -155,6 +183,39 @@ export function asSqliteStorage(storage?: StorageProvider): SqliteStorage | null
 	if (storage instanceof SqliteStorage) return storage;
 	const primary = (storage as { primary?: unknown } | undefined)?.primary;
 	return primary instanceof SqliteStorage ? primary : null;
+}
+
+/** The columns `synthIndex` needs — deliberately no `summary_json`. */
+interface IndexEntryRow {
+	commit_hash: string;
+	parent_hash: string | null;
+	root_hash: string;
+	tree_hash: string | null;
+	commit_type: string | null;
+	commit_message: string | null;
+	commit_date: string | null;
+	branch: string | null;
+	generated_at: string | null;
+	diff_stats_json: string | null;
+}
+
+/**
+ * The `diffStats` key for an index entry, or nothing.
+ *
+ * A conditional spread rather than `?? undefined` for the same reason as its
+ * neighbours: `JSON.stringify` drops undefined either way, but the spread also
+ * keeps key presence and order identical to the file the writer would have
+ * produced. A value that cannot be parsed is treated as absent — an index entry
+ * with no diffStats is a normal shape, so degrading to it costs a badge rather
+ * than the whole index read.
+ */
+function parsedDiffStats(json: string | null): Record<string, unknown> {
+	if (json === null) return {};
+	try {
+		return { diffStats: JSON.parse(json) };
+	} catch {
+		return {};
+	}
 }
 
 export class SqliteStorage implements StorageProvider {
@@ -194,6 +255,19 @@ export class SqliteStorage implements StorageProvider {
 	 * is reachable, not theoretical: `CutoverRouter` answers `no-row` for
 	 * "repo not registered" as well as for "no cutover row", and the
 	 * `legacy-fenced` route builds a bare `SqliteStorage` from it.
+	 *
+	 * The absent answer covers the missing ROW ONLY — an unopenable DATABASE
+	 * still throws, and that asymmetry is deliberate rather than an oversight
+	 * in the contract above. "No row" is a real state of a healthy database;
+	 * "cannot open the file" is not an answer about the data at all, and past
+	 * a cutover this database is the only source there is. Throwing is also
+	 * the RECOVERABLE direction on the path that matters most: a queue entry
+	 * is deleted only after it is processed (`deleteQueueEntry`), so a drain
+	 * that throws leaves the entry for the next worker, while a drain told
+	 * "no data yet" would proceed against nothing and consume it. Read
+	 * surfaces get an error instead of a convincing empty page, which is the
+	 * same trade. Callers that must not act on a guess should ask
+	 * `detectStoredMemories`, whose third state exists for exactly this.
 	 *
 	 * WRITES keep the throwing `withDb` on purpose — landing a memory in a
 	 * repo the registry does not know about must fail loudly, not silently
@@ -306,60 +380,76 @@ export class SqliteStorage implements StorageProvider {
 	 * copy stale values forward. Deriving from the current rows is the fix, not
 	 * a regression — same story as the embedded-children drift in the header.
 	 */
-	/**
-	 * The `diffStats` key for one root entry, or nothing.
-	 *
-	 * A conditional spread rather than `?? undefined` for the same reason as its
-	 * neighbours: `JSON.stringify` drops undefined either way, but the spread
-	 * also keeps key presence and order identical to the file the writer would
-	 * have produced — which the cutover compare checks.
-	 */
-	private diffStatsFor(summary: Record<string, unknown>, row: MemoryRow): Record<string, unknown> {
-		if (summary.diffStats !== undefined) return { diffStats: summary.diffStats };
-		if (row.index_diff_stats_json === null) return {};
-		try {
-			return { diffStats: JSON.parse(row.index_diff_stats_json) };
-		} catch {
-			// A row that cannot be parsed is treated as absent: an index entry with
-			// no diffStats is a normal shape, so degrading to it costs a badge
-			// rather than the whole index read.
-			return {};
-		}
-	}
-
 	private synthIndex(db: DashboardDbHandle, repoId: number): string | null {
-		const rows = this.allMemories(db, repoId);
+		// Columns, NOT bodies. This is the hottest read the database serves — the
+		// sidebar list, the Timeline and the SessionStart briefing all go through
+		// `index.json`, and it is re-read on every refresh — and the entry it
+		// builds needs eight scalars per row, none of which is the body. Pulling
+		// `summary_json` for all of them and `JSON.parse`ing each in JS cost 75 ms
+		// on a 399-row / 9 MB repo (measured); asking SQLite for the generated
+		// columns instead is 16 ms for byte-identical output. `commit_message`,
+		// `branch` and `commit_type` are STORED so they are free; the rest still
+		// pay a per-row `json_extract`, which is where the remaining time is, and
+		// is why nothing else was added to the list.
+		//
+		// `diffStats` is extracted BY SQLITE rather than in JS for the same
+		// reason: the body arrives as a small object instead of a 22 KB blob.
+		// Body first, then the stats the legacy index entry carried, matching what
+		// `flattenSummaryTree` resolved — only the first is recoverable from a
+		// body-only rebuild, so a pre-v4 memory would otherwise lose its diff
+		// badge everywhere it is rendered. Its third step, a live `git diff`,
+		// deliberately does NOT belong here: this is a pure projection of stored
+		// rows and must not shell out.
+		const rows = db
+			.prepare(
+				`SELECT commit_hash, parent_hash, root_hash, tree_hash, commit_type, commit_message,
+				        commit_date, branch, generated_at,
+				        CASE WHEN parent_hash IS NULL
+				             THEN COALESCE(json_extract(summary_json, '$.diffStats'), index_diff_stats_json)
+				        END AS diff_stats_json
+				   FROM memories WHERE repo_id = ? ORDER BY rowid`,
+			)
+			.all(repoId) as ReadonlyArray<IndexEntryRow>;
 		if (rows.length === 0) return null;
-		const kids = childrenOf(rows);
-		const entries = rows.map((r) => {
-			const s = JSON.parse(r.summary_json) as Record<string, unknown>;
-			const isRoot = r.parent_hash === null;
-			return {
-				commitHash: r.commit_hash,
-				parentCommitHash: r.parent_hash,
-				// Conditional spreads, not `?? undefined`: JSON.stringify drops an
-				// undefined value either way, so key order and presence both match
-				// the file the writer would have produced.
-				...(r.tree_hash !== null && { treeHash: r.tree_hash }),
-				...(s.commitType !== undefined && { commitType: s.commitType }),
-				commitMessage: s.commitMessage,
-				commitDate: s.commitDate,
-				branch: s.branch,
-				...(s.generatedAt !== undefined && { generatedAt: s.generatedAt }),
-				...(isRoot && {
-					topicCount: countTopics(assembleSummary(kids, r) as unknown as CommitSummary),
-					// Body first, then the stats the legacy index entry carried.
-					// `flattenSummaryTree` resolved these in three steps and only the
-					// first is recoverable from a body-only rebuild — so a pre-v4
-					// memory silently lost its diff badge everywhere it is rendered
-					// (`jolli view`, the sidebar, the SessionStart briefing) and its
-					// entry stopped matching the file the branch carried. The third
-					// step, a live `git diff`, deliberately does NOT belong here: this
-					// is a pure projection of stored rows and must not shell out.
-					...this.diffStatsFor(s, r),
-				}),
-			};
-		});
+		// One grouped query for every root's topic count, replacing a per-root
+		// tree assembly. `memory_topics` is the projection of the same
+		// `summary.topics` arrays `countTopics` walks, and summing it by
+		// `root_hash` is the same "own topics, summed over the subtree" — verified
+		// equal on all 74 roots of this repo. The one divergence by construction
+		// is a topic with no title, which the projection drops (and which renders
+		// as nothing anyway).
+		const topicCounts = new Map<string, number>(
+			(
+				db
+					.prepare(
+						`SELECT m.root_hash AS root, COUNT(t.rowid) AS n
+						   FROM memories m
+						   LEFT JOIN memory_topics t ON t.repo_id = m.repo_id AND t.commit_hash = m.commit_hash
+						  WHERE m.repo_id = ? GROUP BY m.root_hash`,
+					)
+					.all(repoId) as ReadonlyArray<{ root: string; n: number }>
+			).map((r) => [r.root, r.n]),
+		);
+		const entries = rows.map((r) => ({
+			commitHash: r.commit_hash,
+			parentCommitHash: r.parent_hash,
+			// Conditional spreads, not `?? undefined`: JSON.stringify drops an
+			// undefined value either way, so key order and presence both match
+			// the file the writer would have produced. The three unconditional
+			// fields below go through `?? undefined` for the same reason — a
+			// column is NULL where the body had no key, and `null` is a value
+			// `JSON.stringify` KEEPS.
+			...(r.tree_hash !== null && { treeHash: r.tree_hash }),
+			...(r.commit_type !== null && { commitType: r.commit_type }),
+			commitMessage: r.commit_message ?? undefined,
+			commitDate: r.commit_date ?? undefined,
+			branch: r.branch ?? undefined,
+			...(r.generated_at !== null && { generatedAt: r.generated_at }),
+			...(r.parent_hash === null && {
+				topicCount: topicCounts.get(r.root_hash) ?? 0,
+				...parsedDiffStats(r.diff_stats_json),
+			}),
+		}));
 		const aliasRows = db
 			.prepare("SELECT old_hash, target_hash FROM commit_aliases WHERE repo_id = ? ORDER BY rowid")
 			.all(repoId) as { old_hash: string; target_hash: string }[];

--- a/cli/src/core/StoredMemories.test.ts
+++ b/cli/src/core/StoredMemories.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import type { StorageProvider } from "./StorageProvider.js";
+import { detectStoredMemories } from "./StoredMemories.js";
+
+/** Only the two members the detector touches; the rest would never be called. */
+const storage = (over: Partial<StorageProvider>): StorageProvider =>
+	({
+		kind: "sqlite",
+		exists: async () => true,
+		listFiles: async () => [],
+		...over,
+	}) as unknown as StorageProvider;
+
+describe("detectStoredMemories", () => {
+	it("reports `some` when summaries are stored", async () => {
+		expect(await detectStoredMemories(storage({ listFiles: async () => ["summaries/a.json"] }))).toBe("some");
+	});
+
+	// The case `exists()` gets wrong past a cutover: the database opens and the
+	// repo has a registry row from its first `jolli enable`, but holds nothing.
+	it("reports `none` for an initialized backend with no summaries", async () => {
+		expect(await detectStoredMemories(storage({ exists: async () => true, listFiles: async () => [] }))).toBe(
+			"none",
+		);
+	});
+
+	it("reports `none` without listing when the backend is not initialized", async () => {
+		let listed = false;
+		const result = await detectStoredMemories(
+			storage({
+				exists: async () => false,
+				listFiles: async () => {
+					listed = true;
+					return ["summaries/a.json"];
+				},
+			}),
+		);
+		expect(result).toBe("none");
+		expect(listed).toBe(false);
+	});
+
+	// The whole reason this is three-state: a read failure must not reach the
+	// caller as "none", which is the branch that archives the user's folders.
+	it("reports `unknown` when the listing throws", async () => {
+		const result = await detectStoredMemories(
+			storage({
+				listFiles: async () => {
+					throw new Error("SQLITE_CANTOPEN");
+				},
+			}),
+		);
+		expect(result).toBe("unknown");
+	});
+
+	it("reports `unknown` when the existence probe itself throws", async () => {
+		const result = await detectStoredMemories(
+			storage({
+				exists: async () => {
+					throw new Error("disk gone");
+				},
+			}),
+		);
+		expect(result).toBe("unknown");
+	});
+});

--- a/cli/src/core/StoredMemories.ts
+++ b/cli/src/core/StoredMemories.ts
@@ -1,0 +1,53 @@
+/**
+ * StoredMemories — "does this backend hold any memories?", as a three-state
+ * answer, for the callers that must not act on a guess.
+ *
+ * `StorageProvider.exists()` deliberately answers a DIFFERENT question — "is
+ * the backend initialized?" — and the two used to coincide. On the orphan
+ * branch, the branch existing WAS the data existing: nothing creates
+ * `jollimemory/summaries/v3` except writing a summary to it. Past a cutover
+ * that is no longer true. `SqliteStorage.exists()` is "the database opened and
+ * this repo has a registry row", which every enabled repo satisfies from its
+ * first `jolli enable`, memories or not.
+ *
+ * That silent change of meaning is only dangerous where the caller does
+ * something destructive with the answer, which is why this is not a blanket
+ * replacement for `exists()`: a gate that merely SKIPS work on a false
+ * negative is fine (the next pass picks it up), and `SchemaV5Migration`
+ * genuinely wants the initialization question. The rebuild path is the one
+ * that archives the user's existing Memory Bank folders before re-migrating —
+ * so on a cut-over repo with zero memories it archived the lot and migrated
+ * nothing into a fresh folder.
+ *
+ * The third state is what keeps that safe. A read failure must not collapse
+ * into "none": that is the same destructive branch reached for a different
+ * reason, and after a cutover the database is the only source there is.
+ */
+
+import { createLogger, errMsg } from "../Logger.js";
+import type { StorageProvider } from "./StorageProvider.js";
+
+const log = createLogger("StoredMemories");
+
+/** `unknown` means the backend could not be read — never treat it as `none`. */
+export type StoredMemoryPresence = "some" | "none" | "unknown";
+
+/**
+ * Whether `storage` holds at least one stored memory.
+ *
+ * Asks through `listFiles`, the one primitive every backend implements against
+ * its real contents, rather than a backend-specific probe — a new backend gets
+ * the right answer with no change here.
+ */
+export async function detectStoredMemories(storage: StorageProvider): Promise<StoredMemoryPresence> {
+	try {
+		// An uninitialized backend holds nothing, and `listFiles` on one is not
+		// guaranteed to be cheap (or quiet) — ask the cheap question first.
+		if (!(await storage.exists())) return "none";
+		const summaries = await storage.listFiles("summaries/");
+		return summaries.length > 0 ? "some" : "none";
+	} catch (err) {
+		log.warn("could not determine whether %s holds memories: %s", storage.kind, errMsg(err));
+		return "unknown";
+	}
+}

--- a/cli/src/core/SummaryFormat.ts
+++ b/cli/src/core/SummaryFormat.ts
@@ -287,39 +287,31 @@ const SKILL_SOURCE_LABELS: Readonly<Record<SkillSource, string>> = {
 
 /**
  * Builds the skill document title for pushing to Jolli Space:
- * `Skill · <host label> · <skill id> — <hash8>`.
+ * `Skills used — <hash8>`.
  *
- * Four segments, all load-bearing:
+ * **One title per COMMIT, not per skill** — it names the commit's whole skill
+ * aggregate, because that is what is pushed (see the `skill` definition's
+ * `aggregate` in `push/kinds/index.ts`). The wording is deliberately
+ * `buildSkillsAggregateMarkdown`'s own `# Skills used — <hash8>` heading: the
+ * pushed article and the Memory Bank's `skills--<hash8>.md` are the same document,
+ * so they must not be findable under two different names.
  *
- *   - The `Skill` prefix namespaces the generated slug, so a skill never collides
- *     with a plan / note / summary sharing the same base title — the same job the
- *     source prefix does for a reference.
- *   - The **host label** is required for uniqueness, not decoration: the registry
- *     key is `<source>:<skill>`, so two hosts can hold the same skill id as two
- *     separate rows and therefore two separate articles. Same title + same branch +
- *     same path + same commit is one server-side push identity, so dropping the
- *     host would make the second push collide with the first.
- *   - Middle dots, not colons: `sanitizeTitle` strips `:` (forbidden in document
- *     titles), which is also why a namespaced id like `superpowers:brainstorming`
- *     renders as `superpowers brainstorming` here.
- *   - **The commit's `hash8`, after an em dash** — required since a skill article is
- *     one document per (skill, commit) rather than one per skill (see the `skill`
- *     definition's `baseKey`). A branch folder is flat, so a skill used on four
- *     commits would otherwise show four indistinguishable siblings. The em-dash form
- *     deliberately mirrors `buildSkillsAggregateMarkdown`'s `# Skills used — <hash8>`
- *     heading, which is what the VS Code panel shows for the same record.
+ * The `hash8` is what keeps the articles apart in a flat branch folder — every
+ * commit contributes exactly one, so without it a branch would show N
+ * indistinguishable "Skills used" siblings. It comes from `summary.commitHash`,
+ * NOT from any `archivedKey`'s stamp: the two diverge after a squash (a ref is
+ * re-anchored onto the new root while the orphan file keeps its original name),
+ * and the commit a reader is holding is the one VS Code titles the record with.
  *
- * `summary.commitHash`, NOT the `archivedKey`'s stamp: the two diverge after a
- * squash (a ref is re-anchored onto the new root while the orphan file keeps its
- * original name), and the commit a reader is holding is the one VS Code titles the
- * record with.
+ * No host or skill-id segment any more. Both existed to keep one-article-per-skill
+ * titles unique (two hosts can hold the same skill id as two registry rows, and
+ * same title + branch + path + commit is one server-side push identity); with one
+ * article per commit the hash8 alone carries that uniqueness, and the host lives in
+ * the body's detail list instead.
  */
-export function buildSkillPushTitle(
-	ref: { readonly source: string; readonly skill: string },
-	summary: CommitSummary,
-): string {
+export function buildSkillsPushTitle(summary: CommitSummary): string {
 	const hash8 = summary.commitHash.substring(0, 8);
-	return sanitizeTitle(`Skill · ${skillSourceLabel(ref.source)} · ${ref.skill} — ${hash8}`);
+	return sanitizeTitle(`Skills used — ${hash8}`);
 }
 
 // ─── Topic collection ─────────────────────────────────────────────────────────

--- a/cli/src/core/SummaryMarkdownBuilder.ts
+++ b/cli/src/core/SummaryMarkdownBuilder.ts
@@ -319,9 +319,26 @@ export function buildReferencePushMarkdown(ref: ReferenceCommitRef, description?
 }
 
 /**
- * Builds the article body pushed for a single archived skill (docType `skill`).
+ * Builds the article body pushed for ONE COMMIT's whole skill aggregate (docType
+ * `skill`).
  *
- * **Every figure is THIS COMMIT's increment, read off the `ref` alone.** That is
+ * **One article per commit, listing every skill** — the same set, in the same
+ * table, as the Memory Bank's `skills--<hash8>.md` and the single "Skills used"
+ * Context row every IDE surface renders. It used to be one article per (skill,
+ * commit), so a commit that entered six skills published six documents against a
+ * local Context that shows exactly one file. The local aggregate is the shape the
+ * user already reads; the push now matches it rather than inventing a second
+ * decomposition of the same data.
+ *
+ * The table goes through {@link buildSkillsTable} — the same renderer the local
+ * aggregate and the sidebar use, which owns the em-dash-not-zero rule, the `~`
+ * estimate marker, the `†` inferred footnote and the heaviest-first ordering. That
+ * is what keeps this body byte-identical to the table VS Code shows for the same
+ * commit, and it is also why the per-skill identity (host / plugin / entry paths)
+ * is appended BELOW the table as a detail list rather than folded into it: those
+ * are not measurements and have no column.
+ *
+ * **Every figure is THIS COMMIT's increment, read off the refs alone.** That is
  * the whole contract of this function, and it is a deliberate reversal: the body
  * used to prefer the orphan-branch snapshot's frontmatter, whose counters are the
  * registry row's RUNNING TOTAL across every commit that used the skill (see
@@ -332,10 +349,10 @@ export function buildReferencePushMarkdown(ref: ReferenceCommitRef, description?
  * numbers for one commit, and the article's were the larger, so the memory looked
  * more expensive than it was.
  *
- * Making the increment win is only coherent because the article is now one
- * document per (skill, commit): with the old cross-commit `baseKey` a single
- * shared document would have shown whichever commit pushed last. The two changes
- * are one change — see the `skill` definition's `baseKey` in `push/kinds/index.ts`.
+ * Making the increment win is only coherent because the article is per COMMIT:
+ * with the old cross-commit `baseKey` a single shared document would have shown
+ * whichever commit pushed last. The two changes are one change — see the `skill`
+ * definition's `baseKey` and `aggregate` in `push/kinds/index.ts`.
  *
  * **Three things the old body carried are deliberately gone**, all for the same
  * reason — they are cumulative and cannot be re-derived per commit, so in a
@@ -355,33 +372,42 @@ export function buildReferencePushMarkdown(ref: ReferenceCommitRef, description?
  * identity (HOW the skill is entered), not measurements, so they cannot be read as
  * overstating what this commit cost.
  */
-export function buildSkillPushMarkdown(ref: SkillCommitRef): string {
-	const lines: Array<string> = [];
-	lines.push(`- **Host:** ${escMdLinkText(skillSourceLabel(ref.source))}`);
-	if (ref.plugin !== undefined && ref.plugin !== "") {
-		lines.push(`- **Plugin:** ${escMdLinkText(ref.plugin)}`);
-	}
-	if (ref.entryPaths.length > 0) {
-		lines.push(`- **Entered via:** ${ref.entryPaths.map((p) => escMdLinkText(p)).join(", ")}`);
-	}
-
+export function buildSkillsPushMarkdown(refs: ReadonlyArray<SkillCommitRef>): string {
 	// The token figures go through the SAME renderer every other skill surface
 	// uses, rather than being re-formatted here: `buildSkillsTable` owns the
-	// em-dash-not-zero rule, the `~` estimate marker and the `†` inferred
-	// footnote, and its docstring is explicit that those must not be duplicated.
-	// Passing the ref straight through is what keeps this table byte-identical to
-	// the row the VS Code panel renders for the same commit.
-	lines.push(
-		"",
-		...buildSkillsTable([
-			{
+	// em-dash-not-zero rule, the `~` estimate marker, the `†` inferred footnote and
+	// the heaviest-first ordering, and its docstring is explicit that those must not
+	// be duplicated. Passing the refs straight through is what keeps this table
+	// byte-identical to the one the VS Code panel renders for the same commit.
+	const lines: Array<string> = [
+		...buildSkillsTable(
+			refs.map((ref) => ({
 				skill: ref.skill,
 				invocationCount: ref.invocationCount,
 				...(ref.usage !== undefined && { usage: ref.usage }),
 				...(ref.detection !== undefined && { detection: ref.detection }),
-			},
-		]),
-	);
+			})),
+		),
+	];
+
+	// Identity, not measurement — see the header for why it sits below the table.
+	// Ordered by skill id rather than by weight: this list is looked up by name, and
+	// a stable order keeps a re-push from producing a spurious diff.
+	const detailed = [...refs].sort((a, b) => (a.skill < b.skill ? -1 : a.skill > b.skill ? 1 : 0));
+	const details: Array<string> = [];
+	for (const ref of detailed) {
+		const bits: Array<string> = [`Host: ${escMdLinkText(skillSourceLabel(ref.source))}`];
+		if (ref.plugin !== undefined && ref.plugin !== "") {
+			bits.push(`Plugin: ${escMdLinkText(ref.plugin)}`);
+		}
+		if (ref.entryPaths.length > 0) {
+			bits.push(`Entered via: ${ref.entryPaths.map((p) => escMdLinkText(p)).join(", ")}`);
+		}
+		details.push(`- **${escMdLinkText(ref.skill)}** — ${bits.join(" · ")}`);
+	}
+	if (details.length > 0) {
+		lines.push("", "## Skill details", "", ...details);
+	}
 	return lines.join("\n");
 }
 

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -63,8 +63,10 @@ import { MetadataManager } from "./MetadataManager.js";
 import type { StorageProvider } from "./StorageProvider.js";
 import {
 	AmbiguousHashError,
+	collectChildJolliMeta,
 	collectChildReferences,
 	collectChildSkills,
+	collectChildSkillsDocMeta,
 	deleteNoteVisibleArtifact,
 	deletePlanVisibleArtifact,
 	deleteTranscript,
@@ -4283,6 +4285,102 @@ describe("SummaryStore", () => {
 				nativeId: "KAN-3",
 				title: "Jira ticket",
 			});
+		});
+	});
+
+	describe("collectChildSkillsDocMeta", () => {
+		function node(hash: string, date: string, docId?: number): CommitSummary {
+			return {
+				...createMockSummary(hash, "child"),
+				commitDate: date,
+				generatedAt: date,
+				...(docId !== undefined && {
+					jolliSkillsDocId: docId,
+					jolliSkillsDocUrl: `https://acme.jolli.ai/articles?doc=${docId}`,
+				}),
+			};
+		}
+
+		it("adopts the newest child's skill article and orphans the rest", () => {
+			// Same rule as the memory article's own hoist, deliberately: the merged root's
+			// skill table is the FOLD of its children's, so no child's article is still the
+			// same document — but updating one in place beats deleting N and creating one,
+			// because `cleanupOrphanedDocs` is best-effort and a failed delete would
+			// otherwise leave N stale articles beside the new one instead of N-1 beside a
+			// live one.
+			const result = collectChildSkillsDocMeta([
+				node("c1", "2026-08-01T00:00:00.000Z", 501),
+				node("c2", "2026-08-05T00:00:00.000Z", 502),
+				node("c3", "2026-08-03T00:00:00.000Z", 503),
+			]);
+			expect(result.winner).toEqual({
+				jolliSkillsDocId: 502,
+				jolliSkillsDocUrl: "https://acme.jolli.ai/articles?doc=502",
+			});
+			expect(result.orphanedDocIds.sort()).toEqual([501, 503]);
+		});
+
+		it("ignores a child with an id but no URL", () => {
+			// The URL's origin is what the reuse gate reads to decide which backend an id
+			// belongs to, so an id without one cannot be reused — adopting it would push
+			// the aggregate at whichever backend happened to be configured.
+			const orphanUrl = { ...node("c1", "2026-08-01T00:00:00.000Z"), jolliSkillsDocId: 501 };
+			expect(collectChildSkillsDocMeta([orphanUrl]).winner).toBeNull();
+		});
+
+		it("reaches a grandchild, so a squash of squashes strands nothing", () => {
+			const parent: CommitSummary = {
+				...node("c1", "2026-08-01T00:00:00.000Z"),
+				children: [node("g1", "2026-08-02T00:00:00.000Z", 601)],
+			};
+			const result = collectChildSkillsDocMeta([parent, node("c2", "2026-07-01T00:00:00.000Z", 502)]);
+			expect(result.winner?.jolliSkillsDocId).toBe(601);
+			expect(result.orphanedDocIds).toEqual([502]);
+		});
+
+		it("reports nothing when no child was ever pushed", () => {
+			expect(collectChildSkillsDocMeta([node("c1", "2026-08-01T00:00:00.000Z")])).toEqual({
+				winner: null,
+				orphanedDocIds: [],
+			});
+		});
+
+		it("judges a grandchild on ITS OWN date, not its parent's", () => {
+			// The case that separates this from a parent-stamped hoist: the grandchild
+			// is the newest article in the tree, but its parent is the OLDEST node.
+			// Re-stamping the inner winner with the parent's date (which the
+			// implementation used to do, having no dates to pass up the recursion)
+			// makes it lose to a sibling it should beat — a real divergence from
+			// `collectChildJolliMeta`, which this helper's docstring claims to match.
+			const parent: CommitSummary = {
+				...node("c1", "2026-08-01T00:00:00.000Z"),
+				children: [node("g1", "2026-08-10T00:00:00.000Z", 601)],
+			};
+			const result = collectChildSkillsDocMeta([parent, node("c2", "2026-08-05T00:00:00.000Z", 502)]);
+			expect(result.winner?.jolliSkillsDocId).toBe(601);
+			expect(result.orphanedDocIds).toEqual([502]);
+		});
+
+		it("picks the same node as collectChildJolliMeta on the same tree", () => {
+			// The two documents ride together: one memory article and one skill-usage
+			// article per commit. "Same rule, deliberately" is only true if a single
+			// tree elects the same child for both, so pin it on the tree shape that
+			// used to elect two different ones.
+			const withBoth = (hash: string, date: string, docId: number): CommitSummary => ({
+				...node(hash, date, docId),
+				jolliDocId: docId,
+				jolliDocUrl: `https://acme.jolli.ai/articles?doc=${docId}`,
+			});
+			const tree = [
+				{
+					...node("c1", "2026-08-01T00:00:00.000Z"),
+					children: [withBoth("g1", "2026-08-10T00:00:00.000Z", 601)],
+				},
+				withBoth("c2", "2026-08-05T00:00:00.000Z", 502),
+			];
+			expect(collectChildSkillsDocMeta(tree).winner?.jolliSkillsDocId).toBe(
+				collectChildJolliMeta(tree).winner?.jolliDocId,
+			);
 		});
 	});
 

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -540,6 +540,13 @@ async function migrateOneToOneLocked(
 		...(oldSummary.ticketId && { ticketId: oldSummary.ticketId }),
 		...(oldSummary.jolliDocId && { jolliDocId: oldSummary.jolliDocId }),
 		...(docUrl && { jolliDocUrl: docUrl }),
+		// Skill-usage article — Copy-Hoist beside `skills` below, and for the same
+		// reason the memory article's id is copied: a 1:1 migration carries the SAME
+		// refs onto the new hash, so the article's content is unchanged and the next
+		// push must update it in place. Dropping the id would publish a duplicate and
+		// leave the original stranded under a hash the branch no longer has.
+		...(oldSummary.jolliSkillsDocId && { jolliSkillsDocId: oldSummary.jolliSkillsDocId }),
+		...(oldSummary.jolliSkillsDocUrl && { jolliSkillsDocUrl: oldSummary.jolliSkillsDocUrl }),
 		...(oldSummary.orphanedDocIds && { orphanedDocIds: oldSummary.orphanedDocIds }),
 		...(oldSummary.unresolvedOrphanHashes && { unresolvedOrphanHashes: oldSummary.unresolvedOrphanHashes }),
 		...(oldSummary.plans && { plans: oldSummary.plans }),
@@ -774,7 +781,18 @@ export interface NewlyAssociatedRefs {
 
 /** Returns a deep copy of the summary tree with Jolli metadata stripped from all nodes. */
 function stripJolliMetadata(node: CommitSummary): CommitSummary {
-	const { jolliDocId: _d, jolliDocUrl: _u, orphanedDocIds: _o, unresolvedOrphanHashes: _h, ...rest } = node;
+	const {
+		jolliDocId: _d,
+		jolliDocUrl: _u,
+		// Stripped alongside them: the merge above has already adopted one child's
+		// skill-usage article and orphaned the rest, so leaving an id on a retained
+		// child would make a later squash re-report an article that is gone.
+		jolliSkillsDocId: _sd,
+		jolliSkillsDocUrl: _su,
+		orphanedDocIds: _o,
+		unresolvedOrphanHashes: _h,
+		...rest
+	} = node;
 	if (!rest.children) return rest as CommitSummary;
 	return { ...rest, children: rest.children.map(stripJolliMetadata) } as CommitSummary;
 }
@@ -832,6 +850,90 @@ export function collectChildJolliMeta(nodes: ReadonlyArray<CommitSummary>): Joll
 	const winner = candidates[0];
 	const orphanedDocIds = candidates.slice(1).map((c) => c.jolliDocId);
 	return { winner, orphanedDocIds };
+}
+
+/**
+ * The squash counterpart of {@link collectChildJolliMeta} for the per-commit
+ * SKILL-USAGE article (`CommitSummary.jolliSkillsDocId`).
+ *
+ * **Same rule, deliberately: newest child wins, the rest are orphaned.** A squash
+ * root's skill table is the FOLD of its children's, so no child's article is still
+ * the same document — but exactly one of them can be updated in place instead of
+ * being deleted and replaced, which is both fewer round-trips and one less way to
+ * fail: `cleanupOrphanedDocs` is best-effort, and until a failed delete is retried,
+ * a mint-a-new-one policy leaves N stale articles beside the new one rather than
+ * N-1 beside the live one.
+ *
+ * Adopting the winner also keeps this identical to how the memory article itself
+ * behaves across a squash, which is what makes the two comprehensible together — a
+ * reader does not have to learn a second rule for the sibling document. The winner
+ * is picked by `getDisplayDate` for the same reason, so in practice both ids come
+ * from the same child.
+ *
+ * Recurses like its sibling, so a grandchild's article is not stranded by a squash
+ * of squashes.
+ */
+export function collectChildSkillsDocMeta(nodes: ReadonlyArray<CommitSummary>): {
+	winner: { jolliSkillsDocId: number; jolliSkillsDocUrl: string } | null;
+	orphanedDocIds: number[];
+} {
+	const { winner, orphanedDocIds } = collectDatedChildSkillsDocMeta(nodes);
+	// Dates dropped only HERE, at the outermost call: they exist to be compared,
+	// and the caller stores none of them.
+	return {
+		winner: winner && { jolliSkillsDocId: winner.jolliSkillsDocId, jolliSkillsDocUrl: winner.jolliSkillsDocUrl },
+		orphanedDocIds,
+	};
+}
+
+/** One skill-article candidate, carrying the dates the competition is decided on. */
+interface DatedSkillsDocMeta {
+	readonly jolliSkillsDocId: number;
+	readonly jolliSkillsDocUrl: string;
+	readonly commitDate: string;
+	readonly generatedAt: string;
+}
+
+/**
+ * The recursion behind {@link collectChildSkillsDocMeta}, kept separate for one
+ * reason: a winner must travel with ITS OWN dates.
+ *
+ * This mirrors `JolliMetaHoistResult.winner`, which carries them for exactly the
+ * same purpose, and the mirroring is the point — the two helpers claim to apply
+ * one rule, so a difference here is a difference in which document gets updated
+ * in place. Re-stamping an inner winner with the parent node's dates (which this
+ * used to do, having no dates to pass up) diverges in two ways at once: a
+ * grandchild that won on a fresh `generatedAt` re-enters the outer round wearing
+ * its parent's older date and loses to a sibling it should beat, and a node that
+ * holds an article AND has children produces two candidates with identical dates,
+ * where the stable sort silently prefers the shallower one.
+ */
+function collectDatedChildSkillsDocMeta(nodes: ReadonlyArray<CommitSummary>): {
+	winner: DatedSkillsDocMeta | null;
+	orphanedDocIds: number[];
+} {
+	const candidates: DatedSkillsDocMeta[] = [];
+	for (const node of nodes) {
+		const url = node.jolliSkillsDocUrl;
+		if (node.jolliSkillsDocId && url) {
+			candidates.push({
+				jolliSkillsDocId: node.jolliSkillsDocId,
+				jolliSkillsDocUrl: url,
+				commitDate: node.commitDate,
+				generatedAt: node.generatedAt,
+			});
+		}
+		if (node.children) {
+			// The deeper merge already orphaned its own losers; only its winner
+			// competes here, with the dates that won it that round.
+			const inner = collectDatedChildSkillsDocMeta(node.children);
+			if (inner.winner) candidates.push(inner.winner);
+		}
+	}
+	if (candidates.length === 0) return { winner: null, orphanedDocIds: [] };
+	candidates.sort((a, b) => new Date(getDisplayDate(b)).getTime() - new Date(getDisplayDate(a)).getTime());
+	const [winner, ...losers] = candidates;
+	return { winner, orphanedDocIds: losers.map((c) => c.jolliSkillsDocId) };
 }
 
 /**
@@ -1260,9 +1362,20 @@ async function mergeManyToOneLocked(
 	// off the persisted refs so a re-squash cannot re-report them.
 	const hoistedSkills = foldedSkills.map(stripSupersededDocIds);
 	const jolliMeta = collectChildJolliMeta(children);
+	// The commit's skill-usage article follows the same newest-wins rule as the memory
+	// article — see `collectChildSkillsDocMeta`. Losers join the same orphan list.
+	const skillsDocMeta = collectChildSkillsDocMeta(children);
 	const inheritedOrphanIds = children.flatMap((c) => c.orphanedDocIds ?? []);
+	// LEGACY: ids left on refs from when a skill article was one document per (skill,
+	// commit). Nothing writes them any more (the id lives on the summary), but stored
+	// summaries still carry them and they must still be cleaned up.
 	const supersededSkillDocIds = foldedSkills.flatMap((s) => s.supersededDocIds ?? []);
-	const allOrphanedDocIds = [...jolliMeta.orphanedDocIds, ...inheritedOrphanIds, ...supersededSkillDocIds];
+	const allOrphanedDocIds = [
+		...jolliMeta.orphanedDocIds,
+		...skillsDocMeta.orphanedDocIds,
+		...inheritedOrphanIds,
+		...supersededSkillDocIds,
+	];
 
 	// Children without jolliDocId may have been pushed to Space by a
 	// concurrent pre-push sync that hasn't written back the docId yet (race).
@@ -1331,6 +1444,7 @@ async function mergeManyToOneLocked(
 			jolliDocId: jolliMeta.winner.jolliDocId,
 			jolliDocUrl: jolliMeta.winner.jolliDocUrl,
 		}),
+		...(skillsDocMeta.winner && skillsDocMeta.winner),
 		...(allOrphanedDocIds.length > 0 && { orphanedDocIds: allOrphanedDocIds }),
 		...(unresolvedOrphanHashes.length > 0 && { unresolvedOrphanHashes }),
 		topics: consolidatedTopics,

--- a/cli/src/core/ToolNameClassify.test.ts
+++ b/cli/src/core/ToolNameClassify.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import {
+	builtinTool,
+	classifyCodexToolName,
+	classifyToolName,
+	mcpTool,
+	skillTool,
+	ToolUseTally,
+} from "./ToolNameClassify.js";
+
+describe("constructors", () => {
+	it("marks a bare name as a builtin with no server", () => {
+		expect(builtinTool("Bash")).toEqual({ name: "Bash", kind: "builtin", calls: 0 });
+	});
+
+	it("marks a skill by the skill's own name", () => {
+		expect(skillTool("code-review")).toEqual({ name: "code-review", kind: "skill", calls: 0 });
+	});
+
+	it("folds the server into the display name and keeps it as a field", () => {
+		expect(mcpTool("linear", "list_issues")).toEqual({
+			name: "linear.list_issues",
+			kind: "mcp",
+			server: "linear",
+			calls: 0,
+		});
+	});
+
+	it("keeps a server-only MCP call attributed to the server", () => {
+		expect(mcpTool("linear", "")).toEqual({ name: "linear", kind: "mcp", server: "linear", calls: 0 });
+	});
+});
+
+describe("classifyToolName (mcp__server__tool dialect)", () => {
+	it("classifies a bare name as a builtin", () => {
+		expect(classifyToolName("Bash")).toEqual({ name: "Bash", kind: "builtin", calls: 0 });
+	});
+
+	it("splits server and tool on the first double underscore", () => {
+		expect(classifyToolName("mcp__jollimemory__search")).toEqual({
+			name: "jollimemory.search",
+			kind: "mcp",
+			server: "jollimemory",
+			calls: 0,
+		});
+	});
+
+	it("keeps single underscores inside both segments", () => {
+		expect(classifyToolName("mcp__claude_ai_Linear__list_issues")).toEqual({
+			name: "claude_ai_Linear.list_issues",
+			kind: "mcp",
+			server: "claude_ai_Linear",
+			calls: 0,
+		});
+	});
+
+	it("treats only the first two segments as structural", () => {
+		// A tool name may itself contain `__`; it stays part of the tool.
+		expect(classifyToolName("mcp__srv__a__b")).toEqual({
+			name: "srv.a__b",
+			kind: "mcp",
+			server: "srv",
+			calls: 0,
+		});
+	});
+
+	it("attributes a malformed server-only name to the server rather than dropping it", () => {
+		expect(classifyToolName("mcp__srv")).toEqual({ name: "srv", kind: "mcp", server: "srv", calls: 0 });
+	});
+
+	it("does not treat a single-underscore mcp_ prefix as MCP", () => {
+		expect(classifyToolName("mcp_tool")).toEqual({ name: "mcp_tool", kind: "builtin", calls: 0 });
+	});
+});
+
+describe("classifyCodexToolName (identity lives outside the name)", () => {
+	it("classifies a namespace-less call as a builtin", () => {
+		// Every name observed across 40 real ~/.codex/sessions rollouts is this shape.
+		for (const name of ["exec_command", "wait", "write_stdin", "update_plan", "exec", "apply_patch"]) {
+			expect(classifyCodexToolName(name)).toEqual({ name, kind: "builtin", calls: 0 });
+		}
+	});
+
+	it("treats an empty namespace as absent", () => {
+		expect(classifyCodexToolName("exec", "")).toEqual({ name: "exec", kind: "builtin", calls: 0 });
+	});
+
+	it("takes the connector source, not the gateway, as the server", () => {
+		expect(classifyCodexToolName("list_issues", "mcp__codex_apps__linear")).toEqual({
+			name: "linear.list_issues",
+			kind: "mcp",
+			server: "linear",
+			calls: 0,
+		});
+	});
+
+	it("falls back to the sole segment when the namespace names only a server", () => {
+		expect(classifyCodexToolName("search", "mcp__linear")).toEqual({
+			name: "linear.search",
+			kind: "mcp",
+			server: "linear",
+			calls: 0,
+		});
+	});
+
+	it("uses a non-mcp namespace verbatim as the server", () => {
+		expect(classifyCodexToolName("search", "linear")).toEqual({
+			name: "linear.search",
+			kind: "mcp",
+			server: "linear",
+			calls: 0,
+		});
+	});
+
+	it("does NOT read an mcp__ prefix out of the tool name itself", () => {
+		// The Claude dialect would call this MCP. Codex never names tools that way,
+		// and guessing here is what silently files real MCP calls as builtins.
+		expect(classifyCodexToolName("mcp__srv__tool")).toEqual({
+			name: "mcp__srv__tool",
+			kind: "builtin",
+			calls: 0,
+		});
+	});
+});
+
+describe("ToolUseTally", () => {
+	it("starts empty and reports an empty array, not undefined", () => {
+		expect(new ToolUseTally().values()).toEqual([]);
+	});
+
+	it("sums repeated calls to the same tool", () => {
+		const tally = new ToolUseTally();
+		tally.add(builtinTool("Bash"));
+		tally.add(builtinTool("Bash"));
+		expect(tally.values()).toEqual([{ name: "Bash", kind: "builtin", calls: 2 }]);
+	});
+
+	it("adds a caller-supplied count", () => {
+		const tally = new ToolUseTally();
+		tally.add(builtinTool("Bash"), 3);
+		tally.add(builtinTool("Bash"), 2);
+		expect(tally.values()).toEqual([{ name: "Bash", kind: "builtin", calls: 5 }]);
+	});
+
+	it("keeps a builtin and an MCP tool of the same display name apart", () => {
+		const tally = new ToolUseTally();
+		tally.add(builtinTool("search"));
+		tally.add({ name: "search", kind: "mcp", server: "srv", calls: 0 });
+		expect(tally.values()).toEqual([
+			{ name: "search", kind: "builtin", calls: 1 },
+			{ name: "search", kind: "mcp", server: "srv", calls: 1 },
+		]);
+	});
+
+	it("counts a repeated call id only once", () => {
+		const tally = new ToolUseTally();
+		tally.addOnce("toolu_1", builtinTool("Bash"));
+		tally.addOnce("toolu_1", builtinTool("Bash"));
+		expect(tally.values()).toEqual([{ name: "Bash", kind: "builtin", calls: 1 }]);
+	});
+
+	it("counts distinct call ids separately", () => {
+		const tally = new ToolUseTally();
+		tally.addOnce("toolu_1", builtinTool("Bash"));
+		tally.addOnce("toolu_2", builtinTool("Bash"));
+		expect(tally.values()).toEqual([{ name: "Bash", kind: "builtin", calls: 2 }]);
+	});
+
+	it("counts an id-less call unconditionally rather than dropping it", () => {
+		const tally = new ToolUseTally();
+		tally.addOnce(undefined, builtinTool("Bash"));
+		tally.addOnce(undefined, builtinTool("Bash"));
+		expect(tally.values()).toEqual([{ name: "Bash", kind: "builtin", calls: 2 }]);
+	});
+
+	it("reports whether an id was already counted", () => {
+		const tally = new ToolUseTally();
+		expect(tally.hasSeen("toolu_1")).toBe(false);
+		tally.addOnce("toolu_1", builtinTool("Bash"));
+		expect(tally.hasSeen("toolu_1")).toBe(true);
+	});
+});

--- a/cli/src/core/ToolNameClassify.ts
+++ b/cli/src/core/ToolNameClassify.ts
@@ -1,0 +1,162 @@
+/**
+ * Tool-name classification and per-slice tallying, shared by every transcript
+ * source that can report tool calls.
+ *
+ * ## Why this is per-source and not one function
+ *
+ * The hosts do not agree on how a tool is named, and the disagreement is not
+ * cosmetic — it decides whether a call lands in the `mcp` bucket or the
+ * `builtin` one. A single `mcp__`-prefix test (the shape Claude uses) is not a
+ * neutral default: applied to a host with a different convention it does not
+ * fail, it silently files every MCP call as a builtin. Zero MCP calls looks
+ * exactly like "this person uses no MCP servers", so the error is invisible in
+ * every surface that reads the result.
+ *
+ * The conventions, each read off a real transcript or off the envelope parser
+ * that was written against one:
+ *
+ *   - `mcp__<server>__<tool>` — Claude, and Kimi verbatim (see
+ *     `KimiEnvelopeParser`, which reuses Claude's match path for exactly this
+ *     reason). Also cursor-agent and the Cline CLI, both of which speak the
+ *     Anthropic block format.
+ *   - `<namespace>` + bare `<name>` — Codex, whose MCP identity lives in a
+ *     sibling field (`payload.namespace`, or `invocation.server`) rather than
+ *     inside the name. Its builtin names are bare and undecorated
+ *     (`exec_command`, `wait`, `apply_patch` — real 2026-07/08 rollouts).
+ *   - bare names only — Gemini (`run_shell_command`, `read_file`, `grep_search`
+ *     — real `~/.gemini/tmp/<project>/chats/session-*.json`) and OpenCode
+ *     (`data.tool`, see `OpenCodeSkillScanner`). Neither corpus contains a name
+ *     shape that could be recognised as MCP, so nothing may guess at one.
+ *
+ * A host whose convention is not known yet must NOT be run through a
+ * near-enough classifier: file its calls as builtin and leave the host out of
+ * `TOOL_RECORDING_SOURCES` until a real capture says otherwise.
+ */
+
+import type { ToolCallCount } from "../Types.js";
+
+/** The separator Claude-shaped hosts put between `mcp`, the server and the tool. */
+const MCP_UNDERSCORE_PREFIX = "mcp__";
+const MCP_UNDERSCORE_SEP = "__";
+
+/** A host builtin — the tool ships with the agent, no server behind it. */
+export function builtinTool(name: string): ToolCallCount {
+	return { name, kind: "builtin", calls: 0 };
+}
+
+/**
+ * A skill invocation, re-attributed to the skill it ran rather than to the
+ * generic tool that ran it. "Which skills does this person use" is the question
+ * being asked; counting every invocation as one builtin named `Skill` answers
+ * nothing.
+ */
+export function skillTool(name: string): ToolCallCount {
+	return { name, kind: "skill", calls: 0 };
+}
+
+/**
+ * An MCP call. `server` is kept as its own field (the dashboard groups on it)
+ * and also folded into the display name, so two servers exposing a `search`
+ * tool stay distinguishable in a flat list.
+ */
+export function mcpTool(server: string, tool: string): ToolCallCount {
+	return { name: tool ? `${server}.${tool}` : server, kind: "mcp", server, calls: 0 };
+}
+
+/**
+ * Classifies a raw tool name written in the `mcp__<server>__<tool>` dialect
+ * (Claude, Kimi, cursor-agent, Cline CLI).
+ *
+ * The double underscore is the separator the MCP host itself uses, and a server
+ * or tool name may contain single underscores, so the split is on `__` and only
+ * the FIRST two segments are structural; anything after them is part of the tool
+ * name.
+ */
+export function classifyToolName(raw: string): ToolCallCount {
+	if (!raw.startsWith(MCP_UNDERSCORE_PREFIX)) return builtinTool(raw);
+	const rest = raw.slice(MCP_UNDERSCORE_PREFIX.length);
+	const sep = rest.indexOf(MCP_UNDERSCORE_SEP);
+	// `mcp__server` with no tool segment is malformed; keep it attributed to
+	// the server rather than dropping the call.
+	if (sep === -1) return mcpTool(rest, "");
+	return mcpTool(rest.slice(0, sep), rest.slice(sep + MCP_UNDERSCORE_SEP.length));
+}
+
+/**
+ * Classifies a Codex tool call, whose MCP identity lives OUTSIDE the name.
+ *
+ * Two shapes reach here, both documented against real rollouts in
+ * `CodexEnvelopeParser`:
+ *
+ *   - a `function_call` carrying `namespace: "mcp__codex_apps__<src>"` — the
+ *     connector gateway. The user-meaningful server is the trailing segment
+ *     (`<src>`, e.g. `linear`), not the gateway name shared by every connector.
+ *   - an `mcp_tool_call_end` event carrying `invocation.server` directly, in
+ *     which case the caller passes that server verbatim.
+ *
+ * Everything else — `exec_command`, `wait`, `apply_patch`, `update_plan` — is a
+ * bare builtin name.
+ */
+export function classifyCodexToolName(name: string, namespace?: string): ToolCallCount {
+	if (namespace === undefined || namespace.length === 0) return builtinTool(name);
+	if (!namespace.startsWith(MCP_UNDERSCORE_PREFIX)) return mcpTool(namespace, name);
+	const segments = namespace.slice(MCP_UNDERSCORE_PREFIX.length).split(MCP_UNDERSCORE_SEP);
+	const server = segments[segments.length - 1] || segments[0] || namespace;
+	return mcpTool(server, name);
+}
+
+/**
+ * Accumulates one slice's tool calls into the `ToolCallCount[]` the readers
+ * return.
+ *
+ * Two things it exists to get right, both of which were bugs waiting to happen
+ * in per-reader ad-hoc code:
+ *
+ *   - **Bucketing is on `kind:name`, not on name.** A builtin and an MCP tool
+ *     can share a display name; merging them would fabricate a count.
+ *   - **De-duplication is opt-in and keyed by the call's own id.** Several
+ *     transcripts write one logical call across several lines (Claude repeats a
+ *     whole `message.content` per block; Codex writes a request row and a result
+ *     row). Keying on anything coarser than the call id — a message id, the tool
+ *     name — collapses distinct calls made in the same response into one.
+ */
+export class ToolUseTally {
+	private readonly byKey = new Map<string, ToolCallCount>();
+	private readonly seen = new Set<string>();
+
+	/** Count one call. */
+	add(call: ToolCallCount, calls = 1): void {
+		const key = `${call.kind}:${call.name}`;
+		const prev = this.byKey.get(key);
+		this.byKey.set(key, prev ? { ...prev, calls: prev.calls + calls } : { ...call, calls });
+	}
+
+	/**
+	 * Count one call, ignoring it if `id` has already been counted. An
+	 * `undefined` id means the transcript gave us no identity, so the call is
+	 * counted unconditionally — dropping it would lose a real call, while
+	 * counting a repeat only inflates one bucket.
+	 */
+	addOnce(id: string | undefined, call: ToolCallCount): void {
+		if (id !== undefined) {
+			if (this.seen.has(id)) return;
+			this.seen.add(id);
+		}
+		this.add(call);
+	}
+
+	/** Has `id` already been counted? Lets a caller skip building a call object. */
+	hasSeen(id: string): boolean {
+		return this.seen.has(id);
+	}
+
+	/**
+	 * The slice's buckets. An EMPTY array is meaningful — it says the slice
+	 * genuinely called no tools — and must be returned rather than dropped, or
+	 * the source becomes indistinguishable from one that cannot report tools at
+	 * all (see `TOOL_RECORDING_SOURCES`).
+	 */
+	values(): ToolCallCount[] {
+		return [...this.byKey.values()];
+	}
+}

--- a/cli/src/core/TranscriptParser.ts
+++ b/cli/src/core/TranscriptParser.ts
@@ -12,7 +12,19 @@
 
 import { createLogger } from "../Logger.js";
 import type { ModelTokenUsage, ParsedTurnUsage, ToolCallCount, TranscriptEntry } from "../Types.js";
+import {
+	builtinTool,
+	classifyCodexToolName,
+	classifyToolName,
+	mcpTool,
+	skillTool,
+	ToolUseTally,
+} from "./ToolNameClassify.js";
 import { parseTranscriptLine } from "./TranscriptReader.js";
+
+// Re-exported for the callers that already imported it from here; the shared
+// classifiers now live in ToolNameClassify.ts alongside the other dialects.
+export { classifyToolName } from "./ToolNameClassify.js";
 
 const log = createLogger("TranscriptParser");
 
@@ -49,28 +61,6 @@ export interface TranscriptParser {
 	 *  source's transcripts expose no tool records, and every consumer must
 	 *  report that source as UNCOVERED rather than as "used no tools". */
 	parseToolUse?(lines: ReadonlyArray<string>): ToolCallCount[];
-}
-
-/**
- * Classifies a raw tool name from a transcript.
- *
- * MCP tools arrive as `mcp__<server>__<tool>` — the wire name, which is what
- * makes the server extractable at all. The double underscore is the separator
- * the MCP host itself uses, and a server or tool name may contain single
- * underscores, so the split is on `__` and only the FIRST two segments are
- * structural; anything after them is part of the tool name.
- */
-export function classifyToolName(raw: string): ToolCallCount {
-	if (raw.startsWith("mcp__")) {
-		const rest = raw.slice("mcp__".length);
-		const sep = rest.indexOf("__");
-		// `mcp__server` with no tool segment is malformed; keep it attributed to
-		// the server rather than dropping the call.
-		const server = sep === -1 ? rest : rest.slice(0, sep);
-		const tool = sep === -1 ? "" : rest.slice(sep + 2);
-		return { name: tool ? `${server}.${tool}` : server, kind: "mcp", server, calls: 0 };
-	}
-	return { name: raw, kind: "builtin", calls: 0 };
 }
 
 /**
@@ -159,8 +149,7 @@ export class ClaudeTranscriptParser implements TranscriptParser {
 	 * every skill invocation as one builtin named `Skill` would answer nothing.
 	 */
 	parseToolUse(lines: ReadonlyArray<string>): ToolCallCount[] {
-		const byName = new Map<string, ToolCallCount>();
-		const seen = new Set<string>();
+		const tally = new ToolUseTally();
 		for (const line of lines) {
 			let parsed: unknown;
 			try {
@@ -173,20 +162,15 @@ export class ClaudeTranscriptParser implements TranscriptParser {
 			for (const block of content) {
 				const b = block as { type?: unknown; id?: unknown; name?: unknown; input?: { skill?: unknown } };
 				if (b.type !== "tool_use" || typeof b.name !== "string") continue;
-				if (typeof b.id === "string") {
-					if (seen.has(b.id)) continue;
-					seen.add(b.id);
-				}
-				const classified =
+				tally.addOnce(
+					typeof b.id === "string" ? b.id : undefined,
 					b.name === "Skill" && typeof b.input?.skill === "string"
-						? ({ name: b.input.skill, kind: "skill", calls: 0 } as ToolCallCount)
-						: classifyToolName(b.name);
-				const key = `${classified.kind}:${classified.name}`;
-				const existing = byName.get(key);
-				byName.set(key, existing ? { ...existing, calls: existing.calls + 1 } : { ...classified, calls: 1 });
+						? skillTool(b.input.skill)
+						: classifyToolName(b.name),
+				);
 			}
 		}
-		return [...byName.values()];
+		return tally.values();
 	}
 
 	parseTimestamp(line: string, _lineNum?: number): string | undefined {
@@ -245,7 +229,111 @@ export class CodexTranscriptParser implements TranscriptParser {
 			return null;
 		}
 	}
+
+	/**
+	 * Tool calls over a slice of a Codex rollout.
+	 *
+	 * Codex writes a call across up to three rows sharing one `call_id`, so a call
+	 * is resolved per id and counted once at the end — see
+	 * {@link CODEX_TOOL_CALL_TYPES} for the row types and the evidence behind each.
+	 *
+	 * Identity is NOT read out of the name: Codex names its builtins bare
+	 * (`exec_command`, `wait`, `write_stdin`, `update_plan`, `exec`,
+	 * `apply_patch` — every name present across 40 real 2026-07/08 rollouts) and
+	 * carries MCP identity in a sibling field instead. Running these through the
+	 * Claude `mcp__` test would file every Codex MCP call as a builtin, so
+	 * `classifyCodexToolName` takes the namespace explicitly.
+	 *
+	 * **The last row wins, not the first, and that ordering is load-bearing.** A
+	 * real MCP call is written as a namespace-less `function_call` FIRST and an
+	 * `mcp_tool_call_end` carrying `invocation.{server,tool}` after it — measured
+	 * on a live rollout:
+	 *
+	 *   function_call      call_00_2Rw… name=list_mcp_resources namespace=∅
+	 *   mcp_tool_call_end  call_00_2Rw… invocation={server:"codex", tool:"list_mcp_resources"}
+	 *
+	 * The request row alone is indistinguishable from a builtin, so a
+	 * first-write-wins dedupe files every such call under `builtin` and the server
+	 * is lost — the exact silent mis-bucketing this parser's name-agnostic
+	 * classification exists to prevent. Later rows may only UPGRADE the identity:
+	 * an `mcp_tool_call_end` replaces a builtin guess, and nothing downgrades an
+	 * MCP identity back.
+	 *
+	 * A row missing `call_id` is counted immediately (an unidentifiable call is a
+	 * real call); it just cannot be deduped or upgraded.
+	 */
+	parseToolUse(lines: ReadonlyArray<string>): ToolCallCount[] {
+		const byCallId = new Map<string, ToolCallCount>();
+		const anonymous: ToolCallCount[] = [];
+		for (const line of lines) {
+			let parsed: unknown;
+			try {
+				parsed = JSON.parse(line);
+			} catch {
+				continue;
+			}
+			const payload = (parsed as { payload?: unknown })?.payload;
+			if (payload === null || typeof payload !== "object") continue;
+			const p = payload as {
+				type?: unknown;
+				name?: unknown;
+				namespace?: unknown;
+				call_id?: unknown;
+				invocation?: { server?: unknown; tool?: unknown };
+			};
+			if (typeof p.type !== "string" || !CODEX_TOOL_CALL_TYPES.has(p.type)) continue;
+
+			// `mcp_tool_call_end` states the server outright — the one shape where
+			// no namespace parsing is needed or wanted.
+			const invocationTool = typeof p.invocation?.tool === "string" ? p.invocation.tool : undefined;
+			const server = typeof p.invocation?.server === "string" ? p.invocation.server : "";
+			let call: ToolCallCount;
+			if (invocationTool !== undefined) {
+				call = server ? mcpTool(server, invocationTool) : builtinTool(invocationTool);
+			} else if (typeof p.name === "string" && p.name.length > 0) {
+				call = classifyCodexToolName(p.name, typeof p.namespace === "string" ? p.namespace : undefined);
+			} else {
+				continue;
+			}
+
+			const callId = typeof p.call_id === "string" ? p.call_id : undefined;
+			if (callId === undefined) {
+				anonymous.push(call);
+				continue;
+			}
+			const known = byCallId.get(callId);
+			// Upgrade-only: a builtin guess yields to a resolved MCP identity, and a
+			// later builtin row (the request written after an event, or a result row
+			// echoing the bare name) never overwrites one.
+			if (known === undefined || (known.kind !== "mcp" && call.kind === "mcp")) byCallId.set(callId, call);
+		}
+		const tally = new ToolUseTally();
+		for (const call of [...byCallId.values(), ...anonymous]) tally.add(call);
+		return tally.values();
+	}
 }
+
+/**
+ * The `payload.type` values that represent one Codex tool call.
+ *
+ * Counted from real rollouts under `~/.codex/sessions` (40 files, Jul–Aug 2026):
+ * `custom_tool_call` (804) and `function_call` (415) are the bulk; `web_search_call`
+ * (2) is rarer but is still the agent calling a tool. `mcp_tool_call_end` carries
+ * `invocation.{server,tool}` and is the MCP shape `CodexEnvelopeParser` documents
+ * against 2026-06 connector rollouts (that capture had no MCP traffic, hence no
+ * local count).
+ *
+ * The `*_output` siblings are deliberately absent: they are the SAME call's result
+ * row, and counting them would double every call. `mcp_tool_call_begin` is absent
+ * for the same reason — it pairs with the `_end` row already listed.
+ */
+const CODEX_TOOL_CALL_TYPES: ReadonlySet<string> = new Set([
+	"function_call",
+	"custom_tool_call",
+	"local_shell_call",
+	"web_search_call",
+	"mcp_tool_call_end",
+]);
 
 /**
  * Kimi Code CLI transcript parser.
@@ -305,6 +393,48 @@ export class KimiTranscriptParser implements TranscriptParser {
 		}
 	}
 
+	/**
+	 * Tool calls over a slice of a Kimi `wire.jsonl`.
+	 *
+	 * The signal is a `tool.call` event inside the `context.append_loop_event`
+	 * envelope, correlated elsewhere by `toolCallId` — the same shape
+	 * {@link KimiEnvelopeParser} and {@link KimiSkillScanner} are pinned to
+	 * against real `~/.kimi-code` captures. Only the CALL is counted; the paired
+	 * `tool.result` is the same call's answer and would double it.
+	 *
+	 * Kimi names MCP tools Claude-style (`mcp__<server>__<tool>`), which is why
+	 * `KimiEnvelopeParser` reuses Claude's registry match path verbatim — so the
+	 * Claude classifier is correct here rather than merely close. `Skill` calls
+	 * are re-attributed to `args.skill`, the first-class skill tool
+	 * `KimiSkillScanner` reads.
+	 */
+	parseToolUse(lines: ReadonlyArray<string>): ToolCallCount[] {
+		const tally = new ToolUseTally();
+		for (const line of lines) {
+			// Cheap pre-filter: only the loop-event envelope carries tool activity.
+			if (!line.includes(KIMI_LOOP_EVENT_TYPE)) continue;
+			let parsed: Record<string, unknown>;
+			try {
+				parsed = JSON.parse(line) as Record<string, unknown>;
+			} catch {
+				continue;
+			}
+			if (parsed.type !== KIMI_LOOP_EVENT_TYPE) continue;
+			const event = parsed.event as
+				| { type?: unknown; name?: unknown; toolCallId?: unknown; args?: { skill?: unknown } }
+				| undefined;
+			if (event === null || typeof event !== "object") continue;
+			if (event.type !== "tool.call" || typeof event.name !== "string") continue;
+			tally.addOnce(
+				typeof event.toolCallId === "string" ? event.toolCallId : undefined,
+				event.name === KIMI_SKILL_TOOL_NAME && typeof event.args?.skill === "string"
+					? skillTool(event.args.skill)
+					: classifyToolName(event.name),
+			);
+		}
+		return tally.values();
+	}
+
 	parseTimestamp(line: string, _lineNum?: number): string | undefined {
 		try {
 			return kimiFrameTimestamp(JSON.parse(line) as Record<string, unknown>);
@@ -313,6 +443,11 @@ export class KimiTranscriptParser implements TranscriptParser {
 		}
 	}
 }
+
+/** Kimi's envelope for every loop event, including tool activity. */
+const KIMI_LOOP_EVENT_TYPE = "context.append_loop_event";
+/** Kimi's first-class skill tool — its `args.skill` names the skill that ran. */
+const KIMI_SKILL_TOOL_NAME = "Skill";
 
 /**
  * Extracts the `content.part` object from a Kimi wire event, whether it arrives
@@ -524,8 +659,47 @@ export function getParserForSource(source: "claude" | "codex" | "kimi"): Transcr
 	}
 }
 
-/** The sources this module has a parser for. Others use dedicated readers. */
-const PARSER_BACKED_SOURCES = ["claude", "codex"] as const;
+/**
+ * The sources this module has a parser for. Others use dedicated readers.
+ *
+ * MUST list every case `getParserForSource` accepts. It is the domain the
+ * capability probe below iterates, so a source missing here can never enter
+ * {@link TOOL_RECORDING_SOURCES} no matter what its parser implements — the
+ * probe would report the parser's `parseToolUse` as if it did not exist. `kimi`
+ * was missing for exactly that reason; the compile-time annotation now ties the
+ * list to the factory's parameter type, so adding a parser without extending it
+ * fails to build.
+ */
+const PARSER_BACKED_SOURCES: ReadonlyArray<Parameters<typeof getParserForSource>[0]> = [
+	"claude",
+	"codex",
+	"kimi",
+] as const;
+
+/**
+ * Sources whose tool calls come from a DEDICATED READER rather than a
+ * `TranscriptParser`, and whose reader is known to populate
+ * `TranscriptReadResult.toolUse`.
+ *
+ * This half of the set cannot be probed the way the parser half is: a reader is
+ * a bare async function, not an object with an optional method, so there is
+ * nothing to feature-test. The list is therefore hand-maintained, and the bar
+ * for joining it is deliberately high — **a source belongs here only once its
+ * reader has been written against a real capture of that host's transcripts.**
+ *
+ * Listing a source whose reader silently extracts nothing is strictly worse than
+ * omitting it: every slice would report `toolUse: []`, and the consumers read
+ * that as the positive claim "this agent called no tools" (see the `with_tools`
+ * filters in `DashboardQuery` / `MemoriesQuery`). Omission degrades to
+ * "unavailable", which is merely incomplete rather than false.
+ *
+ * Two layers of test hold this honest, and neither alone would: the membership
+ * of this list is pinned in `TranscriptParserToolUse.test.ts` (which also pins
+ * the sources deliberately kept OUT), while the evidence that each reader really
+ * extracts something lives in that reader's own test file, asserting a non-empty
+ * extraction over a real capture. Adding a source here means adding both.
+ */
+const READER_BACKED_TOOL_SOURCES = ["gemini", "opencode", "antigravity", "cursor-cli", "cline-cli", "devin"] as const;
 
 /**
  * Sources whose transcripts can report tool calls at all — i.e. whose parser
@@ -537,11 +711,14 @@ const PARSER_BACKED_SOURCES = ["claude", "codex"] as const;
  * reader preserves by keeping an empty `toolUse` array rather than dropping the
  * field. Zero records look identical without it.
  *
- * Derived by probing the parsers instead of listing source names, so adding
- * `parseToolUse` to one of them cannot leave this behind. Sources served by a
- * dedicated reader rather than a `TranscriptParser` are absent, which is correct
- * today: none of them extracts tool calls.
+ * The parser half is derived by probing, so adding `parseToolUse` to one of them
+ * cannot leave this behind — provided the source is in
+ * {@link PARSER_BACKED_SOURCES}, which is what makes that list's completeness
+ * load-bearing. The reader half cannot be probed and is listed explicitly; see
+ * {@link READER_BACKED_TOOL_SOURCES} for why the bar for joining it is a real
+ * capture rather than a plausible-looking extractor.
  */
-export const TOOL_RECORDING_SOURCES: ReadonlySet<string> = new Set(
-	PARSER_BACKED_SOURCES.filter((source) => getParserForSource(source).parseToolUse !== undefined),
-);
+export const TOOL_RECORDING_SOURCES: ReadonlySet<string> = new Set<string>([
+	...PARSER_BACKED_SOURCES.filter((source) => getParserForSource(source).parseToolUse !== undefined),
+	...READER_BACKED_TOOL_SOURCES,
+]);

--- a/cli/src/core/TranscriptParserToolUse.test.ts
+++ b/cli/src/core/TranscriptParserToolUse.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+import { getParserForSource, TOOL_RECORDING_SOURCES } from "./TranscriptParser.js";
+
+/** Shorthand: run a parser's parseToolUse over pre-serialized events. */
+function toolUse(source: "claude" | "codex" | "kimi", events: ReadonlyArray<unknown>) {
+	const parser = getParserForSource(source);
+	if (parser.parseToolUse === undefined) throw new Error(`${source} parser has no parseToolUse`);
+	return parser.parseToolUse(events.map((e) => JSON.stringify(e)));
+}
+
+/** A Codex rollout row, in the real `{timestamp, type, payload}` envelope. */
+function codexRow(payload: Record<string, unknown>) {
+	return { timestamp: "2026-08-06T16:03:08.019Z", type: "response_item", payload };
+}
+
+/** A Kimi wire row, in the real `context.append_loop_event` envelope. */
+function kimiRow(event: Record<string, unknown>) {
+	return { type: "context.append_loop_event", event, time: 1786000000000 };
+}
+
+describe("CodexTranscriptParser.parseToolUse", () => {
+	it("counts the builtin call shapes real rollouts contain", () => {
+		// Shapes and names taken from ~/.codex/sessions (Jul–Aug 2026): a
+		// `custom_tool_call` named `exec` and `function_call`s named `exec_command`
+		// / `wait` are 1219 of the 1221 tool rows in that corpus.
+		expect(
+			toolUse("codex", [
+				codexRow({ type: "custom_tool_call", call_id: "call_a", name: "exec", input: "…" }),
+				codexRow({ type: "function_call", call_id: "call_b", name: "exec_command", arguments: "{}" }),
+				codexRow({ type: "function_call", call_id: "call_c", name: "wait", arguments: "{}" }),
+			]),
+		).toEqual([
+			{ name: "exec", kind: "builtin", calls: 1 },
+			{ name: "exec_command", kind: "builtin", calls: 1 },
+			{ name: "wait", kind: "builtin", calls: 1 },
+		]);
+	});
+
+	it("does not count a call's result row twice", () => {
+		// The `_output` sibling repeats the call_id; counting it would double every
+		// call, and the corpus has one output row per call row (804/804, 415/415).
+		expect(
+			toolUse("codex", [
+				codexRow({ type: "function_call", call_id: "call_a", name: "exec_command" }),
+				codexRow({ type: "function_call_output", call_id: "call_a", output: "Wall time: 1s\nOutput:\nok" }),
+			]),
+		).toEqual([{ name: "exec_command", kind: "builtin", calls: 1 }]);
+	});
+
+	it("does not merge distinct calls to the same tool", () => {
+		expect(
+			toolUse("codex", [
+				codexRow({ type: "function_call", call_id: "call_a", name: "exec_command" }),
+				codexRow({ type: "function_call", call_id: "call_b", name: "exec_command" }),
+			]),
+		).toEqual([{ name: "exec_command", kind: "builtin", calls: 2 }]);
+	});
+
+	it("counts an mcp_tool_call_end by its invocation server and tool", () => {
+		expect(
+			toolUse("codex", [
+				codexRow({
+					type: "mcp_tool_call_end",
+					call_id: "call_a",
+					invocation: { server: "linear", tool: "list_issues" },
+				}),
+			]),
+		).toEqual([{ name: "linear.list_issues", kind: "mcp", server: "linear", calls: 1 }]);
+	});
+
+	it("counts a connector function_call by its namespace's source", () => {
+		expect(
+			toolUse("codex", [
+				codexRow({
+					type: "function_call",
+					call_id: "call_a",
+					namespace: "mcp__codex_apps__linear",
+					name: "list_issues",
+				}),
+			]),
+		).toEqual([{ name: "linear.list_issues", kind: "mcp", server: "linear", calls: 1 }]);
+	});
+
+	it("lets a trailing mcp_tool_call_end upgrade the request row's builtin guess", () => {
+		// Verbatim from a live 2026-08-10 rollout: the request row is
+		// namespace-less and looks exactly like a builtin, and the server only
+		// appears on the LATER event. First-write-wins loses the server entirely,
+		// which is the silent mis-bucketing this parser exists to prevent.
+		expect(
+			toolUse("codex", [
+				codexRow({ type: "function_call", call_id: "call_00_2Rw", name: "list_mcp_resources" }),
+				codexRow({
+					type: "mcp_tool_call_end",
+					call_id: "call_00_2Rw",
+					invocation: { server: "codex", tool: "list_mcp_resources", arguments: {} },
+				}),
+			]),
+		).toEqual([{ name: "codex.list_mcp_resources", kind: "mcp", server: "codex", calls: 1 }]);
+	});
+
+	it("never downgrades a resolved MCP identity back to a builtin", () => {
+		expect(
+			toolUse("codex", [
+				codexRow({
+					type: "mcp_tool_call_end",
+					call_id: "call_a",
+					invocation: { server: "jollimemory", tool: "recall" },
+				}),
+				codexRow({ type: "function_call", call_id: "call_a", name: "recall" }),
+			]),
+		).toEqual([{ name: "jollimemory.recall", kind: "mcp", server: "jollimemory", calls: 1 }]);
+	});
+
+	it("counts a request and its mcp_tool_call_end as one call", () => {
+		// Codex writes both for the same call_id — the request first, the event
+		// after. The pair is still one call.
+		expect(
+			toolUse("codex", [
+				codexRow({
+					type: "function_call",
+					call_id: "call_a",
+					namespace: "mcp__codex_apps__linear",
+					name: "list_issues",
+				}),
+				codexRow({
+					type: "mcp_tool_call_end",
+					call_id: "call_a",
+					invocation: { server: "linear", tool: "list_issues" },
+				}),
+			]),
+		).toEqual([{ name: "linear.list_issues", kind: "mcp", server: "linear", calls: 1 }]);
+	});
+
+	it("counts an mcp_tool_call_end with no server as a builtin rather than inventing one", () => {
+		expect(
+			toolUse("codex", [
+				codexRow({ type: "mcp_tool_call_end", call_id: "call_a", invocation: { tool: "search" } }),
+			]),
+		).toEqual([{ name: "search", kind: "builtin", calls: 1 }]);
+	});
+
+	it("counts a call that carries no call_id rather than dropping it", () => {
+		expect(
+			toolUse("codex", [
+				codexRow({ type: "function_call", name: "exec_command" }),
+				codexRow({ type: "function_call", name: "exec_command" }),
+			]),
+		).toEqual([{ name: "exec_command", kind: "builtin", calls: 2 }]);
+	});
+
+	it("ignores conversation rows, malformed lines and payload-less lines", () => {
+		const parser = getParserForSource("codex");
+		expect(
+			parser.parseToolUse?.([
+				JSON.stringify(codexRow({ type: "reasoning", summary: [] })),
+				JSON.stringify({ type: "event_msg", payload: { type: "agent_message", message: "hi" } }),
+				JSON.stringify({ type: "session_meta" }),
+				"{ not json",
+				"",
+			]),
+		).toEqual([]);
+	});
+
+	it("reports an empty array for a tool-free slice, never undefined", () => {
+		expect(toolUse("codex", [])).toEqual([]);
+	});
+});
+
+describe("KimiTranscriptParser.parseToolUse", () => {
+	it("counts a builtin tool.call", () => {
+		expect(
+			toolUse("kimi", [kimiRow({ type: "tool.call", toolCallId: "t1", name: "Read", args: { path: "a.ts" } })]),
+		).toEqual([{ name: "Read", kind: "builtin", calls: 1 }]);
+	});
+
+	it("counts an MCP tool.call by its Claude-shaped name", () => {
+		expect(
+			toolUse("kimi", [kimiRow({ type: "tool.call", toolCallId: "t1", name: "mcp__jollimemory__search" })]),
+		).toEqual([{ name: "jollimemory.search", kind: "mcp", server: "jollimemory", calls: 1 }]);
+	});
+
+	it("re-attributes a Skill call to the skill it ran", () => {
+		expect(
+			toolUse("kimi", [
+				kimiRow({ type: "tool.call", toolCallId: "t1", name: "Skill", args: { skill: "jolli-pr" } }),
+			]),
+		).toEqual([{ name: "jolli-pr", kind: "skill", calls: 1 }]);
+	});
+
+	it("keeps a Skill call with no skill argument as a builtin rather than dropping it", () => {
+		expect(toolUse("kimi", [kimiRow({ type: "tool.call", toolCallId: "t1", name: "Skill", args: {} })])).toEqual([
+			{ name: "Skill", kind: "builtin", calls: 1 },
+		]);
+	});
+
+	it("does not count the paired tool.result", () => {
+		expect(
+			toolUse("kimi", [
+				kimiRow({ type: "tool.call", toolCallId: "t1", name: "Read" }),
+				kimiRow({ type: "tool.result", toolCallId: "t1", result: { output: "…" } }),
+			]),
+		).toEqual([{ name: "Read", kind: "builtin", calls: 1 }]);
+	});
+
+	it("counts a repeated toolCallId once and distinct ids separately", () => {
+		expect(
+			toolUse("kimi", [
+				kimiRow({ type: "tool.call", toolCallId: "t1", name: "Read" }),
+				kimiRow({ type: "tool.call", toolCallId: "t1", name: "Read" }),
+				kimiRow({ type: "tool.call", toolCallId: "t2", name: "Read" }),
+			]),
+		).toEqual([{ name: "Read", kind: "builtin", calls: 2 }]);
+	});
+
+	it("ignores conversation events, unwrapped events and malformed lines", () => {
+		const parser = getParserForSource("kimi");
+		expect(
+			parser.parseToolUse?.([
+				JSON.stringify(kimiRow({ type: "content.part", part: { type: "text", text: "hi" } })),
+				JSON.stringify({ type: "turn.prompt", input: [{ type: "text", text: "hi" }], time: 1 }),
+				JSON.stringify({ type: "context.append_loop_event" }),
+				"{ not json",
+			]),
+		).toEqual([]);
+	});
+
+	it("reports an empty array for a tool-free slice, never undefined", () => {
+		expect(toolUse("kimi", [])).toEqual([]);
+	});
+});
+
+describe("TOOL_RECORDING_SOURCES", () => {
+	it("includes every parser that implements parseToolUse", () => {
+		for (const source of ["claude", "codex", "kimi"] as const) {
+			expect(getParserForSource(source).parseToolUse).toBeTypeOf("function");
+			expect(TOOL_RECORDING_SOURCES.has(source)).toBe(true);
+		}
+	});
+
+	it("includes the reader-backed sources whose readers populate toolUse", () => {
+		// Each of these is pinned behaviourally in its own reader's test file.
+		for (const source of ["gemini", "opencode", "antigravity", "cursor-cli", "cline-cli", "devin"]) {
+			expect(TOOL_RECORDING_SOURCES.has(source)).toBe(true);
+		}
+	});
+
+	it("excludes the sources whose tool records are still unproven", () => {
+		// Not a wish-list: a source here reports `toolUse: []`, which downstream
+		// reads as the positive claim "called no tools". Omission degrades to
+		// "unavailable" instead. Move an entry up only with a real capture.
+		for (const source of ["cursor", "copilot", "copilot-chat", "cline"]) {
+			expect(TOOL_RECORDING_SOURCES.has(source)).toBe(false);
+		}
+	});
+});

--- a/cli/src/core/push/ContextKindDefinition.ts
+++ b/cli/src/core/push/ContextKindDefinition.ts
@@ -80,8 +80,49 @@ export interface ContextBaseKeySpec<F extends string = string> {
 	readonly stripArchiveSuffix?: boolean;
 }
 
+/**
+ * Where a kind's published id/URL live, as a discriminated pair of field names.
+ *
+ * **`"item"` (the default) — one article per item.** The names are checked against
+ * the item type, so a typo or a `Types.ts` rename is a compile error rather than a
+ * silent degradation (see the file header). Omitting them takes the uniform
+ * {@link DEFAULT_DOC_ID_FIELD} / {@link DEFAULT_DOC_URL_FIELD}.
+ *
+ * **`"summary"` — ONE article per commit**, so its id belongs to the commit and the
+ * names are checked against `CommitSummary` instead. Today only `skill`, via
+ * {@link ContextKindDefinition.aggregate}.
+ *
+ * Parking a commit-level id on a representative item is not a harmless shortcut,
+ * which is why this is a scope rather than a convention: the item then travels
+ * through that kind's own per-item merge rules (for skills, `mergeSkillRef`'s fold
+ * by `<source>:<skill>`), which inherit, displace and register-for-deletion an id
+ * under rules written for per-item articles. A squash whose root and child had each
+ * been pushed ended up with TWO refs carrying an id from two different aggregate
+ * articles: the push reused whichever sorted first — retitling another commit's
+ * article in place — and the other became an orphan no cleanup path could see,
+ * since `supersededDocIds` only fires when both sides of ONE fold carry an id.
+ *
+ * Both names are REQUIRED under `"summary"`, deliberately: the uniform defaults are
+ * `CommitSummary.jolliDocId` / `jolliDocUrl`, i.e. the memory article's own fields,
+ * and inheriting them would overwrite it.
+ */
+export type ContextKindDocState<T> =
+	| {
+			readonly docScope?: "item";
+			readonly docIdField?: ItemField<T>;
+			readonly docUrlField?: ItemField<T>;
+	  }
+	| {
+			readonly docScope: "summary";
+			readonly docIdField: ItemField<CommitSummary>;
+			readonly docUrlField: ItemField<CommitSummary>;
+	  };
+
 /** One kind of pushable commit-context artifact, written against its real item type. */
-export interface ContextKindDefinition<T> {
+export type ContextKindDefinition<T> = ContextKindBase<T> & ContextKindDocState<T>;
+
+/** The scope-independent half of a {@link ContextKindDefinition}. */
+interface ContextKindBase<T> {
 	/** Wire `docType` tag, and the registry key. Must be unique across definitions. */
 	readonly docType: string;
 	/** The `CommitSummary` array field holding these items, e.g. `"plans"`. Deliberately unchecked — see the file header. */
@@ -97,10 +138,6 @@ export interface ContextKindDefinition<T> {
 	readonly baseKey: ContextBaseKeySpec<ItemField<T>>;
 	/** Field holding the recency used to pick the winner revision (compared as a STRING, newest wins). */
 	readonly recency: ItemField<T>;
-	/** Defaults to {@link DEFAULT_DOC_ID_FIELD}. */
-	readonly docIdField?: ItemField<T>;
-	/** Defaults to {@link DEFAULT_DOC_URL_FIELD}. */
-	readonly docUrlField?: ItemField<T>;
 	/** Article title. Must be sanitized for a document title by the definition. */
 	readonly title: (item: T, summary: CommitSummary) => string;
 	/** Article body. `undefined` means "skip this item" (unreadable or empty content) — never an error. */
@@ -110,6 +147,32 @@ export interface ContextKindDefinition<T> {
 	 * (only plans need it, to collapse same-named archived snapshots).
 	 */
 	readonly reduce?: (items: ReadonlyArray<T>) => ReadonlyArray<T>;
+	/**
+	 * Optional N→1 (or N→M) collapse applied to the items ONE commit is about to
+	 * push, whichever path selected them. Only `skill` needs it, to publish one
+	 * aggregate article per commit instead of one per skill.
+	 *
+	 * **Deliberately not {@link reduce}.** The two run at different points and mean
+	 * different things:
+	 *
+	 *   - `reduce` runs only on a summary's OWN items, and `reduceOwnItems` applies
+	 *     the same call to the copy the summary markdown is rendered from — because
+	 *     for a plan the collapse is a statement about which items EXIST for that
+	 *     commit. A skill aggregate is not: every skill still exists and the Context
+	 *     section still summarises all of them, so folding it into the rendered copy
+	 *     would delete rows from the memory itself.
+	 *   - `reduce` is skipped when a caller passes an explicit selection, since the
+	 *     cross-commit winner rule has already done that job. An aggregate must run
+	 *     on BOTH paths, or the branch-push path (which always selects) would keep
+	 *     publishing one article per skill.
+	 *
+	 * The returned items must be assignable to `T` and must carry the identity the
+	 * engine reads off them (`entryKey`, `docIdField`, `docUrlField`) from a REAL
+	 * item of the group, so the published URL/docId weaves back onto an entry the
+	 * summary actually holds — otherwise every push mints a fresh article instead of
+	 * updating the one it minted last time.
+	 */
+	readonly aggregate?: (items: ReadonlyArray<T>, summary: CommitSummary) => ReadonlyArray<T>;
 	/** Optional deterministic tiebreak when two revisions share a `recency` value. */
 	readonly tiebreak?: (a: T, b: T) => number;
 	/**
@@ -163,11 +226,13 @@ export interface AnyContextKind {
 	readonly entryKey: string;
 	readonly baseKey: ContextBaseKeySpec;
 	readonly recency: string;
+	readonly docScope?: "item" | "summary";
 	readonly docIdField?: string;
 	readonly docUrlField?: string;
 	readonly title: (item: unknown, summary: CommitSummary) => string;
 	readonly body: (item: unknown, ctx: ContextBodyCtx) => Promise<string | undefined>;
 	readonly reduce?: (items: ReadonlyArray<unknown>) => ReadonlyArray<unknown>;
+	readonly aggregate?: (items: ReadonlyArray<unknown>, summary: CommitSummary) => ReadonlyArray<unknown>;
 	readonly tiebreak?: (a: unknown, b: unknown) => number;
 	readonly linksInMarkdown?: boolean;
 	readonly bestEffortPush?: boolean;
@@ -181,6 +246,7 @@ export interface AnyContextKind {
  */
 export function defineContextKind<T>(def: ContextKindDefinition<T>): AnyContextKind {
 	const reduce = def.reduce;
+	const aggregate = def.aggregate;
 	const tiebreak = def.tiebreak;
 	return {
 		docType: def.docType,
@@ -188,11 +254,16 @@ export function defineContextKind<T>(def: ContextKindDefinition<T>): AnyContextK
 		entryKey: def.entryKey,
 		baseKey: def.baseKey,
 		recency: def.recency,
+		...(def.docScope !== undefined && { docScope: def.docScope }),
 		...(def.docIdField !== undefined && { docIdField: def.docIdField }),
 		...(def.docUrlField !== undefined && { docUrlField: def.docUrlField }),
 		title: (item, summary) => def.title(item as T, summary),
 		body: (item, ctx) => def.body(item as T, ctx),
 		...(reduce !== undefined && { reduce: (items: ReadonlyArray<unknown>) => reduce(items as ReadonlyArray<T>) }),
+		...(aggregate !== undefined && {
+			aggregate: (items: ReadonlyArray<unknown>, summary: CommitSummary) =>
+				aggregate(items as ReadonlyArray<T>, summary),
+		}),
 		...(tiebreak !== undefined && { tiebreak: (a: unknown, b: unknown) => tiebreak(a as T, b as T) }),
 		...(def.linksInMarkdown !== undefined && { linksInMarkdown: def.linksInMarkdown }),
 		...(def.bestEffortPush !== undefined && { bestEffortPush: def.bestEffortPush }),

--- a/cli/src/core/push/ContextKindRegistry.ts
+++ b/cli/src/core/push/ContextKindRegistry.ts
@@ -70,6 +70,15 @@ function validateDefinitions(definitions: ReadonlyArray<AnyContextKind>): Readon
 		if (kind.clientKeyPrefix === "") {
 			throw new Error(`ContextKindDefinition ${label}: clientKeyPrefix must be a non-empty string when set`);
 		}
+		if (kind.docScope === "summary" && (kind.docIdField === undefined || kind.docUrlField === undefined)) {
+			// The defaults are `CommitSummary.jolliDocId` / `jolliDocUrl` — the memory
+			// article's OWN fields — so a summary-scoped kind that inherits them would
+			// overwrite the memory's published identity with its attachment's. The
+			// authoring type already requires both; this covers the erased form.
+			throw new Error(
+				`ContextKindDefinition ${label}: a summary-scoped kind must override both docIdField and docUrlField`,
+			);
+		}
 		const prefix = clientKeyPrefixOf(kind);
 		if (seenPrefixes.has(prefix)) {
 			throw new Error(`ContextKindDefinition ${label}: duplicate clientKeyPrefix ${JSON.stringify(prefix)}`);
@@ -91,6 +100,44 @@ export function docIdFieldOf(kind: AnyContextKind): string {
 
 export function docUrlFieldOf(kind: AnyContextKind): string {
 	return kind.docUrlField ?? DEFAULT_DOC_URL_FIELD;
+}
+
+/** True when this kind's published id/URL live on the `CommitSummary` rather than on each item. */
+export function isSummaryScoped(kind: AnyContextKind): boolean {
+	return kind.docScope === "summary";
+}
+
+/**
+ * The id/URL a prior push recorded for `item`, read from whichever carrier the
+ * kind's `docScope` names.
+ *
+ * The one accessor every push path uses, so the scope decision is made once. Reading
+ * `docIdOf(kind, item)` directly is correct ONLY where the carrier really is the item
+ * (the cross-commit winner rule, which a summary-scoped kind does not participate in).
+ */
+export function storedDocOf(
+	kind: AnyContextKind,
+	summary: CommitSummary,
+	item: unknown,
+): { docId?: number; docUrl?: string } {
+	const carrier = isSummaryScoped(kind) ? summary : item;
+	return { docId: docIdOf(kind, carrier), docUrl: docUrlOf(kind, carrier) };
+}
+
+/** Returns a copy of `summary` carrying a summary-scoped kind's published id + URL. */
+export function withSummaryDoc(
+	kind: AnyContextKind,
+	summary: CommitSummary,
+	url: string,
+	docId: number | undefined,
+): CommitSummary {
+	return {
+		...summary,
+		[docUrlFieldOf(kind)]: url,
+		// A batch push weaves a placeholder URL before the server has minted an id, so
+		// the id stays absent rather than being written as the placeholder string.
+		...(docId !== undefined && { [docIdFieldOf(kind)]: docId }),
+	} as CommitSummary;
 }
 
 /** Whether the summary markdown links these items — drives batch placeholder minting. */

--- a/cli/src/core/push/ContextPush.test.ts
+++ b/cli/src/core/push/ContextPush.test.ts
@@ -49,7 +49,26 @@ vi.mock("./kinds/index.js", async () => {
 		reduce: (items) => items.filter((w) => w.keep !== false),
 		tiebreak: (a, b) => (a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0),
 	});
-	return { CONTEXT_KIND_DEFINITIONS: [widget, gadget] };
+	// A summary-scoped, aggregating kind — the shape `skill` uses. Synthetic for the
+	// same reason as the two above: it is the only way to reach `docScope: "summary"`
+	// and `aggregate` through the generic engine rather than through one real kind's
+	// data. It reuses the REAL `jolliSkillsDocId`/`jolliSkillsDocUrl` names because
+	// those fields must exist on `CommitSummary` for the scope to mean anything.
+	const banner = defineContextKind<BannerItem>({
+		docType: "banner",
+		field: "banners",
+		entryKey: "bid",
+		baseKey: { fields: ["bid"] },
+		recency: "at",
+		docScope: "summary",
+		docIdField: "jolliSkillsDocId",
+		docUrlField: "jolliSkillsDocUrl",
+		linksInMarkdown: false,
+		title: () => "Banners",
+		body: async (b) => b.body,
+		aggregate: (items) => [{ ...items[0], bid: "all", body: items.map((i) => i.body ?? "").join("+") }],
+	});
+	return { CONTEXT_KIND_DEFINITIONS: [widget, gadget, banner] };
 });
 
 import { DocTypeNotAllowedError, type JolliMemoryPushClient } from "../JolliMemoryPushClient.js";
@@ -76,6 +95,12 @@ interface GadgetItem {
 	readonly jolliDocUrl?: string;
 }
 
+interface BannerItem {
+	readonly bid: string;
+	readonly at: string;
+	readonly body?: string;
+}
+
 interface WidgetItem {
 	readonly slug: string;
 	readonly updatedAt: string;
@@ -89,6 +114,7 @@ const BASE = "https://acme.jolli.ai";
 const ENV_KEY = "https://acme.jolli.ai";
 
 interface TestSummary extends CommitSummary {
+	readonly banners?: ReadonlyArray<BannerItem>;
 	readonly gadgets?: ReadonlyArray<GadgetItem>;
 	readonly widgets?: ReadonlyArray<WidgetItem>;
 }
@@ -341,6 +367,46 @@ describe("pushContextAttachments", () => {
 
 // ─── Weaving + reduction ─────────────────────────────────────────────────────
 
+describe("aggregate + summary-scoped doc state", () => {
+	it("pushes ONE article for an aggregating kind and reuses the SUMMARY's id", async () => {
+		const client = fakeClient();
+		const s = summary({
+			banners: [
+				{ bid: "b1", at: "2026-01-01T00:00:00Z", body: "one" },
+				{ bid: "b2", at: "2026-01-02T00:00:00Z", body: "two" },
+			],
+			jolliSkillsDocId: 55,
+			jolliSkillsDocUrl: `${BASE}/articles?doc=55`,
+		});
+		await pushContextAttachments(s, ctxOf(client), ENV_KEY, undefined);
+		const calls = (
+			client.push as unknown as { mock: { calls: Array<[{ docType: string; docId?: number }]> } }
+		).mock.calls.filter((c) => c[0].docType === "banner");
+		expect(calls).toHaveLength(1);
+		// The stored id comes off the summary, not off any item — that is the whole
+		// point of `docScope`, and it is what makes a re-push update in place.
+		expect(calls[0][0].docId).toBe(55);
+	});
+
+	it("aggregates on the SELECTION path too, which is the one branch push always takes", async () => {
+		// `reduce` is skipped for an explicit selection (the winner rule already
+		// collapsed revisions); an aggregate is a per-commit presentation decision no
+		// selection can make, so skipping it there would leave the branch-push path
+		// publishing the un-aggregated set.
+		const client = fakeClient();
+		const banners = [
+			{ bid: "b1", at: "2026-01-01T00:00:00Z", body: "one" },
+			{ bid: "b2", at: "2026-01-02T00:00:00Z", body: "two" },
+		];
+		await pushContextAttachments(summary({ banners }), ctxOf(client), ENV_KEY, new Map([["banner", banners]]));
+		const calls = (
+			client.push as unknown as { mock: { calls: Array<[{ docType: string; content: string }]> } }
+		).mock.calls.filter((c) => c[0].docType === "banner");
+		expect(calls).toHaveLength(1);
+		expect(calls[0][0].content).toBe("one+two");
+	});
+});
+
 describe("applyPublishedUrls / reduceOwnItems", () => {
 	it("weaves onto the default jolliDocId/jolliDocUrl fields, matched by entryKey", () => {
 		const s = summary({
@@ -368,6 +434,33 @@ describe("applyPublishedUrls / reduceOwnItems", () => {
 		) as TestSummary;
 		expect(woven.gadgets?.[0].jolliDocUrl).toBe("{{jolli:doc:gadget-0}}");
 		expect(woven.gadgets?.[0].jolliDocId).toBeUndefined();
+	});
+
+	it("weaves a summary-scoped kind onto the SUMMARY, leaving its items untouched", () => {
+		// One article for the whole commit, so there is no entry that owns it. Holding
+		// the id on a representative item instead put a commit-level identity inside
+		// that kind's per-item merge rules, where a squash could retitle another
+		// commit's article and strand a second one with no cleanup path.
+		const s = summary({ banners: [{ bid: "b1", at: "2026-01-01T00:00:00Z" }] });
+		const woven = applyPublishedUrls(
+			s,
+			new Map([["banner", [{ entryKey: "all", url: `${BASE}/articles?doc=7`, docId: 7 }]]]),
+		) as TestSummary;
+		expect(woven.jolliSkillsDocId).toBe(7);
+		expect(woven.jolliSkillsDocUrl).toBe(`${BASE}/articles?doc=7`);
+		expect(woven.banners?.[0]).not.toHaveProperty("jolliSkillsDocId");
+	});
+
+	it("urlOnly leaves a summary-scoped docId absent too (batch placeholder path)", () => {
+		// A placeholder string in a numeric docId field would break the sidecar schema
+		// exactly as it would on an item.
+		const woven = applyPublishedUrls(
+			summary({ banners: [{ bid: "b1", at: "2026-01-01T00:00:00Z" }] }),
+			new Map([["banner", [{ entryKey: "all", url: "{{jolli:doc:banner-0}}" }]]]),
+			{ urlOnly: true },
+		) as TestSummary;
+		expect(woven.jolliSkillsDocUrl).toBe("{{jolli:doc:banner-0}}");
+		expect(woven.jolliSkillsDocId).toBeUndefined();
 	});
 
 	it("returns the summary by identity when nothing was published for its kinds", () => {

--- a/cli/src/core/push/ContextPush.ts
+++ b/cli/src/core/push/ContextPush.ts
@@ -36,13 +36,16 @@ import {
 	entryKeyOf,
 	getContextKinds,
 	hasField,
+	isSummaryScoped,
 	linksInMarkdown,
 	recencyOf,
 	replaceItems,
 	selectItems,
+	storedDocOf,
 	withDoc,
 	withDocUrl,
 	withSeedDoc,
+	withSummaryDoc,
 } from "./ContextKindRegistry.js";
 import { canReuseDocId } from "./DocIdReuse.js";
 
@@ -174,8 +177,26 @@ function itemWins(kind: AnyContextKind, item: unknown, prev: unknown): boolean {
 	return kind.tiebreak !== undefined && kind.tiebreak(item, prev) < 0;
 }
 
-/** The items one commit should push for `kind`: the caller's selection, or the summary's own (reduced). */
+/**
+ * The items one commit should push for `kind`: the caller's selection, or the
+ * summary's own (reduced) — then the kind's `aggregate`, if it declares one.
+ *
+ * `aggregate` runs on BOTH branches on purpose, unlike `reduce`. `reduce` is
+ * skipped for an explicit selection because the cross-commit winner rule has
+ * already collapsed revisions; an aggregate is a per-commit presentation decision
+ * that no selection can make, so skipping it on the selection branch would leave
+ * the branch-push path (which always selects) publishing the un-aggregated set.
+ */
 export function itemsToPush(
+	kind: AnyContextKind,
+	summary: CommitSummary,
+	selection: ContextSelection | undefined,
+): ReadonlyArray<unknown> {
+	const selected = selectedItems(kind, summary, selection);
+	return kind.aggregate !== undefined && selected.length > 0 ? kind.aggregate(selected, summary) : selected;
+}
+
+function selectedItems(
 	kind: AnyContextKind,
 	summary: CommitSummary,
 	selection: ContextSelection | undefined,
@@ -351,7 +372,7 @@ export async function pushContextAttachments(
 				continue;
 			}
 			const title = kind.title(item, summary);
-			const storedDocId = docIdOf(kind, item);
+			const stored = storedDocOf(kind, summary, item);
 			try {
 				// Live re-read of the opt-out before EVERY send — see assertOutboundStillAllowed.
 				await assertOutboundStillAllowed(ctx.cwd);
@@ -361,8 +382,7 @@ export async function pushContextAttachments(
 					commitHash: summary.commitHash,
 					docType: kind.docType,
 					branch: summary.branch,
-					...(storedDocId !== undefined &&
-						canReuseDocId(docUrlOf(kind, item), envKey) && { docId: storedDocId }),
+					...(stored.docId !== undefined && canReuseDocId(stored.docUrl, envKey) && { docId: stored.docId }),
 					repoUrl: ctx.repoUrl,
 					relativePath: buildBranchRelativePath(summary.branch),
 				});
@@ -409,6 +429,9 @@ function logDocTypeNotAllowed(docType: string, message: string): void {
  * `entryKey` — the exact per-commit array entry, so an item recurring across commits
  * only updates the entry that actually pushed.
  *
+ * A **summary-scoped** kind writes onto the summary's own fields instead: its article
+ * covers the commit, so there is no entry that owns it (see `ContextKindDocState`).
+ *
  * `opts.urlOnly` writes the URL but not the docId: the batch path uses it to weave
  * server-substituted PLACEHOLDER urls into the copy the markdown and summaryJson
  * are built from, where a placeholder string in a numeric docId field would break
@@ -427,6 +450,15 @@ export function applyPublishedUrls(
 	for (const kind of getContextKinds()) {
 		const docs = published.get(kind.docType);
 		if (docs === undefined || docs.length === 0) continue;
+		if (isSummaryScoped(kind)) {
+			// One article for the whole commit, so there is no entry to match: the id/URL
+			// go on the summary itself. `docs` holds exactly one doc for such a kind (its
+			// `aggregate` produced one item), and taking the first keeps that assumption
+			// visible rather than silently letting a later doc win.
+			const doc = docs[0];
+			out = withSummaryDoc(kind, out, doc.url, opts?.urlOnly === true ? undefined : doc.docId);
+			continue;
+		}
 		if (!hasField(kind, out)) continue;
 		const byEntryKey = new Map(docs.map((d) => [d.entryKey, d]));
 		const items = selectItems(kind, out).map((item) => {
@@ -514,14 +546,14 @@ export async function buildContextBatchAttachments(
 			}
 			const clientKey = `${clientKeyPrefixOf(kind)}-${index}`;
 			index++;
-			const storedDocId = docIdOf(kind, item);
+			const stored = storedDocOf(kind, summary, item);
 			attachments.push({
 				clientKey,
 				docType: kind.docType,
 				title: kind.title(item, summary),
 				content,
 				relativePath,
-				...(storedDocId !== undefined && canReuseDocId(docUrlOf(kind, item), envKey) && { docId: storedDocId }),
+				...(stored.docId !== undefined && canReuseDocId(stored.docUrl, envKey) && { docId: stored.docId }),
 			});
 			attachmentKeys.set(clientKey, { docType: kind.docType, key: entryKey });
 			if (linksInMarkdown(kind)) forKind.push({ entryKey, url: docUrlPlaceholder(clientKey) });

--- a/cli/src/core/push/LegacySkillDocIds.test.ts
+++ b/cli/src/core/push/LegacySkillDocIds.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for the per-skill → per-commit skill-article migration.
+ *
+ * What matters here is that the OLD ids are neither honoured as-is nor silently
+ * dropped: a shipped version published one article per (skill, commit), and the
+ * only two ways to get that wrong are to keep pushing against them (which the
+ * aggregate model cannot do — one article, many skills) or to abandon them (which
+ * leaks every one of them, since `cleanupOrphanedDocs` only ever sees
+ * `orphanedDocIds`).
+ */
+
+import { describe, expect, it } from "vitest";
+import type { CommitSummary, SkillCommitRef } from "../../Types.js";
+import { adoptLegacySkillDocIds } from "./LegacySkillDocIds.js";
+
+function ref(overrides: Partial<SkillCommitRef> = {}): SkillCommitRef {
+	return {
+		archivedKey: "claude:a-a1b2c3d4",
+		source: "claude",
+		skill: "a",
+		entryPaths: ["tool"],
+		invocationCount: 1,
+		firstUsedAt: "2026-08-01T10:00:00.000Z",
+		lastUsedAt: "2026-08-05T10:00:00.000Z",
+		...overrides,
+	};
+}
+
+function summary(overrides: Partial<CommitSummary> = {}): CommitSummary {
+	return { commitHash: "a1b2c3d4e5f6", ...overrides } as CommitSummary;
+}
+
+describe("adoptLegacySkillDocIds", () => {
+	it("adopts the newest legacy article and orphans the rest", () => {
+		const out = adoptLegacySkillDocIds(
+			summary({
+				skills: [
+					{ ...ref({ archivedKey: "claude:a-h", lastUsedAt: "2026-08-01T00:00:00.000Z" }), jolliDocId: 501 },
+					{
+						...ref({ archivedKey: "claude:b-h", skill: "b", lastUsedAt: "2026-08-05T00:00:00.000Z" }),
+						jolliDocId: 502,
+						jolliDocUrl: "https://acme.jolli.ai/articles?doc=502",
+					},
+				],
+			}),
+		);
+		// N per-skill articles become 1 aggregate in a single push: the newest is
+		// rewritten into the aggregate, the others are queued for deletion.
+		expect(out.jolliSkillsDocId).toBe(502);
+		expect(out.jolliSkillsDocUrl).toBe("https://acme.jolli.ai/articles?doc=502");
+		expect(out.orphanedDocIds).toEqual([501]);
+	});
+
+	it("strips the legacy fields, so a second call cannot re-adopt them", () => {
+		const once = adoptLegacySkillDocIds(summary({ skills: [{ ...ref(), jolliDocId: 501 }] }));
+		expect(once.skills?.[0]).not.toHaveProperty("jolliDocId");
+		// Deleted, not set to undefined: these refs are serialized as JSON, where a
+		// `null` reads back as a field that exists.
+		expect(JSON.stringify(once.skills?.[0])).not.toContain("jolliDocId");
+		expect(adoptLegacySkillDocIds(once)).toBe(once);
+	});
+
+	it("drains ids a fold banked on a ref but never delivered", () => {
+		// `supersededDocIds` was the per-skill model's own cleanup marker. Once the refs
+		// stop carrying ids, nothing drains it — so this migration is its last reader.
+		const out = adoptLegacySkillDocIds(
+			summary({ skills: [{ ...ref(), jolliDocId: 501, supersededDocIds: [499] }] }),
+		);
+		expect(out.orphanedDocIds).toEqual([499]);
+		expect(out.skills?.[0]).not.toHaveProperty("supersededDocIds");
+	});
+
+	it("never re-points a commit that already has an aggregate article", () => {
+		// Adopting here would abandon the article the commit is actually published as.
+		const already = summary({ jolliSkillsDocId: 900, skills: [{ ...ref(), jolliDocId: 501 }] });
+		expect(adoptLegacySkillDocIds(already).jolliSkillsDocId).toBe(900);
+	});
+
+	it("reclaims legacy ids left on the refs of a commit that already has an aggregate", () => {
+		// A mixed-vintage squash: the root got its aggregate id hoisted from one child
+		// while `mergeSkillRef` KEPT a legacy child's per-ref id on the merged row. That
+		// id is in no `supersededDocIds`, so skipping the whole function stranded the
+		// per-skill article on the Space forever.
+		const already = summary({
+			jolliSkillsDocId: 900,
+			skills: [{ ...ref(), jolliDocId: 501, supersededDocIds: [499] }],
+		});
+		const out = adoptLegacySkillDocIds(already);
+		expect(out.jolliSkillsDocId).toBe(900);
+		expect(out.orphanedDocIds).toEqual([501, 499]);
+		expect(out.skills?.[0]).not.toHaveProperty("jolliDocId");
+		// Idempotent: a second pass has nothing left to reclaim.
+		expect(adoptLegacySkillDocIds(out)).toBe(out);
+	});
+
+	it("returns a summary with nothing to migrate by identity", () => {
+		// Callers use `!==` to detect a rewrite, and an unpushed repo must not churn.
+		const none = summary({ skills: [ref()] });
+		expect(adoptLegacySkillDocIds(none)).toBe(none);
+		expect(adoptLegacySkillDocIds(summary())).toBeDefined();
+	});
+
+	it("keeps ids the summary was already carrying", () => {
+		const out = adoptLegacySkillDocIds(summary({ orphanedDocIds: [300], skills: [{ ...ref(), jolliDocId: 501 }] }));
+		expect(out.orphanedDocIds).toEqual([300]);
+		expect(out.jolliSkillsDocId).toBe(501);
+	});
+});

--- a/cli/src/core/push/LegacySkillDocIds.ts
+++ b/cli/src/core/push/LegacySkillDocIds.ts
@@ -1,0 +1,139 @@
+/**
+ * LegacySkillDocIds — one-way migration from per-skill articles to the per-commit
+ * skill-usage article.
+ *
+ * A shipped version published docType `skill` as ONE DOCUMENT PER (skill, commit),
+ * recording each id on its own `SkillCommitRef.jolliDocId`. The aggregate model
+ * publishes one document per COMMIT, with the id on
+ * `CommitSummary.jolliSkillsDocId`. Without this step a summary carrying the old
+ * shape would simply be pushed as if it had never been published: a fresh article
+ * per commit, and every per-skill article left on the Space forever — invisible to
+ * `cleanupOrphanedDocs`, which only ever sees `orphanedDocIds`.
+ *
+ * So the old ids are converted rather than discarded: the newest is ADOPTED as the
+ * commit's article (the next push retitles and rewrites it into the aggregate),
+ * and the rest are queued for deletion. N per-skill articles become 1 aggregate,
+ * which is exactly the end state the model wants — reached in one push, with no
+ * leak and no separate cleanup pass.
+ *
+ * **Runs before a push, not on load.** It only matters for a summary about to be
+ * pushed, and it must be persisted by the same write-back that stores the push
+ * result; doing it on every read would rewrite stored summaries that may never be
+ * pushed at all.
+ *
+ * Idempotent by construction: the legacy fields are stripped from every ref it
+ * touches, so a second call finds nothing to do and returns by identity. A summary
+ * that already carries `jolliSkillsDocId` keeps it — but any legacy id still left
+ * on its refs is reclaimed rather than ignored, which a mixed-vintage squash tree
+ * can produce (see the note on the early return).
+ */
+
+import { createLogger } from "../../Logger.js";
+import type { CommitSummary, SkillCommitRef } from "../../Types.js";
+
+const log = createLogger("LegacySkillDocIds");
+
+/**
+ * Folds any legacy per-skill article ids into the commit-level one.
+ *
+ * Returns the summary unchanged (by identity) when there is nothing to migrate, so
+ * callers can keep using `!==` to detect a rewrite.
+ */
+export function adoptLegacySkillDocIds(summary: CommitSummary): CommitSummary {
+	const skills = summary.skills;
+	if (skills === undefined || skills.length === 0) return summary;
+	const published = skills.filter((ref) => typeof ref.jolliDocId === "number");
+	// Ids a fold already banked on the refs but that no drain has reached yet. Read
+	// before the early returns below: they are a leak in exactly the same way a live
+	// `jolliDocId` is, and neither is reachable from anywhere but this function.
+	const banked = skills.flatMap((ref) => ref.supersededDocIds ?? []);
+	if (published.length === 0 && banked.length === 0) {
+		// Still strip: a ref carrying only a legacy `jolliDocUrl` has no article to
+		// reclaim, but leaving the field makes the shape ambiguous on the next pass.
+		return skills.some((ref) => ref.jolliDocUrl !== undefined)
+			? { ...summary, skills: skills.map(stripLegacyDocFields) }
+			: summary;
+	}
+
+	// Already migrated — never re-point a live aggregate article at an old per-skill
+	// one, which would abandon the article the commit is actually published as. But
+	// "don't adopt" is not "do nothing": a squash tree can mix vintages, so
+	// `collectChildSkillsDocMeta` can hoist an aggregate id onto the root from one
+	// child while `mergeSkillRef` keeps a legacy-vintage child's per-ref `jolliDocId`
+	// on the hoisted skill row. Returning by identity there strands that per-skill
+	// article on the Space forever: it is the id `mergeSkillRef` KEPT, so it is in no
+	// `supersededDocIds` either, and `cleanupOrphanedDocs` only ever sees
+	// `orphanedDocIds`. Skip the adopt step alone and reclaim the rest.
+	if (summary.jolliSkillsDocId !== undefined) {
+		const orphaned = [
+			...(summary.orphanedDocIds ?? []),
+			...published.map((ref) => ref.jolliDocId as number),
+			...banked,
+		];
+		log.info(
+			"%s: already an aggregate — orphaning %d leftover legacy skill article(s)",
+			summary.commitHash.substring(0, 8),
+			orphaned.length - (summary.orphanedDocIds?.length ?? 0),
+		);
+		return {
+			...summary,
+			skills: skills.map(stripLegacyDocFields),
+			...(orphaned.length > 0 && { orphanedDocIds: [...new Set(orphaned)] }),
+		};
+	}
+	if (published.length === 0) {
+		// Nothing to adopt, but banked ids still have to be reclaimed.
+		return {
+			...summary,
+			skills: skills.map(stripLegacyDocFields),
+			orphanedDocIds: [...new Set([...(summary.orphanedDocIds ?? []), ...banked])],
+		};
+	}
+
+	// Newest first, so the adopted article is the one most recently written — the same
+	// "most recent activity wins" rule the squash paths use to pick a survivor. Ties
+	// break on `archivedKey` so the choice is deterministic across runs.
+	const ordered = [...published].sort((a, b) => {
+		if (a.lastUsedAt !== b.lastUsedAt) return a.lastUsedAt < b.lastUsedAt ? 1 : -1;
+		return a.archivedKey < b.archivedKey ? -1 : a.archivedKey > b.archivedKey ? 1 : 0;
+	});
+	const [adopted, ...superseded] = ordered;
+	const orphaned = [
+		...(summary.orphanedDocIds ?? []),
+		...superseded.map((ref) => ref.jolliDocId as number),
+		...banked,
+	];
+	log.info(
+		"%s: adopting legacy skill article %d as the commit aggregate, orphaning %d",
+		summary.commitHash.substring(0, 8),
+		adopted.jolliDocId,
+		orphaned.length,
+	);
+
+	return {
+		...summary,
+		jolliSkillsDocId: adopted.jolliDocId,
+		// Rides with the id: the reuse gate reads its origin to decide which backend
+		// the id belongs to, so adopting one without the other would make the id
+		// unusable rather than merely untagged.
+		...(adopted.jolliDocUrl !== undefined && { jolliSkillsDocUrl: adopted.jolliDocUrl }),
+		skills: skills.map(stripLegacyDocFields),
+		...(orphaned.length > 0 && { orphanedDocIds: [...new Set(orphaned)] }),
+	};
+}
+
+/**
+ * Drops the three legacy per-ref fields.
+ *
+ * Deletes the keys rather than setting them to `undefined`: these refs are
+ * serialized to the orphan branch as JSON, where `"jolliDocId": null` reads back as
+ * a field that exists — and a ref that still looks published would be re-adopted by
+ * the next call, undoing the migration.
+ */
+function stripLegacyDocFields(ref: SkillCommitRef): SkillCommitRef {
+	if (ref.jolliDocId === undefined && ref.jolliDocUrl === undefined && ref.supersededDocIds === undefined) {
+		return ref;
+	}
+	const { jolliDocId: _id, jolliDocUrl: _url, supersededDocIds: _superseded, ...rest } = ref;
+	return rest;
+}

--- a/cli/src/core/push/kinds/index.ts
+++ b/cli/src/core/push/kinds/index.ts
@@ -18,15 +18,22 @@
  * same ordering every Context surface uses.
  */
 
-import type { NoteReference, PlanReference, ReferenceCommitRef, SkillCommitRef } from "../../../Types.js";
+import type {
+	CommitSummary,
+	NoteReference,
+	PlanReference,
+	ReferenceCommitRef,
+	SkillCommitRef,
+} from "../../../Types.js";
 import { readReferenceMarkdownFromString } from "../../references/ReferenceStore.js";
+import { skillsAggregateKey } from "../../SkillsAggregateMarkdown.js";
 import {
 	buildNotePushTitle,
 	buildPlanPushTitle,
 	buildReferencePushTitle,
-	buildSkillPushTitle,
+	buildSkillsPushTitle,
 } from "../../SummaryFormat.js";
-import { buildReferencePushMarkdown, buildSkillPushMarkdown } from "../../SummaryMarkdownBuilder.js";
+import { buildReferencePushMarkdown, buildSkillsPushMarkdown } from "../../SummaryMarkdownBuilder.js";
 import { readNoteFromBranch, readPlanFromBranch, readReferenceFromBranch } from "../../SummaryStore.js";
 import { type ContextKindDefinition, defineContextKind } from "../ContextKindDefinition.js";
 import { byUpdatedAtDesc, latestPlanPerName } from "../PlanGrouping.js";
@@ -134,21 +141,88 @@ const referenceDefinition: ContextKindDefinition<ReferenceCommitRef> = {
 };
 
 /**
- * `skill` — agent-skill usage recorded on a commit, and the **first kind to take the
- * registry defaults**: it declares no `docIdField`/`docUrlField`, so its published
- * id/URL land on the uniform `jolliDocId`/`jolliDocUrl` (rationale in
- * `ContextKindDefinition`), unlike the three kinds above.
+ * The synthetic item the skill kind pushes: one commit's whole skill set, under a
+ * commit-level identity.
  *
- * It is also the only kind that does NOT dedupe across commits — see `baseKey`.
+ * It extends `SkillCommitRef` only so the definition stays typed against its own
+ * item type; **no field of it is a real ref's**. `archivedKey` is the commit-level
+ * `skills--<hash8>`, matching the Memory Bank file name for the same data, and there
+ * is deliberately no `jolliDocId` on it — this kind is `docScope: "summary"`, so the
+ * published id lives on `CommitSummary.jolliSkillsDocId` and the engine never reads
+ * one off this object.
+ *
+ * That combination is the whole fix. Borrowing a representative ref's `archivedKey`
+ * (as the first cut did) made the aggregate's identity depend on which skills the
+ * commit happened to hold, and put a commit-level docId inside `mergeSkillRef`'s
+ * per-ref fold — see `ContextKindDocState` for the two failures that produced.
+ *
+ * Never stored: it exists only between `itemsToPush` and the push call.
+ */
+interface AggregatedSkillRef extends SkillCommitRef {
+	readonly aggregatedSkills: ReadonlyArray<SkillCommitRef>;
+}
+
+/**
+ * Collapses a commit's skill refs into the single aggregate article it publishes.
+ *
+ * **Why one article per commit.** Every local surface shows a commit's skills as
+ * ONE artifact — the Memory Bank writes `skills--<hash8>.md`, and the Context
+ * section renders one unlinked "Skills used" row (see `SummaryMarkdownBuilder`).
+ * Pushing one article per skill meant a commit whose Context listed a single
+ * `skill.md` arrived at the backend as six documents. The decomposition was never
+ * a product decision; it fell out of the engine being item-per-document.
+ *
+ * The identity is derived from the COMMIT, not from any ref, so it is stable no
+ * matter how the skill set changes between pushes — a squash that folds three refs
+ * into one, or a skill entered after the first push, leaves it untouched.
+ */
+function aggregateSkillRefs(
+	refs: ReadonlyArray<SkillCommitRef>,
+	summary: CommitSummary,
+): ReadonlyArray<SkillCommitRef> {
+	if (refs.length === 0) return refs;
+	// Sorted so the body's detail list and the pushed content are byte-stable across
+	// runs; `buildSkillsTable` does its own ordering for the table itself.
+	const ordered = [...refs].sort((a, b) =>
+		a.archivedKey < b.archivedKey ? -1 : a.archivedKey > b.archivedKey ? 1 : 0,
+	);
+	// The legacy per-ref doc fields are dropped rather than spread through: this kind
+	// is summary-scoped, so an id riding on the synthetic item would be a second,
+	// stale answer to "which article is this?" that a future reader could act on.
+	const { jolliDocId: _legacyId, jolliDocUrl: _legacyUrl, ...carrier } = ordered[0];
+	const hash8 = summary.commitHash.substring(0, 8);
+	const aggregated: AggregatedSkillRef = {
+		...carrier,
+		archivedKey: skillsAggregateKey(hash8),
+		aggregatedSkills: ordered,
+	};
+	return [aggregated];
+}
+
+/** The set an aggregate carries, or the lone ref itself when a caller hands over a plain one. */
+function aggregatedSkillsOf(ref: SkillCommitRef): ReadonlyArray<SkillCommitRef> {
+	const carried = (ref as AggregatedSkillRef).aggregatedSkills;
+	return Array.isArray(carried) && carried.length > 0 ? carried : [ref];
+}
+
+/**
+ * `skill` — agent-skill usage recorded on a commit, and the odd one out in three ways:
+ *
+ *  - it publishes ONE article for many items (see `aggregate`), because that is what
+ *    every local surface already shows;
+ *  - therefore its published id/URL live on the COMMIT (`docScope: "summary"`), not
+ *    on any item — see `ContextKindDocState` for what went wrong when they rode on a
+ *    representative ref;
+ *  - and it does not dedupe across commits (see `baseKey`).
  */
 const skillDefinition: ContextKindDefinition<SkillCommitRef> = {
 	docType: "skill",
 	field: "skills",
-	// The per-commit archive id `<source>:<skill>-<shortHash>`.
+	// `archivedKey`, which on the pushed item is the aggregate's own commit-level
+	// `skills--<hash8>` (see `aggregateSkillRefs`), never a single skill's archive id.
 	entryKey: "archivedKey",
-	// **Per-commit identity, unlike every other kind.** `archivedKey` carries the
-	// archiving commit's hash, so this is `entryKey` — i.e. one Space article per
-	// (skill, commit) rather than one per skill.
+	// **Per-commit identity, unlike every other kind** — equal to `entryKey`, so the
+	// article belongs to one commit and is never shared with another.
 	//
 	// It used to be the registry mapKey `<source>:<skill>`, which collapsed a skill
 	// used across many commits into ONE article. That could only ever report
@@ -160,14 +234,20 @@ const skillDefinition: ContextKindDefinition<SkillCommitRef> = {
 	// A skill is not a plan or a reference: those are one artifact revised over time,
 	// so collapsing revisions is right. A skill record is a MEASUREMENT of one
 	// commit's work, and measurements from different commits are different facts, not
-	// revisions of one. `buildSkillPushTitle` appends the commit's `hash8` so the
-	// per-commit articles are distinguishable in a flat branch folder.
+	// revisions of one. `buildSkillsPushTitle` names the article by the commit's
+	// `hash8` so the per-commit articles are distinguishable in a flat branch folder.
 	baseKey: { fields: ["archivedKey"] },
 	// Only reached now for the one case where the SAME archivedKey appears on two
 	// summaries: a squash root carries its children's hoisted refs and keeps the
 	// children, so a ref can be met from both ends (see `mergeSkillRefs`). Newest
 	// `lastUsedAt` wins, which keeps that collapsing to a single article.
 	recency: "lastUsedAt",
+	// **The published id/URL belong to the COMMIT, not to a skill.** The names are
+	// overridden because the summary-scope defaults would be `jolliDocId`/`jolliDocUrl`
+	// — the memory article's own fields — and taking them would overwrite it.
+	docScope: "summary",
+	docIdField: "jolliSkillsDocId",
+	docUrlField: "jolliSkillsDocUrl",
 	// Auto-extracted context, exactly like `reference`: a skill record is captured
 	// from a transcript, never attached by the user. So a failed skill push must not
 	// abort a strict live share — without this, one transient failure would throw
@@ -178,12 +258,16 @@ const skillDefinition: ContextKindDefinition<SkillCommitRef> = {
 	// aggregate row (see SummaryMarkdownBuilder), so there is no site in the summary
 	// body for a per-skill URL — and therefore no placeholder to mint in a batch push.
 	linksInMarkdown: false,
-	title: (ref, summary) => buildSkillPushTitle(ref, summary),
+	// The ONLY kind that publishes one article for many items — see
+	// `aggregateSkillRefs`, and `docScope` above for where its id then lives.
+	aggregate: aggregateSkillRefs,
+	// Named for the commit, not for a skill: the article covers all of them.
+	title: (_ref, summary) => buildSkillsPushTitle(summary),
 	// The only kind whose body needs no storage read: every figure it prints is on
-	// the ref itself. It used to read the orphan-branch snapshot for the CUMULATIVE
-	// counters and the verbatim invocation list, both of which are gone (see
-	// `buildSkillPushMarkdown`). Still `async` because the contract is.
-	body: async (ref) => buildSkillPushMarkdown(ref),
+	// the refs themselves. It used to read the orphan-branch snapshot for the
+	// CUMULATIVE counters and the verbatim invocation list, both of which are gone
+	// (see `buildSkillsPushMarkdown`). Still `async` because the contract is.
+	body: async (ref) => buildSkillsPushMarkdown(aggregatedSkillsOf(ref)),
 };
 
 /** Cross-commit dedup key for a reference: its stable `<source>:<nativeId>` (Reference.mapKey). */

--- a/cli/src/core/push/kinds/skill.test.ts
+++ b/cli/src/core/push/kinds/skill.test.ts
@@ -6,8 +6,10 @@
  * and is NOT re-tested per kind — that is the point of the table. What is specific
  * to skill, and therefore tested here:
  *
- *  - the article title, its collision-avoidance shape, and the `hash8` segment that
- *    keeps per-commit articles distinguishable,
+ *  - `aggregate`: ONE article per commit rather than one per skill, and the reason
+ *    its identity is borrowed from a real ref rather than invented,
+ *  - the article title and the `hash8` segment that keeps per-commit articles
+ *    distinguishable,
  *  - the per-commit-increment figure rule: every number in the body must match what
  *    the VS Code panel renders for the SAME commit,
  *  - per-commit `baseKey` (this is the only kind that does not dedupe across
@@ -22,7 +24,15 @@
 import { describe, expect, it } from "vitest";
 import type { CommitSummary, SkillCommitRef } from "../../../Types.js";
 import type { AnyContextKind } from "../ContextKindDefinition.js";
-import { baseKeyOfItem, docIdFieldOf, docUrlFieldOf, entryKeyOf, linksInMarkdown } from "../ContextKindRegistry.js";
+import {
+	baseKeyOfItem,
+	docIdFieldOf,
+	docIdOf,
+	docUrlFieldOf,
+	entryKeyOf,
+	isSummaryScoped,
+	linksInMarkdown,
+} from "../ContextKindRegistry.js";
 import { CONTEXT_KIND_DEFINITIONS } from "./index.js";
 
 /** The `skill` definition, looked up from the registry list it is declared in. */
@@ -50,9 +60,14 @@ function summary(commitHash = "a1b2c3d4e5f6789012345678901234567890abcd"): Commi
 }
 
 describe("declaration", () => {
-	it("uses the uniform doc-state field names (the first kind to take the defaults)", () => {
-		expect(docIdFieldOf(skillKind)).toBe("jolliDocId");
-		expect(docUrlFieldOf(skillKind)).toBe("jolliDocUrl");
+	it("keeps its published id on the COMMIT, under names that cannot collide with the memory's", () => {
+		// Summary-scoped because the article covers the commit. The names are overridden
+		// rather than inherited precisely because the defaults (`jolliDocId` /
+		// `jolliDocUrl`) are the MEMORY article's own fields on a summary — taking them
+		// would overwrite the memory's published identity with its attachment's.
+		expect(isSummaryScoped(skillKind)).toBe(true);
+		expect(docIdFieldOf(skillKind)).toBe("jolliSkillsDocId");
+		expect(docUrlFieldOf(skillKind)).toBe("jolliSkillsDocUrl");
 	});
 
 	it("does not link in the summary markdown, so a batch push mints no placeholder", () => {
@@ -93,17 +108,57 @@ describe("declaration", () => {
 	});
 });
 
-describe("title", () => {
-	it("is namespaced by `Skill`, the host label, and the commit's hash8", () => {
-		// The host segment is required for uniqueness, not decoration: the registry key
-		// is `<source>:<skill>`, so two hosts can hold the same skill id as two rows.
-		// Colons become spaces because sanitizeTitle strips them from document titles.
-		expect(skillKind.title(ref(), summary())).toBe("Skill · Claude Code · superpowers brainstorming — a1b2c3d4");
+describe("aggregate", () => {
+	it("publishes ONE article for a commit's whole skill set", () => {
+		// The mismatch this exists to fix: every local surface shows a commit's skills as
+		// ONE artifact (`skills--<hash8>.md`, one "Skills used" Context row), so a commit
+		// whose Context listed a single file used to arrive at the backend as N documents.
+		const refs = [
+			ref({ archivedKey: "claude:a-a1b2c3d4", skill: "a" }),
+			ref({ archivedKey: "claude:b-a1b2c3d4", skill: "b" }),
+		];
+		expect(skillKind.aggregate?.(refs, summary())).toHaveLength(1);
 	});
 
-	it("distinguishes the same skill on two commits, which a flat branch folder needs", () => {
+	it("takes its identity from the COMMIT, so no change to the skill set can move it", () => {
+		// `skills--<hash8>`, the same key the Memory Bank names the local aggregate with.
+		// Deriving it from a representative ref instead made the article's identity
+		// depend on which skills the commit happened to hold — a squash that folds three
+		// refs into one, or a skill entered after the first push, silently re-pointed it.
+		const refs = [ref({ archivedKey: "claude:b-a1b2c3d4" }), ref({ archivedKey: "claude:a-a1b2c3d4" })];
+		const [aggregated] = skillKind.aggregate?.(refs, summary()) ?? [];
+		expect(entryKeyOf(skillKind, aggregated)).toBe("skills--a1b2c3d4");
+		const fewer = skillKind.aggregate?.([refs[0]], summary()) ?? [];
+		expect(entryKeyOf(skillKind, fewer[0])).toBe("skills--a1b2c3d4");
+	});
+
+	it("carries no per-ref docId, so nothing can mistake a stale id for the article's", () => {
+		// The published id lives on the summary (`docScope: "summary"`). A legacy id left
+		// on the carrier ref would be a second, stale answer to "which article is this?".
+		const refs = [{ ...ref(), jolliDocId: 501, jolliDocUrl: "https://acme.jolli.ai/articles?doc=501" }];
+		const [aggregated] = skillKind.aggregate?.(refs, summary()) ?? [];
+		expect((aggregated as { jolliDocId?: number }).jolliDocId).toBeUndefined();
+		expect((aggregated as { jolliDocUrl?: string }).jolliDocUrl).toBeUndefined();
+		// And the engine's own reader finds nothing either — it looks at the summary.
+		expect(docIdOf(skillKind, aggregated)).toBeUndefined();
+	});
+
+	it("leaves an empty set empty, so a commit with no skills pushes nothing", () => {
+		expect(skillKind.aggregate?.([], summary())).toEqual([]);
+	});
+});
+
+describe("title", () => {
+	it("names the COMMIT, not a skill — one article covers all of them", () => {
+		// Deliberately the same wording as `buildSkillsAggregateMarkdown`'s heading and
+		// the Memory Bank's `skills--<hash8>.md`: the pushed article and the local file
+		// are the same document and must not be findable under two names.
+		expect(skillKind.title(ref(), summary())).toBe("Skills used — a1b2c3d4");
+	});
+
+	it("distinguishes two commits' aggregates, which a flat branch folder needs", () => {
 		// Per-commit articles are siblings in one flat folder, so without the hash8 a
-		// skill used on four commits would show four indistinguishable entries.
+		// branch would show N indistinguishable "Skills used" entries.
 		const first = skillKind.title(ref(), summary("a1b2c3d4000000000000000000000000000000ff"));
 		const second = skillKind.title(ref(), summary("deadbeef000000000000000000000000000000ff"));
 		expect(first).toContain("— a1b2c3d4");
@@ -121,12 +176,6 @@ describe("title", () => {
 		);
 		expect(title).toContain("— a1b2c3d4");
 		expect(title).not.toContain("deadbeef");
-	});
-
-	it("distinguishes the same skill id captured from different hosts", () => {
-		const claude = skillKind.title(ref({ source: "claude" }), summary());
-		const codex = skillKind.title(ref({ source: "codex" }), summary());
-		expect(claude).not.toBe(codex);
 	});
 });
 
@@ -146,9 +195,9 @@ describe("body", () => {
 
 	it("includes the host, plugin and entry paths", async () => {
 		const body = await skillKind.body(ref(), { cwd: CWD });
-		expect(body).toContain("**Host:** Claude Code");
-		expect(body).toContain("**Plugin:** superpowers");
-		expect(body).toContain("**Entered via:** tool");
+		expect(body).toContain("Host: Claude Code");
+		expect(body).toContain("Plugin: superpowers");
+		expect(body).toContain("Entered via: tool");
 	});
 
 	it("renders the token table through the shared skills-table renderer", async () => {
@@ -181,14 +230,14 @@ describe("body", () => {
 		// such case now: the body is pure, so pre-archival and foreign data render
 		// identically to anything else.
 		const body = await skillKind.body(ref({ archivedKey: "claude:superpowers:brainstorming" }), { cwd: CWD });
-		expect(body).toContain("**Host:** Claude Code");
+		expect(body).toContain("Host: Claude Code");
 	});
 
 	it("marks an inferred skill and omits an absent plugin", async () => {
 		const body = await skillKind.body(ref({ plugin: undefined, detection: "heuristic", usage: undefined }), {
 			cwd: CWD,
 		});
-		expect(body).not.toContain("**Plugin:**");
+		expect(body).not.toContain("Plugin:");
 		// The dagger + footnote come from the shared table; an unattributed row shows
 		// em dashes rather than zeros.
 		expect(body).toContain("†");
@@ -197,11 +246,27 @@ describe("body", () => {
 
 	it("omits `Entered via` when the ref records no entry path", async () => {
 		const body = await skillKind.body(ref({ entryPaths: [] }), { cwd: CWD });
-		expect(body).not.toContain("**Entered via:**");
+		expect(body).not.toContain("Entered via:");
 	});
 
 	it("omits `Plugin` for an empty-string plugin, not just an absent one", async () => {
 		const body = await skillKind.body(ref({ plugin: "" }), { cwd: CWD });
-		expect(body).not.toContain("**Plugin:**");
+		expect(body).not.toContain("Plugin:");
+	});
+
+	it("lists EVERY skill of the commit — one table plus one detail line each", async () => {
+		const refs = [
+			ref({ archivedKey: "claude:a-a1b2c3d4", skill: "a" }),
+			ref({ archivedKey: "claude:b-a1b2c3d4", skill: "b", source: "codex", plugin: undefined }),
+		];
+		const [aggregated] = skillKind.aggregate?.(refs, summary()) ?? [];
+		const body = await skillKind.body(aggregated, { cwd: CWD });
+		expect(body).toContain("| a | 1 |");
+		expect(body).toContain("| b | 1 |");
+		// Identity sits below the table because it has no column there — and it is
+		// per-skill, so two hosts on one commit both survive.
+		expect(body).toContain("## Skill details");
+		expect(body).toContain("- **a** — Host: Claude Code");
+		expect(body).toContain("- **b** — Host: Codex");
 	});
 });

--- a/cli/src/daemon/DaemonServer.test.ts
+++ b/cli/src/daemon/DaemonServer.test.ts
@@ -208,10 +208,17 @@ describe("runDaemonServer", () => {
 	 * suite would inject refresh lines into these assertions.
 	 */
 	let plansDir: string;
+	/**
+	 * Same for the machine-global `~/.jolli/jollimemory/` the `memory-db` target
+	 * watches: a dashboard write from any other repo on this machine would
+	 * otherwise emit a `memory-db` refresh into these assertions.
+	 */
+	let globalConfigDir: string;
 
 	beforeEach(() => {
 		root = mkdtempSync(join(tmpdir(), "daemon-server-"));
 		plansDir = join(root, "claude-plans");
+		globalConfigDir = join(root, "global-config");
 		mockExec.mockReset();
 		// Default to "not a git repo" so tests don't depend on the host's git.
 		mockExec.mockImplementation(() => {
@@ -229,7 +236,7 @@ describe("runDaemonServer", () => {
 		const chunks: string[] = [];
 		stdout.on("data", (buf) => chunks.push(String(buf)));
 
-		const done = runDaemonServer({ cwd: root, stdin, stdout, plansDir, debounceMs: 10 });
+		const done = runDaemonServer({ cwd: root, stdin, stdout, plansDir, globalConfigDir, debounceMs: 10 });
 
 		// End stdin to trigger shutdown once ready has been written.
 		stdin.end();
@@ -250,7 +257,7 @@ describe("runDaemonServer", () => {
 		const chunks: string[] = [];
 		stdout.on("data", (buf) => chunks.push(String(buf)));
 
-		const done = runDaemonServer({ cwd: root, stdin, stdout, plansDir, debounceMs: 50 });
+		const done = runDaemonServer({ cwd: root, stdin, stdout, plansDir, globalConfigDir, debounceMs: 50 });
 
 		// The queue dir is ensureDir=true, so it exists right after start(). Give
 		// fs.watch a beat to arm on all platforms before writing.
@@ -289,7 +296,7 @@ describe("runDaemonServer", () => {
 		const chunks: string[] = [];
 		stdout.on("data", (buf) => chunks.push(String(buf)));
 
-		const done = runDaemonServer({ cwd: root, stdin, stdout, plansDir, debounceMs: 50 });
+		const done = runDaemonServer({ cwd: root, stdin, stdout, plansDir, globalConfigDir, debounceMs: 50 });
 		await sleep(150);
 
 		// The noise first: if the `.md` gate were missing this would produce its
@@ -329,7 +336,7 @@ describe("runDaemonServer", () => {
 		stdout.on("data", (buf) => chunks.push(String(buf)));
 
 		// ensureDir=true on this target, so the dir exists right after start().
-		const done = runDaemonServer({ cwd: root, stdin, stdout, plansDir, debounceMs: 50 });
+		const done = runDaemonServer({ cwd: root, stdin, stdout, plansDir, globalConfigDir, debounceMs: 50 });
 		await sleep(150);
 
 		// debug.log is the reason this target is gated at all — it is written many
@@ -370,7 +377,7 @@ describe("runDaemonServer", () => {
 		try {
 			const stdout = new PassThrough();
 			const stdin = new PassThrough();
-			const done = runDaemonServer({ cwd: root, stdin, stdout, plansDir, debounceMs: 10 });
+			const done = runDaemonServer({ cwd: root, stdin, stdout, plansDir, globalConfigDir, debounceMs: 10 });
 
 			// Target still doesn't exist — advance a couple of intervals so the
 			// retry callback runs, hits the `watcher.start() === false` path, and
@@ -390,7 +397,7 @@ describe("runDaemonServer", () => {
 		try {
 			const stdout = new PassThrough();
 			const stdin = new PassThrough();
-			const done = runDaemonServer({ cwd: root, stdin, stdout, plansDir, debounceMs: 10 });
+			const done = runDaemonServer({ cwd: root, stdin, stdout, plansDir, globalConfigDir, debounceMs: 10 });
 
 			// The orphan-ref target (`.git/refs/heads/jollimemory/summaries`) doesn't
 			// exist at startup, so a retry interval was armed. Create the dir now and
@@ -415,7 +422,7 @@ describe("runDaemonServer", () => {
 		const resumeSpy = vi.spyOn(process.stdin, "resume").mockImplementation(() => process.stdin);
 
 		try {
-			const done = runDaemonServer({ cwd: root, plansDir });
+			const done = runDaemonServer({ cwd: root, plansDir, globalConfigDir });
 			// Fire 'end' on the real process.stdin so the daemon shuts down.
 			stdinRef.emit("end");
 			await done;
@@ -438,7 +445,7 @@ describe("runDaemonServer", () => {
 		// and shut down cleanly when we fire the `end` event.
 		const stdin = new EventEmitter() as unknown as NodeJS.ReadableStream;
 
-		const done = runDaemonServer({ cwd: root, stdin, stdout, plansDir, debounceMs: 10 });
+		const done = runDaemonServer({ cwd: root, stdin, stdout, plansDir, globalConfigDir, debounceMs: 10 });
 		(stdin as unknown as EventEmitter).emit("end");
 		await done;
 	});
@@ -446,7 +453,7 @@ describe("runDaemonServer", () => {
 	it("treats a stdin 'close' event as shutdown", async () => {
 		const stdout = new PassThrough();
 		const stdin = new PassThrough();
-		const done = runDaemonServer({ cwd: root, stdin, stdout, plansDir, debounceMs: 10 });
+		const done = runDaemonServer({ cwd: root, stdin, stdout, plansDir, globalConfigDir, debounceMs: 10 });
 
 		(stdin as unknown as EventEmitter).emit("close");
 		await done;

--- a/cli/src/daemon/DaemonServer.ts
+++ b/cli/src/daemon/DaemonServer.ts
@@ -68,6 +68,14 @@ export interface DaemonServerOptions {
 	 * unrelated Claude Code session emit refresh lines into the assertions.
 	 */
 	readonly plansDir?: string;
+	/**
+	 * Override for the machine-global `~/.jolli/jollimemory/` dir holding the
+	 * dashboard database. Same reason as `plansDir`: it is watched for real, and
+	 * a dashboard write from ANY repo on the machine (this suite's own git-backed
+	 * tests included) would otherwise emit `memory-db` refresh lines into a test's
+	 * assertions.
+	 */
+	readonly globalConfigDir?: string;
 }
 
 export interface WatchTarget {
@@ -244,7 +252,10 @@ export function runDaemonServer(options: DaemonServerOptions): Promise<void> {
 	// change that pushed the timer late (or removed it twice) would corrupt the
 	// list without any visible failure.
 	const armRetries = new Set<NodeJS.Timeout>();
-	for (const target of computeWatchTargets(cwd, { plansDir: options.plansDir })) {
+	for (const target of computeWatchTargets(cwd, {
+		plansDir: options.plansDir,
+		globalConfigDir: options.globalConfigDir,
+	})) {
 		const watcher = new DaemonWatcher({
 			path: target.path,
 			debounceMs,

--- a/cli/src/dashboard/AutoCutover.test.ts
+++ b/cli/src/dashboard/AutoCutover.test.ts
@@ -1,0 +1,140 @@
+/**
+ * AutoCutover — the wiring that makes the engine reachable without a human
+ * typing `jolli cutover`. The cases that matter are the ones that keep a
+ * failure invisible to the caller and keep the expensive compare off the
+ * per-commit path.
+ */
+
+import { execSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readRepoProfile, updateRepoProfile } from "../core/RepoProfile.js";
+import { ORPHAN_BRANCH } from "../Logger.js";
+import { AUTO_CUTOVER_RETRY_MS, maybeAutoCutover } from "./AutoCutover.js";
+import { resolveCutoverRoute } from "./CutoverRouter.js";
+import { registerRepo } from "./RepoRegistry.js";
+
+let dir: string;
+let cwd: string;
+let dbPath: string;
+let realHome: string | undefined;
+
+const HASH = "a".repeat(40);
+
+async function writeOrphanSummary(hash: string): Promise<void> {
+	const { ensureOrphanBranch, writeMultipleFilesToBranch } = await import("../core/GitOps.js");
+	await ensureOrphanBranch(ORPHAN_BRANCH, cwd);
+	await writeMultipleFilesToBranch(
+		ORPHAN_BRANCH,
+		[
+			{
+				path: `summaries/${hash}.json`,
+				content: JSON.stringify(
+					{
+						version: "5",
+						commitHash: hash,
+						commitMessage: "seed",
+						commitDate: "2026-07-01T00:00:00.000Z",
+						branch: "main",
+						commitType: "commit",
+						topics: [],
+						children: [],
+					},
+					null,
+					"\t",
+				),
+			},
+		],
+		"add",
+		cwd,
+	);
+}
+
+beforeEach(async () => {
+	dir = mkdtempSync(join(tmpdir(), "jolli-autocut-"));
+	const home = join(dir, "home");
+	mkdirSync(home, { recursive: true });
+	realHome = process.env.HOME;
+	process.env.HOME = home;
+	cwd = join(dir, "repo");
+	mkdirSync(cwd, { recursive: true });
+	execSync("git init -q", { cwd });
+	execSync("git config user.email t@t && git config user.name t", { cwd });
+	execSync("git commit -q --allow-empty -m init", { cwd });
+	dbPath = join(dir, "jollimemory.db");
+	await registerRepo({ cwd, now: () => new Date(0) });
+});
+
+afterEach(() => {
+	process.env.HOME = realHome;
+	rmSync(dir, { recursive: true, force: true });
+});
+
+describe("maybeAutoCutover", () => {
+	it("cuts the repo over to SQLite without anyone asking for it", async () => {
+		await writeOrphanSummary(HASH);
+		expect((await resolveCutoverRoute(cwd, { dbPath })).state).toBe("uncutover");
+
+		expect(await maybeAutoCutover(cwd, { dbPath })).toBe("cutover");
+
+		// The observable point of the whole exercise: reads and writes now route
+		// to the database rather than the orphan branch.
+		expect((await resolveCutoverRoute(cwd, { dbPath })).state).toBe("cutover");
+	});
+
+	it("is idempotent — a second call on a cut-over repo is a no-op answer", async () => {
+		await writeOrphanSummary(HASH);
+		await maybeAutoCutover(cwd, { dbPath });
+		const attemptedAt = (await readRepoProfile(cwd)).cutoverAttemptedAtMs;
+		expect(await maybeAutoCutover(cwd, { dbPath })).toBe("cutover");
+		// Short-circuited on the route BEFORE stamping: a repo that is already
+		// done must not keep spending attempt slots.
+		expect((await readRepoProfile(cwd)).cutoverAttemptedAtMs).toBe(attemptedAt);
+	});
+
+	it("reports rather than throws when the repo is not ready", async () => {
+		// No orphan branch at all: `runCutover` answers `not-ready`, and this must
+		// surface as a return value — the callers are `jolli enable` and the
+		// post-commit drain, neither of which may fail because of it.
+		const outcome = await maybeAutoCutover(cwd, { dbPath });
+		expect(outcome).toBe("uncutover");
+		expect(process.exitCode).toBeUndefined();
+		expect((await resolveCutoverRoute(cwd, { dbPath })).state).toBe("uncutover");
+	});
+
+	it("throttles the opportunistic caller, and only that caller", async () => {
+		const now = Date.parse("2026-08-09T12:00:00Z");
+		await updateRepoProfile(cwd, { cutoverAttemptedAtMs: now - 60_000 });
+		await writeOrphanSummary(HASH);
+
+		// Post-commit drain: an attempt just ran, so step 3's full-tree compare
+		// stays off this commit's path.
+		expect(await maybeAutoCutover(cwd, { dbPath, throttle: true, nowMs: now })).toBe("skipped");
+		expect((await resolveCutoverRoute(cwd, { dbPath })).state).toBe("uncutover");
+
+		// Past the window it tries again.
+		expect(await maybeAutoCutover(cwd, { dbPath, throttle: true, nowMs: now + AUTO_CUTOVER_RETRY_MS + 1 })).toBe(
+			"cutover",
+		);
+	});
+
+	it("does not throttle the post-import caller", async () => {
+		const now = Date.parse("2026-08-09T12:00:00Z");
+		await updateRepoProfile(cwd, { cutoverAttemptedAtMs: now - 60_000 });
+		await writeOrphanSummary(HASH);
+		// `importDashboardHistory` passes no throttle: it has just filled the
+		// database from the branch, which is when the compare is most likely to
+		// pass, and the user is waiting on setup anyway.
+		expect(await maybeAutoCutover(cwd, { dbPath, nowMs: now })).toBe("cutover");
+	});
+
+	it("stamps the attempt BEFORE running, so a crashing compare cannot loop", async () => {
+		const now = Date.parse("2026-08-09T12:00:00Z");
+		// No orphan branch → `not-ready`, but the slot is still spent.
+		await maybeAutoCutover(cwd, { dbPath, throttle: true, nowMs: now });
+		expect((await readRepoProfile(cwd)).cutoverAttemptedAtMs).toBe(now);
+		expect(await maybeAutoCutover(cwd, { dbPath, throttle: true, nowMs: now + 1000 })).toBe("skipped");
+	});
+});

--- a/cli/src/dashboard/AutoCutover.ts
+++ b/cli/src/dashboard/AutoCutover.ts
@@ -1,0 +1,106 @@
+/**
+ * AutoCutover — the thing that actually presses the button.
+ *
+ * `CutoverEngine` has always been complete: fence, import, containment compare,
+ * CAS, retry, idempotent resume. What it never had was a caller other than
+ * `jolli cutover` typed by hand, so every repo stayed `uncutover` forever —
+ * writes dual-wrote to the orphan branch and reads came from the folder layer,
+ * and the whole SQLite source-of-truth path was unreachable in practice.
+ *
+ * The decision this module encodes is that the switch is automatic. That is
+ * safe because cutover is a flag scoped to ONE DEVICE and ONE REPO: the fence
+ * lives in that clone's `profile.json`, the CAS row lives in this machine's
+ * `jollimemory.db`, and nothing about it is pushed, synced, or written back to
+ * a remote. There is no other machine to coordinate with and no shared state to
+ * corrupt, so there is nothing for a confirmation prompt to protect.
+ *
+ * Two rules hold everywhere this is called from:
+ *
+ * - **It never throws and never touches `process.exitCode`.** Every outcome
+ *   short of `cutover` is a working state: `uncutover` keeps the orphan branch
+ *   authoritative, `legacy-fenced` already writes SQLite and reads the database
+ *   and only needs the CAS finished. Both converge on a later attempt, so a
+ *   failure here must not turn a successful `jolli enable` red.
+ * - **It is throttled per clone**, because the engine's step 3 reads every file
+ *   the frozen tip lists. That is right after an import and far too expensive
+ *   to repeat on every commit for a repo that keeps answering `not-ready`.
+ */
+
+import { readRepoProfile, updateRepoProfile } from "../core/RepoProfile.js";
+import { createLogger, errMsg } from "../Logger.js";
+import { runCutover } from "./CutoverEngine.js";
+import { resolveCutoverRoute } from "./CutoverRouter.js";
+import { canUseDashboardDb } from "./DashboardDb.js";
+
+const log = createLogger("AutoCutover");
+
+/**
+ * How long a `not-ready` verdict suppresses the next opportunistic attempt.
+ *
+ * Only the opportunistic caller (the post-commit drain) passes a throttle; the
+ * post-import caller does not, because that is the one moment the database is
+ * known to have just been filled from the branch — exactly when the compare is
+ * most likely to pass, and the moment the user is waiting on setup anyway.
+ */
+export const AUTO_CUTOVER_RETRY_MS = 6 * 60 * 60 * 1000;
+
+export interface AutoCutoverOptions {
+	/** Skip when an attempt ran less than {@link AUTO_CUTOVER_RETRY_MS} ago. */
+	readonly throttle?: boolean;
+	readonly nowMs?: number;
+	readonly dbPath?: string;
+}
+
+/**
+ * Runs (or resumes) the cutover for `cwd` when it can, reporting nothing.
+ *
+ * Returns the state the repo ended in, for tests and for callers that want to
+ * log it — never for control flow, since every state is workable.
+ */
+export async function maybeAutoCutover(
+	cwd: string,
+	opts: AutoCutoverOptions = {},
+): Promise<"cutover" | "legacy-fenced" | "uncutover" | "skipped"> {
+	// No flag-free `node:sqlite` → no database to cut over TO. Same gate every
+	// other dashboard entry point self-applies.
+	if (!canUseDashboardDb()) return "skipped";
+	const now = opts.nowMs ?? Date.now();
+	try {
+		// Cheap check first: `cutover` is done and `blocked` has no safe backend
+		// to move to (the repo needs `doctor --recover`, not another attempt).
+		const route = await resolveCutoverRoute(cwd, opts.dbPath ? { dbPath: opts.dbPath } : {});
+		if (route.state === "cutover") return "cutover";
+		if (route.state === "blocked") {
+			log.info("skipping auto-cutover for %s — routing is blocked: %s", cwd, route.reason);
+			return "skipped";
+		}
+		if (opts.throttle) {
+			const last = (await readRepoProfile(cwd)).cutoverAttemptedAtMs;
+			if (typeof last === "number" && now - last < AUTO_CUTOVER_RETRY_MS) return "skipped";
+		}
+		// Stamped BEFORE the attempt, not after: a run that dies partway (the
+		// process is killed, the machine sleeps) must still spend its slot, or a
+		// repeatedly-crashing compare would re-run on every single commit.
+		await updateRepoProfile(cwd, { cutoverAttemptedAtMs: now });
+
+		const outcome = await runCutover(cwd, opts.dbPath ? { dbPath: opts.dbPath } : {});
+		if (outcome.status === "committed" || outcome.status === "already-cutover") {
+			log.info("auto-cutover: %s is now served from SQLite", cwd);
+			return "cutover";
+		}
+		// `not-ready` / `retry-exhausted`. Expected, and not a problem: a stale
+		// surface, a moved tip, a compare that has not converged. Which of the two
+		// workable states the repo landed in is re-read rather than inferred —
+		// `retry-exhausted` in particular leaves it FENCED, which is the state
+		// worth naming in the log because writes are already going to SQLite.
+		const after = await resolveCutoverRoute(cwd, opts.dbPath ? { dbPath: opts.dbPath } : {});
+		log.info("auto-cutover deferred for %s (%s): %s", cwd, after.state, outcome.reason);
+		return after.state === "legacy-fenced" ? "legacy-fenced" : "uncutover";
+	} catch (err) {
+		// `runCutover` answers with data rather than throwing, so reaching here
+		// means something below it did (a profile lock timeout, a git failure).
+		// Still not the caller's problem — see the header.
+		log.warn("auto-cutover failed for %s: %s", cwd, errMsg(err));
+		return "skipped";
+	}
+}

--- a/cli/src/dashboard/Backfill.test.ts
+++ b/cli/src/dashboard/Backfill.test.ts
@@ -114,7 +114,7 @@ beforeEach(() => {
 	vi.mocked(listFilesInBranch).mockResolvedValue([]);
 	vi.mocked(collectCommitEvents).mockResolvedValue([commitEvent("aaa"), commitEvent("bbb")]);
 	vi.mocked(collectSessionEvents).mockResolvedValue([sessionEvent]);
-	vi.mocked(collectSummaryEvents).mockResolvedValue([]);
+	vi.mocked(collectSummaryEvents).mockResolvedValue({ events: [], complete: true });
 	vi.mocked(collectWorktreeEvent).mockResolvedValue(worktreeEvent);
 	// No knowledge graph by default — it is opt-in per test, like the summaries.
 	vi.mocked(collectRepoGraph).mockResolvedValue(null);
@@ -223,6 +223,55 @@ describe("backfillRepo — bootstrap", () => {
 		await backfillRepo({ repo, dbPath });
 		expect((await query("SELECT hash FROM commits")).length).toBe(2);
 	});
+
+	// The write-ahead log's retention pass rides `applyStatsEvents`, which this
+	// path does not use (it calls `applyToDb` directly to stay inside one
+	// handle). `events_raw.event_id` is deliberately not unique, so without a
+	// prune of its own a machine that only ever runs `jolli dashboard` grows the
+	// log forever.
+	it("prunes aged projected events on the way out", async () => {
+		const OLD = new Date(Date.parse("2026-01-01T00:00:00Z")).toISOString();
+		await withDashboardDb(
+			(db) => {
+				db.prepare(
+					`INSERT INTO events_raw (event_id, repo_identity, type, schema_version, received_at,
+					                         data_json, projection_status)
+					 VALUES ('stale', ?, 'session.upserted', 1, ?, '{}', 'projected')`,
+				).run(repo.repoIdentity, OLD);
+			},
+			{ dbPath },
+		);
+		expect((await query("SELECT event_id FROM events_raw WHERE event_id = 'stale'")).length).toBe(1);
+
+		await backfillRepo({ repo, dbPath, now: () => Date.parse("2026-08-09T00:00:00Z") });
+
+		expect((await query("SELECT event_id FROM events_raw WHERE event_id = 'stale'")).length).toBe(0);
+	});
+
+	// `pending` and `failed` are never pruned regardless of age: pending is the
+	// crash-recovery record a later writer drains, failed is the evidence.
+	it("leaves aged pending and failed events alone", async () => {
+		const OLD = new Date(Date.parse("2026-01-01T00:00:00Z")).toISOString();
+		await withDashboardDb(
+			(db) => {
+				for (const status of ["pending", "failed"]) {
+					db.prepare(
+						`INSERT INTO events_raw (event_id, repo_identity, type, schema_version, received_at,
+						                         data_json, projection_status)
+						 VALUES (?, ?, 'unknown.type', 1, ?, '{}', ?)`,
+					).run(status, repo.repoIdentity, OLD, status);
+				}
+			},
+			{ dbPath },
+		);
+
+		await backfillRepo({ repo, dbPath, now: () => Date.parse("2026-08-09T00:00:00Z") });
+
+		const kept = await query<{ event_id: string }>(
+			"SELECT event_id FROM events_raw WHERE event_id IN ('pending','failed') ORDER BY event_id",
+		);
+		expect(kept.map((r) => r.event_id)).toEqual(["failed", "pending"]);
+	});
 });
 
 describe("backfillRepo — recovery", () => {
@@ -249,6 +298,49 @@ describe("backfillRepo — recovery", () => {
 		});
 		await backfillRepo({ repo, dbPath });
 		expect(collectCommitEvents).toHaveBeenCalled();
+	});
+
+	it("projects only the commits a re-sweep actually changed", async () => {
+		// The daily case: a commit lands on the branch being worked on. The sweep has
+		// to LIST every reachable commit (the prune is computed against that set, and
+		// branch reachability changes for old commits whenever a branch moves), but
+		// projecting the unchanged ones re-ran an UPSERT + DELETE + re-INSERT per
+		// commit to arrive at the bytes already there. Measured on a real 2.5k-commit
+		// repo: one new commit went from 2457 projections to 1.
+		await backfillRepo({ repo, dbPath });
+		// A pass with nothing to do still re-projects the always-on tiers, so THAT is
+		// the baseline to compare against rather than a hard-coded count.
+		const idle = await backfillRepo({ repo, dbPath });
+		vi.mocked(getHeadHash).mockResolvedValue("head-2");
+		vi.mocked(collectCommitEvents).mockResolvedValue([commitEvent("aaa"), commitEvent("bbb"), commitEvent("ccc")]);
+		const result = await backfillRepo({ repo, dbPath });
+		// Exactly one more: `ccc`. `aaa` and `bbb` are listed by the sweep and used
+		// for the prune, but neither reaches the projection.
+		expect(result.eventsApplied).toBe(idle.eventsApplied + 1);
+		const hashes = (await query<{ hash: string }>("SELECT hash FROM commits ORDER BY hash")).map((r) => r.hash);
+		expect(hashes).toEqual(["aaa", "bbb", "ccc"]);
+	});
+
+	it("re-projects a commit whose branch reachability changed", async () => {
+		// `branches` is replace-when-present, so a stale set is a wrong answer to
+		// "group by branch" — this is the one field that legitimately changes for an
+		// OLD commit, and skipping it is what a naive "already stored" test would do.
+		await backfillRepo({ repo, dbPath });
+		vi.mocked(getHeadHash).mockResolvedValue("head-2");
+		vi.mocked(collectCommitEvents).mockResolvedValue([
+			{ ...commitEvent("aaa"), branches: ["main", "feature/x"] },
+			commitEvent("bbb"),
+		]);
+		await backfillRepo({ repo, dbPath });
+		const names = (
+			await query<{ name: string }>(
+				`SELECT b.name FROM commit_branches cb
+				   JOIN branches b ON b.id = cb.branch_id
+				   JOIN commits c  ON c.id = cb.commit_id
+				  WHERE c.hash = 'aaa' ORDER BY b.name`,
+			)
+		).map((r) => r.name);
+		expect(names).toEqual(["feature/x", "main"]);
 	});
 
 	it("prunes commits that a rewrite made unreachable (set reconciliation)", async () => {
@@ -533,7 +625,7 @@ describe("backfillRepo — summaries sweep (memory tier)", () => {
 
 	it("sweeps summaries during bootstrap and enriches the commit row", async () => {
 		vi.mocked(getIndex).mockResolvedValue({ version: 3, entries: [] });
-		vi.mocked(collectSummaryEvents).mockResolvedValue([summaryEvent]);
+		vi.mocked(collectSummaryEvents).mockResolvedValue({ events: [summaryEvent], complete: true });
 
 		await backfillRepo({ repo, dbPath });
 
@@ -546,7 +638,7 @@ describe("backfillRepo — summaries sweep (memory tier)", () => {
 
 	it("skips the sweep when the index fingerprint is unchanged, re-sweeps when it changes", async () => {
 		vi.mocked(getIndex).mockResolvedValue({ version: 3, entries: [] });
-		vi.mocked(collectSummaryEvents).mockResolvedValue([summaryEvent]);
+		vi.mocked(collectSummaryEvents).mockResolvedValue({ events: [summaryEvent], complete: true });
 
 		await backfillRepo({ repo, dbPath });
 		expect(collectSummaryEvents).toHaveBeenCalledTimes(1);
@@ -578,12 +670,35 @@ describe("backfillRepo — summaries sweep (memory tier)", () => {
 		expect(collectSummaryEvents).not.toHaveBeenCalled();
 	});
 
+	// The cursor is the index's content hash, so advancing it after a partial
+	// sweep makes every later pass skip collection outright — one transient
+	// `git show` failure would hide that memory from the dashboard forever.
+	it("does not advance the summaries cursor after an incomplete sweep", async () => {
+		vi.mocked(getIndex).mockResolvedValue({ version: 3, entries: [] });
+		vi.mocked(collectSummaryEvents).mockResolvedValue({ events: [summaryEvent], complete: false });
+
+		await backfillRepo({ repo, dbPath });
+		expect(collectSummaryEvents).toHaveBeenCalledTimes(1);
+
+		// Same index content, but the cursor never moved — so the next pass
+		// re-reads instead of trusting an incomplete result.
+		await backfillRepo({ repo, dbPath });
+		expect(collectSummaryEvents).toHaveBeenCalledTimes(2);
+
+		// A clean sweep finally parks it.
+		vi.mocked(collectSummaryEvents).mockResolvedValue({ events: [summaryEvent], complete: true });
+		await backfillRepo({ repo, dbPath });
+		expect(collectSummaryEvents).toHaveBeenCalledTimes(3);
+		await backfillRepo({ repo, dbPath });
+		expect(collectSummaryEvents).toHaveBeenCalledTimes(3);
+	});
+
 	it("announces the sweep only when it is going to run", async () => {
 		// The marker is the caller's evidence that something is worth narrating, so
 		// a skipped sweep has to be silent — announcing "Indexing stored memories…"
 		// and then doing nothing is what made every launch look like a re-migration.
 		vi.mocked(getIndex).mockResolvedValue({ version: 3, entries: [] });
-		vi.mocked(collectSummaryEvents).mockResolvedValue([summaryEvent]);
+		vi.mocked(collectSummaryEvents).mockResolvedValue({ events: [summaryEvent], complete: true });
 		const kinds = async (): Promise<string[]> => {
 			const seen: string[] = [];
 			await backfillRepo({

--- a/cli/src/dashboard/Backfill.ts
+++ b/cli/src/dashboard/Backfill.ts
@@ -48,7 +48,7 @@ import {
 	resolveProtectNewerThanMs,
 	type SotImportResult,
 } from "./SotImport.js";
-import { applyToDb } from "./StatsWriter.js"; // recordRepoGraph parked — see SotSchema
+import { applyToDb, pruneProjectedEvents } from "./StatsWriter.js"; // recordRepoGraph parked — see SotSchema
 
 const log = createLogger("Backfill");
 
@@ -153,6 +153,16 @@ export interface RepoProgress {
 	 * two are one motionless line.
 	 */
 	readonly detail?: string;
+	/**
+	 * Set on a `commits` phase-start marker when this repo has never completed a
+	 * bootstrap — i.e. when the sweep really will read the whole history.
+	 *
+	 * The caller's "this can take a few minutes" warning is gated on it. Since the
+	 * sweep skips `--numstat` for commits already stored, a steady-state pass over
+	 * a 2.5k-commit history is well under a second (measured 6.3 s → 0.44 s), and
+	 * warning about minutes there is simply false.
+	 */
+	readonly firstRun?: boolean;
 }
 
 /** {@link RepoProgress} plus the repo's place in a multi-repo run. */
@@ -205,6 +215,21 @@ function writeCursor(db: DashboardDbHandle, repoIdentity: string, source: string
 }
 
 /**
+ * Commit hashes already stored for this repo.
+ *
+ * Two callers, two uses of the same set: the prune asks which stored hashes are
+ * no longer reachable, and the collection asks which reachable hashes it can skip
+ * the `--numstat` for (see `CollectCommitsOptions.knownHashes`). Deriving both
+ * from one query keeps them from disagreeing about what "already stored" means.
+ */
+function storedCommitHashes(db: DashboardDbHandle, repoIdentity: string): Set<string> {
+	const rows = db
+		.prepare("SELECT c.hash FROM commits c JOIN repos r ON r.id = c.repo_id WHERE r.repo_identity = ?")
+		.all(repoIdentity) as ReadonlyArray<{ hash: string }>;
+	return new Set(rows.map((r) => r.hash));
+}
+
+/**
  * Prunes commit rows that are no longer reachable from any tracked ref — the
  * delete half of set reconciliation, run whenever a full commit collection has
  * the complete reachable set in hand. FK CASCADE removes branch links and
@@ -215,12 +240,9 @@ export function pruneUnreachableCommits(
 	repoIdentity: string,
 	reachable: ReadonlySet<string>,
 ): number {
-	const rows = db
-		.prepare("SELECT c.hash FROM commits c JOIN repos r ON r.id = c.repo_id WHERE r.repo_identity = ?")
-		.all(repoIdentity) as ReadonlyArray<{
-		hash: string;
-	}>;
-	const stale = rows.filter((r) => !reachable.has(r.hash));
+	const stale = [...storedCommitHashes(db, repoIdentity)]
+		.filter((hash) => !reachable.has(hash))
+		.map((hash) => ({ hash }));
 	if (stale.length === 0) return 0;
 	const remove = db.prepare(
 		"DELETE FROM commits WHERE repo_id = (SELECT id FROM repos WHERE repo_identity = ?) AND hash = ?",
@@ -232,6 +254,91 @@ export function pruneUnreachableCommits(
 	return stale.length;
 }
 
+/**
+ * The commit rows this repo already has, in the shape {@link unchangedCommitEvent}
+ * compares against — one query for the columns, one for the branch sets.
+ */
+function storedCommitRows(
+	db: DashboardDbHandle,
+	repoIdentity: string,
+): Map<string, { row: Record<string, unknown>; branches: Set<string> }> {
+	const rows = db
+		.prepare(
+			`SELECT c.id, c.hash, c.branch, c.message, c.author_name, c.author_email, c.committed_at_ms,
+			        c.files_changed, c.insertions, c.deletions
+			   FROM commits c JOIN repos r ON r.id = c.repo_id
+			  WHERE r.repo_identity = ?`,
+		)
+		.all(repoIdentity) as ReadonlyArray<Record<string, unknown> & { id: number; hash: string }>;
+	const byId = new Map<number, { row: Record<string, unknown>; branches: Set<string> }>();
+	const byHash = new Map<string, { row: Record<string, unknown>; branches: Set<string> }>();
+	for (const row of rows) {
+		const entry = { row, branches: new Set<string>() };
+		byId.set(row.id, entry);
+		byHash.set(row.hash, entry);
+	}
+	const links = db
+		.prepare(
+			`SELECT cb.commit_id, b.name
+			   FROM commit_branches cb
+			   JOIN branches b ON b.id = cb.branch_id
+			   JOIN repos r    ON r.id = b.repo_id
+			  WHERE r.repo_identity = ?`,
+		)
+		.all(repoIdentity) as ReadonlyArray<{ commit_id: number; name: string }>;
+	for (const link of links) byId.get(link.commit_id)?.branches.add(link.name);
+	return byHash;
+}
+
+/**
+ * True when projecting `event` would write nothing new.
+ *
+ * **This is what makes a routine sweep cheap.** The collection has to produce an
+ * event for EVERY reachable commit — that list is what the prune is computed
+ * against, and branch reachability changes for old commits whenever a branch
+ * moves — but on a normal day only the handful of commits on the branch being
+ * worked on have actually changed. Projecting the other 2,450 re-ran an UPSERT,
+ * a DELETE and a re-INSERT per commit to arrive at the bytes already there.
+ *
+ * The comparison MIRRORS {@link projectCommit}'s write, and has to stay in step
+ * with it — a column added there without a case here would silently stop being
+ * updated on any commit that matched on the others:
+ *
+ *  - The nullable columns are written with `COALESCE(excluded.x, commits.x)`, so
+ *    an ABSENT value on the event cannot change anything and is not a difference.
+ *    A present one must equal what is stored.
+ *  - `committed_at_ms` is written unconditionally, so it is compared even when
+ *    every other field matches.
+ *  - `branches` is replace-when-present, so a present set must match exactly;
+ *    absent (a failed branch scan) means "leave the rows alone".
+ *  - `files` present is never skipped. It is replace-when-present too, and the
+ *    stored file rows are not read here — a commit whose files this pass actually
+ *    scanned is by construction a new one, so this costs nothing in practice.
+ */
+function unchangedCommitEvent(
+	event: CommitCreatedEvent,
+	stored: { row: Record<string, unknown>; branches: Set<string> } | undefined,
+): boolean {
+	if (!stored) return false;
+	if (event.files) return false;
+	const { row, branches } = stored;
+	if (row.committed_at_ms !== event.committedAtMs) return false;
+	const sameNullable = (column: string, value: string | number | undefined): boolean =>
+		value === undefined || row[column] === value;
+	if (!sameNullable("branch", event.branch)) return false;
+	if (!sameNullable("message", event.message)) return false;
+	if (!sameNullable("author_name", event.authorName)) return false;
+	if (!sameNullable("author_email", event.authorEmail)) return false;
+	if (!sameNullable("files_changed", event.filesChanged)) return false;
+	if (!sameNullable("insertions", event.insertions)) return false;
+	if (!sameNullable("deletions", event.deletions)) return false;
+	if (event.branches) {
+		if (event.branches.length !== branches.size) return false;
+		for (const branch of event.branches) if (!branches.has(branch)) return false;
+	}
+	return true;
+}
+
 /** Wraps events in envelopes and applies them in small batches. */
 function applyBatches(
 	db: DashboardDbHandle,
@@ -239,17 +346,29 @@ function applyBatches(
 	producerKind: ProducerKind,
 	now: () => number,
 	onChunk?: (done: number, total: number) => void,
-): number {
+): { applied: number; pending: number } {
 	let applied = 0;
+	let pending = 0;
 	for (let start = 0; start < events.length; start += BATCH_SIZE) {
 		const batch: StatsEventEnvelope[] = events
 			.slice(start, start + BATCH_SIZE)
 			.map((event) => ({ event, producerKind }));
 		const result = applyToDb(db, batch, { producerKind, now });
 		applied += result.projected;
+		// Reported, not just discarded: an event that stayed pending did NOT
+		// reach the projection tables, so a caller whose cursor would skip the
+		// next sweep has to treat it the same as a failed read.
+		//
+		// OVERWRITTEN, never accumulated: `drainPending` counts the rows still
+		// unprojected for these repos at the end of each call — an absolute
+		// backlog, not this batch's delta. Summing it makes a backlog that batch
+		// 1 reported and batch 2 drained keep a non-zero total forever, so the
+		// summaries cursor never advances and every later pass re-collects the
+		// whole index. The last batch's count is the state that survives the loop.
+		pending = result.pending;
 		onChunk?.(Math.min(start + BATCH_SIZE, events.length), events.length);
 	}
-	return applied;
+	return { applied, pending };
 }
 
 /** The `repo.enabled` projection for a registry entry. */
@@ -345,7 +464,7 @@ export async function backfillRepo(opts: BackfillOptions): Promise<BackfillResul
 	return withDashboardDb(
 		async (db) => {
 			// Project the registry entry first so FK targets exist with real names.
-			let applied = applyBatches(db, [repoEnabledEvent(repo)], producerKind, now);
+			let applied = applyBatches(db, [repoEnabledEvent(repo)], producerKind, now).applied;
 
 			// After the repo row (FK target), and idempotent on the artifact's own
 			// build stamp — so every recovery pass can offer it unconditionally and
@@ -388,6 +507,10 @@ export async function backfillRepo(opts: BackfillOptions): Promise<BackfillResul
 				// other clone knows. Observed on a two-clone repo: 7 of 26 branches
 				// unique to the second checkout vanished that way.
 				const merged = new Map<string, CommitCreatedEvent>();
+				// Read ONCE for the whole checkout loop, before any of them writes: a
+				// per-checkout read would let the first checkout's upserts mark the
+				// second one's commits "known" and skip their file scan.
+				const knownHashes = storedCommitHashes(db, repo.repoIdentity);
 				// A checkout whose `git log` failed contributes nothing, which is
 				// indistinguishable from "this checkout reaches no commits" once the events
 				// are merged. Prune and the cursor advance are therefore both gated on a
@@ -401,11 +524,19 @@ export async function backfillRepo(opts: BackfillOptions): Promise<BackfillResul
 						repoName: repo.repoName,
 						kind: "commits",
 						done: 0,
+						...(isBootstrap ? { firstRun: true } : {}),
 						...(worktrees.length > 1 ? { detail: `checkout ${i + 1} of ${worktrees.length}` } : {}),
 					});
 					let events: ReadonlyArray<CommitCreatedEvent>;
 					try {
-						events = await collectCommitEvents({ repoIdentity: repo.repoIdentity, cwd: worktree });
+						events = await collectCommitEvents({
+							repoIdentity: repo.repoIdentity,
+							cwd: worktree,
+							// Skips the whole-history `--numstat` for commits already stored —
+							// the step this sweep's wall clock is made of. A bootstrap has an
+							// empty set and so still scans everything.
+							knownHashes,
+						});
 					} catch (err) {
 						// Not fatal for the repo: sessions and memories still import, and the
 						// commits already stored stay stored. Only this pass's destructive half
@@ -429,9 +560,24 @@ export async function backfillRepo(opts: BackfillOptions): Promise<BackfillResul
 					}
 				}
 				const commitEvents = [...merged.values()];
-				applied += applyBatches(db, commitEvents, producerKind, now, (done, total) =>
-					opts.onProgress?.({ repoName: repo.repoName, kind: "commits", done, total }),
+				// Only the events that would actually change a row are projected. The
+				// prune below still uses the COMPLETE set — see `unchangedCommitEvent`
+				// for why the collection cannot be narrowed but the projection can.
+				const storedRows = storedCommitRows(db, repo.repoIdentity);
+				const changed = commitEvents.filter(
+					(event) => !unchangedCommitEvent(event, storedRows.get(event.hash)),
 				);
+				if (changed.length !== commitEvents.length) {
+					log.info(
+						"%s: %d of %d commit events unchanged, skipping their projection",
+						repo.repoName,
+						commitEvents.length - changed.length,
+						commitEvents.length,
+					);
+				}
+				applied += applyBatches(db, changed, producerKind, now, (done, total) =>
+					opts.onProgress?.({ repoName: repo.repoName, kind: "commits", done, total }),
+				).applied;
 				if (collectionComplete) {
 					const reachable = new Set(commitEvents.map((e) => e.hash));
 					// Prune against the UNION: pruning per worktree would delete commits that
@@ -465,13 +611,29 @@ export async function backfillRepo(opts: BackfillOptions): Promise<BackfillResul
 				// then did nothing — and a phase marker is the caller's evidence that
 				// there is work worth narrating.
 				opts.onProgress?.({ repoName: repo.repoName, kind: "summaries", done: 0 });
-				const summaryEvents = await collectSummaryEvents({
+				const summaries = await collectSummaryEvents({
 					repoIdentity: repo.repoIdentity,
 					cwd,
 					storage: orphanStorage,
 				});
-				applied += applyBatches(db, summaryEvents, producerKind, now);
-				writeCursor(db, repo.repoIdentity, CURSOR_SUMMARIES, indexFingerprint, now());
+				const summaryApply = applyBatches(db, summaries.events, producerKind, now);
+				applied += summaryApply.applied;
+				// Same rule as the commit tier's `collectionComplete` above, and for
+				// the same reason: this cursor is the index's content hash, so
+				// advancing it after a partial sweep makes every later pass skip
+				// collection outright. A summary that failed to read (or to project)
+				// would then be missing from the dashboard forever, since a re-read
+				// is only ever triggered by index.json itself changing.
+				if (summaries.complete && summaryApply.pending === 0) {
+					writeCursor(db, repo.repoIdentity, CURSOR_SUMMARIES, indexFingerprint, now());
+				} else {
+					log.warn(
+						"skipping summaries cursor advance for %s -- %d unreadable, %d unprojected",
+						repo.repoName,
+						summaries.complete ? 0 : 1,
+						summaryApply.pending,
+					);
+				}
 			}
 
 			// Sessions: always re-project the currently discoverable set. A global
@@ -486,7 +648,7 @@ export async function backfillRepo(opts: BackfillOptions): Promise<BackfillResul
 			});
 			applied += applyBatches(db, sessionEvents, producerKind, now, (done, total) =>
 				opts.onProgress?.({ repoName: repo.repoName, kind: "sessions", done, total }),
-			);
+			).applied;
 			const maxUpdated = sessionEvents.reduce((max, e) => Math.max(max, e.updatedAtMs), 0);
 			if (maxUpdated > 0) writeCursor(db, repo.repoIdentity, CURSOR_SESSIONS, String(maxUpdated), now());
 
@@ -498,7 +660,7 @@ export async function backfillRepo(opts: BackfillOptions): Promise<BackfillResul
 			// state needs the worktree path in that primary key — a schema change, and
 			// deliberately not smuggled into a defect fix.
 			const worktree = await collectWorktreeEvent(repo.repoIdentity, cwd, now);
-			if (worktree) applied += applyBatches(db, [worktree], producerKind, now);
+			if (worktree) applied += applyBatches(db, [worktree], producerKind, now).applied;
 
 			// SOT tables (v7): the orphan branch imported verbatim into
 			// memory_nodes/revisions, transcripts, docs, plan_progress and the topic
@@ -665,6 +827,17 @@ export async function backfillRepo(opts: BackfillOptions): Promise<BackfillResul
 				new Date(now()).toISOString(),
 				repo.repoIdentity,
 			);
+
+			// The write-ahead log's retention pass. It normally rides `applyStatsEvents`,
+			// which this path does NOT use — `applyBatches` calls `applyToDb` directly to
+			// stay inside the one handle this whole pass holds. `events_raw.event_id` is
+			// deliberately not unique (see SotSchema: the same event may be written
+			// repeatedly, and idempotency lives in the projection tables), so without a
+			// prune here a machine that only ever runs `jolli dashboard` / `jolli enable`
+			// grows the log without bound. Bounded per pass and inside the lock we already
+			// hold, exactly as on the writer path.
+			const pruned = pruneProjectedEvents(db, now);
+			if (pruned > 0) log.debug("pruned %d projected event rows for %s", pruned, repo.repoName);
 
 			const mode = isBootstrap ? "bootstrapped" : "recovered";
 			log.info("%s %s: %d events applied", mode, repo.repoName, applied);

--- a/cli/src/dashboard/CutoverEngine.test.ts
+++ b/cli/src/dashboard/CutoverEngine.test.ts
@@ -471,6 +471,67 @@ describe("runCutover", () => {
 		expect(ok.ok).toBe(true);
 	});
 
+	it("accepts a union view that CONTAINS the source, for both topics/ views", async () => {
+		const { SqliteStorage } = await import("../core/SqliteStorage.js");
+		const { compareSourceContainment } = await import("./CutoverEngine.js");
+		void SqliteStorage;
+		const provider = (files: Record<string, string>) => ({
+			async readFile(path: string): Promise<string | null> {
+				return files[path] ?? null;
+			},
+			async batchReadFiles(paths: string[]): Promise<Map<string, string | null>> {
+				return new Map(paths.map((p) => [p, files[p] ?? null]));
+			},
+			async listFiles(prefix: string): Promise<string[]> {
+				return Object.keys(files).filter((p) => p.startsWith(prefix));
+			},
+			async writeFiles(): Promise<void> {},
+			async exists(): Promise<boolean> {
+				return true;
+			},
+			async ensure(): Promise<void> {},
+		});
+		// Two clones of one remote import into ONE repo id, so both synthesized
+		// views render A∪B. Equality could never hold against either clone's
+		// file, which left such a repo permanently un-cutoverable.
+		const cloneA = {
+			"topics/index.json": JSON.stringify({ schemaVersion: 1, topics: [{ stableSlug: "a" }] }),
+			"topics/processed.json": JSON.stringify({
+				schemaVersion: 1,
+				processed: { summary: ["s1"], plan: [], note: [], userfile: [] },
+			}),
+		};
+		const union = {
+			"topics/index.json": JSON.stringify({
+				schemaVersion: 1,
+				topics: [{ stableSlug: "b" }, { stableSlug: "a" }],
+			}),
+			"topics/processed.json": JSON.stringify({
+				schemaVersion: 1,
+				processed: { summary: ["s2", "s1"], plan: ["p1"], note: [], userfile: [] },
+			}),
+		};
+		const contained = await compareSourceContainment(
+			provider(cloneA),
+			provider(union) as unknown as InstanceType<typeof SqliteStorage>,
+		);
+		expect(contained.ok).toBe(true);
+
+		// Containment is one-directional: an entry the SOURCE lists and the
+		// database lacks is still drift.
+		const missing = await compareSourceContainment(
+			provider(cloneA),
+			provider({
+				...union,
+				"topics/processed.json": JSON.stringify({
+					schemaVersion: 1,
+					processed: { summary: ["s2"], plan: [], note: [], userfile: [] },
+				}),
+			}) as unknown as InstanceType<typeof SqliteStorage>,
+		);
+		expect(missing).toMatchObject({ ok: false, detail: "topics/processed.json: content differs" });
+	});
+
 	it("increments the cutover version over a prior generation", async () => {
 		await writeOrphanSummary(HASH, "seed");
 		const identity = await resolveIdentity();

--- a/cli/src/dashboard/CutoverEngine.ts
+++ b/cli/src/dashboard/CutoverEngine.ts
@@ -52,7 +52,7 @@ import { SqliteStorage } from "../core/SqliteStorage.js";
 import type { StorageProvider } from "../core/StorageProvider.js";
 import { createLogger, errMsg, ORPHAN_BRANCH } from "../Logger.js";
 import type { CutoverRecord } from "./CutoverRouter.js";
-import { DashboardSchemaAheadError, inTransaction, withDashboardDb } from "./DashboardDb.js";
+import { DashboardSchemaAheadError, inTransaction, withDashboardDb, withReadonlyDashboardDb } from "./DashboardDb.js";
 import { existingWorktrees, type RegisteredRepo, readRepoRegistry, resolveRepoIdentityForCwd } from "./RepoRegistry.js";
 import { countMemoriesAbsentFromListing, importRepoMemory } from "./SotImport.js";
 
@@ -143,13 +143,21 @@ export async function compareSourceContainment(
 			if (a === b) continue;
 			if (a == null || b == null) return { ok: false, detail: `${path}: missing from the database` };
 			if (path.startsWith("summaries/") && summariesEquivalent(a, b)) continue;
-			// `topics/index.json` ALONE. It is a synthesized view whose entry order
-			// falls out of a query, so order-insensitive equality is the right
-			// criterion there. A topic PAGE is not that: `topic_source_refs.pos`
-			// exists precisely to preserve its array order, and the `startsWith`
-			// this used to carry swallowed every page into the loose compare,
-			// certifying a reordered page as contained.
-			if (path === "topics/index.json" && jsonSetEquivalent(a, b)) continue;
+			// `topics/index.json` and `topics/processed.json` ALONE. Both are
+			// synthesized UNION views: they are rendered from every row of the repo
+			// id, and step 2 imports every registered source into that one id
+			// (identity is the shared remote). So for a repo with two clones — which
+			// `collectSources` supports — the database renders A∪B and equality
+			// against A's file, or B's, can never hold; byte-comparing them made such
+			// a repo answer `not-ready` on every attempt and never converge. The
+			// criterion is CONTAINMENT (every entry the source lists is in the
+			// database), which is the same thing the family loop asserts for every
+			// other path and is why `index.json` / `catalog.json` are skipped below.
+			// A topic PAGE is not one of these: `topic_source_refs.pos` exists
+			// precisely to preserve its array order, and the `startsWith` this used
+			// to carry swallowed every page into the loose compare, certifying a
+			// reordered page as contained.
+			if (TOPIC_UNION_VIEWS.has(path) && jsonContains(a, b)) continue;
 			return { ok: false, detail: `${path}: content differs` };
 		}
 	}
@@ -184,27 +192,65 @@ function summariesEquivalent(a: string, b: string): boolean {
 }
 
 /** Order-insensitive JSON equivalence for the synthesized topic index. */
-function jsonSetEquivalent(a: string, b: string): boolean {
+/**
+ * The reason string for a step 2 / step 3 failure, told from the caller's side.
+ *
+ * Once ANY source is fenced the repo is already `legacy-fenced` — a working
+ * state, not a broken one (it writes SQLite and reads the database) — so the
+ * only thing the user needs is that re-running finishes the CAS.
+ */
+function importOrCompareFailure(err: unknown, fenced: boolean): string {
+	const detail = err instanceof DashboardSchemaAheadError ? errMsg(err) : `import/compare failed: ${errMsg(err)}`;
+	return fenced ? `${detail} — this repo is legacy-fenced; re-run \`jolli cutover\` to finish` : detail;
+}
+
+/** The two synthesized union views — see the containment note in the compare. */
+const TOPIC_UNION_VIEWS = new Set(["topics/index.json", "topics/processed.json"]);
+
+/**
+ * Does `db` contain everything `source` lists?
+ *
+ * Arrays are compared as SETS (their order in a synthesized view falls out of a
+ * query, and a union interleaves two sources' rows); objects need every key the
+ * source carries, and may carry more; leaves must be equal. Deliberately one-
+ * directional: extra entries in `db` are the whole point of a union view, and
+ * an entry only the database has is never a reason to refuse a cutover — the
+ * frozen tips are what must be readable back, nothing more.
+ */
+function jsonContains(source: string, db: string): boolean {
 	try {
-		const canon = (x: unknown): string => {
-			if (Array.isArray(x)) {
-				return JSON.stringify(x.map(canon).sort());
-			}
-			if (x && typeof x === "object") {
-				return JSON.stringify(
-					Object.fromEntries(
-						Object.entries(x as Record<string, unknown>)
-							.sort()
-							.map(([k, v]) => [k, canon(v)]),
-					),
-				);
-			}
-			return JSON.stringify(x);
-		};
-		return canon(JSON.parse(a)) === canon(JSON.parse(b));
+		return contains(JSON.parse(source), JSON.parse(db));
 	} catch {
 		return false;
 	}
+}
+
+function contains(a: unknown, b: unknown): boolean {
+	if (Array.isArray(a)) {
+		if (!Array.isArray(b)) return false;
+		const have = new Set(b.map((v) => canonJson(v)));
+		return a.every((v) => have.has(canonJson(v)));
+	}
+	if (a && typeof a === "object") {
+		if (!b || typeof b !== "object" || Array.isArray(b)) return false;
+		const other = b as Record<string, unknown>;
+		return Object.entries(a as Record<string, unknown>).every(([k, v]) => k in other && contains(v, other[k]));
+	}
+	return canonJson(a) === canonJson(b);
+}
+
+function canonJson(x: unknown): string {
+	if (Array.isArray(x)) return JSON.stringify(x.map(canonJson).sort());
+	if (x && typeof x === "object") {
+		return JSON.stringify(
+			Object.fromEntries(
+				Object.entries(x as Record<string, unknown>)
+					.sort()
+					.map(([k, v]) => [k, canonJson(v)]),
+			),
+		);
+	}
+	return JSON.stringify(x);
 }
 
 /**
@@ -265,16 +311,28 @@ export async function probeCutoverDrift(
 ): Promise<DriftReport[]> {
 	const { identity } = await resolveRepoIdentityForCwd(cwd);
 	const dbOpts = opts.dbPath ? { dbPath: opts.dbPath } : {};
-	const record = await withDashboardDb((db) => {
-		const row = db.prepare("SELECT id FROM repos WHERE repo_identity = ?").get(identity) as
-			| { id: number }
-			| undefined;
-		if (!row) return null;
-		const state = db.prepare("SELECT value FROM repo_state WHERE repo_id = ? AND key = 'cutover'").get(row.id) as
-			| { value: string }
-			| undefined;
-		return state ? (JSON.parse(state.value) as CutoverRecord) : null;
-	}, dbOpts);
+	// READ-ONLY, and tolerant of a database this build cannot open. A writable
+	// open runs `migrateDashboardDb`, so a probe would migrate the schema as a
+	// side effect; and on a database a NEWER surface already migrated, every
+	// writable open throws — which `runCutover` guards for and `--probe` did not,
+	// so it stack-traced out of `CutoverCommand`'s uncaught action. An absent or
+	// unreadable database has no cutover record, which is "no drift to report".
+	let record: CutoverRecord | null;
+	try {
+		record = await withReadonlyDashboardDb((db) => {
+			const row = db.prepare("SELECT id FROM repos WHERE repo_identity = ?").get(identity) as
+				| { id: number }
+				| undefined;
+			if (!row) return null;
+			const state = db
+				.prepare("SELECT value FROM repo_state WHERE repo_id = ? AND key = 'cutover'")
+				.get(row.id) as { value: string } | undefined;
+			return state ? (JSON.parse(state.value) as CutoverRecord) : null;
+		}, dbOpts);
+	} catch (err) {
+		log.info("cutover probe: no readable dashboard database (%s)", errMsg(err));
+		return [];
+	}
 	if (!record) return [];
 	const registry = await readRepoRegistry();
 	const repo = registry.repos.find((r) => r.repoIdentity === identity);
@@ -507,29 +565,44 @@ export async function runCutover(cwd: string, opts: CutoverOptions = {}): Promis
 		// trade — legacy-fenced writes SQLite and reads the database, so it costs
 		// a stuck cutover and a named path in the reason, where importing anyway
 		// costs the regenerated memory with nothing to recover it from.
-		for (const source of sources) {
-			const pinned = new GitRefStorage(source.tip, source.root);
-			const fenceMs = fencedRoots.get(source.root);
-			await withDashboardDb(
-				(db) =>
-					importRepoMemory(db, {
-						repo,
-						storage: pinned,
-						nowMs,
-						mode: seedLegal ? "seed" : "catch-up",
-						...(fenceMs !== undefined && Number.isFinite(fenceMs) ? { protectNewerThanMs: fenceMs } : {}),
-					}),
-				dbOpts,
-			);
-		}
-
-		// 3. Full compare at the pinned tips (containment — see header).
-		const sqlite = new SqliteStorage(identity, opts.dbPath);
-		for (const source of sources) {
-			const verdict = await compare(new GitRefStorage(source.tip, source.root), sqlite);
-			if (!verdict.ok) {
-				return { status: "not-ready", reason: `compare failed for ${source.root}: ${verdict.detail}` };
+		// Steps 2 and 3 answer `not-ready` rather than throwing. On a RETRY they
+		// run with the fence already up, and both can fail for reasons that have
+		// nothing to do with this repo's readiness — `DashboardSchemaAheadError`, a
+		// concurrent QueueWorker holding the writer past `busy_timeout`, a git read
+		// failure. Letting that escape lands in `CutoverCommand`'s uncaught
+		// commander action: a stack trace, and no word to the user that the repo is
+		// now `legacy-fenced` and that re-running finishes the CAS. That is the one
+		// outcome the lock-timeout and null-row guards below were both written to
+		// prevent; they just never covered the two steps the retry re-executes.
+		try {
+			for (const source of sources) {
+				const pinned = new GitRefStorage(source.tip, source.root);
+				const fenceMs = fencedRoots.get(source.root);
+				await withDashboardDb(
+					(db) =>
+						importRepoMemory(db, {
+							repo,
+							storage: pinned,
+							nowMs,
+							mode: seedLegal ? "seed" : "catch-up",
+							...(fenceMs !== undefined && Number.isFinite(fenceMs)
+								? { protectNewerThanMs: fenceMs }
+								: {}),
+						}),
+					dbOpts,
+				);
 			}
+
+			// 3. Full compare at the pinned tips (containment — see header).
+			const sqlite = new SqliteStorage(identity, opts.dbPath);
+			for (const source of sources) {
+				const verdict = await compare(new GitRefStorage(source.tip, source.root), sqlite);
+				if (!verdict.ok) {
+					return { status: "not-ready", reason: `compare failed for ${source.root}: ${verdict.detail}` };
+				}
+			}
+		} catch (err) {
+			return { status: "not-ready", reason: importOrCompareFailure(err, fencedRoots.size > 0) };
 		}
 
 		// Fence: every source gets the pair, or the fence did not go up. Only

--- a/cli/src/dashboard/DashboardCollector.test.ts
+++ b/cli/src/dashboard/DashboardCollector.test.ts
@@ -286,6 +286,120 @@ describe("collectCommitEvents", () => {
 		}
 	});
 
+	it("scans --numstat only for commits the caller has not stored", async () => {
+		// The one expensive step in this collection (6.3 s → 0.44 s on a real 2.5k
+		// commit history), and the reason a moved branch tip no longer costs a
+		// whole-history scan. A commit's diff is immutable, so a stored hash can
+		// never need re-scanning.
+		const calls: string[][] = [];
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			calls.push([...args]);
+			if (args[0] === "log") {
+				return git(
+					[
+						`aaa${SEP}2026-07-30T08:00:00+08:00${SEP}F${SEP}f@x.com${SEP}new`,
+						`bbb${SEP}2026-07-29T08:00:00+08:00${SEP}F${SEP}f@x.com${SEP}old`,
+					].join("\n"),
+				);
+			}
+			if (args[0] === "for-each-ref") return git("main\n");
+			if (args[0] === "rev-list") return git("aaa\nbbb\n");
+			if (args[0] === "-c") return git([`${REC}aaa`, "1\t0\tsrc/a.ts"].join("\n"));
+			throw new Error(`unexpected git ${args.join(" ")}`);
+		});
+		vi.mocked(getIndex).mockResolvedValue(null);
+
+		const events = await collectCommitEvents({
+			repoIdentity: "r",
+			cwd: "/w",
+			knownHashes: new Set(["bbb"]),
+		});
+
+		// `--no-walk <hash>` for the new commit only — never the whole-history form.
+		const numstat = calls.find((c) => c[0] === "-c");
+		expect(numstat).toContain("--no-walk");
+		expect(numstat).toContain("aaa");
+		expect(numstat).not.toContain("bbb");
+		// Both commits are still emitted: the commit list is what the prune is
+		// computed against, and branch reachability changes for OLD commits every
+		// time a branch moves — neither may be narrowed to the new arrivals.
+		expect(events.map((e) => e.hash)).toEqual(["aaa", "bbb"]);
+		expect(events[0].files).toHaveLength(1);
+		// ABSENT, not empty: absent means "keep the stored rows", while `[]` would
+		// claim the commit touches no files and delete them.
+		expect(events[1]).not.toHaveProperty("files");
+	});
+
+	it("falls back to the whole-history scan when too many commits are new", async () => {
+		// The incremental form passes every hash as an argv entry, and Windows caps a
+		// command line at ~32 KB — so past the limit it does not run slower, it fails
+		// to spawn.
+		const many = Array.from({ length: 401 }, (_, i) => `h${i}`);
+		const calls: string[][] = [];
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			calls.push([...args]);
+			if (args[0] === "log") {
+				return git(
+					many.map((h) => `${h}${SEP}2026-07-30T08:00:00+08:00${SEP}F${SEP}f@x.com${SEP}m`).join("\n"),
+				);
+			}
+			if (args[0] === "for-each-ref") return git("main\n");
+			return git("");
+		});
+		vi.mocked(getIndex).mockResolvedValue(null);
+		await collectCommitEvents({ repoIdentity: "r", cwd: "/w", knownHashes: new Set() });
+		const numstat = calls.find((c) => c[0] === "-c");
+		expect(numstat).not.toContain("--no-walk");
+		expect(numstat).toContain("--branches");
+	});
+
+	// The `--count` cap is a documented reachability gap, but it must not be
+	// expressed as the CLAIM `branches: []` — that array is replace-when-present,
+	// so a commit only the branches past the cap reach would have its correct
+	// stored attribution deleted on every pass.
+	it("omits branches for a commit no listed branch reaches when the ref list was truncated", async () => {
+		const listed = Array.from({ length: 51 }, (_, i) => `b${i}`);
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			if (args[0] === "log") {
+				return git(
+					[
+						`aaa${SEP}2026-07-30T08:00:00+08:00${SEP}F${SEP}f@x${SEP}one`,
+						`bbb${SEP}2026-07-29T08:00:00+08:00${SEP}F${SEP}f@x${SEP}two`,
+					].join("\n"),
+				);
+			}
+			// One past the cap: this is what makes truncation detectable at all.
+			if (args[0] === "for-each-ref") {
+				expect(args).toContain("--count=51");
+				return git(`${listed.join("\n")}\n`);
+			}
+			if (args[0] === "rev-list" && args[1] === "b0") return git("aaa\n");
+			return git("");
+		});
+		vi.mocked(getIndex).mockResolvedValue(null);
+		const events = await collectCommitEvents({ repoIdentity: "r", cwd: "/w" });
+		// Reached by a listed branch → its (capped) attribution still refreshes.
+		expect(events[0]).toMatchObject({ hash: "aaa", branches: ["b0"] });
+		// Reached by nothing listed → could be on a branch past the cap, so the
+		// stored value is left alone rather than claimed empty.
+		expect(events[1]).not.toHaveProperty("branches");
+		// Only the branches WITHIN the cap are walked.
+		expect(vi.mocked(execGit).mock.calls.filter((c) => c[0][0] === "rev-list")).toHaveLength(50);
+	});
+
+	it("still emits an empty branches array when the ref list exactly fills the cap", async () => {
+		// 50 listed is not truncation — asking for 51 and getting 50 proves it.
+		const listed = Array.from({ length: 50 }, (_, i) => `b${i}`);
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			if (args[0] === "log") return git(`aaa${SEP}2026-07-30T08:00:00+08:00${SEP}F${SEP}f@x${SEP}one`);
+			if (args[0] === "for-each-ref") return git(`${listed.join("\n")}\n`);
+			return git("");
+		});
+		vi.mocked(getIndex).mockResolvedValue(null);
+		const events = await collectCommitEvents({ repoIdentity: "r", cwd: "/w" });
+		expect(events[0]?.branches).toEqual([]);
+	});
+
 	it("still emits commits when only the numstat pass fails, without a files field", async () => {
 		// The numstat pass is deliberately separate so its failure costs file
 		// detail and nothing else — this is the test that pins that down.
@@ -311,17 +425,50 @@ describe("collectCommitEvents", () => {
 		await expect(collectCommitEvents({ repoIdentity: "r", cwd: "/w" })).rejects.toThrow(/git log failed/);
 	});
 
-	it("still tolerates a rev-list failure per branch once the log itself succeeded", async () => {
+	// `branches` is REPLACE-when-present in the projection, so the distinction
+	// this asserts is the whole guard: `[]` claims no branch reaches the commit
+	// (and deletes its rows), `undefined` says "not observed" and leaves them.
+	it("omits branches entirely when a per-branch rev-list failed", async () => {
 		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
 			if (args[0] === "log") return git(`aaa${SEP}2026-07-30T08:00:00+08:00${SEP}F${SEP}f@x${SEP}feat: one`);
 			if (args[0] === "for-each-ref") return git("main\n");
-			// The per-branch reachability pass fails; the commit survives unattributed.
+			// The per-branch reachability pass fails; the commit survives, but its
+			// stored attribution must not be replaced by a partial union.
 			return gitFail("rev-list exploded");
 		});
 		vi.mocked(getIndex).mockResolvedValue(null);
 		const events = await collectCommitEvents({ repoIdentity: "r", cwd: "/w" });
 		expect(events).toHaveLength(1);
-		expect(events[0].branches ?? []).toEqual([]);
+		expect(events[0]).not.toHaveProperty("branches");
+	});
+
+	// The worse half of the same bug: one failed ref listing used to emit `[]`
+	// for EVERY commit, wiping the repo's whole branch attribution in one pass.
+	it("omits branches entirely when the ref listing itself failed", async () => {
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			if (args[0] === "log") return git(`aaa${SEP}2026-07-30T08:00:00+08:00${SEP}F${SEP}f@x${SEP}feat: one`);
+			if (args[0] === "for-each-ref") return gitFail("boom");
+			return git("");
+		});
+		vi.mocked(getIndex).mockResolvedValue(null);
+		const events = await collectCommitEvents({ repoIdentity: "r", cwd: "/w" });
+		expect(events).toHaveLength(1);
+		expect(events[0]).not.toHaveProperty("branches");
+	});
+
+	// And the case that must keep emitting `[]`: a clean scan where no branch
+	// reaches the commit is a real answer, and the only thing that can prune a
+	// branch the commit has genuinely left.
+	it("emits an empty branches array when the scan succeeded and found none", async () => {
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			if (args[0] === "log") return git(`aaa${SEP}2026-07-30T08:00:00+08:00${SEP}F${SEP}f@x${SEP}feat: one`);
+			if (args[0] === "for-each-ref") return git("main\n");
+			if (args[0] === "rev-list") return git("zzz\n"); // reaches some other commit
+			return git("");
+		});
+		vi.mocked(getIndex).mockResolvedValue(null);
+		const events = await collectCommitEvents({ repoIdentity: "r", cwd: "/w" });
+		expect(events[0].branches).toEqual([]);
 	});
 
 	it("skips malformed log lines and survives a missing summary index", async () => {
@@ -795,15 +942,53 @@ describe("summaryEventFromCommitSummary", () => {
 		});
 		vi.mocked(readTranscriptsForCommits).mockResolvedValue(transcripts);
 
-		const events = await collectSummaryEvents({ repoIdentity: "repo-1", cwd: "/w" });
+		const { events, complete } = await collectSummaryEvents({ repoIdentity: "repo-1", cwd: "/w" });
 
 		expect(events).toHaveLength(1);
 		expect(events[0].hash).toBe("abc123");
 		expect(getSummary).toHaveBeenCalledTimes(2); // roots only, never the child
+		// The whole point of surviving it: the caller must NOT advance its cursor,
+		// or this sweep's blind spot becomes permanent.
+		expect(complete).toBe(false);
 	});
 
-	it("collectSummaryEvents returns empty when there is no index", async () => {
+	it("collectSummaryEvents reports a clean sweep as complete", async () => {
+		vi.mocked(getIndex).mockResolvedValue({
+			version: 3,
+			// biome-ignore lint/suspicious/noExplicitAny: minimal index fixture
+			entries: [{ commitHash: "abc123", parentCommitHash: null }] as any,
+		});
+		vi.mocked(getSummary).mockResolvedValue(baseSummary);
+		vi.mocked(readTranscriptsForCommits).mockResolvedValue(new Map());
+
+		const { events, complete } = await collectSummaryEvents({ repoIdentity: "repo-1", cwd: "/w" });
+		expect(events).toHaveLength(1);
+		expect(complete).toBe(true);
+	});
+
+	// A root the index names but the store no longer has is "not there", not a
+	// failure — pruning is normal, and treating it as a failure would stall the
+	// cursor forever on a repo that has one.
+	it("collectSummaryEvents treats a null summary as absent, not a failed read", async () => {
+		vi.mocked(getIndex).mockResolvedValue({
+			version: 3,
+			// biome-ignore lint/suspicious/noExplicitAny: minimal index fixture
+			entries: [{ commitHash: "gone", parentCommitHash: null }] as any,
+		});
+		vi.mocked(getSummary).mockResolvedValue(null);
+
+		const { events, complete } = await collectSummaryEvents({ repoIdentity: "repo-1", cwd: "/w" });
+		expect(events).toEqual([]);
+		expect(complete).toBe(true);
+	});
+
+	it("collectSummaryEvents returns empty and incomplete when there is no index", async () => {
 		vi.mocked(getIndex).mockResolvedValue(null);
-		expect(await collectSummaryEvents({ repoIdentity: "repo-1", cwd: "/w" })).toEqual([]);
+		// Incomplete, not complete-and-empty: an unreadable index says nothing
+		// about what is stored, so the cursor must not move past it.
+		expect(await collectSummaryEvents({ repoIdentity: "repo-1", cwd: "/w" })).toEqual({
+			events: [],
+			complete: false,
+		});
 	});
 });

--- a/cli/src/dashboard/DashboardCollector.ts
+++ b/cli/src/dashboard/DashboardCollector.ts
@@ -293,7 +293,25 @@ export interface CollectCommitsOptions {
 	readonly sinceMs?: number;
 	/** Storage for the summary-index enrichment read. See {@link CollectSummariesOptions.storage}. */
 	readonly storage?: StorageProvider;
+	/**
+	 * Commit hashes whose file rows are already stored — their `--numstat` is
+	 * skipped. See {@link INCREMENTAL_NUMSTAT_LIMIT} for the whole rationale;
+	 * omit it (bootstrap) to scan every commit.
+	 */
+	readonly knownHashes?: ReadonlySet<string>;
 }
+
+/**
+ * Above this many NEW commits, the incremental `--no-walk` pass is abandoned for
+ * the whole-history one.
+ *
+ * Two reasons, and the first is a hard limit rather than a tuning choice: the
+ * incremental form passes every hash as an argv entry (40 bytes each), and
+ * Windows caps a command line at ~32 KB — so a large enough set does not run
+ * slower, it fails to spawn. The second is that past a few hundred commits the
+ * two forms cost about the same anyway, and one `git log` beats a long argv.
+ */
+const INCREMENTAL_NUMSTAT_LIMIT = 400;
 
 /** Field separator for the git log format string (US, U+001F) — cannot appear in a commit subject. */
 const SEP = "\u001f";
@@ -441,7 +459,9 @@ export async function collectFilesForCommits(
  * branch at all, because `refs/heads` could never explain where it came from.
  * Aligning them means "in the dashboard" and "attributable to a local branch"
  * are one statement. The one gap left is {@link MAX_BRANCHES}: a commit reachable
- * only from a branch past the cap is collected but unattributed.
+ * only from a branch past the cap is collected but unattributed — left absent, not
+ * emitted as `branches: []`, so the replace-when-present projection keeps whatever
+ * a fuller earlier pass stored instead of erasing it.
  *
  * Summary-index metadata (recorded branch, diff stats) enriches commits the
  * memory pipeline saw; plain `git log` fields cover the rest.
@@ -479,14 +499,44 @@ export async function collectCommitEvents(opts: CollectCommitsOptions): Promise<
 
 	// Branch reachability: newest-committed branches first, capped.
 	const refsResult = await execGit(
-		["for-each-ref", "refs/heads", "--sort=-committerdate", "--format=%(refname:short)", `--count=${MAX_BRANCHES}`],
+		// One past the cap, so truncation is DETECTABLE rather than inferred from a
+		// full page: `--count=${MAX_BRANCHES}` returning exactly that many is
+		// indistinguishable from a repo with exactly that many branches.
+		[
+			"for-each-ref",
+			"refs/heads",
+			"--sort=-committerdate",
+			"--format=%(refname:short)",
+			`--count=${MAX_BRANCHES + 1}`,
+		],
 		opts.cwd,
 	);
-	const branches = refsResult.exitCode === 0 ? refsResult.stdout.split("\n").filter(Boolean) : [];
+	// Tracked for the same reason `files` is (see below): `branches` is
+	// REPLACE-when-present in the projection, so emitting a partial union is a
+	// claim that the missing branches no longer reach the commit. A failed
+	// `for-each-ref` would have emitted `[]` for every commit and wiped the
+	// repo's whole branch attribution in one pass; a single branch that was
+	// deleted or repacked between the ref list and its own `rev-list` (an
+	// ordinary concurrent rebase) would silently have stripped just that one.
+	// Incomplete means: emit nothing, keep what is stored.
+	let branchScanComplete = refsResult.exitCode === 0;
+	const listed = refsResult.exitCode === 0 ? refsResult.stdout.split("\n").filter(Boolean) : [];
+	// A repo past {@link MAX_BRANCHES} is the documented reachability gap, but it
+	// must not be expressed as the CLAIM `branches: []`. The union is
+	// replace-when-present, so emitting an empty array for a commit that only the
+	// branches past the cap reach would delete a correct stored attribution on
+	// every pass. Truncated therefore behaves like a partially failed scan for the
+	// commits nothing listed reaches — see the emit below — while the commits the
+	// listed branches DO reach keep getting their (capped) attribution refreshed.
+	const branchesTruncated = listed.length > MAX_BRANCHES;
+	const branches = branchesTruncated ? listed.slice(0, MAX_BRANCHES) : listed;
 	const branchesByHash = new Map<string, string[]>();
 	for (const branch of branches) {
 		const revs = await execGit(["rev-list", branch, ...sinceArgs], opts.cwd);
-		if (revs.exitCode !== 0) continue;
+		if (revs.exitCode !== 0) {
+			branchScanComplete = false;
+			continue;
+		}
 		for (const hash of revs.stdout.split("\n")) {
 			if (!hash) continue;
 			const list = branchesByHash.get(hash);
@@ -495,13 +545,50 @@ export async function collectCommitEvents(opts: CollectCommitsOptions): Promise<
 		}
 	}
 
+	if (!branchScanComplete) {
+		log.warn("branch scan incomplete for %s -- leaving stored branch attribution untouched", opts.cwd);
+	} else if (branchesTruncated) {
+		log.warn(
+			"branch list truncated at %d for %s -- commits reached only by older branches keep their stored attribution",
+			MAX_BRANCHES,
+			opts.cwd,
+		);
+	}
+
 	// Summary-index enrichment, keyed by commit hash.
 	const index = await getIndex(opts.cwd, opts.storage).catch(() => null);
 	const summaryByHash = new Map(index?.entries.map((e) => [e.commitHash, e]) ?? []);
-	const filesByHash = await collectCommitFiles(opts.cwd, sinceArgs);
+
+	const logLines = logResult.stdout.split("\n").filter(Boolean);
+	// **The one expensive step, and the only one made incremental.**
+	//
+	// `git log --numstat` over the whole history is where this collection's wall
+	// clock goes (6-12 s per checkout, measured), and it is pure waste for a commit
+	// whose file rows are already stored: a commit's diff is immutable, so a hash
+	// already in the database can never need a re-scan. Everything ELSE here stays
+	// whole-history on purpose — the commit list is what the prune is computed
+	// against, and branch reachability changes for OLD commits every time a branch
+	// moves, so neither can be narrowed to the new arrivals.
+	//
+	// Omitting `files` for a known commit is not a downgrade: absent means "keep
+	// what is stored" in the projection (the same contract a failed numstat pass
+	// relies on), while an empty array would mean "this commit touches nothing".
+	//
+	// The one thing it gives up: a commit whose file rows were never stored (its
+	// numstat failed once) is never revisited while it stays known. That is a
+	// bounded, self-correcting gap — a bootstrap re-scan restores it — and paying
+	// a full-history numstat on every launch to close it is the cost this exists
+	// to remove.
+	const newHashes = opts.knownHashes
+		? logLines.map((line) => line.split(SEP)[0] ?? "").filter((hash) => hash && !opts.knownHashes?.has(hash))
+		: null;
+	const filesByHash =
+		newHashes !== null && newHashes.length <= INCREMENTAL_NUMSTAT_LIMIT
+			? await collectFilesForCommits(newHashes, opts.cwd)
+			: await collectCommitFiles(opts.cwd, sinceArgs);
 
 	const events: CommitCreatedEvent[] = [];
-	for (const line of logResult.stdout.split("\n")) {
+	for (const line of logLines) {
 		if (!line) continue;
 		const [hash, dateIso, authorName, authorEmail, subject] = line.split(SEP);
 		const committedAtMs = Date.parse(dateIso ?? "");
@@ -518,7 +605,15 @@ export async function collectCommitEvents(opts: CollectCommitsOptions): Promise<
 			// The summary's recorded branch is where the commit was actually made;
 			// reachability can only say where it is visible NOW.
 			...(summary?.branch ? { branch: summary.branch } : {}),
-			branches: branchesByHash.get(hash) ?? [],
+			// Absent (not empty) when the scan above was incomplete — an empty
+			// array here is the meaningful claim "no branch reaches this commit",
+			// and it is only true when every local branch was actually walked. Under
+			// truncation the same reasoning applies per commit: a hit is still a hit,
+			// but "nothing reached it" may just mean the branch that does sits past
+			// the cap, so that case falls back to leaving the stored value alone.
+			...(branchScanComplete && (!branchesTruncated || branchesByHash.has(hash))
+				? { branches: branchesByHash.get(hash) ?? [] }
+				: {}),
 			// Absent (not empty) when the numstat pass failed, so a transient git
 			// failure leaves previously collected file rows in place.
 			...(filesByHash.has(hash) ? { files: filesByHash.get(hash) } : {}),
@@ -553,6 +648,14 @@ export function summaryEventFromCommitSummary(
 	summary: CommitSummary,
 	transcripts: ReadonlyMap<string, { readonly sessions: ReadonlyArray<StoredSessionLike> }>,
 ): CommitSummaryEvent | null {
+	// PROVISIONAL. `summary.commitDate` is the AUTHOR date (`GitOps` reads it
+	// with `%aI`), and this feeds a committer-date column. It is the best this
+	// event can do — a stored summary carries no committer date — and it is
+	// self-correcting: `projectCommit` overwrites `committed_at_ms` from the
+	// `%cI` collection, and only a commit that never gets a `commit.created`
+	// event (outside the `--since` window, or pruned from `git log`) keeps the
+	// approximation. Queries that window memories therefore prefer the `commits`
+	// row and fall back to this — see `buildMemoryCards`.
 	const committedAtMs = Date.parse(summary.commitDate);
 	if (!Number.isFinite(committedAtMs)) return null;
 
@@ -709,6 +812,21 @@ export interface CollectSummariesOptions {
 	readonly storage?: StorageProvider;
 }
 
+/** {@link collectSummaryEvents}' result: the events, plus whether the sweep saw everything. */
+export interface SummaryCollection {
+	readonly events: ReadonlyArray<CommitSummaryEvent>;
+	/**
+	 * False when the index was unreadable, or any single summary failed to read.
+	 *
+	 * The caller's cursor is the whole index's content hash, so advancing it
+	 * after a partial sweep makes every LATER pass skip collection entirely —
+	 * one transient `git show` failure would hide that memory from the dashboard
+	 * permanently, until `index.json` itself happened to change. The commit tier
+	 * has carried this guard (`collectionComplete`) from the start.
+	 */
+	readonly complete: boolean;
+}
+
 /**
  * Collects one `commit.summary` per ROOT summary in the store.
  *
@@ -716,18 +834,21 @@ export interface CollectSummariesOptions {
  * turns/tokens the root already aggregates — projecting them too would double
  * count every consolidated commit.
  */
-export async function collectSummaryEvents(opts: CollectSummariesOptions): Promise<ReadonlyArray<CommitSummaryEvent>> {
+export async function collectSummaryEvents(opts: CollectSummariesOptions): Promise<SummaryCollection> {
 	const storage = opts.storage;
 	const index = await getIndex(opts.cwd, storage).catch(() => null);
-	if (!index) return [];
+	if (!index) return { events: [], complete: false };
 	const rootHashes = index.entries
 		.filter((e) => e.parentCommitHash === null || e.parentCommitHash === undefined)
 		.map((e) => e.commitHash);
 
 	const events: CommitSummaryEvent[] = [];
+	let complete = true;
 	for (const hash of rootHashes) {
 		try {
 			const summary = await getSummary(hash, opts.cwd, storage);
+			// A null read is "not there" per the StorageProvider contract, not a
+			// failure — the index can name a summary a prune has since removed.
 			if (!summary) continue;
 			const transcriptIds = getTranscriptIds(summary);
 			const transcripts =
@@ -737,10 +858,11 @@ export async function collectSummaryEvents(opts: CollectSummariesOptions): Promi
 			const event = summaryEventFromCommitSummary(opts.repoIdentity, summary, transcripts);
 			if (event) events.push(event);
 		} catch (err) {
+			complete = false;
 			log.warn("summary %s unreadable for dashboard: %s", hash.slice(0, 8), errMsg(err));
 		}
 	}
-	return events;
+	return { events, complete };
 }
 
 /** Collects the current worktree dirty-state, or null when unreadable. */

--- a/cli/src/dashboard/DashboardDb.ts
+++ b/cli/src/dashboard/DashboardDb.ts
@@ -29,7 +29,13 @@ import { dirname, join } from "node:path";
 import { getGlobalConfigDir } from "../core/SessionTracker.js";
 import { classifyScanError } from "../core/SqliteHelpers.js";
 import { createLogger, errMsg, isEnoent } from "../Logger.js";
-import { ACTIVITY_DDL, MEMORY_SOT_DDL, RECALL_RECEIPTS_DDL, SKILL_CONTEXT_KIND_DDL } from "./SotSchema.js";
+import {
+	ACTIVITY_DDL,
+	EVENT_FAILED_KIND_DDL,
+	MEMORY_SOT_DDL,
+	RECALL_RECEIPTS_DDL,
+	SKILL_CONTEXT_KIND_DDL,
+} from "./SotSchema.js";
 
 const log = createLogger("DashboardDb");
 
@@ -41,8 +47,10 @@ const log = createLogger("DashboardDb");
  * able to `SELECT` the columns it knows about after a newer build has migrated
  * up.
  *
- * It is 3. Entry 0 is the whole schema as it first landed; entry 1 adds
- * `recall_receipts`; entry 2 registers `skill` as the fourth `context` kind.
+ * It is 4. Entry 0 is the whole schema as it first landed; entry 1 adds
+ * `recall_receipts`; entry 2 registers `skill` as the fourth `context` kind;
+ * entry 3 adds `events_raw.failed_kind` so an event parked by an older build
+ * that did not know its type can be un-parked by one that does.
  * Nothing has shipped yet, so entry 0 could in principle
  * have absorbed the new table — it deliberately does not, because dev
  * databases (including the one every developer on this repo is using) are
@@ -57,7 +65,7 @@ const log = createLogger("DashboardDb");
  * user's database (other processes may hold the file open, and the memory half
  * is the only copy there is).
  */
-export const DASHBOARD_SCHEMA_VERSION = 3;
+export const DASHBOARD_SCHEMA_VERSION = 4;
 
 /**
  * Minimum Node that ships `node:sqlite` **without** `--experimental-sqlite`.
@@ -222,6 +230,7 @@ BEGIN SELECT RAISE(ABORT, 'repos are never deleted: set disabled_at instead'); E
 		MEMORY_SOT_DDL,
 	RECALL_RECEIPTS_DDL,
 	SKILL_CONTEXT_KIND_DDL,
+	EVENT_FAILED_KIND_DDL,
 ];
 
 /** Reads the stored schema version, treating a fresh DB as 0. */

--- a/cli/src/dashboard/DashboardModel.ts
+++ b/cli/src/dashboard/DashboardModel.ts
@@ -413,11 +413,18 @@ export interface SettingsModel {
 // ── Memories page ───────────────────────────────────────────────────────────
 
 /**
- * Most rows one Memories list payload carries — same reasoning as
- * {@link DECISIONS_LIMIT}: the model is inlined into the HTML, so this is a
- * page budget, not a data-retention statement.
+ * Rows per Memories list page — the size of the inlined first page, and of
+ * every `/api/memories` page the browser pulls after it.
+ *
+ * A page budget, not a cap: the whole model is inlined into a `<script>` block,
+ * so the full set cannot ride the HTML (an all-repos scope is the sum of every
+ * enabled repo's entire history), but the tree's search box filters the loaded
+ * array client-side, so dropping the tail outright would turn "search my
+ * memories" into "search my recent memories". Paging satisfies both — and the
+ * later pages are fetched on a "Load more" click, never prefetched, so a reader
+ * who never asks pays for exactly one page.
  */
-export const MEMORIES_LIST_LIMIT = 200;
+export const MEMORIES_PAGE_SIZE = 250;
 
 /** One row in the Memories tree — a repo>branch>memory browser groups these client-side. */
 export interface MemoryListItem {
@@ -580,11 +587,14 @@ export interface MemoryDetail {
 
 /** The Memories page payload. */
 export interface MemoriesModel {
-	/** Newest first, across every repo in scope. */
+	/**
+	 * Newest first, across every repo in scope — the first {@link MEMORIES_PAGE_SIZE}
+	 * rows. `items.length < totalCount` is the client's "another page exists" test:
+	 * it is what puts the tree's "Load more" button on screen, and each click pulls
+	 * one more page from `/api/memories`.
+	 */
 	readonly items: ReadonlyArray<MemoryListItem>;
 	readonly totalCount: number;
-	/** True when `items` hit {@link MEMORIES_LIST_LIMIT} and more were dropped. */
-	readonly truncated: boolean;
 	readonly vitals: { readonly memories: number; readonly topics: number; readonly repos: number };
 	/** Present only when the request named a `?hash=` this scope can resolve. */
 	readonly selected?: MemoryDetail;
@@ -1021,12 +1031,14 @@ export const RECALL_SKILL_NAMES: ReadonlyArray<string> = [RECALL_SKILL_NAME, "jo
 /**
  * Tool, skill and MCP-server usage over the window.
  *
- * Coverage is the load-bearing part of this shape. Only Claude transcripts
- * record tool calls today, so `sessionsWithTools` / `sessionsInWindow` and the
- * explicit `uncoveredSources` list travel with every payload: without them a
- * machine that runs one Claude session and forty Codex ones would present
- * Claude's tool mix as the whole team's, and an unused MCP server would be
- * indistinguishable from one used only from an unreadable agent.
+ * Coverage is the load-bearing part of this shape. Not every source's
+ * transcripts can be read for tool calls (`TOOL_RECORDING_SOURCES` is the
+ * authority, and it is deliberately evidence-gated rather than aspirational), so
+ * `sessionsWithTools` / `sessionsInWindow` and the explicit `uncoveredSources`
+ * list travel with every payload: without them a machine that runs one covered
+ * session and forty uncovered ones would present the covered agent's tool mix as
+ * the whole team's, and an unused MCP server would be indistinguishable from one
+ * used only from an unreadable agent.
  *
  * There is deliberately no "unused servers" figure. Knowing a server was never
  * called requires knowing which servers are REGISTERED, which lives in each

--- a/cli/src/dashboard/DashboardQuery.test.ts
+++ b/cli/src/dashboard/DashboardQuery.test.ts
@@ -791,7 +791,7 @@ describe("buildDashboardModel — tool usage", () => {
 	const sessionWith = (
 		sessionId: string,
 		tools?: ReadonlyArray<{ name: string; kind: "builtin" | "mcp" | "skill"; server?: string; calls: number }>,
-		source: "claude" | "codex" = "claude",
+		source: "claude" | "codex" | "cline" = "claude",
 	): StatsEventEnvelope => ({
 		producerKind: "cli",
 		event: {
@@ -935,9 +935,10 @@ describe("buildDashboardModel — tool usage", () => {
 			[
 				repoEvent,
 				sessionWith("s1", [{ name: "Bash", kind: "builtin", calls: 4 }]),
-				// Codex sessions are counted but carry no tool records at all.
-				sessionWith("s2", undefined, "codex"),
-				sessionWith("s3", undefined, "codex"),
+				// Cline (VS Code) sessions are counted but carry no tool records at all
+				// — its transcripts express tool results only as prose.
+				sessionWith("s2", undefined, "cline"),
+				sessionWith("s3", undefined, "cline"),
 			],
 			{ producerKind: "cli", dbPath },
 		);
@@ -946,7 +947,7 @@ describe("buildDashboardModel — tool usage", () => {
 		// have seen the one session that has rows.
 		expect(result?.sessionsWithTools).toBe(1);
 		expect(result?.sessionsInWindow).toBe(3);
-		expect(result?.uncoveredSources).toEqual(["codex"]);
+		expect(result?.uncoveredSources).toEqual(["cline"]);
 	});
 
 	it("does not call a readable source uncovered just because it used no tools", async () => {
@@ -957,12 +958,12 @@ describe("buildDashboardModel — tool usage", () => {
 				// record tool calls, so this zero is a real zero — reporting "claude"
 				// as uncovered made the page claim its transcripts cannot be read.
 				sessionWith("s1", undefined, "claude"),
-				sessionWith("s2", undefined, "codex"),
+				sessionWith("s2", undefined, "cline"),
 			],
 			{ producerKind: "cli", dbPath },
 		);
 		const result = await usage();
-		expect(result?.uncoveredSources).toEqual(["codex"]);
+		expect(result?.uncoveredSources).toEqual(["cline"]);
 		expect(result?.sessionsWithTools).toBe(0);
 		expect(result?.sessionsInWindow).toBe(2);
 	});
@@ -1112,6 +1113,20 @@ describe("buildDashboardModel — recall usage", () => {
 		const result = await recallUsage();
 		expect(result?.sessionsWithContext).toBe(1);
 		expect(result?.sessionsInWindow).toBe(3);
+	});
+
+	it("counts a recalling session that has no sessions row yet", async () => {
+		// A receipt is written at the edge the moment `recall` is called; the
+		// `sessions` row only appears when StopHook or the editor tick runs. With
+		// the denominator taken from `sessions` alone, a fresh agent that recalled
+		// on its first turn rendered "1 of 0 sessions got prior context".
+		await applySummaryEvents(
+			[repoEvent, recall(hit("a".repeat(40), "2026-07-25"), { sessionId: "brand-new", atMs: nowMs - 60_000 })],
+			{ producerKind: "cli", dbPath },
+		);
+		const result = await recallUsage();
+		expect(result?.sessionsWithContext).toBe(1);
+		expect(result?.sessionsInWindow).toBe(1);
 	});
 
 	it("counts a session-less call in the totals but attributes it to no session", async () => {
@@ -1319,6 +1334,61 @@ describe("buildDashboardModel — memory tier (phase 2)", () => {
 		expect(model.stats?.memoriesCreated).toBe(2);
 	});
 
+	it("windows memory cards on the committer date, matching the captured count", async () => {
+		await seedMemory();
+		// A rebased commit: authored days ago (what `CommitSummary.commitDate`
+		// records, via `%aI`), landed today (what the collector records, via
+		// `%cI`). The captured count has always used the committer date; the card
+		// list used the author date, so the header counted a memory the feed
+		// below it did not render.
+		await withDashboardDb(
+			(db) => {
+				const { id: repoId } = db.prepare("SELECT id FROM repos WHERE repo_identity = 'repo-1'").get() as {
+					id: number;
+				};
+				db.prepare("UPDATE memories SET commit_date_ms = ? WHERE repo_id = ? AND commit_hash = 'mem1'").run(
+					nowMs - 400 * 24 * 3_600_000,
+					repoId,
+				);
+			},
+			{ dbPath },
+		);
+		const model = await withDashboardDb(
+			(db) => buildDashboardModel(db, { view: "stats", scope: { kind: "all" }, timeZone: "UTC", nowMs }),
+			{ dbPath },
+		);
+		expect(model.stats?.memoriesCreated).toBe(2);
+		expect(model.stats?.memoryCards?.map((c) => c.commitHash).sort()).toEqual(["mem1", "mem2"]);
+	});
+
+	it("orders and stamps memory cards on the committer date the page was selected by", async () => {
+		await seedMemory();
+		// Same rebased shape as above: mem1 landed today but was AUTHORED 400 days
+		// ago. The page is selected and windowed on the committer date, so ordering
+		// the payload query by `commit_date_ms` re-sorted it by author date behind
+		// the selection — and the card then rendered a timestamp outside the very
+		// window it was chosen for.
+		await withDashboardDb(
+			(db) => {
+				const { id: repoId } = db.prepare("SELECT id FROM repos WHERE repo_identity = 'repo-1'").get() as {
+					id: number;
+				};
+				db.prepare("UPDATE memories SET commit_date_ms = ? WHERE repo_id = ? AND commit_hash = 'mem1'").run(
+					nowMs - 400 * 24 * 3_600_000,
+					repoId,
+				);
+			},
+			{ dbPath },
+		);
+		const model = await withDashboardDb(
+			(db) => buildDashboardModel(db, { view: "stats", scope: { kind: "all" }, timeZone: "UTC", nowMs }),
+			{ dbPath },
+		);
+		// mem1 is the most recently LANDED commit, so it leads the feed.
+		expect(model.stats?.memoryCards?.map((c) => c.commitHash)).toEqual(["mem1", "mem2"]);
+		expect(model.stats?.memoryCards?.[0]?.committedAtMs).toBe(nowMs - 3 * 3_600_000);
+	});
+
 	it("credits a rewritten commit as captured through commit_aliases, decision included", async () => {
 		await seedMemory();
 		// Simulate mem1 getting rebased/amended after it was summarized: the live
@@ -1385,6 +1455,47 @@ describe("buildDashboardModel — memory tier (phase 2)", () => {
 		expect(stats.seriesKeys).toEqual(["feature/dash", "main"]);
 		const total = stats.series.reduce((sum, p) => sum + p.tokens, 0);
 		expect(total).toBe(28000);
+	});
+
+	it("apportions a multi-branch commit so the day totals do not multiply", async () => {
+		await seedMemory();
+		// `commit_branches` is a per-branch `git rev-list` union, so a commit on
+		// `main` is also listed under every feature branch based off it. Without
+		// apportionment each extra branch added the commit's whole spend to the
+		// day again — five branches turned a 20k-token commit into 120k.
+		await applySummaryEvents(
+			[
+				{
+					producerKind: "cli",
+					event: {
+						type: "commit.created",
+						repoIdentity: "repo-1",
+						hash: "mem1",
+						committedAtMs: nowMs - 3 * 3_600_000,
+						branches: ["feature/dash", "main", "release/1.x"],
+					},
+				},
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		const model = await withDashboardDb(
+			(db) =>
+				buildDashboardModel(db, {
+					view: "stats",
+					scope: { kind: "all" },
+					dimension: "branch",
+					timeZone: "UTC",
+					nowMs,
+				}),
+			{ dbPath },
+		);
+		const stats = model.stats;
+		if (!stats) throw new Error("stats missing");
+		expect(stats.seriesKeys).toEqual(["feature/dash", "main", "release/1.x"]);
+		// Still the real total, with mem1's 20k split three ways across the axis.
+		expect(stats.series.reduce((sum, p) => sum + p.tokens, 0)).toBe(28000);
+		const today = stats.series[stats.series.length - 1];
+		expect(today.tokens).toBe(20000);
 	});
 
 	it("builds the category dimension from memory_topics, sharing a commit's tokens across them", async () => {

--- a/cli/src/dashboard/DashboardQuery.ts
+++ b/cli/src/dashboard/DashboardQuery.ts
@@ -577,24 +577,37 @@ function buildSeries(
 		// COUNT(*) is 1 and their whole spend lands in '(uncategorised)'.
 		rows = db
 			.prepare(
-				`SELECT m.commit_date_ms AS at_ms, COALESCE(t.category, '(uncategorised)') AS key,
+				`SELECT COALESCE(cm.committed_at_ms, m.commit_date_ms) AS at_ms,
+				        COALESCE(t.category, '(uncategorised)') AS key,
 				        COALESCE(m.tokens, 0) * 1.0
 				          / COUNT(*) OVER (PARTITION BY m.repo_id, m.commit_hash) AS tokens,
 				        COALESCE(m.est_cost_usd, 0) * 1.0
 				          / COUNT(*) OVER (PARTITION BY m.repo_id, m.commit_hash) AS cost
 				   FROM memories m
 				   LEFT JOIN memory_topics t ON t.repo_id = m.repo_id AND t.commit_hash = m.commit_hash
-				  WHERE m.tokens IS NOT NULL AND m.commit_date_ms >= ? AND m.commit_date_ms < ?${filter.sql}`,
+				   LEFT JOIN commits cm ON cm.repo_id = m.repo_id AND cm.hash = m.commit_hash
+				  WHERE m.tokens IS NOT NULL
+				    AND COALESCE(cm.committed_at_ms, m.commit_date_ms) >= ?
+				    AND COALESCE(cm.committed_at_ms, m.commit_date_ms) < ?${filter.sql}`,
 			)
 			.all(fromMs, toMs, ...filter.params) as UsageRow[];
 	} else if (effective === "branch") {
 		const filter = scopeFilter(scopeToRepoId(db, scope), "c.repo_id");
 		// A commit reachable from several branches contributes to each — the axis
-		// answers "where did the spend land", not "sum to the exact total".
+		// answers "where did the spend land", not "sum to the exact total". That
+		// licenses duplication ACROSS SERIES, never in the day totals, which is
+		// why the spend is apportioned exactly as the category axis apportions
+		// across topics. `commit_branches` is a per-branch `git rev-list` union,
+		// so every commit on `main` is also listed under every feature branch
+		// based off it: unapportioned, one 10k-token commit on a repo with five
+		// such branches added 60k tokens (and 6x the cost) to the day.
 		rows = db
 			.prepare(
 				`SELECT c.committed_at_ms AS at_ms, br.name AS key,
-				        COALESCE(m.tokens, 0) AS tokens, COALESCE(m.est_cost_usd, 0) AS cost
+				        COALESCE(m.tokens, 0) * 1.0
+				          / COUNT(*) OVER (PARTITION BY c.repo_id, c.hash) AS tokens,
+				        COALESCE(m.est_cost_usd, 0) * 1.0
+				          / COUNT(*) OVER (PARTITION BY c.repo_id, c.hash) AS cost
 				   FROM commits c JOIN commit_branches b ON b.commit_id = c.id
 			                        JOIN branches br ON br.id = b.branch_id
 			                        JOIN memories m ON m.repo_id = c.repo_id AND m.commit_hash = c.hash
@@ -999,7 +1012,7 @@ function buildStandup(
 
 	const categoryLabels = commitCategoryLabels(db, scope);
 	const toStandupCommit = (c: CommitRow): StandupCommit => {
-		const workCategory = categoryLabels.get(`${c.repo_name}\0${c.hash}`);
+		const workCategory = categoryLabels.get(`${c.repo_identity}\0${c.hash}`);
 		return {
 			hash: c.hash,
 			message: c.message ?? "",
@@ -1076,7 +1089,7 @@ interface MemoryCardRow {
 	readonly repo_identity: string;
 	readonly commit_hash: string;
 	readonly commit_message: string | null;
-	readonly commit_date_ms: number;
+	readonly committed_at_ms: number;
 	readonly recap: string | null;
 	readonly turns: number | null;
 	readonly est_cost_usd: number | null;
@@ -1147,14 +1160,25 @@ function buildMemoryCards(
 		// showing the two survivors of the twenty most recent rows instead of the
 		// twenty most recent surviving memories. Step one is deliberately narrow —
 		// the payload blob is only read for the page that is actually rendered.
+		// Windowed on the COMMITTER date, falling back to the memory's own
+		// `commit_date_ms` only when no `commits` row exists yet. Those two are
+		// different clocks: `commit_date_ms` comes from `CommitSummary.commitDate`,
+		// which `GitOps.getHeadCommitInfo` reads with `%aI` (author date), while
+		// `commits.committed_at_ms` is collected with `%cI` — deliberately, since
+		// every other window in this file is a committer-date window. Filtering
+		// the cards on the author date put a rebased or cherry-picked commit in a
+		// different bucket from the "N of M captured" line directly above the
+		// list, so the header counted memories the feed did not show.
 		const keys = db
 			.prepare(
 				`SELECT c.commit_hash, r.repo_identity
 				   FROM memories c
 				   JOIN repos r ON r.id = c.repo_id
+				   LEFT JOIN commits cm ON cm.repo_id = c.repo_id AND cm.hash = c.commit_hash
 				  WHERE c.parent_hash IS NULL
-				    AND c.commit_date_ms >= ? AND c.commit_date_ms < ?${filter.sql}
-				  ORDER BY c.commit_date_ms DESC`,
+				    AND COALESCE(cm.committed_at_ms, c.commit_date_ms) >= ?
+				    AND COALESCE(cm.committed_at_ms, c.commit_date_ms) < ?${filter.sql}
+				  ORDER BY COALESCE(cm.committed_at_ms, c.commit_date_ms) DESC`,
 			)
 			.all(window.startMs, window.endMs, ...filter.params) as ReadonlyArray<{
 			commit_hash: string;
@@ -1167,12 +1191,21 @@ function buildMemoryCards(
 		const holes = page.map(() => "?").join(",");
 		rows = db
 			.prepare(
-				`SELECT c.commit_hash, c.commit_message, c.commit_date_ms, c.recap, c.turns, c.est_cost_usd,
+				// Same COALESCE as the key query above, for both the sort and the
+				// timestamp the card renders. Ordering on `c.commit_date_ms` alone
+				// re-sorted the page by AUTHOR date after it had been selected and
+				// windowed on the committer date, so a rebased or cherry-picked commit
+				// landed out of order and rendered a timestamp that could fall outside
+				// the window it was selected for.
+				`SELECT c.commit_hash, c.commit_message,
+				        COALESCE(cm.committed_at_ms, c.commit_date_ms) AS committed_at_ms,
+				        c.recap, c.turns, c.est_cost_usd,
 				        c.branch, c.insertions, c.deletions, c.summary_json, r.repo_identity, r.repo_name
 				   FROM memories c
 				   JOIN repos r ON r.id = c.repo_id
+				   LEFT JOIN commits cm ON cm.repo_id = c.repo_id AND cm.hash = c.commit_hash
 				  WHERE c.parent_hash IS NULL AND c.commit_hash IN (${holes})${filter.sql}
-				  ORDER BY c.commit_date_ms DESC`,
+				  ORDER BY COALESCE(cm.committed_at_ms, c.commit_date_ms) DESC`,
 			)
 			.all(...page.map((k) => k.commit_hash), ...filter.params) as ReadonlyArray<MemoryCardRow>;
 		// `IN (hashes)` is keyed on the hash alone, so an unscoped dashboard whose
@@ -1208,7 +1241,7 @@ function buildMemoryCards(
 			title: row.commit_message ?? "",
 			...(category ? { category } : {}),
 			severity: changed >= MEMORY_CARD_MAJOR_LINES ? ("major" as const) : ("minor" as const),
-			committedAtMs: row.commit_date_ms,
+			committedAtMs: row.committed_at_ms,
 			...(decision ? { decision } : {}),
 			...(row.est_cost_usd != null ? { estCostUsd: row.est_cost_usd } : {}),
 			...(row.turns != null ? { turns: row.turns } : {}),
@@ -1467,25 +1500,38 @@ function buildRecallUsage(
 
 	const totalCalls = usedCalls + setAsideCalls;
 
-	// Coverage denominator: sessions in the window, PLUS any session a receipt in
-	// the window points at. The second arm is what keeps `sessionsWithContext`
-	// (counted off the receipts above) from ever exceeding it — a session last
-	// touched before the window can still have made an in-window recall call.
+	// Coverage denominator: the UNION of sessions touched in the window and the
+	// sessions in-window receipts point at, counted by identity so the two arms
+	// cannot double-count. It has to be a union rather than a filter over
+	// `sessions`, because the numerator (`sessionsWithContext`, taken off the
+	// receipts) can name a session that has NO `sessions` row yet: a receipt is
+	// written at the edge the moment `recall` is called, while the row appears
+	// only when StopHook or the editor's 60 s tick runs. A fresh agent calling
+	// recall on its first turn therefore rendered "1 of 0 sessions got prior
+	// context" — an EXISTS arm cannot rescue a session that is not in the table
+	// being filtered.
 	const sessionFilter = scopeFilter(repoId, "s.repo_id");
+	const receiptScope = scopeFilter(repoId, "r.repo_id");
 	const sessionRows = db
 		.prepare(
-			`SELECT COUNT(*) AS total
-			   FROM sessions s
-			  WHERE (
-			          (s.updated_at_ms >= ? AND s.updated_at_ms < ?)
-			          OR EXISTS (
-			               SELECT 1 FROM recall_receipts r
-			                WHERE r.repo_id = s.repo_id AND r.session_id = s.session_id
-			                  AND r.at_ms >= ? AND r.at_ms < ?
-			             )
-			        )${sessionFilter.sql}`,
+			`SELECT COUNT(*) AS total FROM (
+			   SELECT s.repo_id AS repo_id, s.session_id AS session_id
+			     FROM sessions s
+			    WHERE s.updated_at_ms >= ? AND s.updated_at_ms < ?${sessionFilter.sql}
+			   UNION
+			   SELECT r.repo_id, r.session_id
+			     FROM recall_receipts r
+			    WHERE r.at_ms >= ? AND r.at_ms < ?${receiptScope.sql}
+			 )`,
 		)
-		.get(window.startMs, window.endMs, window.startMs, window.endMs, ...sessionFilter.params) as { total: number };
+		.get(
+			window.startMs,
+			window.endMs,
+			...sessionFilter.params,
+			window.startMs,
+			window.endMs,
+			...receiptScope.params,
+		) as { total: number };
 
 	// Skill invocations: the `jolli-recall` skill being run, which is NOT a
 	// recall call (see RecallUsage.skillInvocations for why it stays out of the

--- a/cli/src/dashboard/DashboardScopeUtil.ts
+++ b/cli/src/dashboard/DashboardScopeUtil.ts
@@ -73,7 +73,7 @@ export function commitCategoryLabels(db: DashboardDbHandle, scope: DashboardScop
 	const filter = scopeFilter(scopeToRepoId(db, scope), "t.repo_id");
 	const rows = db
 		.prepare(
-			`SELECT r.repo_name, ranked.commit_hash, ranked.category
+			`SELECT r.repo_identity, ranked.commit_hash, ranked.category
 			   FROM (SELECT t.repo_id, t.commit_hash, t.category,
 			                COUNT(*) AS n, MIN(t.pos) AS first_pos,
 			                ROW_NUMBER() OVER (PARTITION BY t.repo_id, t.commit_hash ORDER BY COUNT(*) DESC, MIN(t.pos) ASC) AS rn
@@ -83,8 +83,14 @@ export function commitCategoryLabels(db: DashboardDbHandle, scope: DashboardScop
 			   JOIN repos r ON r.id = ranked.repo_id
 			  WHERE ranked.rn = 1`,
 		)
-		.all(...filter.params) as ReadonlyArray<{ repo_name: string; commit_hash: string; category: string }>;
-	return new Map(rows.map((row) => [`${row.repo_name}\0${row.commit_hash}`, row.category]));
+		.all(...filter.params) as ReadonlyArray<{ repo_identity: string; commit_hash: string; category: string }>;
+	// Keyed by repo_identity, NOT repo_name: the name is a display label and two
+	// registered repos can share one (an upstream and its fork, two clones of the
+	// same project). Their hashes overlap by construction, so in the all-repos
+	// scope a name-keyed map collided and painted one repo's category label onto
+	// the other's memories and standup rows. `CommitRow.repo_identity` carries
+	// the same warning for the same reason.
+	return new Map(rows.map((row) => [`${row.repo_identity}\0${row.commit_hash}`, row.category]));
 }
 
 /**

--- a/cli/src/dashboard/DashboardServer.test.ts
+++ b/cli/src/dashboard/DashboardServer.test.ts
@@ -319,6 +319,80 @@ describe("routes", () => {
 		expect(((await res.json()) as DashboardModel).view).toBe("stats");
 	});
 
+	// A cross-site `no-cors` GET reaches this route (no Origin to reject, a
+	// loopback Host to accept), so the token is what separates our own page's
+	// poll from one — and only the money-spending part of the answer depends
+	// on it. The route itself stays open: `curl /api/model` must keep working.
+	describe("/api/model model-spend gate", () => {
+		const spendFlags: Array<boolean | undefined> = [];
+		const spyServer = () =>
+			testServer({
+				token: "tok",
+				buildModel: async (req) => {
+					spendFlags.push(req.allowModelSpend);
+					return model(req.view);
+				},
+			});
+
+		beforeEach(() => spendFlags.splice(0));
+
+		it("withholds spend from a token-free call but still answers it", async () => {
+			const port = await listen(spyServer());
+			const res = await get(port, "/api/model?view=stats");
+			expect(res.status).toBe(200);
+			expect(((await res.json()) as DashboardModel).view).toBe("stats");
+			expect(spendFlags).toEqual([false]);
+		});
+
+		it("withholds spend when the token is wrong", async () => {
+			const port = await listen(spyServer());
+			await get(port, "/api/model?view=stats", { "X-Jolli-Dashboard-Token": "nope" });
+			expect(spendFlags).toEqual([false]);
+		});
+
+		it("allows spend for our own page's poll, which carries the token", async () => {
+			const port = await listen(spyServer());
+			await get(port, "/api/model?view=stats", { "X-Jolli-Dashboard-Token": "tok" });
+			expect(spendFlags).toEqual([true]);
+		});
+
+		// `/repositories` rather than a GATED_PATH: the shared `model()` helper
+		// has no repos, so /dashboard would 302 before rendering.
+		it("allows spend for a page render — the by-hand URL keeps its full payload", async () => {
+			const port = await listen(spyServer());
+			expect((await get(port, "/repositories")).status).toBe(200);
+			expect(spendFlags).toEqual([true]);
+		});
+
+		// The page routes take no token (that is the product call), so this is
+		// the only thing standing between `<img src="…/stats">` on a hostile tab
+		// and a real LLM call.
+		it("withholds spend from a cross-site page load", async () => {
+			const port = await listen(spyServer());
+			const res = await get(port, "/repositories", { "Sec-Fetch-Site": "cross-site" });
+			expect(res.status).toBe(200);
+			expect(spendFlags).toEqual([false]);
+		});
+
+		it("withholds spend from a cross-site /api/model even with a valid token", async () => {
+			const port = await listen(spyServer());
+			await get(port, "/api/model?view=stats", {
+				"X-Jolli-Dashboard-Token": "tok",
+				"Sec-Fetch-Site": "cross-site",
+			});
+			expect(spendFlags).toEqual([false]);
+		});
+
+		it("still allows spend for our own page's same-origin poll", async () => {
+			const port = await listen(spyServer());
+			await get(port, "/api/model?view=stats", {
+				"X-Jolli-Dashboard-Token": "tok",
+				"Sec-Fetch-Site": "same-origin",
+			});
+			expect(spendFlags).toEqual([true]);
+		});
+	});
+
 	it("serves every view as a page and over the API, and rejects an unknown one", async () => {
 		const port = await listen(testServer());
 		const page = await get(port, "/repositories");
@@ -533,7 +607,18 @@ describe("assembleDashboardHtml", () => {
 	it("neutralizes </script> breakouts in the embedded model", () => {
 		const html = assembleDashboardHtml(assetsDir, JSON.stringify({ title: "</script><script>alert(1)" }));
 		expect(html).not.toContain("</script><script>alert(1)");
-		expect(html).toContain("<\\/script>");
+		expect(html).toContain("\\u003c/script>");
+	});
+
+	// A `<!--` in model text used to survive the escape and put the tokenizer
+	// into script-data-escaped state, so the data block's own `</script>` no
+	// longer closed it and every app script after it was swallowed as text.
+	it("neutralizes a <!-- comment opener in the embedded model", () => {
+		const html = assembleDashboardHtml(assetsDir, JSON.stringify({ title: "<!--<script>" }));
+		expect(html).not.toContain("<!--");
+		// The model block still closes: the app scripts after it stay real tags.
+		expect(html).toContain("/* main.js */");
+		expect(html.indexOf("window.__JOLLI_DASHBOARD__")).toBeLessThan(html.indexOf("/* main.js */"));
 	});
 });
 
@@ -1125,6 +1210,73 @@ describe("defaultModelBuilder (no injected buildModel)", () => {
 		expect((body.memories?.items ?? []).map((item) => item.commitHash)).toEqual(["reachable-hash"]);
 	});
 
+	// The "Load more" fetch. Filtered by the SAME reachability the page render
+	// uses — that is what makes the cursor a position in the list the client is
+	// actually holding, rather than in a longer one only this route can see.
+	it("serves one page of memories after a cursor, and rejects half a cursor", async () => {
+		const dbPath = join(dir, "memories-page.db");
+		const configDir = join(dir, "config-page");
+		await applyStatsEvents(
+			[
+				{
+					producerKind: "cli",
+					event: {
+						type: "repo.enabled",
+						repoIdentity: "repo-1",
+						repoName: "jolli",
+						worktreeRoot: "/w/jolli",
+						enabledAt: "t",
+					},
+				},
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		await withDashboardDb(
+			(db) => {
+				const { id } = db.prepare("SELECT id FROM repos WHERE repo_identity = ?").get("repo-1") as {
+					id: number;
+				};
+				// `listReachableCommits` is stubbed to return "reachable-hash" only, so
+				// the second row is here to prove the route filters like the page does.
+				for (const [hash, dateMs] of [
+					["reachable-hash", 2],
+					["rewritten-hash", 1],
+				] as const) {
+					db.prepare(
+						`INSERT INTO memories (repo_id, commit_hash, parent_hash, child_pos, root_hash, depth,
+						                       summary_json, first_seen_ms, written_at_ms, commit_date_ms)
+						 VALUES (?, ?, NULL, NULL, ?, 0, ?, 1, 1, ?)`,
+					).run(id, hash, hash, JSON.stringify({ commitHash: hash, topics: [] }), dateMs);
+				}
+			},
+			{ dbPath },
+		);
+
+		const port = await listen(createDashboardServer({ port: 0, assetsDir, dbPath, configDir }));
+
+		const first = await get(port, "/api/memories");
+		expect(first.status).toBe(200);
+		expect(
+			((await first.json()) as { items: Array<{ commitHash: string }> }).items.map((i) => i.commitHash),
+		).toEqual(["reachable-hash"]);
+
+		// Cursor on the only reachable row — nothing follows it.
+		const after = await get(port, "/api/memories?afterRepo=repo-1&afterHash=reachable-hash");
+		expect(after.status).toBe(200);
+		const afterBody = (await after.json()) as { items: unknown[]; cursorMissing?: true };
+		expect(afterBody.items).toEqual([]);
+		expect(afterBody.cursorMissing).toBeUndefined();
+
+		// The unreachable row is not a position in this list.
+		const missing = await get(port, "/api/memories?afterRepo=repo-1&afterHash=rewritten-hash");
+		expect(((await missing.json()) as { cursorMissing?: true }).cursorMissing).toBe(true);
+
+		// Half a cursor cannot identify a row, and paging from the top instead
+		// would look like a working button that repeats the first page.
+		expect((await get(port, "/api/memories?afterHash=reachable-hash")).status).toBe(400);
+		expect((await get(port, "/api/memories?afterRepo=repo-1")).status).toBe(400);
+	});
+
 	// The Context dialog's fetch. A read like every other GET here — no token —
 	// and it opens the database itself rather than going through buildModel,
 	// because a document body is not part of any page payload.
@@ -1239,9 +1391,9 @@ describe("Decisions card gist (Stats view only)", () => {
 		mockGetDecisionGist.mockResolvedValueOnce("Picked SQLite for local durability.");
 
 		const port = await listen(
-			createDashboardServer({ port: 0, assetsDir, dbPath, configDir: join(dir, "config") }),
+			createDashboardServer({ port: 0, assetsDir, dbPath, configDir: join(dir, "config"), token: "tok" }),
 		);
-		const res = await get(port, "/api/model?view=stats");
+		const res = await get(port, "/api/model?view=stats", { "X-Jolli-Dashboard-Token": "tok" });
 
 		expect(res.status).toBe(200);
 		const body = (await res.json()) as DashboardModel;
@@ -1254,6 +1406,26 @@ describe("Decisions card gist (Stats view only)", () => {
 			"- **Picked SQLite**: needed local durability without a server.",
 			expect.anything(),
 		);
+	});
+
+	// The actual protection: this is the only browser-reachable route that can
+	// spend money, and a cross-site tab can reach it. It must answer — with the
+	// decision, un-compressed — without ever calling the model.
+	it("serves a token-free /api/model?view=stats without calling getDecisionGist", async () => {
+		const dbPath = join(dir, "dashboard.db");
+		await seedDecisionCommit(dbPath, "mem1", "- **Picked SQLite**: needed local durability without a server.");
+		mockGetDecisionGist.mockResolvedValue("should never be reached");
+
+		const port = await listen(
+			createDashboardServer({ port: 0, assetsDir, dbPath, configDir: join(dir, "config"), token: "tok" }),
+		);
+		const res = await get(port, "/api/model?view=stats");
+
+		expect(res.status).toBe(200);
+		const latest = ((await res.json()) as DashboardModel).stats?.decisions?.latest;
+		expect(latest).toMatchObject({ commitHash: "mem1" });
+		expect(latest).not.toHaveProperty("gist");
+		expect(mockGetDecisionGist).not.toHaveBeenCalled();
 	});
 
 	it("falls back to the raw decision text when getDecisionGist fails open", async () => {

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -59,6 +59,18 @@
  *      file. GET-only readers (session counts, tokens, cost, commit subjects,
  *      mined insights) still need no credential — nothing there is a
  *      secret, and the API key is never part of any model this serves.
+ *   4. `Sec-Fetch-Site` gates the one thing a GET can do that is NOT free:
+ *      building the Stats payload can fire a DecisionGist LLM call. Layers
+ *      1+2 do not stop a hostile tab from ISSUING a GET (a `no-cors` request
+ *      carries no `Origin` to reject and a loopback `Host` to accept) — they
+ *      only stop it reading the reply, which is enough when the reply is the
+ *      only thing at stake and not enough when producing it spends money. So
+ *      a cross-site request still gets its answer, minus the parts that cost
+ *      anything; see {@link ModelRequest.allowModelSpend}. This layer is what
+ *      covers the PAGE routes, which deliberately demand no token, and it
+ *      degrades to the token check on a client that sends no Fetch-Metadata.
+ *      An absent header is trusted as `curl` — a local process spending the
+ *      local user's own budget, which needs no help from us to do that.
  */
 
 import { randomBytes, timingSafeEqual } from "node:crypto";
@@ -68,6 +80,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { dirname, join } from "node:path";
 import { fileURLToPath, URL } from "node:url";
 import { getProjectRootDir, listReachableCommits } from "../core/GitOps.js";
+import { escapeForInlineScript } from "../core/InlineScript.js";
 import { getGlobalConfigDir, loadConfigFromDir } from "../core/SessionTracker.js";
 import { trackAs } from "../core/Telemetry.js";
 import { isTelemetryEventName, type TelemetryEventName } from "../core/TelemetryEvents.js";
@@ -91,7 +104,7 @@ import type {
 } from "./DashboardModel.js";
 import { buildDashboardModel, type QueryOptions } from "./DashboardQuery.js";
 import { getDecisionGist } from "./DecisionGist.js";
-import { type ReachableCommits, readContextDoc } from "./MemoriesQuery.js";
+import { buildMemoriesPage, type ReachableCommits, readContextDoc } from "./MemoriesQuery.js";
 import { probeRepo } from "./RepoProbe.js";
 import { deregisterRepo, existingWorktrees, readRepoRegistry, registerRepo } from "./RepoRegistry.js";
 import { buildRepositoriesModel } from "./RepositoriesQuery.js";
@@ -215,14 +228,6 @@ export function resolveDashboardAssetsDir(baseDir: string = HERE): string {
 	throw new Error("Dashboard assets not found — reinstall @jolli.ai/cli (the dashboard needs its bundled assets).");
 }
 
-/** Same inline-script hardening as GraphExport: no `</script` breakout. */
-function escapeForInlineScript(json: string): string {
-	return json
-		.replace(/<\/script/gi, "<\\/script")
-		.replace(new RegExp(String.fromCharCode(0x2028), "g"), "\\u2028")
-		.replace(new RegExp(String.fromCharCode(0x2029), "g"), "\\u2029");
-}
-
 /**
  * Assembles one self-contained page: template + inlined CSS + the model behind
  * `window.__JOLLI_DASHBOARD__` + inlined app scripts. No external fetches, so
@@ -259,20 +264,40 @@ export function assembleDashboardHtml(assetsDir: string, modelJson: string, toke
  * because the query layer keeps gaining optional axes, and each new one would
  * otherwise be a positional argument every caller has to thread through.
  */
-export type ModelRequest = Omit<QueryOptions, "timeZone" | "nowMs">;
+export type ModelRequest = Omit<QueryOptions, "timeZone" | "nowMs"> & {
+	/**
+	 * Whether this request may spend model budget (today: the Decisions gist).
+	 * Set for a page render, and for an `/api/model` call that presented the
+	 * token — i.e. one our own page made. A token-free `/api/model` still gets
+	 * the full payload, minus the parts that cost money.
+	 *
+	 * The gate exists because `/api/model` is reachable cross-site in a way the
+	 * page routes are not: a `no-cors` GET carries no `Origin` (so layer 2 never
+	 * fires) and `Host: 127.0.0.1:<port>` passes layer 1, so a background tab
+	 * could loop `?view=stats` with varied window params — each miss on
+	 * DecisionGist's 256-entry cache being a real LLM call the user never sees.
+	 * The `/` redirect below already avoids this one view for the same reason;
+	 * this closes the route that redirect cannot cover.
+	 */
+	readonly allowModelSpend?: boolean;
+};
 
 /** Builds the model for one request. Injectable so tests skip the real DB. */
 export type ModelBuilder = (request: ModelRequest) => Promise<DashboardModel>;
 
 /**
- * Views whose payload renders per-MEMORY rows, and therefore pay for one
- * `git rev-list --branches` per repo. Deliberately not `standup`: its commit
- * lists — like the stats heatmap and KPI row — report activity, and a commit
- * that has since been squashed away still happened. Only the memory-facing
- * rows are filtered, because a rewritten commit's `memories` row is a
- * DUPLICATE of the surviving one, not a record of separate work.
+ * Views whose payload counts or renders per-MEMORY rows, and therefore pay for
+ * one `git rev-list --branches` per repo. Deliberately not `standup`: its
+ * commit lists — like the stats heatmap and KPI row — report activity, and a
+ * commit that has since been squashed away still happened. Only the
+ * memory-facing rows are filtered, because a rewritten commit's `memories` row
+ * is a DUPLICATE of the surviving one, not a record of separate work.
+ *
+ * `repositories` is here for its per-repo memory badge alone: that number must
+ * answer the same question the Memories tree does, or the two pages contradict
+ * each other for any repo whose history was rewritten away.
  */
-const REACHABILITY_VIEWS: ReadonlySet<DashboardView> = new Set<DashboardView>(["stats", "memories"]);
+const REACHABILITY_VIEWS: ReadonlySet<DashboardView> = new Set<DashboardView>(["stats", "memories", "repositories"]);
 
 /**
  * One `git rev-list --branches` per enabled repo, mapped to {@link ReachableCommits}.
@@ -320,14 +345,14 @@ async function defaultModelBuilder(
 	await ensureDashboardDbExists(dbPath ? { dbPath } : {});
 	return withReadonlyDashboardDb(
 		async (db) => {
-			const repositories =
-				request.view === "repositories" ? await buildRepositoriesModel(db, configDir) : undefined;
 			// A rebase/reset/squash that rewrites history away leaves the old
 			// commits' rows in `commits` and `memories` forever, since nothing
 			// else notices they dropped off every branch — see `ReachableCommits`.
 			// Every view that renders per-commit rows pays for the check: the
 			// memories tree, the stats page's Memory Activity feed and captured
-			// counts, and standup's yesterday/today commit lists.
+			// counts, and the Repositories page's per-repo memory badge.
+			//
+			// Computed BEFORE the repositories model, which consumes it.
 			const reachableCommits = REACHABILITY_VIEWS.has(request.view)
 				? await readReachableCommitsByRepo(
 						db
@@ -335,6 +360,10 @@ async function defaultModelBuilder(
 							.all() as ReadonlyArray<{ repo_identity: string; worktree_root: string }>,
 					)
 				: undefined;
+			const repositories =
+				request.view === "repositories"
+					? await buildRepositoriesModel(db, configDir, reachableCommits)
+					: undefined;
 			const model = buildDashboardModel(db, {
 				...request,
 				...(repositories ? { repositoriesModel: repositories } : {}),
@@ -353,12 +382,17 @@ async function defaultModelBuilder(
  * compress isn't known until that call returns the `latest` decision. Fails
  * open — a missing API key, LLM error, or timeout just leaves `latest.text`
  * as-is; see DecisionGist.ts.
+ *
+ * This is the ONLY place a browser-reachable route can spend model budget, so
+ * it is also where `allowModelSpend` is enforced; skipping it degrades the card
+ * to its un-compressed text, which is what a gist failure already does.
  */
 async function attachDecisionGist(
 	model: DashboardModel,
 	request: ModelRequest,
 	configDir: string | undefined,
 ): Promise<DashboardModel> {
+	if (!request.allowModelSpend) return model;
 	const stats = request.view === "stats" ? model.stats : undefined;
 	const decisions = stats?.decisions;
 	const latest = decisions?.latest;
@@ -474,6 +508,30 @@ function hasValidToken(req: IncomingMessage, token: string): boolean {
 	const expected = Buffer.from(token, "utf-8");
 	if (given.length !== expected.length) return false;
 	return timingSafeEqual(given, expected);
+}
+
+/**
+ * Whether a request may build a payload that costs money — see
+ * {@link ModelRequest.allowModelSpend}. Two independent signals, because
+ * neither covers the whole surface on its own:
+ *
+ *   - `Sec-Fetch-Site` (sent by every current browser, and by nothing else)
+ *     names the initiator. `cross-site`/`same-site` is a page we did not
+ *     serve, whatever it is loading us as — and it is the ONLY signal that
+ *     covers the PAGE routes, which an `<img src="…/stats">` reaches just as
+ *     easily as `/api/model` and where no token can be demanded without
+ *     breaking "open the URL by hand".
+ *   - The token covers `/api/model` for a client that sends no Fetch-Metadata
+ *     at all (an old browser), where the header's absence is indistinguishable
+ *     from `curl`.
+ *
+ * An absent header therefore means "not a browser" and is trusted: that is
+ * `curl` on the user's own machine, which can spend the user's own budget by
+ * a hundred easier routes than this one.
+ */
+function isCrossSiteRequest(req: IncomingMessage): boolean {
+	const site = req.headers["sec-fetch-site"];
+	return typeof site === "string" && site !== "same-origin" && site !== "none";
 }
 
 /** Caps a POST body — this is a local settings form, never a file upload. */
@@ -764,7 +822,16 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 
 		const pageView = VIEW_PATHS[url.pathname];
 		if (pageView) {
-			const model = await buildModel({ view: pageView, scope: parseScope(url), ...parseWindow(url) });
+			// A page render is a top-level navigation the user can see, and it is
+			// what the product call ("opening the URL by hand just works") is about
+			// — so no token here. A cross-site `<img src="…/stats">` reaches this
+			// route too, though, and only Fetch-Metadata can tell the two apart.
+			const model = await buildModel({
+				view: pageView,
+				scope: parseScope(url),
+				...parseWindow(url),
+				allowModelSpend: !isCrossSiteRequest(req),
+			});
 			if (GATED_PATHS.has(url.pathname) && model.repos.length === 0) {
 				res.writeHead(302, { Location: "/repositories" });
 				res.end();
@@ -783,7 +850,60 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 		if (url.pathname === "/api/model") {
 			const requested = url.searchParams.get("view") ?? "";
 			const view: DashboardView = VIEW_TOKENS.has(requested) ? (requested as DashboardView) : "stats";
-			sendJson(res, 200, await buildModel({ view, scope: parseScope(url), ...parseWindow(url) }));
+			// Deliberately NOT a 403 without the token: this route stays open, as
+			// the module header's layer 3 promises. The token only decides whether
+			// the answer may cost money — see `ModelRequest.allowModelSpend`.
+			sendJson(
+				res,
+				200,
+				await buildModel({
+					view,
+					scope: parseScope(url),
+					...parseWindow(url),
+					allowModelSpend: hasValidToken(req, token) && !isCrossSiteRequest(req),
+				}),
+			);
+			return;
+		}
+
+		// One page of the Memories tree, behind that page's "Load more" button.
+		// Same reasoning as `/api/context` below — the model is inlined into the
+		// page HTML, so only the first page can ride there, and the rest is
+		// fetched when the reader asks for it. A read like every other GET here:
+		// no token, and a cursor naming a memory that no longer exists restarts
+		// from the top rather than erroring.
+		if (url.pathname === "/api/memories") {
+			// Both halves or neither: a hash without the repo it belongs to cannot
+			// identify a row in an all-repos scope, and silently paging from the top
+			// would look like a working "Load more" that repeats the first page.
+			const afterRepo = url.searchParams.get("afterRepo");
+			const afterHash = url.searchParams.get("afterHash");
+			if (!afterRepo !== !afterHash) {
+				sendJson(res, 400, { error: "afterRepo and afterHash must be given together" });
+				return;
+			}
+			const cursor = afterRepo && afterHash ? { repoIdentity: afterRepo, commitHash: afterHash } : undefined;
+			const scope = parseScope(url);
+			try {
+				// Recomputed per page rather than cached with the page's first
+				// render: reachability is what decides which rows exist at all, so
+				// a stale set would page over memories a rebase already removed.
+				const page = await withReadonlyDashboardDb(
+					async (db) => {
+						const reachable = await readReachableCommitsByRepo(
+							db
+								.prepare("SELECT repo_identity, worktree_root FROM repos WHERE disabled_at IS NULL")
+								.all() as ReadonlyArray<{ repo_identity: string; worktree_root: string }>,
+						);
+						return buildMemoriesPage(db, scope, cursor, reachable);
+					},
+					{ ...(options.dbPath ? { dbPath: options.dbPath } : {}) },
+				);
+				sendJson(res, 200, page);
+			} catch (err) {
+				log.warn("memories page read failed: %s", errMsg(err));
+				sendJson(res, 500, { error: "could not read that page of memories" });
+			}
 			return;
 		}
 

--- a/cli/src/dashboard/MemoriesQuery.test.ts
+++ b/cli/src/dashboard/MemoriesQuery.test.ts
@@ -5,8 +5,13 @@ import { deflateSync } from "node:zlib";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { withDashboardDb } from "./DashboardDb.js";
 import type { DashboardScope } from "./DashboardModel.js";
-import { MEMORIES_LIST_LIMIT } from "./DashboardModel.js";
-import { buildMemories, buildMemoriesList, buildMemoryDetail, readContextDoc } from "./MemoriesQuery.js";
+import {
+	buildMemories,
+	buildMemoriesList,
+	buildMemoriesPage,
+	buildMemoryDetail,
+	readContextDoc,
+} from "./MemoriesQuery.js";
 import { applyStatsEvents } from "./StatsWriter.js";
 
 const ALL: DashboardScope = { kind: "all" };
@@ -274,15 +279,42 @@ describe("MemoriesQuery", () => {
 			expect(list.items[1].memoryRefId).toBeUndefined();
 			expect(list.items[1].category).toBeUndefined();
 			expect(list.totalCount).toBe(2);
-			expect(list.truncated).toBe(false);
 			expect(list.vitals).toEqual({ memories: 2, topics: 1, repos: 1 });
 		});
 
-		it("scopes to one repo and truncates past MEMORIES_LIST_LIMIT", async () => {
+		// Two registered repos can share a display NAME — an upstream and its fork,
+		// or two clones of the same project — and their commit hashes then overlap
+		// by construction. `commitCategoryLabels` used to key its map by repo_name,
+		// so in the all-repos scope one repo's category was painted onto the
+		// other's memory. Keyed by repo_identity, each keeps its own.
+		it("keeps category labels apart for two repos that share a display name", async () => {
+			const hash = "d".repeat(40);
+			await seedRepo(dbPath, "repo-upstream", "jolliai");
+			await seedRepo(dbPath, "repo-fork", "jolliai");
+			await seedMemory(dbPath, "repo-upstream", hash, "same hash, upstream", {
+				commitDateMs: 2000,
+				topics: [{ title: "t", category: "feature" }],
+			});
+			await seedMemory(dbPath, "repo-fork", hash, "same hash, fork", {
+				commitDateMs: 1000,
+				topics: [{ title: "t", category: "bugfix" }],
+			});
+
+			const list = await withDashboardDb((db) => buildMemoriesList(db, ALL), { dbPath });
+
+			const byRepo = new Map(list.items.map((i) => [i.repoIdentity, i.category]));
+			expect(byRepo.get("repo-upstream")).toBe("feature");
+			expect(byRepo.get("repo-fork")).toBe("bugfix");
+		});
+
+		// The list used to be capped at 200 rows. It no longer is: a repo with more
+		// history than that must still render every memory, not a "most recent" page.
+		it("scopes to one repo and lists every memory past the old 200-row cap", async () => {
+			const total = 205;
 			await seedRepo(dbPath, "repo-1", "acme-api");
 			await seedRepo(dbPath, "repo-2", "acme-web");
 			await seedMemory(dbPath, "repo-2", "c".repeat(40), "other repo's commit", { commitDateMs: 1 });
-			for (let n = 0; n < MEMORIES_LIST_LIMIT + 5; n++) {
+			for (let n = 0; n < total; n++) {
 				await seedMemory(dbPath, "repo-1", n.toString(16).padStart(40, "0"), `commit ${n}`, {
 					commitDateMs: n + 100,
 				});
@@ -294,9 +326,8 @@ describe("MemoriesQuery", () => {
 					dbPath,
 				},
 			);
-			expect(scoped.items).toHaveLength(MEMORIES_LIST_LIMIT);
-			expect(scoped.truncated).toBe(true);
-			expect(scoped.totalCount).toBe(MEMORIES_LIST_LIMIT + 5);
+			expect(scoped.items).toHaveLength(total);
+			expect(scoped.totalCount).toBe(total);
 			expect(scoped.items.every((i) => i.repoIdentity === "repo-1")).toBe(true);
 		});
 
@@ -326,6 +357,74 @@ describe("MemoriesQuery", () => {
 			const list = await withDashboardDb((db) => buildMemoriesList(db, ALL), { dbPath });
 			expect(list.items.map((item) => item.commitHash)).toEqual([current]);
 			expect(list.totalCount).toBe(1);
+		});
+	});
+
+	describe("buildMemoriesPage", () => {
+		/** Three memories, newest first: c > b > a. */
+		async function seedThree(): Promise<void> {
+			await seedRepo(dbPath, "repo-1", "acme-api");
+			await seedMemory(dbPath, "repo-1", "a".repeat(40), "oldest", { commitDateMs: 1000 });
+			await seedMemory(dbPath, "repo-1", "b".repeat(40), "middle", { commitDateMs: 2000 });
+			await seedMemory(dbPath, "repo-1", "c".repeat(40), "newest", { commitDateMs: 3000 });
+		}
+
+		it("continues after the cursor's memory, and reports the whole reachable total", async () => {
+			await seedThree();
+
+			const page = await withDashboardDb(
+				(db) => buildMemoriesPage(db, ALL, { repoIdentity: "repo-1", commitHash: "c".repeat(40) }),
+				{ dbPath },
+			);
+
+			expect(page.items.map((i) => i.commitHash)).toEqual(["b".repeat(40), "a".repeat(40)]);
+			// The total is the LIST's length, not the page's — it is what the client
+			// compares its loaded count against to decide there is more to ask for.
+			expect(page.totalCount).toBe(3);
+			expect(page.cursorMissing).toBeUndefined();
+		});
+
+		it("starts at the top when no cursor is given", async () => {
+			await seedThree();
+
+			const page = await withDashboardDb((db) => buildMemoriesPage(db, ALL, undefined), { dbPath });
+
+			expect(page.items.map((i) => i.commitHash)).toEqual(["c".repeat(40), "b".repeat(40), "a".repeat(40)]);
+			expect(page.cursorMissing).toBeUndefined();
+		});
+
+		it("flags a cursor whose memory is gone and answers with the first page", async () => {
+			// The rebase case: the reader's last-loaded memory dropped off every
+			// branch mid-session. Answering an empty page would strand the tree;
+			// restarting SILENTLY would return rows the client already holds, which
+			// its dedupe drops — a "Load more" that does nothing however often it is
+			// clicked. The flag is what lets the client re-seat itself.
+			await seedThree();
+
+			const page = await withDashboardDb(
+				(db) => buildMemoriesPage(db, ALL, { repoIdentity: "repo-1", commitHash: "f".repeat(40) }),
+				{ dbPath },
+			);
+
+			expect(page.cursorMissing).toBe(true);
+			expect(page.items.map((i) => i.commitHash)).toEqual(["c".repeat(40), "b".repeat(40), "a".repeat(40)]);
+		});
+
+		it("does not treat an unreachable memory as a valid cursor", async () => {
+			// Same row, two answers: the cursor names a memory that IS in the table
+			// but which git no longer reaches, so it is not in the list being paged
+			// and cannot be a position in it.
+			await seedThree();
+			const reachable = new Map([["repo-1", new Set(["a".repeat(40), "b".repeat(40)])]]);
+
+			const page = await withDashboardDb(
+				(db) => buildMemoriesPage(db, ALL, { repoIdentity: "repo-1", commitHash: "c".repeat(40) }, reachable),
+				{ dbPath },
+			);
+
+			expect(page.cursorMissing).toBe(true);
+			expect(page.items.map((i) => i.commitHash)).toEqual(["b".repeat(40), "a".repeat(40)]);
+			expect(page.totalCount).toBe(2);
 		});
 	});
 
@@ -477,18 +576,19 @@ describe("MemoriesQuery", () => {
 			await seedRepo(dbPath, "repo-1", "acme-api");
 			const hash = "a".repeat(40);
 			await seedMemory(dbPath, "repo-1", hash, "feat: x");
-			// codex cannot record tool calls today — a linked codex session with no
+			// The Cline VS Code extension cannot record tool calls (its tool results
+			// are prose, not structure) — a linked session of its with no
 			// session_tool_use rows must not read as "this memory used no tools".
 			await seedLinkedSession(dbPath, "repo-1", hash, {
-				source: "codex",
+				source: "cline",
 				sessionId: "s1",
-				title: "Codex session",
+				title: "Cline session",
 				messageCount: 5,
 			});
 
 			const detail = await withDashboardDb((db) => buildMemoryDetail(db, ALL, hash), { dbPath });
 			expect(detail?.activity).toEqual([]);
-			expect(detail?.activityUncoveredSources).toEqual(["codex"]);
+			expect(detail?.activityUncoveredSources).toEqual(["cline"]);
 		});
 
 		it("reads per-file diffs from commit_files, and e2e scenarios verbatim", async () => {

--- a/cli/src/dashboard/MemoriesQuery.ts
+++ b/cli/src/dashboard/MemoriesQuery.ts
@@ -42,7 +42,7 @@ import type { DashboardDbHandle } from "./DashboardDb.js";
 import {
 	type ContextDoc,
 	type DashboardScope,
-	MEMORIES_LIST_LIMIT,
+	MEMORIES_PAGE_SIZE,
 	type MemoriesModel,
 	type MemoryActivityRow,
 	type MemoryContextRow,
@@ -97,18 +97,29 @@ export function isReachable(reachable: ReachableCommits | undefined, repoIdentit
 	return set == null || set.has(hash);
 }
 
-/** The tree's list of rows and the sidebar's vitals — no per-memory detail. */
-export function buildMemoriesList(
+/**
+ * The reachable root memories for a scope, newest first — the whole set, before
+ * any page is cut from it.
+ *
+ * No SQL LIMIT and no SQL OFFSET, both for the same reason: reachability can
+ * only be checked in JS (git, not the DB), so a row the filter drops would make
+ * a database-level window skip a different memory on every page. The set is
+ * small (one row per root memory), and the cost this page cares about is bytes
+ * on the wire, not rows read.
+ *
+ * `commit_hash` is the second sort key, and it is load-bearing rather than
+ * cosmetic: two memories can share a `commit_date_ms` to the millisecond (a
+ * squash, a scripted series of commits), and the page cursor is a position in
+ * THIS order. Ordering by the date alone leaves those rows in whatever order
+ * SQLite happens to produce, so the same cursor could land on either side of the
+ * pair between two requests — dropping one memory or repeating it.
+ */
+function reachableMemoryRows(
 	db: DashboardDbHandle,
-	scope: DashboardScope,
+	resolved: ReturnType<typeof scopeToRepoId>,
 	reachable?: ReachableCommits,
-): Omit<MemoriesModel, "selected"> {
-	const resolved = scopeToRepoId(db, scope);
+): ReadonlyArray<MemoryListRow> {
 	const listFilter = scopeFilter(resolved, "m.repo_id");
-	// No SQL LIMIT: reachability can only be checked in JS (git, not the DB),
-	// so the full root-memory set for this scope is fetched, filtered, then
-	// paged — `memories` only grows with real commits, so this scales with a
-	// single repo's history, not with the git-cost of the check itself.
 	const allRows = db
 		.prepare(
 			`SELECT m.commit_hash, m.branch, m.commit_message, m.commit_date_ms, m.ticket_id, m.jolli_doc_id,
@@ -117,32 +128,82 @@ export function buildMemoriesList(
 			   JOIN repos r ON r.id = m.repo_id
 			  WHERE m.parent_hash IS NULL
 				${listFilter.sql}
-			  ORDER BY m.commit_date_ms DESC`,
+			  ORDER BY m.commit_date_ms DESC, m.commit_hash DESC`,
 		)
 		.all(...listFilter.params) as ReadonlyArray<MemoryListRow>;
-	const rows = allRows.filter((row) => isReachable(reachable, row.repo_identity, row.commit_hash));
+	return allRows.filter((row) => isReachable(reachable, row.repo_identity, row.commit_hash));
+}
 
-	const truncated = rows.length > MEMORIES_LIST_LIMIT;
-	const page = truncated ? rows.slice(0, MEMORIES_LIST_LIMIT) : rows;
-	const categoryLabels = commitCategoryLabels(db, scope);
+/**
+ * One page of tree rows — what `/api/memories` answers, and what the inlined
+ * model's first page is cut with.
+ *
+ * Paged rather than capped: the tree's search box filters this array in the
+ * browser, so a hard cap would quietly turn "search my memories" into "search
+ * my recent memories". But the model is inlined into a `<script>` block on
+ * every render, so the whole set cannot ride there either — an all-repos scope
+ * is the sum of every enabled repo's entire history. The HTML carries the first
+ * {@link MEMORIES_PAGE_SIZE} rows and the tree's "Load more" button pulls each
+ * further page from this same function over HTTP.
+ *
+ * `totalCount` is the reachable total, so `items.length < totalCount` is the
+ * client's "there is another page" test — no separate truncation flag to keep
+ * in step with it.
+ *
+ * **Keyed on the last row the client holds, never on an offset.** The set this
+ * pages over is filtered by git reachability at request time, so it SHRINKS
+ * under a rebase mid-browse: with an offset, every row after the vanished one
+ * moves up a slot, and the one that lands on the boundary falls inside the
+ * already-loaded range and is never shown again. A gap is the failure mode that
+ * matters here, because the client can dedupe a repeat but cannot notice
+ * something it was never sent. A cursor has no such window — it says "continue
+ * after this exact memory" and stays correct however the rows around it move.
+ */
+export function buildMemoriesPage(
+	db: DashboardDbHandle,
+	scope: DashboardScope,
+	cursor: MemoriesPageCursor | undefined,
+	reachable?: ReachableCommits,
+): {
+	readonly items: ReadonlyArray<MemoryListItem>;
+	readonly totalCount: number;
+	readonly cursorMissing?: true;
+} {
+	const resolved = scopeToRepoId(db, scope);
+	const rows = reachableMemoryRows(db, resolved, reachable);
+	const at = cursor
+		? rows.findIndex((row) => row.repo_identity === cursor.repoIdentity && row.commit_hash === cursor.commitHash)
+		: -1;
+	// A cursor whose memory is gone (rebased away while the reader browsed) gets
+	// the FIRST page plus a flag — not an empty page, and not a silent restart.
+	// Empty would strand the tree at what it had loaded; a silent restart would
+	// return rows the client already holds, which its dedupe drops, leaving a
+	// "Load more" button that visibly does nothing however often it is clicked.
+	// The flag is what lets the client re-seat itself on a list it can page.
+	const cursorMissing = cursor !== undefined && at < 0;
+	const start = cursorMissing ? 0 : at + 1;
+	return {
+		items: toListItems(db, scope, rows.slice(start, start + MEMORIES_PAGE_SIZE)),
+		totalCount: rows.length,
+		...(cursorMissing ? { cursorMissing: true as const } : {}),
+	};
+}
 
-	const items: MemoryListItem[] = page.map((row) => {
-		const category = categoryLabels.get(`${row.repo_name}\0${row.commit_hash}`);
-		const memoryRefId = formatMemoryRefId(row.jolli_doc_id == null ? undefined : Number(row.jolli_doc_id));
-		return {
-			repoIdentity: row.repo_identity,
-			repoName: row.repo_name,
-			commitHash: row.commit_hash,
-			shortHash: row.commit_hash.slice(0, 7),
-			...(memoryRefId ? { memoryRefId } : {}),
-			title: row.commit_message ?? "",
-			...(row.branch ? { branch: row.branch } : {}),
-			committedAtMs: row.commit_date_ms,
-			...(row.ticket_id ? { ticketId: row.ticket_id } : {}),
-			...(category ? { category } : {}),
-			synced: row.jolli_doc_id != null,
-		};
-	});
+/** Position in the list: the last row the client already holds. */
+export interface MemoriesPageCursor {
+	readonly repoIdentity: string;
+	readonly commitHash: string;
+}
+
+/** The tree's first page and the sidebar's vitals — no per-memory detail. */
+export function buildMemoriesList(
+	db: DashboardDbHandle,
+	scope: DashboardScope,
+	reachable?: ReachableCommits,
+): Omit<MemoriesModel, "selected"> {
+	const resolved = scopeToRepoId(db, scope);
+	const rows = reachableMemoryRows(db, resolved, reachable);
+	const items = toListItems(db, scope, rows.slice(0, MEMORIES_PAGE_SIZE));
 
 	const plainFilter = scopeFilter(resolved);
 	const memoriesTotal = rows.length;
@@ -162,9 +223,34 @@ export function buildMemoriesList(
 	return {
 		items,
 		totalCount: memoriesTotal,
-		truncated,
 		vitals: { memories: memoriesTotal, topics: topicsTotal, repos: reposTotal },
 	};
+}
+
+/** Row → tree item. Shared by the inlined first page and every `/api/memories` page. */
+function toListItems(
+	db: DashboardDbHandle,
+	scope: DashboardScope,
+	rows: ReadonlyArray<MemoryListRow>,
+): ReadonlyArray<MemoryListItem> {
+	const categoryLabels = commitCategoryLabels(db, scope);
+	return rows.map((row) => {
+		const category = categoryLabels.get(`${row.repo_identity}\0${row.commit_hash}`);
+		const memoryRefId = formatMemoryRefId(row.jolli_doc_id == null ? undefined : Number(row.jolli_doc_id));
+		return {
+			repoIdentity: row.repo_identity,
+			repoName: row.repo_name,
+			commitHash: row.commit_hash,
+			shortHash: row.commit_hash.slice(0, 7),
+			...(memoryRefId ? { memoryRefId } : {}),
+			title: row.commit_message ?? "",
+			...(row.branch ? { branch: row.branch } : {}),
+			committedAtMs: row.commit_date_ms,
+			...(row.ticket_id ? { ticketId: row.ticket_id } : {}),
+			...(category ? { category } : {}),
+			synced: row.jolli_doc_id != null,
+		};
+	});
 }
 
 interface MemoryDetailRow {
@@ -381,7 +467,7 @@ export function buildMemoryDetail(
 	const summary = (assembleMemoryTree(db, row.repo_id, hash) ?? JSON.parse(row.summary_json)) as CommitSummary;
 
 	const categoryLabels = commitCategoryLabels(db, scope);
-	const category = categoryLabels.get(`${row.repo_name}\0${row.commit_hash}`);
+	const category = categoryLabels.get(`${row.repo_identity}\0${row.commit_hash}`);
 
 	const filesRows = db
 		.prepare(

--- a/cli/src/dashboard/Recovery.ts
+++ b/cli/src/dashboard/Recovery.ts
@@ -19,6 +19,7 @@
  * - Same-directory temp + rename, exactly like snapshot creation.
  */
 
+import { randomUUID } from "node:crypto";
 import { copyFileSync, existsSync, readdirSync, readFileSync, renameSync, rmSync, statSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { peekKBPath } from "../core/KBPathResolver.js";
@@ -275,9 +276,35 @@ export async function restoreFromSnapshot(
 		// the one path that has to work is the one that cannot. Same helper as
 		// `openDb`, so the restored file lands under an owner-only directory.
 		ensureOwnerOnlyDir(dbPath);
-		const temp = join(dirname(dbPath), `.${basename(dbPath)}.restore-tmp`);
-		rmSync(temp, { force: true });
-		copyFileSync(snapshotPath, temp);
+		// PID + nonce, never a shared fixed name. Two overlapping recoveries (two
+		// terminals, or a script re-invoking after a perceived hang) on one temp
+		// path interleave as: A removes it, A starts copying, B removes it and
+		// starts its own copy, A renames a partially-copied file over the LIVE
+		// database — with the sidecars already gone and nothing left to restore
+		// from. `Backup.ts` carries the same suffix after being bitten by exactly
+		// this; here the blast radius is a corrupt database rather than a missed
+		// snapshot.
+		const temp = join(
+			dirname(dbPath),
+			`.${basename(dbPath)}.restore-${process.pid}-${randomUUID().slice(0, 8)}.tmp`,
+		);
+		try {
+			copyFileSync(snapshotPath, temp);
+			// Verify the COPY, not just the source: the check above proves the
+			// snapshot was sound, not that it arrived intact (a short write on a full
+			// disk does not throw here). Installing an unverified file is the one
+			// failure this function cannot walk back from.
+			if (!(await verifySnapshotFile(temp))) {
+				rmSync(temp, { force: true });
+				return {
+					status: "failed",
+					reason: "restored copy failed integrity_check — the database was left untouched",
+				};
+			}
+		} catch (err) {
+			rmSync(temp, { force: true });
+			throw err;
+		}
 		// The dead database's WAL must not be replayed over the restored file —
 		// and the sidecars have to go BEFORE the rename: a concurrent opener in
 		// the gap would otherwise pair the fresh file with the dead WAL. Removing

--- a/cli/src/dashboard/RepoRegistry.test.ts
+++ b/cli/src/dashboard/RepoRegistry.test.ts
@@ -279,3 +279,21 @@ describe("instance id stamp", () => {
 		expect(await readRegistryInstanceId(configDir)).toBe("id-1");
 	});
 });
+
+describe("a registry the writers could not read", () => {
+	it("refuses the write instead of read-modify-writing over an empty one", async () => {
+		await registerRepo({ cwd: "/home/dev/jolli", configDir, now: () => new Date(0) });
+		await stampRegistryInstanceId("id-1", configDir);
+		// A torn write leaves unparsable JSON. Reads still fail open (nothing is
+		// lost by showing no repos); a WRITER must not, or it cements the loss.
+		writeFileSync(getRepoRegistryPath(configDir), "{ truncated");
+		vi.mocked(getProjectRootDir).mockResolvedValue("/home/dev/other");
+		await expect(registerRepo({ cwd: "/home/dev/other", configDir })).rejects.toThrow();
+		await expect(stampRegistryInstanceId("id-2", configDir)).rejects.toThrow();
+		await expect(deregisterRepo({ cwd: "/home/dev/other", configDir })).rejects.toThrow();
+		await expect(ensureWorktreeListed({ cwd: "/home/dev/other", configDir })).rejects.toThrow();
+		// The damaged file is still there to be repaired, not overwritten.
+		expect(readFileSync(getRepoRegistryPath(configDir), "utf-8")).toBe("{ truncated");
+		expect((await readRepoRegistry(configDir)).repos).toEqual([]);
+	});
+});

--- a/cli/src/dashboard/RepoRegistry.ts
+++ b/cli/src/dashboard/RepoRegistry.ts
@@ -22,8 +22,9 @@
 
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { writeFileAtomic } from "../core/AtomicJsonFile.js";
 import { getProjectRootDir } from "../core/GitOps.js";
 import { deriveRepoNameFromUrl, getCanonicalRepoUrl } from "../core/GitRemoteUtils.js";
 import { withRepoRegistryLock } from "../core/Locks.js";
@@ -153,39 +154,65 @@ export function getRepoRegistryPath(configDir: string = getGlobalConfigDir()): s
  * down every read path with it.
  */
 export async function readRepoRegistry(configDir?: string): Promise<RepoRegistryFile> {
-	const path = getRepoRegistryPath(configDir);
 	try {
-		const raw = JSON.parse(await readFile(path, "utf-8")) as RepoRegistryFile;
-		if (!Array.isArray(raw?.repos)) {
-			log.warn("repo registry at %s has no repos array — treating as empty", path);
-			return EMPTY;
-		}
-		return {
-			version: 1,
-			repos: raw.repos,
-			// Preserve the identity stamp: every registry rewrite goes through a
-			// read-modify-write, and dropping it here would erase the deletion
-			// detector's witness on the next repo registration.
-			...(typeof raw.instanceId === "string" && { instanceId: raw.instanceId }),
-		};
+		return await readRepoRegistryStrict(configDir);
 	} catch (err) {
-		if (!isEnoent(err)) log.warn("repo registry unreadable (%s) — treating as empty", errMsg(err));
+		log.warn("repo registry unreadable (%s) — treating as empty", errMsg(err));
 		return EMPTY;
 	}
 }
 
+/**
+ * The same read, but it THROWS on a registry it could not read.
+ *
+ * Every writer below is a read-modify-write over the returned value, so a read
+ * that fails open is not a graceful degradation there — it is a delete. One
+ * transient EACCES / EMFILE / Windows AV hold, or a single truncated file, and
+ * the next `registerRepo` writes back a registry containing only the repo it
+ * happens to be handling, dropping every other repo AND `instanceId`. The
+ * damage is silent and lands where it hurts most: `readRegistryInstanceId`
+ * returns null, so `classifyIdentity` calls a genuinely deleted database a
+ * `fresh-install` and suppresses the alarm, while `doctor --recover` iterates
+ * none of the lost repos. Failing the one operation is strictly better.
+ *
+ * "Absent" is NOT a failure: a registry that does not exist yet is genuinely
+ * empty, and that is the case the fail-open contract was written for.
+ */
+export async function readRepoRegistryStrict(configDir?: string): Promise<RepoRegistryFile> {
+	const path = getRepoRegistryPath(configDir);
+	let text: string;
+	try {
+		text = await readFile(path, "utf-8");
+	} catch (err) {
+		if (isEnoent(err)) return EMPTY;
+		throw err;
+	}
+	const raw = JSON.parse(text) as RepoRegistryFile;
+	if (!Array.isArray(raw?.repos)) throw new Error(`repo registry at ${path} has no repos array`);
+	return {
+		version: 1,
+		repos: raw.repos,
+		// Preserve the identity stamp: every registry rewrite goes through a
+		// read-modify-write, and dropping it here would erase the deletion
+		// detector's witness on the next repo registration.
+		...(typeof raw.instanceId === "string" && { instanceId: raw.instanceId }),
+	};
+}
+
 /** Writes the registry with user-only permissions (it lists local paths). */
 async function writeRepoRegistry(file: RepoRegistryFile, configDir?: string): Promise<void> {
-	const path = getRepoRegistryPath(configDir);
-	await mkdir(join(path, ".."), { recursive: true });
-	await writeFile(path, `${JSON.stringify(file, null, 2)}\n`, { encoding: "utf-8", mode: 0o600 });
+	// Atomic: a torn write reads back as corrupt JSON, and the very next writer
+	// would cement that loss through its read-modify-write (see
+	// `readRepoRegistryStrict`). This file outranks `profile.json`, which has
+	// used temp+rename for the same reason since it shipped.
+	await writeFileAtomic(getRepoRegistryPath(configDir), `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
 }
 
 /** Records the database's instance id; no-op when already current. */
 export async function stampRegistryInstanceId(id: string, configDir?: string): Promise<void> {
 	await withRepoRegistryLock(
 		async () => {
-			const registry = await readRepoRegistry(configDir);
+			const registry = await readRepoRegistryStrict(configDir);
 			if (registry.instanceId === id) return;
 			await writeRepoRegistry({ ...registry, instanceId: id }, configDir);
 		},
@@ -284,7 +311,7 @@ export async function registerRepo(opts: RegisterRepoOptions): Promise<Registere
 		async () => {
 			// Re-read INSIDE the lock: a concurrent registrar's write between our
 			// git resolution above and here must not be lost-updated by ours.
-			const registry = await readRepoRegistry(opts.configDir);
+			const registry = await readRepoRegistryStrict(opts.configDir);
 			const existing = registry.repos.find((r) => r.repoIdentity === identity);
 			// Union rather than replace: two clones of one remote share an identity, and
 			// overwriting would leave the other clone's commits uncollected with nothing to
@@ -324,7 +351,7 @@ export async function ensureWorktreeListed(opts: RegisterRepoOptions): Promise<R
 	const { identity } = await resolveRepoIdentity(worktreeRoot);
 	return withRepoRegistryLock(
 		async () => {
-			const registry = await readRepoRegistry(opts.configDir);
+			const registry = await readRepoRegistryStrict(opts.configDir);
 			const existing = registry.repos.find((r) => r.repoIdentity === identity);
 			// No entry to extend: the identity-unknown case belongs to registerRepo,
 			// which builds the full row. Racing a concurrent deregister here is fine —
@@ -356,7 +383,7 @@ export async function deregisterRepo(opts: RegisterRepoOptions): Promise<string 
 	const now = (opts.now ?? (() => new Date()))().toISOString();
 	return withRepoRegistryLock(
 		async () => {
-			const registry = await readRepoRegistry(opts.configDir);
+			const registry = await readRepoRegistryStrict(opts.configDir);
 			const existing = registry.repos.find((r) => r.repoIdentity === identity);
 			if (!existing) return null;
 			const repos = registry.repos.map((r) => (r.repoIdentity === identity ? { ...r, disabledAt: now } : r));

--- a/cli/src/dashboard/RepositoriesQuery.test.ts
+++ b/cli/src/dashboard/RepositoriesQuery.test.ts
@@ -127,6 +127,60 @@ describe("buildRepositoriesModel", () => {
 		expect(model.repos[0].sessions).toBeGreaterThanOrEqual(1);
 	});
 
+	// The badge and the Memories tree must answer the same question. The tree
+	// drops roots no local branch can still reach; without the same filter here
+	// the badge read high for every repo whose history had been rebased away.
+	it("drops roots no local branch can still reach, and fails open without a set", async () => {
+		writeRegistry(configDir, {
+			version: 1,
+			repos: [{ repoIdentity: "repo-1", repoName: "jolli", worktreeRoot: "/w", enabledAt: "t" }],
+		});
+		await applyStatsEvents(
+			[
+				{
+					producerKind: "cli",
+					event: {
+						type: "repo.enabled",
+						repoIdentity: "repo-1",
+						repoName: "jolli",
+						worktreeRoot: "/w",
+						enabledAt: "t",
+					},
+				},
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		const live = "a".repeat(40);
+		const rewrittenAway = "c".repeat(40);
+		await withDashboardDb(
+			(db) => {
+				const { id } = db.prepare("SELECT id FROM repos WHERE repo_identity = 'repo-1'").get() as {
+					id: number;
+				};
+				const insert = db.prepare(
+					`INSERT INTO memories (repo_id, commit_hash, parent_hash, child_pos, root_hash, depth, summary_json, first_seen_ms, written_at_ms, commit_date_ms)
+					 VALUES (?, ?, NULL, NULL, ?, 0, '{}', 1, 1, 1)`,
+				);
+				insert.run(id, live, live);
+				insert.run(id, rewrittenAway, rewrittenAway);
+			},
+			{ dbPath },
+		);
+
+		const filtered = await withDashboardDb(
+			(db) => buildRepositoriesModel(db, configDir, new Map([["repo-1", new Set([live])]])),
+			{ dbPath },
+		);
+		expect(filtered.repos[0].memories).toBe(1);
+
+		// No set computed for the repo (git failed, or a view that does not pay
+		// for `git rev-list`): count everything rather than hide real memories.
+		const failOpen = await withDashboardDb((db) => buildRepositoriesModel(db, configDir, new Map()), { dbPath });
+		expect(failOpen.repos[0].memories).toBe(2);
+		const noArg = await withDashboardDb((db) => buildRepositoriesModel(db, configDir), { dbPath });
+		expect(noArg.repos[0].memories).toBe(2);
+	});
+
 	// The model carries repos and the manifest, nothing else: there is no job
 	// field to rejoin because this server starts no long-running work.
 	it("returns only repos and the hooks manifest", async () => {

--- a/cli/src/dashboard/RepositoriesQuery.ts
+++ b/cli/src/dashboard/RepositoriesQuery.ts
@@ -12,6 +12,7 @@
 
 import type { DashboardDbHandle } from "./DashboardDb.js";
 import type { RepositoriesModel, RepositoryRow } from "./DashboardModel.js";
+import { isReachable, type ReachableCommits } from "./MemoriesQuery.js";
 import { type RegisteredRepo, readRepoRegistry } from "./RepoRegistry.js";
 
 /** The setup card's "what gets installed" manifest — shared by Repositories and Settings → Hooks. */
@@ -22,38 +23,66 @@ export const HOOKS_MANIFEST: ReadonlyArray<{ readonly title: string; readonly de
 	{ title: "Memory branch", detail: "an orphan branch in this repo, so memories travel with it" },
 ];
 
-interface CountsRow {
+interface SessionCountsRow {
 	readonly repo_identity: string;
-	readonly memories: number;
 	readonly sessions: number;
 }
 
-function readCounts(db: DashboardDbHandle): Map<string, { memories: number; sessions: number }> {
-	const rows = db
+interface RootMemoryRow {
+	readonly repo_identity: string;
+	readonly commit_hash: string;
+}
+
+function readCounts(
+	db: DashboardDbHandle,
+	reachable: ReachableCommits | undefined,
+): Map<string, { memories: number; sessions: number }> {
+	const counts = new Map<string, { memories: number; sessions: number }>();
+	const sessionRows = db
 		.prepare(
-			// Both counted live off the detail tables, over their repo_id indexes.
-			// `sessions` used to read a stored aggregate that the projection path
-			// maintained for this one query; counting it here the same way memories
-			// were already counted removed that whole write path, and with it the
-			// window where a prune left the aggregate describing rows it had just
-			// deleted. This page lists a handful of repos — two indexed COUNTs.
-			//
-			// `parent_hash IS NULL` counts MEMORIES, not memory ROWS: `memories` is
-			// a tree (amend/squash/rebase file the follow-up under the original as a
-			// child — see SotSchema's root_hash/depth), so a plain COUNT(*) inflated
-			// every repo by its rewrite history and disagreed with the Memories
-			// browser, which lists roots only (`buildMemoriesList`). Keep the two
-			// predicates in step. The browser additionally drops roots no local
-			// branch can still reach, which needs a `git rev-list` per repo and so
-			// is not reproduced here — this count can therefore still read high for
-			// a repo whose history was rewritten away.
+			// Counted live off the detail table, over its repo_id index. `sessions`
+			// used to read a stored aggregate that the projection path maintained
+			// for this one query; counting it here removed that whole write path,
+			// and with it the window where a prune left the aggregate describing
+			// rows it had just deleted. This page lists a handful of repos.
 			`SELECT r.repo_identity,
-			        (SELECT COUNT(*) FROM memories m WHERE m.repo_id = r.id AND m.parent_hash IS NULL) AS memories,
 			        (SELECT COUNT(*) FROM sessions s WHERE s.repo_id = r.id) AS sessions
 			   FROM repos r`,
 		)
-		.all() as ReadonlyArray<CountsRow>;
-	return new Map(rows.map((row) => [row.repo_identity, { memories: row.memories, sessions: row.sessions }]));
+		.all() as ReadonlyArray<SessionCountsRow>;
+	for (const row of sessionRows) counts.set(row.repo_identity, { memories: 0, sessions: row.sessions });
+
+	// Memories are counted by the SAME two rules the Memories browser applies —
+	// keep the pair in step, or the badge and the tree report different totals
+	// for one repo (they did: the badge read ~2.5x high on a machine whose
+	// branches had been rebased away).
+	//
+	// (1) `parent_hash IS NULL` counts MEMORIES, not memory ROWS: `memories` is
+	// a tree (amend/squash/rebase file the follow-up under the original as a
+	// child — see SotSchema's root_hash/depth), so a plain COUNT(*) inflates
+	// every repo by its rewrite history.
+	//
+	// (2) git reachability drops roots no local branch can still reach. That
+	// cannot be expressed in SQL, so — exactly like `buildMemoriesList` — the
+	// hashes are fetched and filtered here rather than COUNTed. The row set is
+	// one machine's root memories, not the whole `memories` tree. `reachable`
+	// is undefined for callers that did not pay for the `git rev-list` (and
+	// `isReachable` fails open per repo), which restores the old raw count.
+	const rootRows = db
+		.prepare(
+			`SELECT r.repo_identity, m.commit_hash
+			   FROM memories m
+			   JOIN repos r ON r.id = m.repo_id
+			  WHERE m.parent_hash IS NULL`,
+		)
+		.all() as ReadonlyArray<RootMemoryRow>;
+	for (const row of rootRows) {
+		if (!isReachable(reachable, row.repo_identity, row.commit_hash)) continue;
+		const entry = counts.get(row.repo_identity);
+		if (entry) entry.memories += 1;
+		else counts.set(row.repo_identity, { memories: 1, sessions: 0 });
+	}
+	return counts;
 }
 
 function toRow(repo: RegisteredRepo, counts: Map<string, { memories: number; sessions: number }>): RepositoryRow {
@@ -69,9 +98,13 @@ function toRow(repo: RegisteredRepo, counts: Map<string, { memories: number; ses
 	};
 }
 
-export async function buildRepositoriesModel(db: DashboardDbHandle, configDir?: string): Promise<RepositoriesModel> {
+export async function buildRepositoriesModel(
+	db: DashboardDbHandle,
+	configDir?: string,
+	reachable?: ReachableCommits,
+): Promise<RepositoriesModel> {
 	const registry = await readRepoRegistry(configDir);
-	const counts = readCounts(db);
+	const counts = readCounts(db, reachable);
 	return {
 		repos: registry.repos.map((repo) => toRow(repo, counts)),
 		hooksManifest: HOOKS_MANIFEST,

--- a/cli/src/dashboard/SotImport.test.ts
+++ b/cli/src/dashboard/SotImport.test.ts
@@ -900,6 +900,24 @@ describe("importRepoMemory — prune (set reconciliation)", () => {
 		).toBe(0);
 	});
 
+	it("skips the processed-sources prune when the file is unparsable, not deleting the mark", async () => {
+		const files = fixture();
+		await runImport(files);
+		const before = await withDashboardDb(
+			(db) => (db.prepare("SELECT COUNT(*) AS n FROM topic_processed_sources").get() as { n: number }).n,
+			{ dbPath },
+		);
+		expect(before).toBeGreaterThan(0);
+		// A truncated file must not read as "nothing is processed" — that would
+		// wipe the topic KB's high-water mark and make every ingested source look
+		// unprocessed again, silently.
+		const damaged = fixture();
+		damaged.set("topics/processed.json", "{ truncated");
+		const { result, query } = await runImport(damaged, 2_000);
+		expect((await query<{ n: number }>("SELECT COUNT(*) AS n FROM topic_processed_sources"))[0].n).toBe(before);
+		expect(result.skipped).toBeGreaterThan(0);
+	});
+
 	it("converges — a further run over the same shrunken branch prunes nothing", async () => {
 		const files = fixture();
 		await runImport(files);

--- a/cli/src/dashboard/SotImport.ts
+++ b/cli/src/dashboard/SotImport.ts
@@ -31,7 +31,7 @@
 import { deflateSync } from "node:zlib";
 
 import { GitRefStorage, resolveCommittish } from "../core/GitRefStorage.js";
-import { readProcessedSet } from "../core/ProcessedSourceStore.js";
+import { readProcessedSetOrNull } from "../core/ProcessedSourceStore.js";
 import { readCutoverFence } from "../core/RepoProfile.js";
 import { readReferenceMarkdownFromString } from "../core/references/ReferenceStore.js";
 import type { StorageProvider } from "../core/StorageProvider.js";
@@ -708,6 +708,22 @@ export function remountRepo(db: DashboardDbHandle, repoId: number): void {
  * writes the `repo_state key='orphan-import'` marker on completion.
  */
 export async function importRepoMemory(db: DashboardDbHandle, opts: SotImportOptions): Promise<SotImportResult> {
+	// Seed and protect are mutually exclusive by MEANING, and the check belongs
+	// here rather than as a guard inside `writeMemorySeed`. Protect exists for a
+	// FROZEN source: rows the database stamped after the freeze outrank anything
+	// the import can read back. A seed reconciles against the source as the whole
+	// truth — pruning rows it does not list — so a seed that is also protecting
+	// rows is asking for two contradictory things. Today's callers derive
+	// `seedLegal` from the same fence witnesses that leave `protectNewerThanMs`
+	// unset, but nothing in the option type says so, and the failure would be
+	// silent: `writeMemorySeed` overwrites unconditionally, rolling a post-fence
+	// regenerated summary back to its pre-fence body with a frozen branch as the
+	// only place to recover it from.
+	if (opts.mode === "seed" && opts.protectNewerThanMs !== undefined) {
+		throw new Error(
+			"importRepoMemory: seed mode implies an unfrozen source — protectNewerThanMs is not applicable",
+		);
+	}
 	try {
 		return await runRepoImport(db, opts);
 	} catch (err) {
@@ -1725,8 +1741,14 @@ async function runRepoImport(db: DashboardDbHandle, opts: SotImportOptions): Pro
 		topics++;
 	});
 
-	const processed = await readProcessedSet(cwd, storage);
-	const processedRows = Object.entries(processed.processed).flatMap(([type, ids]) =>
+	// `null` = the file is there and unparsable. It must NOT reconcile as an
+	// empty live-set: seed mode would then delete every `topic_processed_sources`
+	// row for the repo, losing the topic KB's high-water mark silently (one
+	// log line, `skipped` unaffected) and making every ingested source look
+	// unprocessed again. Same treatment the alias index gets a few families up.
+	const processed = await readProcessedSetOrNull(cwd, storage);
+	if (processed === null) skip("processed sources", `topics/processed.json is unparsable — prune skipped`);
+	const processedRows = Object.entries(processed?.processed ?? {}).flatMap(([type, ids]) =>
 		ids.map((id) => [type, id] as const),
 	);
 	inChunkedTransactions(db, processedRows, ([type, id]) => {
@@ -1796,13 +1818,15 @@ async function runRepoImport(db: DashboardDbHandle, opts: SotImportOptions): Pro
 		pruned += pruneTable(db, "context", ["kind", "context_key"], repoId, liveDocs);
 		pruned += pruneTable(db, "plan_progress", ["plan_slug"], repoId, liveProgress);
 		pruned += pruneTable(db, "topic_pages", ["stable_slug"], repoId, new Set(slugs));
-		pruned += pruneTable(
-			db,
-			"topic_processed_sources",
-			["source_type", "source_id"],
-			repoId,
-			new Set(processedRows.map(([type, id]) => keyOf(type, id))),
-		);
+		if (processed !== null) {
+			pruned += pruneTable(
+				db,
+				"topic_processed_sources",
+				["source_type", "source_id"],
+				repoId,
+				new Set(processedRows.map(([type, id]) => keyOf(type, id))),
+			);
+		}
 	}
 
 	// ── completion marker ──────────────────────────────────────────────────

--- a/cli/src/dashboard/SotSchema.ts
+++ b/cli/src/dashboard/SotSchema.ts
@@ -428,6 +428,28 @@ INSERT INTO context_kinds (kind) VALUES ('skill');
 `;
 
 /**
+ * Records WHY a `failed` event was parked, so the one recoverable reason can be
+ * un-parked later.
+ *
+ * `projectEvent`'s `default:` throw exists as the runtime backstop for an older
+ * build draining a NEWER producer's event — `schema_version` gates payload
+ * changes and cannot gate a new event TYPE. The comment there promises the row
+ * "survives for a build that understands it", but the claim query selects
+ * `pending` only and nothing ever reset `failed`, so upgrading did not recover
+ * it: the event was lost permanently, which is the exact outcome the two-phase
+ * WAL was built to prevent. A genuine defect must NOT be revived the same way
+ * (it would burn the attempt budget on every drain forever), hence a reason
+ * rather than a bare flag.
+ *
+ * Additive column with no default backfill: rows parked by an older build read
+ * back NULL, which is treated as "unknown reason — leave parked", the same
+ * conservative answer they get today.
+ */
+export const EVENT_FAILED_KIND_DDL = `
+ALTER TABLE events_raw ADD COLUMN failed_kind TEXT;
+`;
+
+/**
  * The memory tables, `context`, plan progress and the topic KB.
  *
  * Applied as one statement batch inside the caller's transaction. Ordering

--- a/cli/src/dashboard/SotWrite.test.ts
+++ b/cli/src/dashboard/SotWrite.test.ts
@@ -180,6 +180,96 @@ describe("summary trees", () => {
 		]);
 	});
 
+	it("reorders siblings when the batch lists a child's own file before the parent's", async () => {
+		// The child file re-anchors itself from its stored mount point, which at
+		// that moment is parked in the offset region. Leaving it parked is what
+		// keeps the parent's walk from colliding with it — see landSummaries.
+		await storage.writeFiles(
+			[
+				file(
+					`summaries/${H("a")}.json`,
+					summary(H("a"), { children: [summary(H("b")), summary(H("c")), summary(H("d"))] }),
+				),
+			],
+			"m",
+		);
+		await storage.writeFiles(
+			[
+				file(`summaries/${H("c")}.json`, summary(H("c"))),
+				file(
+					`summaries/${H("a")}.json`,
+					summary(H("a"), { children: [summary(H("d")), summary(H("b")), summary(H("c"))] }),
+				),
+			],
+			"m",
+		);
+		const kids = await rows<{ commit_hash: string; child_pos: number }>(
+			"SELECT commit_hash, child_pos FROM memories WHERE parent_hash = ? ORDER BY child_pos",
+			H("a"),
+		);
+		expect(kids).toEqual([
+			{ commit_hash: H("d"), child_pos: 0 },
+			{ commit_hash: H("b"), child_pos: 1 },
+			{ commit_hash: H("c"), child_pos: 2 },
+		]);
+		expect(await rows("SELECT COUNT(*) AS n FROM memories WHERE child_pos >= 1000000")).toEqual([{ n: 0 }]);
+	});
+
+	it("re-grounds a re-anchoring top node whose ground position the new set took", async () => {
+		await storage.writeFiles(
+			[file(`summaries/${H("a")}.json`, summary(H("a"), { children: [summary(H("b")), summary(H("c"))] }))],
+			"m",
+		);
+		// b's own file rides in the same batch that drops b from a's children and
+		// moves c onto b's old position 0.
+		await storage.writeFiles(
+			[
+				file(`summaries/${H("b")}.json`, summary(H("b"))),
+				file(`summaries/${H("a")}.json`, summary(H("a"), { children: [summary(H("c"))] })),
+			],
+			"m",
+		);
+		expect(await rows("SELECT parent_hash, child_pos FROM memories WHERE commit_hash = ?", H("b"))).toEqual([
+			{ parent_hash: null, child_pos: null },
+		]);
+		expect(await rows("SELECT child_pos FROM memories WHERE commit_hash = ?", H("c"))).toEqual([{ child_pos: 0 }]);
+		expect(await rows("SELECT COUNT(*) AS n FROM memories WHERE child_pos >= 1000000")).toEqual([{ n: 0 }]);
+	});
+
+	it("re-grounds a re-anchoring top node the new set dropped, free ground slot or not", async () => {
+		// Same shape as above except b sat LAST, so nothing in the new set takes
+		// its position 2. A free slot is not a reason to keep the edge: `a.json`
+		// no longer lists b, and a seed import of these same files makes b a root.
+		await storage.writeFiles(
+			[
+				file(
+					`summaries/${H("a")}.json`,
+					summary(H("a"), { children: [summary(H("c")), summary(H("d")), summary(H("b"))] }),
+				),
+			],
+			"m",
+		);
+		await storage.writeFiles(
+			[
+				file(`summaries/${H("b")}.json`, summary(H("b"))),
+				file(`summaries/${H("a")}.json`, summary(H("a"), { children: [summary(H("c")), summary(H("d"))] })),
+			],
+			"m",
+		);
+		expect(await rows("SELECT parent_hash, child_pos, depth FROM memories WHERE commit_hash = ?", H("b"))).toEqual([
+			{ parent_hash: null, child_pos: null, depth: 0 },
+		]);
+		const kids = await rows<{ commit_hash: string; child_pos: number }>(
+			"SELECT commit_hash, child_pos FROM memories WHERE parent_hash = ? ORDER BY child_pos",
+			H("a"),
+		);
+		expect(kids).toEqual([
+			{ commit_hash: H("c"), child_pos: 0 },
+			{ commit_hash: H("d"), child_pos: 1 },
+		]);
+		expect(await rows("SELECT COUNT(*) AS n FROM memories WHERE child_pos >= 1000000")).toEqual([{ n: 0 }]);
+	});
+
 	it("remounts an old root as a child, moving its whole subtree", async () => {
 		// b is a root with child c (depth 1). An amend then claims b under a.
 		await storage.writeFiles(
@@ -255,11 +345,15 @@ describe("summary trees", () => {
 			[file(`summaries/${H("a")}.json`, summary(H("a"), { children: [summary(H("b"))] }))],
 			"m",
 		);
-		// b's file now claims a as ITS child: with a's stored mount under b kept,
-		// the edges form a↔b and neither is a root.
+		// The batch claims both directions at once -- a.json keeps b as its child
+		// while b.json claims a as ITS child -- so the edges form a↔b and neither
+		// is a root.
 		await expect(
 			storage.writeFiles(
-				[file(`summaries/${H("b")}.json`, summary(H("b"), { children: [summary(H("a"))] }))],
+				[
+					file(`summaries/${H("a")}.json`, summary(H("a"), { children: [summary(H("b"))] })),
+					file(`summaries/${H("b")}.json`, summary(H("b"), { children: [summary(H("a"))] })),
+				],
 				"m",
 			),
 		).rejects.toThrow(/cycle/);
@@ -297,6 +391,47 @@ describe("links", () => {
 		]);
 	});
 
+	// The reverse write order — summary first, transcript later — is what
+	// `saveTranscriptsBatch` (ide-bridge `transcripts-save`) produces. The link
+	// used to be dropped as "dangling" and nothing re-derived it, so the
+	// dashboard's session↔commit join silently lost the commit.
+	it("links a transcript stored AFTER the summary that references it", async () => {
+		await storage.writeFiles([file(`summaries/${H("a")}.json`, summary(H("a"), { transcripts: ["t-1"] }))], "m");
+		expect(await rows("SELECT COUNT(*) AS n FROM memory_transcripts")).toEqual([{ n: 0 }]);
+
+		await storage.writeFiles([file("transcripts/t-1.json", { sessions: [{ sessionId: "s1" }] })], "m");
+		expect(await rows("SELECT commit_hash, transcript_id FROM memory_transcripts")).toEqual([
+			{ commit_hash: H("a"), transcript_id: "t-1" },
+		]);
+	});
+
+	it("does not link a transcript to a memory that never referenced it", async () => {
+		await storage.writeFiles([file(`summaries/${H("a")}.json`, summary(H("a"), { transcripts: ["t-9"] }))], "m");
+		await storage.writeFiles([file("transcripts/t-1.json", { sessions: [{ sessionId: "s1" }] })], "m");
+		expect(await rows("SELECT COUNT(*) AS n FROM memory_transcripts")).toEqual([{ n: 0 }]);
+	});
+
+	// A batch carrying both must keep landLinks' replacement authoritative:
+	// the backfill runs after it and must not resurrect a dropped link.
+	it("lets a same-batch summary write remain the authority on its link set", async () => {
+		await storage.writeFiles(
+			[
+				file("transcripts/t-1.json", { sessions: [{ sessionId: "s1" }] }),
+				file(`summaries/${H("a")}.json`, summary(H("a"), { transcripts: ["t-1"] })),
+			],
+			"m",
+		);
+		// Re-written with an empty transcript list, alongside the transcript again.
+		await storage.writeFiles(
+			[
+				file("transcripts/t-1.json", { sessions: [{ sessionId: "s1" }] }),
+				file(`summaries/${H("a")}.json`, summary(H("a"), { transcripts: [] })),
+			],
+			"m",
+		);
+		expect(await rows("SELECT COUNT(*) AS n FROM memory_transcripts")).toEqual([{ n: 0 }]);
+	});
+
 	it("deleting a transcript clears its links and sessions first", async () => {
 		await storage.writeFiles(
 			[
@@ -311,10 +446,16 @@ describe("links", () => {
 		expect(await rows("SELECT COUNT(*) AS n FROM transcript_sessions")).toEqual([{ n: 0 }]);
 	});
 
-	it("rejects an unparsable transcript", async () => {
-		await expect(storage.writeFiles([file("transcripts/t-1.json", "{]")], "m")).rejects.toThrow(
-			/unparsable transcript/,
+	// The batch is ONE transaction, so throwing on a bad artifact rolls back the
+	// memory riding alongside it — the orphan backend stored these bytes verbatim
+	// and could not fail this way at all. Skip loudly, keep the rest.
+	it("skips an unparsable transcript without losing the memory in the same batch", async () => {
+		await storage.writeFiles(
+			[file(`summaries/${H("a")}.json`, summary(H("a"))), file("transcripts/t-1.json", "{]")],
+			"m",
 		);
+		expect(await rows("SELECT commit_hash FROM memories")).toEqual([{ commit_hash: H("a") }]);
+		expect(await rows("SELECT COUNT(*) AS n FROM transcripts")).toEqual([{ n: 0 }]);
 	});
 });
 
@@ -424,10 +565,15 @@ describe("context and topics", () => {
 		expect(await rows("SELECT COUNT(*) AS n FROM context WHERE kind = 'note'")).toEqual([{ n: 0 }]);
 	});
 
-	it("rejects a reference with unparsable frontmatter", async () => {
-		await expect(storage.writeFiles([file("references/x/y.md", "no frontmatter")], "m")).rejects.toThrow(
-			/frontmatter/,
+	// One odd legacy reference used to take EVERY reference for that commit with
+	// it, plus the memory itself. SotImport has always skipped the same file.
+	it("skips a reference with unparsable frontmatter and keeps its batch", async () => {
+		await storage.writeFiles(
+			[file(`summaries/${H("a")}.json`, summary(H("a"))), file("references/x/y.md", "no frontmatter")],
+			"m",
 		);
+		expect(await rows("SELECT commit_hash FROM memories")).toEqual([{ commit_hash: H("a") }]);
+		expect(await rows("SELECT COUNT(*) AS n FROM context WHERE kind = 'reference'")).toEqual([{ n: 0 }]);
 	});
 
 	it("round-trips a topic page and applies the index-borne summary", async () => {
@@ -482,11 +628,28 @@ describe("context and topics", () => {
 		expect(await rows("SELECT COUNT(*) AS n FROM topic_source_refs")).toEqual([{ n: 0 }]);
 	});
 
-	it("rejects unparsable topic artifacts", async () => {
-		await expect(storage.writeFiles([file("topics/bad.json", "{}")], "m")).rejects.toThrow(/unparsable topic page/);
-		await expect(storage.writeFiles([file("topics/processed.json", "{}")], "m")).rejects.toThrow(
-			/unparsable topics\/processed/,
+	it("skips unparsable topic artifacts and keeps its batch", async () => {
+		await storage.writeFiles(
+			[file(`summaries/${H("a")}.json`, summary(H("a"))), file("topics/bad.json", "{}")],
+			"m",
 		);
+		expect(await rows("SELECT commit_hash FROM memories")).toEqual([{ commit_hash: H("a") }]);
+		expect(await rows("SELECT COUNT(*) AS n FROM topic_pages")).toEqual([{ n: 0 }]);
+	});
+
+	// Skipping keeps the PREVIOUS high-water set — the safe direction, since
+	// re-processing a source is idempotent. And it must not swallow the
+	// unrelated v5-state write that rides in the same batch.
+	it("skips an unparsable processed set, keeping the stored one and the rest of the batch", async () => {
+		await storage.writeFiles([file("topics/processed.json", { processed: { summary: ["s1"] } })], "m");
+		expect(await rows("SELECT source_id FROM topic_processed_sources")).toEqual([{ source_id: "s1" }]);
+
+		await storage.writeFiles(
+			[file("topics/processed.json", "{}"), file("schema-v5-migration.json", { done: true })],
+			"m",
+		);
+		expect(await rows("SELECT source_id FROM topic_processed_sources")).toEqual([{ source_id: "s1" }]);
+		expect(await rows("SELECT COUNT(*) AS n FROM repo_state WHERE key = 'v5-migration'")).toEqual([{ n: 1 }]);
 	});
 
 	it("refuses writes for an unregistered repo", async () => {
@@ -541,9 +704,10 @@ describe("edge shapes the main flows never hit", () => {
 
 	it("progress: delete, unparsable content and path-slug fallback", async () => {
 		await storage.writeFiles([file("plans/p1.md", "# p1")], "m");
-		await expect(storage.writeFiles([file("plan-progress/p1.json", "{]")], "m")).rejects.toThrow(
-			/unparsable plan-progress/,
-		);
+		// Skipped, not thrown: same one-transaction reasoning as the orphaned-plan
+		// case this function already handled that way.
+		await storage.writeFiles([file("plan-progress/p1.json", "{]")], "m");
+		expect(await rows("SELECT COUNT(*) AS n FROM plan_progress")).toEqual([{ n: 0 }]);
 		// No planSlug in the artifact: the path names the plan.
 		await storage.writeFiles([file("plan-progress/p1.json", { version: 2 })], "m");
 		expect(await rows("SELECT plan_slug FROM plan_progress")).toEqual([{ plan_slug: "p1" }]);

--- a/cli/src/dashboard/SotWrite.ts
+++ b/cli/src/dashboard/SotWrite.ts
@@ -217,6 +217,29 @@ function classify(files: ReadonlyArray<FileWrite>): Classified {
 	return c;
 }
 
+/**
+ * Drops one unparsable artifact from the batch, loudly, instead of throwing.
+ *
+ * The whole `writeFiles` batch is ONE transaction, and a commit's context files
+ * ride in it alongside its own `summaries/<hash>.json` — so a throw does not
+ * reject the bad file, it rolls back the memory the file was attached to. The
+ * orphan backend stored these bytes verbatim and could not fail this way at
+ * all, which makes it a cutover regression rather than a stricter check: one
+ * odd legacy reference took every reference for that commit with it.
+ *
+ * This is the rule `landProgress` already reached on its own for an orphaned
+ * artifact (see the comment there); the rest of this module now follows it.
+ * `SotImport` has always skipped-and-counted the same files, so the importer
+ * and the writer finally converge — a repo could otherwise import cleanly and
+ * then fail to re-write what it had just imported.
+ *
+ * Deliberately NOT silent: an unparsable artifact still means a producer bug,
+ * and `warn` is what makes it visible without costing the user their memory.
+ */
+function dropUnparsable(what: string, detail: string): void {
+	log.warn("SotWrite: dropping unparsable %s (%s) -- keeping the rest of the batch", what, detail);
+}
+
 /** `branch` for a `<key>-<hash8>` context key, from the memories table. */
 function branchFromMemories(db: DashboardDbHandle, repoId: number, key: string): string | null {
 	const match = /-([0-9a-f]{8})$/.exec(key);
@@ -250,6 +273,22 @@ function landSummaries(db: DashboardDbHandle, repoId: number, c: Classified, now
 	);
 	for (const parent of rewritten) shift.run(repoId, parent);
 
+	// The child positions this batch's trees CLAIM, per parent. A top node that
+	// re-anchors itself below needs this to tell three cases apart, and getting
+	// it wrong is a lost write rather than a lost position: `applyMemoryWrites`
+	// runs the batch in one transaction, so a UNIQUE(repo_id, parent_hash,
+	// child_pos) violation rolls back the memory plus every transcript, plan and
+	// reference riding along with it.
+	const claimed = new Map<string, Map<string, number>>();
+	for (const tree of c.summaryTrees) {
+		for (const node of tree) {
+			if (node.parentInFile === null || node.pos === null) continue;
+			const siblings = claimed.get(node.parentInFile) ?? new Map<string, number>();
+			siblings.set(node.hash, node.pos);
+			claimed.set(node.parentInFile, siblings);
+		}
+	}
+
 	const upsert = db.prepare(
 		`INSERT INTO memories (repo_id, commit_hash, parent_hash, child_pos, root_hash, depth,
 		                       summary_json, tree_hash, first_seen_ms, written_at_ms, commit_date_ms)
@@ -275,10 +314,41 @@ function landSummaries(db: DashboardDbHandle, repoId: number, c: Classified, now
 				if (existing) {
 					parent = existing.parent_hash;
 					pos = existing.child_pos;
-					// The mount point may itself sit in the offset region (its
-					// parent's set is being rewritten and settles later in this
-					// same batch); strip the offset so the settled value wins.
-					if (pos !== null && pos >= REORDER_OFFSET) pos -= REORDER_OFFSET;
+					// The mount point may itself sit in the offset region: its
+					// parent's set is being rewritten and settles later in this same
+					// batch. What to do with it then depends on whether that new set
+					// still claims this node, and stripping unconditionally (as this
+					// used to) is wrong when it does -- it drops the row into the live
+					// position space while its siblings are still parked, so the walk
+					// below hands the same position to a different sibling and the
+					// UNIQUE constraint rolls the whole batch back. Correctness then
+					// depended on the caller ordering the parent's file ahead of the
+					// child's, which this module's header explicitly does not promise
+					// (measured: `ProducerHooks.refreshMemoryRows` emits a commit and
+					// its later amend child-first).
+					//
+					// A parked position always means the parent IS being rewritten
+					// (only `rewritten` parents get shifted), so "nobody will settle
+					// it" is never the case: either the new set claims the node, or the
+					// set dropped it and the module's rule applies -- re-ground, never
+					// keep an edge the file model no longer claims. Restoring the
+					// stored mount here (which this used to do whenever the ground slot
+					// happened to be free) left the database carrying an edge
+					// `<parent>.json` does not list, so a seed import from the same
+					// files converged to a different tree.
+					if (pos !== null && pos >= REORDER_OFFSET) {
+						const siblings = parent === null ? undefined : claimed.get(parent);
+						if (siblings?.has(node.hash)) {
+							// The new set still claims this node -- stay parked and let
+							// the parent's own walk place it.
+						} else {
+							// Dropped from the set. Re-ground it, which is what
+							// `reground` below would do for the same row had its own
+							// file not been in the batch.
+							parent = null;
+							pos = null;
+						}
+					}
 				}
 			}
 			const summaryJson = JSON.stringify(
@@ -354,7 +424,8 @@ function landAliases(db: DashboardDbHandle, repoId: number, c: Classified, nowMs
 }
 
 /** Lands transcript rows + their session projection. */
-function landTranscripts(db: DashboardDbHandle, repoId: number, c: Classified, nowMs: number): void {
+function landTranscripts(db: DashboardDbHandle, repoId: number, c: Classified, nowMs: number): ReadonlySet<string> {
+	const landed = new Set<string>();
 	for (const id of c.transcriptDeletes) {
 		db.prepare("DELETE FROM transcript_sessions WHERE repo_id = ? AND transcript_id = ?").run(repoId, id);
 		db.prepare("DELETE FROM memory_transcripts WHERE repo_id = ? AND transcript_id = ?").run(repoId, id);
@@ -362,7 +433,10 @@ function landTranscripts(db: DashboardDbHandle, repoId: number, c: Classified, n
 	}
 	for (const { id, content } of c.transcriptWrites) {
 		const parsed = tryParse<StoredTranscript>(content);
-		if (!parsed || !Array.isArray(parsed.sessions)) throw new Error(`SotWrite: unparsable transcript ${id}`);
+		if (!parsed || !Array.isArray(parsed.sessions)) {
+			dropUnparsable("transcript", id);
+			continue;
+		}
 		db.prepare(
 			`INSERT INTO transcripts (repo_id, transcript_id, sessions_blob, written_at_ms) VALUES (?, ?, ?, ?)
 			 ON CONFLICT(repo_id, transcript_id) DO UPDATE SET sessions_blob = excluded.sessions_blob,
@@ -375,6 +449,79 @@ function landTranscripts(db: DashboardDbHandle, repoId: number, c: Classified, n
 				`INSERT INTO transcript_sessions (repo_id, transcript_id, session_id, source) VALUES (?, ?, ?, ?)
 				 ON CONFLICT(repo_id, transcript_id, session_id) DO UPDATE SET source = excluded.source`,
 			).run(repoId, id, session.sessionId, session.source ?? null);
+		}
+		landed.add(id);
+	}
+	return landed;
+}
+
+/**
+ * Links a newly stored transcript to memories that ALREADY reference it.
+ *
+ * `landLinks` below can only link the summaries in its own batch, so it covers
+ * exactly one ordering: transcript first, summary second. The other order —
+ * `saveTranscriptsBatch` storing a transcript for a commit whose summary landed
+ * earlier, reachable from the ide-bridge `transcripts-save` action — dropped the
+ * link permanently, because the id was not yet in `transcripts` when the summary
+ * was written (logged as "dangling") and nothing ever re-derived it. The file
+ * backend had no such dependency: it resolved links from `summary.transcripts`
+ * at READ time, so order never mattered there.
+ *
+ * The `LIKE` is a candidate filter only — cheap narrowing over `summary_json`,
+ * with `resolveTranscriptIdsFiltered` making the actual decision, so a pattern
+ * metacharacter inside an id can only widen the candidate set, never shrink it.
+ */
+function backfillLinksForNewTranscripts(
+	db: DashboardDbHandle,
+	repoId: number,
+	c: Classified,
+	written: ReadonlySet<string>,
+): void {
+	// `landTranscripts`' landed set, NOT `c.transcriptWrites`: an unparsable
+	// transcript is dropped there and never reaches the `transcripts` table, so
+	// linking it here inserts a `memory_transcripts` row whose parent does not
+	// exist. `defer_foreign_keys` only moves that violation to COMMIT, which
+	// rolls back the WHOLE batch — re-creating exactly the data loss the drop
+	// exists to avoid, and doing it to every other memory in the same write.
+	// The set is also the filter passed to `resolveTranscriptIdsFiltered`, so a
+	// dropped id would otherwise pass its own membership test.
+	if (written.size === 0) return;
+	// Nodes this batch also wrote already had their link set REPLACED wholesale
+	// by landLinks; re-adding here would resurrect a link that write removed.
+	const replaced = new Set(c.summaryTrees.flat().map((n) => n.hash));
+	// Ids this batch's own summaries claim. `landLinks` has already resolved those
+	// links against the `transcripts` rows `landTranscripts` just wrote, so the
+	// scan below can only re-derive what it already did — and the `LIKE` is an
+	// unindexable full scan of `memories`' JSON blobs, paid once per id on
+	// EVERY ordinary commit, where the summary and its transcript always arrive in
+	// the same batch. The orderings this function exists for are the ones where a
+	// transcript arrives without its summary (the ide-bridge `transcripts-save`
+	// action writes transcripts alone, so `summaryTrees` is empty and nothing here
+	// is skipped). Residual: a transcript claimed by BOTH a batch summary and an
+	// older memory outside the batch keeps only the batch link until that
+	// transcript is written again — a bounded, self-healing gap, and far cheaper
+	// than a full scan on every commit that by construction finds nothing.
+	const claimedByBatch = new Set(
+		c.summaryTrees.flat().flatMap((n) => [...resolveTranscriptIdsFiltered(n.summary, written)]),
+	);
+	const pending = [...written].filter((id) => !claimedByBatch.has(id));
+	if (pending.length === 0) return;
+	const candidates = db.prepare(
+		"SELECT commit_hash, summary_json FROM memories WHERE repo_id = ? AND summary_json LIKE ?",
+	);
+	const insert = db.prepare(
+		`INSERT INTO memory_transcripts (repo_id, commit_hash, transcript_id) VALUES (?, ?, ?)
+		 ON CONFLICT(repo_id, commit_hash, transcript_id) DO NOTHING`,
+	);
+	for (const id of pending) {
+		const rows = candidates.all(repoId, `%${id}%`) as Array<{ commit_hash: string; summary_json: string }>;
+		for (const row of rows) {
+			if (replaced.has(row.commit_hash)) continue;
+			const summary = tryParse<CommitSummary>(row.summary_json);
+			if (!summary) continue;
+			if (!resolveTranscriptIdsFiltered(summary, written).includes(id)) continue;
+			insert.run(repoId, row.commit_hash, id);
+			log.info("linked stored transcript %s to memory %s written earlier", id, row.commit_hash);
 		}
 	}
 }
@@ -434,7 +581,10 @@ function landContext(db: DashboardDbHandle, repoId: number, c: Classified, nowMs
 	for (const { kind, key, body } of c.contextWrites) {
 		if (kind === "reference") {
 			const parsed = readReferenceMarkdownFromString(body);
-			if (!parsed) throw new Error(`SotWrite: unparsable reference frontmatter at references/${key}.md`);
+			if (!parsed) {
+				dropUnparsable("reference frontmatter", `references/${key}.md`);
+				continue;
+			}
 			upsert.run(
 				repoId,
 				kind,
@@ -484,7 +634,11 @@ function landProgress(db: DashboardDbHandle, repoId: number, c: Classified, nowM
 	}
 	for (const { pathSlug, content } of c.progressWrites) {
 		const parsed = tryParse<{ planSlug?: string }>(content);
-		if (!parsed) throw new Error(`SotWrite: unparsable plan-progress at plan-progress/${pathSlug}.json`);
+		// Same reasoning as the orphaned-plan skip below — and the same batch.
+		if (!parsed) {
+			dropUnparsable("plan-progress", `plan-progress/${pathSlug}.json`);
+			continue;
+		}
 		const slug = parsed.planSlug ?? pathSlug;
 		// A live write whose plan is missing IS a caller bug — but throwing here is
 		// the wrong way to say so. This batch is one transaction, and a commit's
@@ -530,7 +684,8 @@ function landTopics(db: DashboardDbHandle, repoId: number, c: Classified, nowMs:
 	for (const { slug, content } of c.topicPageWrites) {
 		const page = tryParse<PageFile>(content);
 		if (!page?.stableSlug || page.title === undefined || page.content === undefined || !page.lastUpdatedAt) {
-			throw new Error(`SotWrite: unparsable topic page topics/${slug}.json`);
+			dropUnparsable("topic page", `topics/${slug}.json`);
+			continue;
 		}
 		db.prepare(
 			`INSERT INTO topic_pages (repo_id, stable_slug, title, summary, content_md,
@@ -571,16 +726,23 @@ function landTopics(db: DashboardDbHandle, repoId: number, c: Classified, nowMs:
 	}
 	if (c.processedSet !== null) {
 		const parsed = tryParse<{ processed?: Record<string, string[]> }>(c.processedSet);
-		if (!parsed?.processed) throw new Error("SotWrite: unparsable topics/processed.json");
-		// The file is the WHOLE high-water mark, so landing it is set
-		// replacement — an upsert-only pass could never shrink it.
-		db.prepare("DELETE FROM topic_processed_sources WHERE repo_id = ?").run(repoId);
-		const insert = db.prepare(
-			`INSERT INTO topic_processed_sources (repo_id, source_type, source_id) VALUES (?, ?, ?)
-			 ON CONFLICT(repo_id, source_type, source_id) DO NOTHING`,
-		);
-		for (const [type, ids] of Object.entries(parsed.processed)) {
-			for (const id of ids) insert.run(repoId, type, id);
+		// Skipping keeps the PREVIOUS high-water set, which is the safe direction:
+		// re-processing a source is idempotent, where a rolled-back batch would
+		// have cost the memories written alongside it. Not an early return — the
+		// v5-state write below is an unrelated part of this same batch.
+		if (!parsed?.processed) {
+			dropUnparsable("processed set", "topics/processed.json");
+		} else {
+			// The file is the WHOLE high-water mark, so landing it is set
+			// replacement — an upsert-only pass could never shrink it.
+			db.prepare("DELETE FROM topic_processed_sources WHERE repo_id = ?").run(repoId);
+			const insert = db.prepare(
+				`INSERT INTO topic_processed_sources (repo_id, source_type, source_id) VALUES (?, ?, ?)
+				 ON CONFLICT(repo_id, source_type, source_id) DO NOTHING`,
+			);
+			for (const [type, ids] of Object.entries(parsed.processed)) {
+				for (const id of ids) insert.run(repoId, type, id);
+			}
 		}
 	}
 	if (c.v5State !== null) {
@@ -610,8 +772,11 @@ export function applyMemoryWrites(
 		db.exec("PRAGMA defer_foreign_keys = ON");
 		landSummaries(db, repoId, c, nowMs);
 		landAliases(db, repoId, c, nowMs);
-		landTranscripts(db, repoId, c, nowMs);
+		const landedTranscripts = landTranscripts(db, repoId, c, nowMs);
 		landLinks(db, repoId, c);
+		// AFTER landLinks: it replaces the link set of the summaries in this
+		// batch, so the backfill must not run first and have its rows deleted.
+		backfillLinksForNewTranscripts(db, repoId, c, landedTranscripts);
 		landContext(db, repoId, c, nowMs);
 		landProgress(db, repoId, c, nowMs);
 		landTopics(db, repoId, c, nowMs);

--- a/cli/src/dashboard/StatsWriter.test.ts
+++ b/cli/src/dashboard/StatsWriter.test.ts
@@ -146,6 +146,21 @@ describe("applyStatsEvents — projection", () => {
 		expect(rows[0]).toEqual({ input_tokens: 7, est_cost_usd: 0.1 });
 	});
 
+	it("keeps the model split when a usage-less re-read sends models: []", async () => {
+		await applyStatsEvents([envelope(session())], { producerKind: "cli", dbPath });
+		const before = await query<{ n: number }>("SELECT COUNT(*) AS n FROM session_model_usage");
+		expect(before[0].n).toBeGreaterThan(0);
+		// `models: []` with no scalar token fields is "tokens unobserved", the
+		// same shape the carry-forward above recognises. Deleting the split on it
+		// left the session reporting tokens in the KPI row while the model
+		// dimension reported none — the orphaned state this guard exists for.
+		await applyStatsEvents([envelope(session({ models: [] }))], { producerKind: "cli", dbPath });
+		expect(await query<{ n: number }>("SELECT COUNT(*) AS n FROM session_model_usage")).toEqual(before);
+		expect(await query<{ input_tokens: number }>("SELECT input_tokens FROM sessions")).toEqual([
+			{ input_tokens: 100 },
+		]);
+	});
+
 	it("leaves session cost NULL when no model carries an estimate and the event has none", async () => {
 		await applyStatsEvents(
 			[
@@ -319,12 +334,139 @@ describe("write-ahead log", () => {
 			{ dbPath },
 		);
 		const result = await applyStatsEvents([], { producerKind: "cli", dbPath });
-		expect(result).toMatchObject({ projected: 0, pending: 1 });
+		// pending: 0, not 1 — the row is parked in the table (asserted below) but
+		// is not part of the backlog this build can ever work off, and `pending` is
+		// a cursor gate rather than a table census. See the head-of-line test.
+		expect(result).toMatchObject({ projected: 0, pending: 0 });
 		const rows = await query<{ projection_status: string; attempts: number }>(
 			"SELECT projection_status, attempts FROM events_raw",
 		);
 		// Untouched: no attempt burned on an event this build cannot understand.
 		expect(rows).toEqual([{ projection_status: "pending", attempts: 0 }]);
+	});
+
+	it("reports the rows the claim LIMIT never reached as pending", async () => {
+		// `Backfill.applyBatches` refuses to advance the summaries cursor while
+		// anything is unprojected, so `pending` has to mean exactly that. The
+		// tally it replaces counted only future-schema rows plus this pass's own
+		// failures — so a first tick with more sessions than one batch reported a
+		// clean drain over hundreds of events that were still waiting.
+		await withDashboardDb(
+			(db) => {
+				for (let i = 0; i < 505; i++) {
+					db.prepare(
+						`INSERT INTO events_raw (event_id, repo_identity, type, schema_version, received_at, data_json)
+					 VALUES (?, 'repo-1', 'session.upserted', ?, 't', ?)`,
+					).run(
+						`session:repo-1:claude:s${i}`,
+						STATS_EVENT_SCHEMA_VERSION,
+						JSON.stringify(session({ sessionId: `s${i}` })),
+					);
+				}
+			},
+			{ dbPath },
+		);
+		const result = await applyStatsEvents([], { producerKind: "cli", dbPath });
+		expect(result.projected).toBe(500);
+		expect(result.pending).toBe(5);
+	});
+
+	it("scopes pending to the repos the caller is reporting on", async () => {
+		// `events_raw` is machine-global but the caller's gate is per-repo:
+		// `Backfill` asks "may I advance repo-1's summaries cursor?". Counting
+		// another repo's in-flight rows answers a question nobody asked and holds
+		// repo-1 back for a reason repo-1 cannot act on. Unlike the future-schema
+		// case this one is self-healing, so it is scoped rather than an error.
+		await withDashboardDb(
+			(db) => {
+				const insert = db.prepare(
+					`INSERT INTO events_raw (event_id, repo_identity, type, schema_version, received_at, data_json)
+					 VALUES (?, ?, 'session.upserted', ?, 't', ?)`,
+				);
+				// repo-1's own row goes in FIRST: the claim is `ORDER BY seq LIMIT n`,
+				// so seeding it behind repo-2's overflow would leave it genuinely
+				// undrained and `pending: 1` would be the right answer for the wrong
+				// reason — the assertion has to fail only when the SCOPE is missing.
+				insert.run(
+					"session:repo-1:claude:mine",
+					"repo-1",
+					STATS_EVENT_SCHEMA_VERSION,
+					JSON.stringify(session({ sessionId: "mine" })),
+				);
+				for (let i = 0; i < 505; i++) {
+					insert.run(
+						`session:repo-2:claude:o${i}`,
+						"repo-2",
+						STATS_EVENT_SCHEMA_VERSION,
+						JSON.stringify(session({ repoIdentity: "repo-2", sessionId: `o${i}` })),
+					);
+				}
+			},
+			{ dbPath },
+		);
+		// One drain: 500 rows claimed — repo-1's, plus 499 of repo-2's. repo-2 is
+		// left with 6 undrained, which are none of repo-1's business.
+		const scoped = await withDashboardDb((db) => drainPending(db, { pendingScope: ["repo-1"] }), { dbPath });
+		expect(scoped.projected).toBe(500);
+		expect(scoped.pending).toBe(0);
+		// Asserted against the table, not a second drain: re-running the drain to
+		// prove the backlog exists would consume it, and `pending: 0` above would
+		// then pass for the trivial reason that nothing was left either way. The
+		// empty-scope fallback to a global count is covered by the LIMIT test.
+		expect(
+			await query<{ n: number }>(
+				"SELECT COUNT(*) AS n FROM events_raw WHERE projection_status = 'pending' AND repo_identity = 'repo-2'",
+			),
+		).toEqual([{ n: 6 }]);
+	});
+
+	it("un-parks an unknown-type event once a build that understands it drains", async () => {
+		// The promise `projectEvent`'s default throw makes — "the event survives
+		// for a build that understands it" — was not kept: the claim selects
+		// 'pending' and nothing reset 'failed'. Only THAT reason is revivable; a
+		// genuinely defective event must stay parked rather than burn its attempt
+		// budget again on every drain.
+		await withDashboardDb(
+			(db) => {
+				db.prepare(
+					`INSERT INTO events_raw (event_id, type, schema_version, received_at, data_json)
+				 VALUES ('future', 'commit.vibes', ?, 't', '{"type":"commit.vibes"}')`,
+				).run(STATS_EVENT_SCHEMA_VERSION);
+				db.prepare(
+					`INSERT INTO events_raw (event_id, type, schema_version, received_at, data_json)
+				 VALUES ('bad', 'session.upserted', ?, 't', 'not json')`,
+				).run(STATS_EVENT_SCHEMA_VERSION);
+			},
+			{ dbPath },
+		);
+		for (let i = 0; i < 5; i++) await applyStatsEvents([], { producerKind: "cli", dbPath });
+		expect(
+			await query<{ event_id: string; failed_kind: string | null }>(
+				"SELECT event_id, failed_kind FROM events_raw WHERE projection_status = 'failed' ORDER BY event_id",
+			),
+		).toEqual([
+			{ event_id: "bad", failed_kind: "error" },
+			{ event_id: "future", failed_kind: "unknown-type" },
+		]);
+
+		// Now this build knows the type: the row returns to the queue, attempts
+		// reset. The defective one is untouched.
+		await withDashboardDb(
+			(db) => db.prepare("UPDATE events_raw SET type = 'session.upserted' WHERE event_id = 'future'").run(),
+			{ dbPath },
+		);
+		await withDashboardDb(
+			(db) =>
+				db
+					.prepare("UPDATE events_raw SET data_json = ? WHERE event_id = 'future'")
+					.run(JSON.stringify(session())),
+			{ dbPath },
+		);
+		const result = await applyStatsEvents([], { producerKind: "cli", dbPath });
+		expect(result.projected).toBe(1);
+		expect(await query("SELECT event_id FROM events_raw WHERE projection_status = 'failed'")).toEqual([
+			{ event_id: "bad" },
+		]);
 	});
 
 	it("poison-pills an event that keeps failing, without blocking the rest", async () => {
@@ -446,8 +588,13 @@ describe("write-ahead log", () => {
 
 		const result = await withDashboardDb((db) => drainPending(db), { dbPath });
 		expect(result.projected).toBe(1);
-		// Every future row is still pending — deferred, never dropped or guessed.
-		expect(result.pending).toBe(600);
+		// Reported as a CLEAR backlog even though 600 rows are still pending in the
+		// table. `pending` gates `Backfill`'s summaries cursor, and a future-schema
+		// row can never be claimed by this build — `attempts` stays 0, so it never
+		// ages out either. Counting it stalls that cursor permanently, for every
+		// repo, and each pass then re-collects the whole index. The rows staying
+		// parked is asserted below; that is the "deferred, never dropped" promise.
+		expect(result.pending).toBe(0);
 		const rows = await withDashboardDb(
 			(db) =>
 				db

--- a/cli/src/dashboard/StatsWriter.ts
+++ b/cli/src/dashboard/StatsWriter.ts
@@ -134,7 +134,12 @@ export function applyToDb(
 	// how any writer picks up rows a crashed predecessor committed but never
 	// projected. The batch just inserted is itself pending, so this is also what
 	// projects it.
-	const drained = drainPending(db, { now });
+	// The repos this call speaks for, so `drainPending`'s pending tally answers
+	// "is MY backlog clear?" rather than the machine's — see the note there.
+	const pendingScope = [...new Set(envelopes.map((e) => e.event.repoIdentity))].filter(
+		(id): id is string => typeof id === "string" && id.length > 0,
+	);
+	const drained = drainPending(db, { now, pendingScope });
 	return { accepted: envelopes.length, projected: drained.projected, pending: drained.pending };
 }
 
@@ -188,7 +193,7 @@ interface PendingRow {
  */
 export function drainPending(
 	db: DashboardDbHandle,
-	opts: { readonly now?: () => number } = {},
+	opts: { readonly now?: () => number; readonly pendingScope?: ReadonlyArray<string> } = {},
 ): { projected: number; pending: number } {
 	const now = opts.now ?? Date.now;
 	// Future-schema rows are excluded from the CLAIM, not just skipped in the
@@ -198,6 +203,21 @@ export function drainPending(
 	// build can never reach its own newer pending rows, and its projections
 	// stall silently until a new-build writer happens to drain. They still stay
 	// `pending` and are still counted, so nothing is lost or guessed at.
+	// Un-park what THIS build can now project. A row reaches `failed_kind =
+	// 'unknown-type'` only via `projectEvent`'s default throw — an older build
+	// draining a newer producer's event — and that comment promises the event
+	// survives for a build that understands it. It did not: the claim below
+	// selects `pending`, and nothing reset `failed`, so upgrading never
+	// recovered it. Scoped to types this build knows and to that one reason, so
+	// a genuinely defective event stays parked instead of burning its attempt
+	// budget again on every drain.
+	const revivable = KNOWN_EVENT_TYPES.map(() => "?").join(", ");
+	db.prepare(
+		`UPDATE events_raw SET projection_status = 'pending', attempts = 0, failed_kind = NULL
+		  WHERE projection_status = 'failed' AND failed_kind = 'unknown-type'
+		    AND type IN (${revivable})`,
+	).run(...KNOWN_EVENT_TYPES);
+
 	const rows = db
 		.prepare(
 			`SELECT seq, type, schema_version, data_json, attempts
@@ -207,19 +227,8 @@ export function drainPending(
 			  LIMIT ?`,
 		)
 		.all(MAX_PROJECTION_ATTEMPTS, STATS_EVENT_SCHEMA_VERSION, DRAIN_BATCH_SIZE) as ReadonlyArray<PendingRow>;
-	// Counted separately so the returned `pending` still reports them (the loop
-	// below no longer sees them at all).
-	const deferred = db
-		.prepare(
-			`SELECT COUNT(*) AS n FROM events_raw
-			  WHERE projection_status = 'pending' AND attempts < ? AND schema_version > ?`,
-		)
-		.get(MAX_PROJECTION_ATTEMPTS, STATS_EVENT_SCHEMA_VERSION) as { n: number };
 
 	let projected = 0;
-	// An event from a newer producer stays pending rather than being dropped or
-	// guessed at: a later build that understands the shape will project it.
-	let pending = deferred.n;
 	for (const row of rows) {
 		try {
 			inTransaction(db, () => {
@@ -249,7 +258,6 @@ export function drainPending(
 			// anyway, so there is no queue to starve.
 			if (classifyScanError(err)?.kind === "locked") {
 				log.warn("event seq=%d (%s) deferred — database busy: %s", row.seq, row.type, errMsg(err));
-				pending++;
 				continue;
 			}
 			// The attempt counter was rolled back with the transaction, so bump it
@@ -257,20 +265,111 @@ export function drainPending(
 			// forever and starve the rest of the queue.
 			const attempts = row.attempts + 1;
 			const status = attempts >= MAX_PROJECTION_ATTEMPTS ? "failed" : "pending";
-			db.prepare("UPDATE events_raw SET attempts = ?, projection_status = ? WHERE seq = ?").run(
+			// The reason is recorded, not just the verdict: only an unknown TYPE is
+			// recoverable by a later build (see the revival above).
+			const kind = isUnknownTypeError(err) ? "unknown-type" : "error";
+			db.prepare("UPDATE events_raw SET attempts = ?, projection_status = ?, failed_kind = ? WHERE seq = ?").run(
 				attempts,
 				status,
+				status === "failed" ? kind : null,
 				row.seq,
 			);
 			if (status === "failed") {
 				log.error("event seq=%d (%s) failed %d times — parked: %s", row.seq, row.type, attempts, errMsg(err));
 			} else {
 				log.warn("event seq=%d (%s) projection failed, will retry: %s", row.seq, row.type, errMsg(err));
-				pending++;
 			}
 		}
 	}
-	return { projected, pending };
+	// Counted from the table, never accumulated. `pending` is what
+	// `Backfill.applyBatches` consults before advancing the summaries cursor, so
+	// it has to mean "events still unprojected" — the tally it replaces counted
+	// only future-schema rows plus this pass's own failures, and said 0 while
+	// everything the `LIMIT` did not reach was still waiting. One first tick on a
+	// machine with more sessions than DRAIN_BATCH_SIZE was enough to report a
+	// clean drain over hundreds of unprojected events.
+	//
+	// The two filters below are what keep "unprojected" from meaning
+	// "unprojectABLE", and the caller's gate is `pending === 0` — so a row this
+	// runtime can never claim is not a delay, it is a permanent cursor stall.
+	//
+	//  - `schema_version <= ?` mirrors the claim query above EXACTLY. A row
+	//    written by a newer CLI is never selected for projection, so `attempts`
+	//    stays 0 and it can never age out: without this the summaries cursor
+	//    stops advancing forever (for every repo), and each pass re-collects the
+	//    whole index from scratch. Any change to the claim predicate has to be
+	//    made here too, or the gate silently stops matching what drains.
+	//  - `repo_identity IN (…)` scopes the answer to the repos the caller is
+	//    actually reporting on (`pendingScope`). `events_raw` is machine-global,
+	//    so another repo's in-flight rows would otherwise hold back THIS repo's
+	//    cursor. That kind is self-healing (the other repo drains, the next pass
+	//    advances), which is why it is scoped rather than counted as an error.
+	//    An empty scope means the caller has no repo to attribute this to, and
+	//    the global count is then the honest answer.
+	const scoped = (opts.pendingScope ?? []).filter((id) => id.length > 0);
+	const remaining = (
+		scoped.length > 0
+			? db
+					.prepare(
+						`SELECT COUNT(*) AS n FROM events_raw
+						  WHERE projection_status = 'pending' AND attempts < ? AND schema_version <= ?
+						    AND repo_identity IN (${scoped.map(() => "?").join(",")})`,
+					)
+					.get(MAX_PROJECTION_ATTEMPTS, STATS_EVENT_SCHEMA_VERSION, ...scoped)
+			: db
+					.prepare(
+						`SELECT COUNT(*) AS n FROM events_raw
+						  WHERE projection_status = 'pending' AND attempts < ? AND schema_version <= ?`,
+					)
+					.get(MAX_PROJECTION_ATTEMPTS, STATS_EVENT_SCHEMA_VERSION)
+	) as { n: number };
+	return { projected, pending: remaining.n };
+}
+
+/**
+ * Every event type {@link projectEvent} can dispatch — the revival's allowlist.
+ *
+ * `as const satisfies` rather than a plain `ReadonlyArray<StatsEvent["type"]>`
+ * annotation, so {@link KnownEventTypesAreExhaustive} below can see the literals.
+ * The annotation widened every element to the full union, which made that check
+ * vacuously true.
+ */
+const KNOWN_EVENT_TYPES = [
+	"repo.enabled",
+	"repo.disabled",
+	"session.upserted",
+	"commit.created",
+	"commit.summary",
+	"worktree.status",
+	"recall.observed",
+] as const satisfies ReadonlyArray<StatsEvent["type"]>;
+
+/**
+ * Compile error the day a member of `StatsEvent["type"]` is missing from
+ * {@link KNOWN_EVENT_TYPES} — the mirror of the `never` assignment in
+ * {@link projectEvent}'s `default` arm.
+ *
+ * The two together are what keep the list and the switch in lockstep: the switch
+ * cannot fall behind `StatsEvent` (that arm), and the list cannot fall behind it
+ * either (this one), so neither can drift from the other. Only the switch was
+ * guarded before, and the asymmetry was silent by construction — a type missing
+ * from the list is not an error anywhere, it just means `reviveStuckEvents` never
+ * offers that type a second attempt, so a transient failure becomes permanent for
+ * that one kind of event and nothing says so.
+ *
+ * On a mismatch the error names the missing member rather than reading
+ * `true is not assignable to never`.
+ */
+type MissingEventType = Exclude<StatsEvent["type"], (typeof KNOWN_EVENT_TYPES)[number]>;
+const KnownEventTypesAreExhaustive: [MissingEventType] extends [never]
+	? true
+	: ["KNOWN_EVENT_TYPES is missing", MissingEventType] = true;
+void KnownEventTypesAreExhaustive;
+
+const UNKNOWN_TYPE_MARKER = "StatsWriter: no projection for event type";
+
+function isUnknownTypeError(err: unknown): boolean {
+	return err instanceof Error && err.message.startsWith(UNKNOWN_TYPE_MARKER);
 }
 
 /** Dispatches one event to its projection. Must run inside a transaction. */
@@ -312,7 +411,7 @@ function projectEvent(db: DashboardDbHandle, event: StatsEvent): void {
 			// through the attempt counter to `failed`, which is retained forever and
 			// logged loudly — the event survives for a build that understands it.
 			const unknown: never = event;
-			throw new Error(`StatsWriter: no projection for event type ${(unknown as StatsEvent).type}`);
+			throw new Error(`${UNKNOWN_TYPE_MARKER} ${(unknown as StatsEvent).type}`);
 		}
 	}
 }
@@ -478,7 +577,15 @@ function projectSession(db: DashboardDbHandle, event: SessionUpsertedEvent): voi
 	// before. Only when the event actually OBSERVED usage, though: a usage-less
 	// event carried the tokens forward above, and deleting the split here would
 	// leave the scalars orphaned from an empty split.
-	if (event.models !== undefined) {
+	//
+	// The condition is `hasUsage`, the SAME predicate the carry-forward used.
+	// Testing `event.models !== undefined` instead let one shape fall between
+	// them: `models: []` with no scalar token fields is "unobserved" to the
+	// carry-forward (which keeps the stored 175 tokens) and "provided" to this
+	// delete (which empties the split), leaving a session whose KPI reports
+	// tokens while the model-dimension series reports none. `models: []` is an
+	// accepted producer shape, so the gap was one producer away from shipping.
+	if (hasUsage && event.models !== undefined) {
 		db.prepare("DELETE FROM session_model_usage WHERE session_event_id = ?").run(eventId);
 		const insertModel = db.prepare(
 			`INSERT INTO session_model_usage

--- a/cli/src/dashboard/assets/js/memories.js
+++ b/cli/src/dashboard/assets/js/memories.js
@@ -139,6 +139,40 @@ window.JD = window.JD || {};
 		);
 	}
 
+	/**
+	 * The tree's footer: how much of the corpus is loaded, and the button that
+	 * fetches the next page.
+	 *
+	 * Deliberately NOT {@link JD.moreToggle}, which the detail pane's lists use:
+	 * that one only expands rows the server already sent, so its label can
+	 * promise "Show all N". This button costs a round trip per click, so it says
+	 * what it will actually do and never claims to finish the list in one.
+	 *
+	 * Nothing at all once everything is loaded — a footer that only ever reads
+	 * "N of N" is noise on the far more common small-corpus page.
+	 */
+	function loadMoreRow(memories) {
+		var loaded = (memories.items || []).length;
+		if (!loaded || loaded >= memories.totalCount) return "";
+		var label = memories.loadingPage ? "Loading…" : memories.loadError ? "Try again" : "Load more";
+		return (
+			'<div class="more-row"><span class="more-count">' +
+			loaded +
+			" of " +
+			memories.totalCount +
+			" memories loaded" +
+			/* The failure is stated in the footer rather than a toast: it is the
+			   reason this button is still here, and it belongs next to the count it
+			   stopped from growing. */
+			(memories.loadError && !memories.loadingPage ? " — could not load more" : "") +
+			'</span><button type="button" class="cta ghost sm" id="memLoadMore"' +
+			(memories.loadingPage ? " disabled" : "") +
+			">" +
+			label +
+			"</button></div>"
+		);
+	}
+
 	/** The tree body only — toolbar (tabs + search) is rendered once and left alone,
 	    so re-filtering on every keystroke never steals focus from the search input. */
 	function renderTreeBody(model) {
@@ -180,24 +214,21 @@ window.JD = window.JD || {};
 				});
 			});
 		}
-		/* Skipped when the search filter itself is why nothing is showing — pairing
-		   "no matches" with "showing 200 of 773" would claim two different counts
-		   of what's on screen at once. */
-		if (memories.truncated && filtered.length) {
-			/* `items.length` is the SERVER's page, not what survived the client-side
-			   filter — the two are only equal with an empty query. Report the page size
-			   against the total (both server-side figures) so the sentence stays one
-			   consistent statement about the fetch; `filtered.length` above is what the
-			   tree actually shows and belongs to a different claim. */
+		/* Never merged into one count with the footer below: the filter ran over what
+		   is LOADED, so both of its numbers are client-side, while the footer compares
+		   two server-side figures. Pairing "showing N" with `totalCount` would state a
+		   match count against a set the filter never saw — and until every page is in,
+		   those two sets genuinely differ. Skipped when nothing matched; that branch
+		   already says so. */
+		if (filtered.length && filtered.length !== items.length) {
 			html +=
-				'<p class="empty-note">Showing the ' +
+				'<p class="empty-note">Showing ' +
+				filtered.length +
+				" of " +
 				items.length +
-				" most recent of " +
-				memories.totalCount +
-				" memories" +
-				(filtered.length !== items.length ? " (" + filtered.length + " match the filter)" : "") +
-				".</p>";
+				" loaded memories matching the filter.</p>";
 		}
+		html += loadMoreRow(memories);
 		return html;
 	}
 
@@ -228,6 +259,11 @@ window.JD = window.JD || {};
 				}
 			};
 		});
+		/* Rebound on every tree repaint, including the one `loadMoreMemories`
+		   itself triggers — the footer is part of the tree body, so each page
+		   replaces this element rather than updating it. */
+		var loadMore = document.getElementById("memLoadMore");
+		if (loadMore) loadMore.onclick = () => loadMoreMemories(model);
 	}
 
 	function refreshTree(model) {
@@ -665,6 +701,94 @@ window.JD = window.JD || {};
 		};
 	}
 
+	/**
+	 * Fetches ONE more page and appends it — the "Load more" button's handler,
+	 * and the only thing that grows the loaded set.
+	 *
+	 * Never chained or auto-fired. A render-driven chain (each arriving page
+	 * re-rendering, which then asks for the next) reads as jank: the tree grows
+	 * and reflows under the reader's cursor mid-click, and it spends a request
+	 * per page on history the reader may never scroll into. The inlined first
+	 * page is already a working tree; anything past it earns its round trip only
+	 * when asked for.
+	 *
+	 * Repaints the tree ONLY, through `refreshTree` rather than
+	 * `JD.renderMemories`: the toolbar keeps its focus and caret, and the detail
+	 * pane — a full memory read that has nothing to do with this list — is left
+	 * alone instead of being rebuilt under the reader.
+	 *
+	 * All the paging state lives ON `memories`, never on JD: a `/api/model`
+	 * refresh replaces that object with a fresh one from the server, which then
+	 * starts again from its own first page. Module-level flags would survive the
+	 * swap and either strand the new model at page 1 or append its pages onto
+	 * the old one's items.
+	 */
+	function loadMoreMemories(model) {
+		var memories = model.memories;
+		if (!memories || memories.loadingPage) return;
+		var items = memories.items || [];
+		if (items.length >= memories.totalCount) return;
+		memories.loadingPage = true;
+		memories.loadError = false;
+		refreshTree(model);
+		/* A cursor, not an offset: the server pages over the memories git still
+		   reaches, so a rebase mid-browse shortens that list and an offset would
+		   step over whichever row moved onto the boundary — a gap the client
+		   cannot even detect. "Continue after this exact memory" survives rows
+		   appearing or vanishing on either side of it. */
+		var last = items[items.length - 1];
+		var query = JD.query(model, {});
+		JD.getJson(
+			"/api/memories" +
+				(query ? query + "&" : "?") +
+				"afterRepo=" +
+				encodeURIComponent(last.repoIdentity) +
+				"&afterHash=" +
+				encodeURIComponent(last.commitHash),
+		)
+			.then((page) => {
+				memories.loadingPage = false;
+				/* An empty page while `items.length < totalCount` means those two
+				   disagree — the total moved under us. Believe the page: there is
+				   nothing after this cursor, so retire the footer rather than leave a
+				   button that answers every click with nothing. */
+				if (!page.items || !page.items.length) {
+					memories.totalCount = items.length;
+					refreshTree(model);
+					return;
+				}
+				if (page.cursorMissing) {
+					/* The memory we were paging from is gone (a rebase during the
+					   session), so the server answered with the first page instead.
+					   REPLACE rather than append: appending would re-add rows the dedupe
+					   then drops, and the next click would send the same dead cursor
+					   again — a button that does nothing forever. Re-seating on page 1
+					   is exactly what a reload would give, and paging works from there. */
+					memories.items = page.items;
+				} else {
+					/* Deduped even so: rows can shift under a commit landing between two
+					   clicks, and a repeat is cheap to drop where a gap would be
+					   invisible. */
+					var seen = new Set(items.map((item) => item.repoIdentity + " " + item.commitHash));
+					memories.items = items.concat(
+						page.items.filter((item) => !seen.has(item.repoIdentity + " " + item.commitHash)),
+					);
+				}
+				/* Adopted from the page, not left at the value the HTML was rendered
+				   with: it is what the footer states and what decides whether there is
+				   more to ask for, and a commit (or a rebase) moves it. */
+				memories.totalCount = page.totalCount;
+				refreshTree(model);
+			})
+			.catch(() => {
+				/* Kept, not cleared: every page that did arrive stays usable, and the
+				   footer turns into a retry instead of a dead end. */
+				memories.loadingPage = false;
+				memories.loadError = true;
+				refreshTree(model);
+			});
+	}
+
 	JD.renderMemories = (model) => {
 		/* The 30s page tick calls this again. Rebuilding the whole page then
 		   replaces the live #memSearch input, so a user mid-filter silently
@@ -680,7 +804,7 @@ window.JD = window.JD || {};
 			if (detail) detail.innerHTML = '<div class="mem-read-inner">' + renderDetail(model) + "</div>";
 			wireTree(model);
 			wireDetail(model);
-			return;
+				return;
 		}
 		document.getElementById("app").innerHTML =
 			'<section class="memories-page"><aside class="mem-navigator" aria-label="Memory browser">' +

--- a/cli/src/dashboard/assets/js/shell.js
+++ b/cli/src/dashboard/assets/js/shell.js
@@ -582,10 +582,16 @@ window.JD = window.JD || {};
 			},
 		);
 
-	/* One model re-fetch (same params the page was rendered with). */
+	/* One model re-fetch (same params the page was rendered with).
+
+	   Carries the token like JD.getJson does, even though /api/model answers
+	   without one: the token is what tells the server this is our own page
+	   rather than a cross-site GET, and a token-free answer omits the parts
+	   that cost model budget (the Decisions gist). Without it a poll would
+	   silently drop the gist the page was rendered with. */
 	JD.refreshNow = (render) => {
 		var model = window.__JOLLI_DASHBOARD__;
-		fetch(JD.modelUrl(model))
+		fetch(JD.modelUrl(model), { headers: { "X-Jolli-Dashboard-Token": window.__JOLLI_DASHBOARD_TOKEN__ || "" } })
 			.then((res) => {
 				if (!res.ok) throw new Error("refresh failed: " + res.status);
 				return res.json();
@@ -605,7 +611,14 @@ window.JD = window.JD || {};
 				render(fresh);
 			})
 			.catch(() => {
-				/* transient — the next tick retries; the page keeps its last data */
+				/* Transient — keep the last data, but still REPAINT it. Callers clear
+				   local UI state before calling this and depend on the re-render to
+				   show it: repoAction sets `busyRepo = null` and then hands the
+				   repaint to us, so swallowing this silently left the row stuck on
+				   "Working…" with no buttons until a manual reload. Only Stats has a
+				   poll to recover on the next tick; every other view calls this once,
+				   on a user action. Re-rendering the same model is idempotent. */
+				render(window.__JOLLI_DASHBOARD__);
 			});
 	};
 

--- a/cli/src/dashboard/assets/js/standup.js
+++ b/cli/src/dashboard/assets/js/standup.js
@@ -12,9 +12,6 @@ window.JD = window.JD || {};
 	   supposed to be a to-do list under things nobody can act on today. */
 	var TODAY_KINDS = ["todo"];
 	var RISK_KINDS = ["blocker", "question", "gotcha"];
-	/* Past this many days an age tag turns critical; the mockup marks its 4-day
-	   blocker `.old` and leaves the 2-day one plain. */
-	var STALE_DAYS = 3;
 
 	/* ---- rows -------------------------------------------------------------- */
 
@@ -162,12 +159,16 @@ window.JD = window.JD || {};
 
 	/* Age, in the mockup's own tag shape. It reads from the commit the insight came
 	   out of, which is the only date on record — an unanswered question is as old as
-	   the commit that asked it. */
+	   the commit that asked it.
+	   No critical/stale variant: the mockup's red 4-day blocker cannot occur here,
+	   because buildStandupInsights only selects commits from [yesterday, tomorrow),
+	   so this label is bounded at "2 days". Reintroducing a threshold means widening
+	   that window first — an unclosed blocker is only interesting once it is old. */
 	function ageTag(insight, model) {
 		if (insight.committedAtMs == null) return "";
 		var days = Math.floor((model.generatedAtMs - insight.committedAtMs) / 86400000);
 		var label = days < 1 ? "today" : days === 1 ? "1 day" : days + " days";
-		return '<span class="tag age' + (days > STALE_DAYS ? " old" : "") + '">' + label + "</span>";
+		return '<span class="tag age">' + label + "</span>";
 	}
 
 	function riskItem(insight, model) {
@@ -257,12 +258,17 @@ window.JD = window.JD || {};
 		});
 
 		var lines = ["## Standup — " + standup.today, "", "**Yesterday**"];
-		if (standup.yesterdayCommits.length === 0 && standup.yesterdaySessions.length === 0)
-			lines.push("- (nothing recorded)");
+		/* Built into its own array first, so the "nothing recorded" test asks what
+		   this section will ACTUALLY emit. Counting the raw inputs instead was one
+		   filter out of date: at the memory tier the session loop below is skipped,
+		   so a day with agent sessions but no commits counted as non-empty and then
+		   printed nothing — `**Yesterday**` immediately followed by `**Today**`,
+		   while the board column correctly said "Nothing recorded." */
+		var yesterday = [];
 		standup.yesterdayCommits.forEach((commit) => {
 			var prefix = commit.ticketId ? commit.ticketId + ": " : "";
 			var decisions = decisionsByHash[commit.hash] || [];
-			lines.push(
+			yesterday.push(
 				"- " +
 					prefix +
 					commit.message +
@@ -278,31 +284,27 @@ window.JD = window.JD || {};
 		   are outcomes, the session trail is noise in a standup. */
 		if (!standup.insights) {
 			standup.yesterdaySessions.forEach((session) => {
-				lines.push("- [" + session.source + "] " + session.title);
+				yesterday.push("- [" + session.source + "] " + session.title);
 			});
 		}
+		lines.push(yesterday.length > 0 ? yesterday.join("\n") : "- (nothing recorded)");
 
 		lines.push("", "**Today**");
-		if (
-			standup.todayCommits.length === 0 &&
-			standup.todaySessions.length === 0 &&
-			standup.workspaces.length === 0 &&
-			todos.length === 0
-		) {
-			lines.push("- (nothing yet)");
-		}
+		/* Same construction as Yesterday, and for the same reason: the session loop
+		   drops non-live rows at the memory tier, so the raw counts overstate it. */
+		var today = [];
 		standup.todayCommits.forEach((commit) => {
-			lines.push("- " + commit.message + " (`" + commit.hash.slice(0, 7) + "`)");
+			today.push("- " + commit.message + " (`" + commit.hash.slice(0, 7) + "`)");
 		});
 		standup.todaySessions.forEach((session) => {
 			if (standup.insights && !session.isLive) return;
-			lines.push("- [" + session.source + "] " + session.title + (session.isLive ? " (in progress)" : ""));
+			today.push("- [" + session.source + "] " + session.title + (session.isLive ? " (in progress)" : ""));
 		});
 		todos.forEach((todo) => {
-			lines.push("- TODO: " + todo.text + " (`" + todo.commitHash.slice(0, 7) + "`)");
+			today.push("- TODO: " + todo.text + " (`" + todo.commitHash.slice(0, 7) + "`)");
 		});
 		standup.workspaces.forEach((workspace) => {
-			lines.push(
+			today.push(
 				"- Uncommitted on " +
 					(workspace.branch || "detached HEAD") +
 					" · +" +
@@ -316,6 +318,7 @@ window.JD = window.JD || {};
 					")",
 			);
 		});
+		lines.push(today.length > 0 ? today.join("\n") : "- (nothing yet)");
 
 		if (risks.length > 0) {
 			lines.push("", "**Risks · Blockers · Questions**");

--- a/cli/src/dashboard/assets/styles/main.css
+++ b/cli/src/dashboard/assets/styles/main.css
@@ -649,7 +649,9 @@ body {
     height: 32px; font-size: 13px; color: var(--muted); padding: 0 6px; min-width: 0;
   }
   /* Same rule as .rl-name: a long repo or branch name truncates here instead of
-     shoving its count off the panel. `.cnt` keeps its margin-left:auto below. */
+     shoving its count off the panel. The count sits immediately after the name
+     (see `.cnt` below), so the ellipsis is what keeps the pair together on a
+     narrow panel — the label shrinks, the count never moves. */
   .mem-group-head .lbl {
     color: var(--ink); font-weight: 500;
     overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;
@@ -664,7 +666,11 @@ body {
     stroke: currentColor; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round;
   }
   .mem-group-head[aria-expanded="false"] .chev svg { transform: rotate(-90deg); }
-  .mem-group-head .cnt { margin-left: auto; flex: none; }
+  /* Reads as part of the name ("local_web_service 2"), not as a right-hand
+     column: right-aligning it put the number against the scrollbar and, with
+     one branch per row at different name lengths, left a ragged gap that made
+     the count look unrelated to the row it belongs to. */
+  .mem-group-head .cnt { flex: none; }
   .mem-group-head:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
   .mem-group-head.mem-branch-head { padding-left: 18px; }
   .mem-group-head.mem-branch-head .lbl { font-weight: 500; }
@@ -826,7 +832,6 @@ body {
   .tag.kind-blocker   { border-color: transparent; background: color-mix(in srgb, var(--crit) 12%, transparent); color: var(--crit); font-weight: 600; }
   .tag.kind-question  { border-color: transparent; background: var(--accent-soft); color: var(--accent); font-weight: 600; }
   .tag.age { border-style: dashed; }
-  .tag.age.old { color: var(--crit); border-color: var(--crit); }
   /* ---------- hot files ---------- */
   /* Four columns: path (elides), a proportional bar, the commit count, churn.
      The path column is min-width:0 so a long path shrinks rather than pushing

--- a/cli/src/graph/GraphExport.test.ts
+++ b/cli/src/graph/GraphExport.test.ts
@@ -38,12 +38,14 @@ afterEach(() => {
 });
 
 describe("escapeForInlineScript", () => {
-	it("neutralizes </script and the U+2028/U+2029 terminators", () => {
+	// The behaviour itself is pinned in core/InlineScript.test.ts — this only
+	// holds the re-export, since assembleGraphHtml below depends on it.
+	it("re-exports the shared escape and leaves no raw < in the output", () => {
 		const ls = String.fromCharCode(0x2028),
 			ps = String.fromCharCode(0x2029);
 		const out = escapeForInlineScript(`{"x":"</script>${ls}${ps}"}`);
-		expect(out).toContain("<\\/script");
-		expect(out).not.toContain("</script>");
+		expect(out).not.toContain("<");
+		expect(out).toContain("\\u003c");
 		expect(out).toContain("\\u2028");
 		expect(out).toContain("\\u2029");
 		expect(out).not.toContain(ls);
@@ -78,7 +80,7 @@ describe("assembleGraphHtml", () => {
 
 	it("escapes </script inside the embedded graph data", () => {
 		const html = assembleGraphHtml({ ...PARTS, graphJson: '{"x":"</script>bad"}' });
-		expect(html).toContain("<\\/script");
+		expect(html).toContain("\\u003c/script");
 		expect(html).not.toContain("</script>bad");
 	});
 

--- a/cli/src/graph/GraphExport.ts
+++ b/cli/src/graph/GraphExport.ts
@@ -16,6 +16,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { escapeForInlineScript } from "../core/InlineScript.js";
 import { createStorage } from "../core/StorageFactory.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -43,16 +44,11 @@ export interface GraphHtmlParts {
 }
 
 /**
- * Neutralize an inline-script breakout in the embedded JSON: the `</script`
- * close sequence (any case) plus the two raw JS line terminators U+2028/U+2029
- * that JSON leaves unescaped (inert on ES2019+, cheap defense in depth).
+ * Re-exported so this module's own callers (and its tests) keep their import,
+ * while the implementation stays single-sourced — see `core/InlineScript.ts`
+ * for why three private copies of it was the bug.
  */
-export function escapeForInlineScript(json: string): string {
-	return json
-		.replace(/<\/script/gi, "<\\/script")
-		.replace(new RegExp(String.fromCharCode(0x2028), "g"), "\\u2028")
-		.replace(new RegExp(String.fromCharCode(0x2029), "g"), "\\u2029");
-}
+export { escapeForInlineScript };
 
 /** Replace a single template marker, throwing if it is absent (no silent no-op). */
 function replaceMarker(html: string, marker: RegExp, replacement: () => string, label: string): string {

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -19,6 +19,19 @@ vi.mock("../core/RepoProfile.js", () => ({
 	// Pre-cutover default: no fence (plain fn — survives mock resets).
 	readCutoverFence: async () => null,
 	readManualDisableFlag: vi.fn().mockResolvedValue(false),
+	// The drain's opportunistic auto-cutover reads the attempt stamp and writes
+	// it back. Stubbed as "never attempted" so the throttle is not what stops it
+	// — the pinned `uncutover` route below is, via `runCutover`'s own checks.
+	readRepoProfile: async () => ({}),
+	updateRepoProfile: async () => {},
+}));
+
+// The drain's opportunistic auto-cutover. Stubbed so the tests never reach the
+// real compare (git + the machine database), and so its call ORDER relative to
+// the ingest phase is observable — see "lands the cutover fence only after the
+// ingest phase".
+vi.mock("../dashboard/AutoCutover.js", () => ({
+	maybeAutoCutover: vi.fn().mockResolvedValue("skipped"),
 }));
 
 // The worker's Node-floor gate consults the cutover route at its entrance;
@@ -593,6 +606,7 @@ import { storeSummary, withRequiredOrphanWriteLock } from "../core/SummaryStore.
 import { associateSkillsWithCommit } from "../core/skills/SkillArchive.js";
 import { renderTopicKBWiki } from "../core/TopicWikiRenderer.js";
 import { buildMultiSessionContext, readTranscript } from "../core/TranscriptReader.js";
+import { maybeAutoCutover } from "../dashboard/AutoCutover.js";
 import { recordCommitsFromWorker } from "../dashboard/ProducerHooks.js";
 import { buildKnowledgeGraph } from "../graph/GraphBuilder.js";
 import { recordPendingIngest, wakePendingIngest } from "../sync/PendingIngest.js";
@@ -1076,6 +1090,40 @@ describe("QueueWorker", () => {
 			await runWorker("/test/cwd");
 
 			expect(recordCommitsFromWorker).not.toHaveBeenCalled();
+		});
+
+		it("lands the cutover fence only after the ingest phase, not before it", async () => {
+			// `storage` is resolved once at the top of the run, while the repo is still
+			// `uncutover` — a provider whose system of record is the orphan branch.
+			// Fencing the branch first leaves the ingest below writing through that
+			// stale provider, and `OrphanBranchStorage.writeFiles` re-reads the fence
+			// and throws: the ingest's LLM work is discarded as "non-fatal" and its
+			// queue entries survive for a redo.
+			vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-test" } as never);
+			const order: string[] = [];
+			vi.mocked(drainIngest).mockImplementation(async () => {
+				order.push("drainIngest");
+				return { batches: 1, ingested: 1, outcome: "OK", topicFailures: [] };
+			});
+			vi.mocked(maybeAutoCutover).mockImplementation(async () => {
+				order.push("maybeAutoCutover");
+				return "skipped";
+			});
+
+			const ingestEntry = {
+				op: { type: "ingest", triggeredBy: "post-commit", createdAt: "2026-04-01T12:00:00.000Z" },
+				filePath: "/tmp/queue/ingest.json",
+			};
+			vi.mocked(dequeueAllGitOperations)
+				.mockResolvedValueOnce([{ op: makeCommitOp(), filePath: "/tmp/queue/entry.json" }])
+				// Everything after the drain: the chain-spawn check (ingest-only, so it
+				// spawns nothing), the ingest pre-check and the re-read under ingest.lock.
+				.mockResolvedValue([ingestEntry] as never);
+			setupPipelineMocks();
+
+			await runWorker("/test/cwd");
+
+			expect(order).toEqual(["drainIngest", "maybeAutoCutover"]);
 		});
 	});
 

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -150,6 +150,7 @@ import { generateTranscriptId } from "../core/TranscriptId.js";
 import { getParserForSource } from "../core/TranscriptParser.js";
 import type { SessionTranscript } from "../core/TranscriptReader.js";
 import { buildMultiSessionContext, readTranscript } from "../core/TranscriptReader.js";
+import { maybeAutoCutover } from "../dashboard/AutoCutover.js";
 import { opportunisticSnapshot } from "../dashboard/Backup.js";
 import { recordCommitsFromWorker } from "../dashboard/ProducerHooks.js";
 import { buildKnowledgeGraph } from "../graph/GraphBuilder.js";
@@ -306,6 +307,11 @@ function hoistMetadataFromOldSummary(oldSummary: CommitSummary | null | undefine
 	return {
 		...(oldSummary.jolliDocId != null && { jolliDocId: oldSummary.jolliDocId }),
 		...(oldSummary.jolliDocUrl && { jolliDocUrl: oldSummary.jolliDocUrl }),
+		// The skill-usage article's id travels exactly like the memory article's, and
+		// for the same reason: an amend is the SAME commit rewritten, so the next push
+		// must update those two articles rather than mint siblings and strand them.
+		...(oldSummary.jolliSkillsDocId != null && { jolliSkillsDocId: oldSummary.jolliSkillsDocId }),
+		...(oldSummary.jolliSkillsDocUrl && { jolliSkillsDocUrl: oldSummary.jolliSkillsDocUrl }),
 		...(oldSummary.orphanedDocIds && { orphanedDocIds: oldSummary.orphanedDocIds }),
 		...(oldSummary.unresolvedOrphanHashes && { unresolvedOrphanHashes: oldSummary.unresolvedOrphanHashes }),
 		...(oldSummary.plans && { plans: oldSummary.plans }),
@@ -593,6 +599,9 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 	// backstop in the outer finally).
 	let workerRefreshTimer: ReturnType<typeof setInterval> | undefined;
 	let workerLockReleased = true;
+	// Set by the drain, consumed AFTER both locks are released — see the
+	// auto-cutover call below for why it cannot run inside the lock window.
+	let summariesLandedThisRun = false;
 	const releaseWorker = async (): Promise<void> => {
 		if (workerLockReleased) return;
 		workerLockReleased = true;
@@ -818,6 +827,8 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 				// plan's "no daemon" schedule). Internally gated to once a day,
 				// floor-guarded, and never throws — a failure is a log line.
 				await opportunisticSnapshot();
+				// Auto-cutover runs after the locks come off, not here.
+				summariesLandedThisRun = true;
 			}
 			/* v8 ignore start -- catch block only reached if dequeueAllGitOperations throws unexpectedly */
 		} catch (error: unknown) {
@@ -920,6 +931,34 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 				// `wakePendingIngest` will re-spawn us once it releases.
 			}
 		}
+
+		// Auto-cutover's SECOND chance. `importDashboardHistory` covers a repo being
+		// enabled; nothing covers the repos enabled before auto-cutover shipped, which
+		// never pass through the front door again and would sit `uncutover` forever
+		// with the whole SQLite read path unreachable. The post-commit drain is where
+		// they get another opportunity — the database was just written, so the compare
+		// has as good a chance here as it does after an import.
+		//
+		// **Deliberately AFTER both releases.** Its step 3 reads every file the frozen
+		// tip lists, which on a large repo is seconds — and `vault-write.lock` is
+		// per-VAULT, held across this worker's whole drain, so waiting for that scan
+		// inside the lock window stalls the summary worker of every OTHER repo sharing
+		// the Memory Bank. It needs neither lock: the engine takes its own per-source
+		// locks for the CAS. The 6 h throttle bounds how often a `not-ready` repo pays
+		// the scan at all, but bounding frequency is not the same as bounding who
+		// waits. Never throws, reports nothing.
+		//
+		// **And deliberately after the ingest phase**, not between the releases and the
+		// chain-spawn. `storage` was resolved once at the top of this run, while the
+		// repo was still `uncutover` — a `DualWriteStorage` whose system of record is
+		// the orphan branch. Landing the fence first would leave the ingest below
+		// writing through that stale provider, and `OrphanBranchStorage.writeFiles`
+		// re-reads the fence from disk and throws on a frozen branch: the ingest's LLM
+		// work is discarded (the catch above logs it as non-fatal), its queue entries
+		// survive un-deleted, and the next worker redoes it. Cutting over after the
+		// ingest costs one drain's delay on a 6 h-throttled, opportunistic step and
+		// keeps every write in this run on the provider that matches the repo's state.
+		if (summariesLandedThisRun) await maybeAutoCutover(cwd, { throttle: true });
 	} finally {
 		// Backstops (idempotent): cover the early-return and mid-run-throw paths
 		// where the explicit releases above didn't run. worker.lock is released

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -307,11 +307,24 @@ tasks.named<PrepareSandboxTask>("prepareSandbox") {
     // Fail fast with an actionable message instead of silently syncing an empty
     // cli-dist (which only surfaces much later as a runtime BundleMissing).
     doFirst {
-        val cliJs = vscodeDistDir.file("Cli.js").asFile
-        if (!cliJs.exists()) {
+        // Both are checked, because Gradle's `from(<missing dir>)` is a silent
+        // no-op: a vscode/dist produced before the dashboard existed — or by
+        // `build:watch`, which used to skip the asset copy — has Cli.js and
+        // DashboardServerEntry.js but no dashboard-assets/, and that ships a
+        // plugin whose `jolli dashboard` throws "Dashboard assets not found" at
+        // runtime instead of failing here where the message is actionable.
+        // index.html stands in for the tree: the copy is all-or-nothing, and the
+        // per-file inventory is asserted by the plugins' own publish scripts.
+        val required = listOf(
+            vscodeDistDir.file("Cli.js").asFile,
+            vscodeDistDir.file("dashboard-assets/index.html").asFile,
+        )
+        val missing = required.filterNot { it.exists() }
+        if (missing.isNotEmpty()) {
             throw GradleException(
-                "Bundled CLI not found at ${cliJs.path}. Run `npm run build` at the repo root " +
-                    "first (it builds vscode/dist/*.js), then re-run the Gradle build.",
+                "Bundled CLI incomplete — missing ${missing.joinToString(", ") { it.path }}. " +
+                    "Run `npm run build` at the repo root first (it builds vscode/dist/ including " +
+                    "dashboard-assets/), then re-run the Gradle build.",
             )
         }
     }

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/RepoProfileBridge.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/RepoProfileBridge.kt
@@ -106,12 +106,34 @@ object RepoProfileBridge {
         val profileFile = resolveProfileJsonPath(cwd) ?: return null
         if (!profileFile.isFile) return null
         return try {
-            val flag = JsonParser.parseString(profileFile.readText(Charsets.UTF_8))
-                ?.asJsonObject?.get("manuallyDisabled")
-            if (flag == null || flag.isJsonNull) null else flag.asBoolean
+            readUserDisabled(JsonParser.parseString(profileFile.readText(Charsets.UTF_8))?.asJsonObject)
         } catch (_: Exception) {
             null
         }
+    }
+
+    /**
+     * The disable axis, in the CLI's own precedence order — see
+     * [readManualDisableFlagSync in RepoProfile.ts].
+     *
+     * `userDisabled` FIRST, and `manuallyDisabled` only when it is absent. The
+     * two are not synonyms since the cutover split them: `manuallyDisabled` is a
+     * DERIVED composite (`userDisabled OR a cutover fence is present`), recomputed
+     * on every write and never authored by hand. Reading it as the answer means a
+     * repo that was merely fenced — a normal, non-user-initiated cutover state —
+     * reads back as "the user disabled this", so IntelliJ shows the DisabledPanel
+     * and skips auto-install for a repo nobody disabled. The composite survives
+     * only as the migration fallback for a profile written before the split.
+     *
+     * Returns null for "undecided" (absent or malformed), so the caller falls back
+     * rather than inventing a decision.
+     */
+    private fun readUserDisabled(obj: JsonObject?): Boolean? {
+        val user = obj?.get("userDisabled")
+        if (user != null && !user.isJsonNull) return user.asBoolean
+        val legacy = obj?.get("manuallyDisabled")
+        if (legacy != null && !legacy.isJsonNull) return legacy.asBoolean
+        return null
     }
 
     /**
@@ -140,11 +162,13 @@ object RepoProfileBridge {
         if (profileFile != null && profileFile.isFile) {
             try {
                 val parsed = JsonParser.parseString(profileFile.readText(Charsets.UTF_8))
-                val flag = parsed?.asJsonObject?.get("manuallyDisabled")
-                if (flag != null && !flag.isJsonNull) {
-                    return flag.asBoolean
+                // userDisabled first, composite only as the pre-split fallback —
+                // see [readUserDisabled] for why the two are not interchangeable.
+                val flag = readUserDisabled(parsed?.asJsonObject)
+                if (flag != null) {
+                    return flag
                 }
-                // profile.json exists but the field is absent — fall through
+                // profile.json exists but neither field is present — fall through
                 // to the legacy per-worktree marker so a pre-migration disable
                 // still counts as disabled.
             } catch (_: Exception) {

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/RepoProfileBridgeTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/RepoProfileBridgeTest.kt
@@ -79,6 +79,36 @@ class RepoProfileBridgeTest {
         RepoProfileBridge.readManuallyDisabledFromDisk(repo.absolutePath) shouldBe false
     }
 
+    // ── The cutover split: userDisabled is the axis, manuallyDisabled is derived ──
+    // `manuallyDisabled` is recomputed on every write as `userDisabled OR a cutover
+    // fence is present`, so a merely-FENCED repo carries manuallyDisabled=true while
+    // the user disabled nothing. Reading the composite would show the DisabledPanel
+    // and skip auto-install for that repo. The CLI's readManualDisableFlagSync
+    // prefers `userDisabled`; this mirror must too.
+
+    @Test
+    fun `userDisabled=false wins over a fence-derived manuallyDisabled=true`() {
+        writeProfileJson("""{"userDisabled":false,"cutoverFence":{"reason":"cutover","at":"t"},"manuallyDisabled":true}""")
+        RepoProfileBridge.readManuallyDisabledFromDisk(repo.absolutePath) shouldBe false
+        RepoProfileBridge.readExplicitManualDisable(repo.absolutePath) shouldBe false
+    }
+
+    @Test
+    fun `userDisabled=true still reads as disabled`() {
+        writeProfileJson("""{"userDisabled":true,"manuallyDisabled":true}""")
+        RepoProfileBridge.readManuallyDisabledFromDisk(repo.absolutePath) shouldBe true
+        RepoProfileBridge.readExplicitManualDisable(repo.absolutePath) shouldBe true
+    }
+
+    @Test
+    fun `a pre-split profile still honours the composite as the migration fallback`() {
+        // Pre-split profile written by an OLD runtime, then fenced: the composite is
+        // all there is, so it is honoured — this is the migration fallback, and the
+        // reason the composite read cannot simply be deleted.
+        writeProfileJson("""{"manuallyDisabled":true}""")
+        RepoProfileBridge.readManuallyDisabledFromDisk(repo.absolutePath) shouldBe true
+    }
+
     @Test
     fun `profile json missing the field falls through to the legacy marker`() {
         // The classic "profile.json exists (backfillDismissed only) but the async

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -329,7 +329,7 @@
 		"test": "node ./scripts/run-vitest.mjs --coverage",
 		"test:changed": "node ./scripts/run-vitest.mjs --changed origin/main --reporter=dot",
 		"build": "npm run clean && node ./scripts/copy-codicons.mjs && node esbuild.config.mjs && node ./scripts/copy-graph-assets.mjs && node ./scripts/copy-dashboard-assets.mjs",
-		"build:watch": "node esbuild.config.mjs --watch",
+		"build:watch": "node ./scripts/copy-dashboard-assets.mjs && node esbuild.config.mjs --watch",
 		"package": "npm run build && npx @vscode/vsce package --no-dependencies --allow-missing-repository",
 		"install:vsix": "node -e \"const v=require('./package.json').version;const {execSync}=require('child_process');const fs=require('fs');const path=require('path');const isWin=process.platform==='win32';let code;if(isWin){code=path.join(process.env.LOCALAPPDATA||'','Programs','Microsoft VS Code','bin','code.cmd')}else{const candidates=['/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code','/usr/bin/code','/snap/bin/code'];code=candidates.find(p=>fs.existsSync(p))||'code'}execSync((isWin?'\\\"'+code+'\\\"':'\\\"'+code+'\\\"')+' --install-extension jollimemory-vscode-'+v+'.vsix --force',{stdio:'inherit'});\"",
 		"deploy": "npm --prefix ../cli run build && npm install -g ../cli && npm run build && npm run package && npm run install:vsix",

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -727,7 +727,14 @@ const {
 		readConfig: vi.fn(() => ({})),
 		saveConfig: vi.fn(),
 	};
-	const sot = { exists: vi.fn(async () => false) };
+	// `detectStoredMemories` asks `exists()` first and only then lists, so these
+	// cases keep steering on `exists` alone: a test that sets it true means "this
+	// repo has memories", which the non-empty default listing preserves. A case
+	// that wants the new "initialized but empty" state overrides `listFiles`.
+	const sot = {
+		exists: vi.fn(async () => false),
+		listFiles: vi.fn(async () => ["summaries/aaa.json"]),
+	};
 	const folder = { ensure: vi.fn(async () => undefined) };
 	const engine = {
 		runMigration: vi.fn(async () => ({
@@ -2028,12 +2035,17 @@ describe("Extension", () => {
 
 		// initializeKB is a fire-and-forget async block at activate time —
 		// any throw inside must funnel through the surrounding catch so the
-		// extension doesn't unhandled-reject during activation. Pinned by
-		// rejecting orphan.exists() (the first await inside the try block)
-		// and asserting the catch-side log.error gets fired with the right
-		// log key.
-		it("logs the catch path when initializeKB throws (orphan.exists rejects)", async () => {
-			mockSotInstance.exists.mockRejectedValueOnce(new Error("git failed"));
+		// extension doesn't unhandled-reject during activation. Driven from
+		// readMigrationState rather than the storage probe: the probe's own
+		// failures are absorbed by `detectStoredMemories` on purpose (see the
+		// case below), so it can no longer stand in for "something threw".
+		it("logs the catch path when initializeKB throws", async () => {
+			mockSotInstance.exists.mockResolvedValueOnce(true);
+			mockMetadataManagerInstance.readMigrationState.mockImplementationOnce(
+				() => {
+					throw new Error("migration state unreadable");
+				},
+			);
 
 			activate(makeContext());
 
@@ -2044,6 +2056,26 @@ describe("Extension", () => {
 					expect.any(Error),
 				);
 			});
+		});
+
+		// A storage read that fails must NOT be read as "this repo has no
+		// memories": that is the branch which runs a 0-entry migration and marks
+		// it `completed`, suppressing the real one once memories do arrive.
+		it("skips the migration entirely when the storage probe fails", async () => {
+			mockSotInstance.exists.mockRejectedValueOnce(new Error("db gone"));
+			mockMigrationEngineInstance.runMigration.mockClear();
+
+			activate(makeContext());
+
+			await vi.waitFor(() => {
+				expect(mockSotInstance.exists).toHaveBeenCalled();
+			});
+			expect(mockMigrationEngineInstance.runMigration).not.toHaveBeenCalled();
+			expect(error).not.toHaveBeenCalledWith(
+				"activate",
+				"KB folder init/migration failed",
+				expect.any(Error),
+			);
 		});
 
 		it("releases the sync gate via the 60s watchdog when initializeKB never settles", () => {
@@ -5801,6 +5833,28 @@ describe("Extension", () => {
 			await vi.waitFor(() => {
 				expect(mockMemoriesStore.refresh).toHaveBeenCalled();
 			});
+		});
+
+		// A memory-store refresh is background work, not a command: nothing the
+		// user did triggered it, and the database watcher that shares this
+		// handler is MACHINE-GLOBAL, so a write from an unrelated repo could pop
+		// a modal in a window whose own repo is merely mid-rebase. `handleError`
+		// (which does pop one) is for commands.
+		it("logs a failed background refresh instead of popping an error toast", async () => {
+			mockCommitsStore.refresh.mockRejectedValueOnce(new Error("git index locked"));
+			showErrorMessage.mockClear();
+			// Watcher indices: 0=sessions, 1=head, 2=orphan-ref, 3=lock.
+			const orphanWatcher = createFileSystemWatcher.mock.results[2]?.value;
+			const onChange = orphanWatcher?.onDidChange.mock.calls[0]?.[0] as
+				| (() => void)
+				| undefined;
+
+			onChange?.();
+
+			await vi.waitFor(() => {
+				expect(mockCommitsStore.refresh).toHaveBeenCalled();
+			});
+			expect(showErrorMessage).not.toHaveBeenCalled();
 		});
 
 		it("refreshes memories on orphan-ref change when hasFirstLoaded is true", async () => {

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -5,7 +5,7 @@
  * Called by VSCode when the extension activates (workspaceContains:.git).
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { clearTimeout, setTimeout } from "node:timers";
 import * as vscode from "vscode";
@@ -319,6 +319,15 @@ function revertFailureHint(reason: "missing" | "malformed" | "unlinkFailed"): st
 const divergenceMessageShown = new Set<string>();
 
 // ─── activate ─────────────────────────────────────────────────────────────────
+
+/**
+ * How long a burst of memory-database file events is collapsed before one
+ * refresh runs. A stored memory is many small writes (the queue worker lands a
+ * summary, its topics and the index in one transaction each), and every one of
+ * them is a separate watcher event; the user-visible latency of waiting this
+ * long is nil next to the refresh itself.
+ */
+const MEMORY_DB_WATCH_DEBOUNCE_MS = 300;
 
 /**
  * Commands the extension may receive in degraded mode (no workspace / no git).
@@ -1834,6 +1843,9 @@ export function activate(context: vscode.ExtensionContext): void {
 			const { resolveSotStorage } = await import(
 				"../../cli/src/core/SotStorageResolver.js"
 			);
+			const { detectStoredMemories } = await import(
+				"../../cli/src/core/StoredMemories.js"
+			);
 			const { FolderStorage } = await import(
 				"../../cli/src/core/FolderStorage.js"
 			);
@@ -1876,7 +1888,11 @@ export function activate(context: vscode.ExtensionContext): void {
 			// folder from it silently omits every memory written since the
 			// fence, and a clone made after one has no branch at all.
 			const sot = await resolveSotStorage(workspaceRoot);
-			if (await sot.exists()) {
+			// `detectStoredMemories`, not `exists()`: a 0-entry run here writes a
+			// `completed` migration state, which then suppresses the real migration
+			// once memories do arrive. Past a cutover `exists()` is true from the
+			// first `jolli enable`, so that became reachable on every fresh repo.
+			if ((await detectStoredMemories(sot)) === "some") {
 				const mm = new MetadataManager(join(kbRoot, ".jolli"));
 				const migrationState = mm.readMigrationState();
 				if (!migrationState || migrationState.status !== "completed") {
@@ -2065,14 +2081,31 @@ export function activate(context: vscode.ExtensionContext): void {
 	);
 	// Shared by the ref watcher and the database watcher below: the panels do
 	// not care WHICH backend just gained a memory, only that one did.
-	const onMemoryStored = (source: string) => () => {
+	//
+	// Failures are LOGGED, not surfaced. `handleError` exists for commands — it
+	// pops a modal, which is right when a user action failed and wrong here:
+	// nothing the user did triggered this, and the database watcher below is
+	// machine-global, so a write from an unrelated repo could pop an error
+	// toast in a window whose own repo is merely mid-rebase.
+	const onBackgroundRefreshError = (source: string) => (err: unknown) => {
+		log.warn("watcher", `${source} refresh failed: ${err instanceof Error ? err.message : String(err)}`);
+	};
+	// Awaitable form. Only the database watcher below needs to know when the
+	// refresh has SETTLED — its echo guard compares a stat signature taken after
+	// the reads this refresh performs, so it must not sample mid-flight.
+	const refreshStoredMemory = async (source: string): Promise<void> => {
 		bridge.invalidateEntriesCache();
-		commitsStore.refresh().catch(handleError(source));
-		// Lazy-load gate: if the user never opened Memories, do NOT silently
-		// wake it up in the background (would trigger listSummaryEntries).
-		if (memoriesStore.hasFirstLoaded()) {
-			memoriesStore.refresh().catch(handleError(`${source}.memories`));
-		}
+		await Promise.allSettled([
+			commitsStore.refresh().catch(onBackgroundRefreshError(source)),
+			// Lazy-load gate: if the user never opened Memories, do NOT silently
+			// wake it up in the background (would trigger listSummaryEntries).
+			memoriesStore.hasFirstLoaded()
+				? memoriesStore.refresh().catch(onBackgroundRefreshError(`${source}.memories`))
+				: Promise.resolve(),
+		]);
+	};
+	const onMemoryStored = (source: string) => () => {
+		void refreshStoredMemory(source);
 	};
 
 	if (orphanRefPath) {
@@ -2194,19 +2227,107 @@ export function activate(context: vscode.ExtensionContext): void {
 	// Both are watched because a repo can be on either side of the fence.
 	//
 	// The `-wal` sibling is what actually moves per write (the main `.db` mtime
-	// only changes at checkpoint), hence the glob. Machine-global, so writes
-	// from OTHER repos wake this too; the refreshes are cheap and idempotent,
-	// and over-refreshing is the safe way to be wrong.
+	// only changes at checkpoint), hence both are watched. Machine-global, so
+	// writes from OTHER repos wake this too; over-refreshing is the safe way to
+	// be wrong — but only up to a point, see the echo guard below.
+	//
+	// `-shm` is deliberately NOT watched, and the callback is deliberately not
+	// `onMemoryStored` directly. Once a repo is cut over, the refresh this
+	// watcher triggers reads through `SqliteStorage`, and every such read is an
+	// open → query → close against this very database; in WAL mode that rewrites
+	// `-shm`. A `jollimemory.db*` glob therefore made the refresh re-trigger
+	// itself with nothing to damp it: measured at ~5 refresh rounds per second,
+	// each doing the full multi-repo re-read (`invalidateEntriesCache` denies it
+	// the cache), pegging the extension host at 75% CPU indefinitely. Nothing
+	// looked broken — the sidebar kept painting — but every user command queued
+	// behind the storm, so `Commit Memory` took minutes to open its QuickPick.
+	// The `.db` / `-wal` mtimes stayed frozen throughout that loop, which is the
+	// evidence that a read-only cycle touches `-shm` and nothing else, and why
+	// dropping it from the glob is the narrow fix rather than a heuristic.
+	//
+	// Two more layers, because a WRITABLE handle checkpoints on close and can
+	// delete + recreate `-wal`, which would close the loop again: coalesce a
+	// burst onto one refresh, and skip a refresh whose signature matches what we
+	// last saw. The signature is sampled AFTER the refresh settles, so our own
+	// read churn is already folded into it — an echo compares equal and stops,
+	// while a real write from the queue worker moves it again.
 	//
 	// Created LAST on purpose: `Extension.test.ts` addresses watchers by their
 	// `createFileSystemWatcher` call index, so inserting one mid-sequence
 	// silently re-points half those assertions at the wrong watcher.
+	const memoryDbDir = dirname(getDashboardDbPath());
+	const memoryDbSignature = (): string =>
+		["jollimemory.db", "jollimemory.db-wal"]
+			.map((name) => {
+				try {
+					const s = statSync(join(memoryDbDir, name));
+					return `${s.mtimeMs}:${s.size}`;
+				} catch {
+					// Absent is a signature too — a repo that has not been cut over
+					// has no database, and it appearing later is a real change.
+					return "-";
+				}
+			})
+			.join("|");
+	let memoryDbSeen = memoryDbSignature();
+	let memoryDbTimer: ReturnType<typeof setTimeout> | undefined;
+	let memoryDbRefreshing = false;
+	// An event that lands DURING a refresh must not be dropped. The post-refresh
+	// signature is taken after that write, so the echo guard would then treat the
+	// write as already-seen and suppress it permanently — the refresh would only
+	// come back on some later, unrelated write. Remembering the event and
+	// re-arming the timer once the refresh settles is what keeps the guard's
+	// "ignore our own churn" from also swallowing somebody else's.
+	//
+	// Re-arming alone is NOT enough, and that is the subtle half: the `finally`
+	// used to publish the post-refresh signature unconditionally, so the very
+	// write we re-armed for was already folded into `memoryDbSeen` and the next
+	// tick compared equal and returned. When an event was missed we therefore
+	// KEEP the pre-refresh signature, which guarantees the next tick sees a
+	// difference and refreshes once more. The cost is one extra refresh when the
+	// missed event was only our own read churn; the alternative is a sidebar that
+	// stays stale until some unrelated write happens to come along.
+	let memoryDbMissedEvent = false;
+	const onMemoryDbChanged = (): void => {
+		if (memoryDbRefreshing) {
+			memoryDbMissedEvent = true;
+			return;
+		}
+		if (memoryDbTimer) clearTimeout(memoryDbTimer);
+		memoryDbTimer = setTimeout(() => {
+			memoryDbTimer = undefined;
+			const signature = memoryDbSignature();
+			if (signature === memoryDbSeen) return;
+			memoryDbRefreshing = true;
+			memoryDbMissedEvent = false;
+			void refreshStoredMemory("memoryDbWatcher").finally(() => {
+				const missed = memoryDbMissedEvent;
+				// Only publish the post-refresh signature when nothing landed while we
+				// were reading — otherwise it would absorb the missed write and make
+				// the re-armed tick a no-op (see the note on `memoryDbMissedEvent`).
+				if (!missed) memoryDbSeen = memoryDbSignature();
+				memoryDbRefreshing = false;
+				// Re-arm rather than refresh immediately: the debounce still collapses a
+				// burst, and the signature check on the next tick still runs — it just
+				// compares against the pre-refresh signature now, so a real write cannot
+				// compare equal.
+				if (missed) {
+					memoryDbMissedEvent = false;
+					onMemoryDbChanged();
+				}
+			});
+		}, MEMORY_DB_WATCH_DEBOUNCE_MS);
+	};
 	const memoryDbWatcher = watchFile(
-		vscode.Uri.file(dirname(getDashboardDbPath())),
-		"jollimemory.db*",
-		onMemoryStored("memoryDbWatcher"),
+		vscode.Uri.file(memoryDbDir),
+		"{jollimemory.db,jollimemory.db-wal}",
+		onMemoryDbChanged,
 	);
-	context.subscriptions.push(memoryDbWatcher);
+	context.subscriptions.push(memoryDbWatcher, {
+		dispose: () => {
+			if (memoryDbTimer) clearTimeout(memoryDbTimer);
+		},
+	});
 
 
 	// COMMITS title updates are handled by the commitsStore.onChange subscription
@@ -2309,6 +2430,9 @@ export function activate(context: vscode.ExtensionContext): void {
 					const { resolveSotStorage } = await import(
 						"../../cli/src/core/SotStorageResolver.js"
 					);
+					const { detectStoredMemories } = await import(
+						"../../cli/src/core/StoredMemories.js"
+					);
 					const { FolderStorage } = await import(
 						"../../cli/src/core/FolderStorage.js"
 					);
@@ -2324,10 +2448,20 @@ export function activate(context: vscode.ExtensionContext): void {
 						| undefined;
 
 					const sot = await resolveSotStorage(workspaceRoot);
-					if (!(await sot.exists())) {
+					// NOT `exists()`: this branch archives every existing Memory
+					// Bank folder for the repo before re-migrating, and past a
+					// cutover `exists()` is true for any enabled repo — memories
+					// or not. `unknown` (a read failure) takes the same exit as
+					// `none`, because the destructive path must never run on a
+					// guess. See cli/src/core/StoredMemories.ts.
+					const presence = await detectStoredMemories(sot);
+					if (presence !== "some") {
 						return {
 							ok: false,
-							message: "No stored memories found — nothing to rebuild.",
+							message:
+								presence === "none"
+									? "No stored memories found — nothing to rebuild."
+									: "Could not read stored memories — leaving the Memory Bank untouched.",
 						};
 					}
 

--- a/vscode/src/services/JolliPushOrchestrator.test.ts
+++ b/vscode/src/services/JolliPushOrchestrator.test.ts
@@ -298,11 +298,38 @@ describe("pushSummaryWithAttachments", () => {
 
 	it("reports ONE skipped entry for a kind however many of its items failed", async () => {
 		// The caller renders these into a notification. Per-item entries made a commit
-		// with a dozen skills produce a dozen titles in one toast.
+		// with a dozen references produce a dozen titles in one toast.
 		mockPushToJolli.mockImplementation((_b, _k, p: { docType: string }) => {
-			if (p.docType === "skill") return Promise.reject(new Error("skill 500"));
+			if (p.docType === "reference") return Promise.reject(new Error("ref 500"));
 			return Promise.resolve({ docId: 100 });
 		});
+		const references = ["ENG-1", "ENG-2", "ENG-3"].map((id) => ({
+			archivedKey: `linear:${id}-a1b2c3d4`,
+			source: "linear",
+			nativeId: id,
+			title: `Fix ${id}`,
+			url: "https://linear.app/x",
+			referencedAt: "t",
+			sourceToolName: "Claude Code",
+		}));
+		const result = await pushSummaryWithAttachments(makeSummary({ references }), makeContext(), {
+			plans: [],
+			notes: [],
+			references,
+		});
+		expect(result.skippedAttachments).toHaveLength(1);
+		expect(result.skippedAttachments[0].label).toBe("3 reference article(s)");
+		expect(result.attachmentFailures).toEqual([]);
+	});
+
+	it("publishes ONE aggregate article for a commit's whole skill set", async () => {
+		// The mismatch this kind's `aggregate` exists to fix: the Context surfaces show a
+		// commit's skills as ONE artifact (`skills--<hash8>.md` / a single "Skills used"
+		// row), so a commit that entered three skills used to arrive at the backend as
+		// three documents the user had no local counterpart for.
+		mockPushToJolli.mockImplementation((_b, _k, p: { docType: string }) =>
+			Promise.resolve({ docId: p.docType === "summary" ? 100 : 501 }),
+		);
 		const skills = ["one", "two", "three"].map((name) => ({
 			archivedKey: `claude:${name}-a1b2c3d4`,
 			source: "claude" as const,
@@ -317,9 +344,16 @@ describe("pushSummaryWithAttachments", () => {
 			makeContext(),
 			new Map([["skill", skills]]),
 		);
-		expect(result.skippedAttachments).toHaveLength(1);
-		expect(result.skippedAttachments[0].label).toBe("3 skill article(s)");
-		expect(result.attachmentFailures).toEqual([]);
+		const skillCalls = mockPushToJolli.mock.calls.filter((c) => (c[2] as { docType: string }).docType === "skill");
+		expect(skillCalls).toHaveLength(1);
+		const payload = skillCalls[0][2] as { title: string; content: string };
+		// One article, named for the commit, listing every skill in the shared table.
+		expect(payload.title).toBe("Skills used — abc123");
+		for (const name of ["one", "two", "three"]) expect(payload.content).toContain(name);
+		// The id lands on the COMMIT, not on any skill entry — the article covers all of
+		// them, so a re-push updates it no matter how the skill set changes.
+		expect(result.updatedSummary.jolliSkillsDocId).toBe(501);
+		expect(result.updatedSummary.skills?.some((s) => s.jolliDocId !== undefined)).toBe(false);
 	});
 
 	it("reports a docType refusal as skipped instead of only logging it", async () => {
@@ -344,7 +378,8 @@ describe("pushSummaryWithAttachments", () => {
 			makeContext(),
 			new Map([["skill", skills]]),
 		);
-		// Short-circuited after the first item: the second was never attempted.
+		// One call either way — the kind aggregates a commit's skills into a single
+		// article — and the refusal short-circuits the rest of the kind.
 		expect(mockPushToJolli.mock.calls.filter((c) => (c[2] as { docType: string }).docType === "skill")).toHaveLength(
 			1,
 		);
@@ -375,7 +410,7 @@ describe("pushSummaryWithAttachments", () => {
 		);
 		const skillCall = mockPushToJolli.mock.calls.find((c) => (c[2] as { docType: string }).docType === "skill");
 		expect(skillCall).toBeDefined();
-		expect(result.updatedSummary.skills?.[0]).toMatchObject({ jolliDocId: 501 });
+		expect(result.updatedSummary.jolliSkillsDocId).toBe(501);
 	});
 
 	it("skips a snippet note with no content and pushes a markdown note's body", async () => {
@@ -648,6 +683,21 @@ describe("serializeSummaryJson", () => {
 		expect(Object.keys(parsed)).not.toEqual(
 			expect.arrayContaining(["jolliDocId", "jolliDocUrl", "orphanedDocIds"]),
 		);
+	});
+
+	it("strips the skill-article publish state too (the skill push runs first and weaves it on)", () => {
+		const json = serializeSummaryJson(
+			makeSummary({
+				jolliSkillsDocId: 42,
+				jolliSkillsDocUrl: "https://acme.jolli.ai/articles?doc=42",
+				skills: [{ source: "claude", skill: "jolli-recall", uses: 2 }],
+			} as unknown as Partial<CommitSummary>),
+		);
+		const parsed = JSON.parse(json ?? "");
+		expect(parsed.jolliSkillsDocId).toBeUndefined();
+		expect(parsed.jolliSkillsDocUrl).toBeUndefined();
+		// The skill rows themselves are commit content and stay.
+		expect(parsed.skills).toHaveLength(1);
 	});
 
 	it("keeps nested plan/note/reference docId/url (needed to render the article links)", () => {

--- a/vscode/src/services/JolliPushOrchestrator.ts
+++ b/vscode/src/services/JolliPushOrchestrator.ts
@@ -35,8 +35,7 @@ import { isOutboundPushAllowed } from "../../../cli/src/core/PushControl.js";
 import { isRepoWideRefusal } from "../../../cli/src/core/PushRefusal.js";
 import {
 	baseKeyOfItem,
-	docIdOf,
-	docUrlOf,
+	storedDocOf,
 	entryKeyOf,
 	getContextKinds,
 } from "../../../cli/src/core/push/ContextKindRegistry.js";
@@ -48,6 +47,7 @@ import {
 	reduceOwnItems,
 } from "../../../cli/src/core/push/ContextPush.js";
 import { canReuseDocId } from "../../../cli/src/core/push/DocIdReuse.js";
+import { adoptLegacySkillDocIds } from "../../../cli/src/core/push/LegacySkillDocIds.js";
 import { track } from "../../../cli/src/core/Telemetry.js";
 import { log } from "../util/Logger.js";
 import { buildBranchRelativePath, buildPushTitle } from "../views/SummaryUtils.js";
@@ -100,14 +100,24 @@ const MAX_SUMMARY_JSON_BYTES = 1_572_864;
 /**
  * Serializes a summary for the `summaryJson` push field: the enriched
  * `summaryForMarkdown` copy (plan/note URLs woven in) minus the client push-state
- * fields — `jolliDocId`/`jolliDocUrl` churn per push and `orphanedDocIds` is
+ * fields — `jolliDocId`/`jolliDocUrl` and their skill-article siblings
+ * `jolliSkillsDocId`/`jolliSkillsDocUrl` churn per push and `orphanedDocIds` is
  * cleanup bookkeeping, none of which is commit content the share page should see
  * (stripping them also keeps a re-push of unchanged content byte-identical, so
- * the server upsert can no-op). Returns undefined (with a warning) above
+ * the server upsert can no-op). The skill aggregate is pushed BEFORE the summary
+ * in the same run, so `applyPublishedUrls` has already woven its id/URL onto the
+ * summary by the time we serialize. Returns undefined (with a warning) above
  * {@link MAX_SUMMARY_JSON_BYTES}.
  */
 export function serializeSummaryJson(summary: CommitSummary): string | undefined {
-	const { jolliDocId: _docId, jolliDocUrl: _docUrl, orphanedDocIds: _orphaned, ...content } = summary;
+	const {
+		jolliDocId: _docId,
+		jolliDocUrl: _docUrl,
+		jolliSkillsDocId: _skillsDocId,
+		jolliSkillsDocUrl: _skillsDocUrl,
+		orphanedDocIds: _orphaned,
+		...content
+	} = summary;
 	const json = JSON.stringify(content);
 	if (Buffer.byteLength(json, "utf-8") > MAX_SUMMARY_JSON_BYTES) {
 		log.warn(
@@ -245,12 +255,16 @@ export interface PushSummaryOptions {
  * orphans, and returns the doc ids + renderable result. UI-free — see file header.
  */
 export async function pushSummaryWithAttachments(
-	summary: CommitSummary,
+	original: CommitSummary,
 	ctx: PushContext,
 	attachments?: AttachmentSelection | ContextSelection,
 	options: PushSummaryOptions = {},
 	retried = false,
 ): Promise<PushSummaryResult> {
+	// Convert any per-skill article ids published by an older version into the
+	// commit-level one before anything reads them — see `adoptLegacySkillDocIds`.
+	// Idempotent, so the `retried` re-entry below costs nothing.
+	const summary = adoptLegacySkillDocIds(original);
 	// Story 2: fail fast for a push-disabled repo before uploading anything.
 	// Checking here (not only inside each HTTP call) avoids issuing a doomed
 	// per-attachment push that would be mislabeled as an attachment failure. The
@@ -458,7 +472,7 @@ async function pushAttachmentKinds(
 				}
 				continue;
 			}
-			const storedDocId = docIdOf(kind, item);
+			const stored = storedDocOf(kind, summary, item);
 			let pushResult: Awaited<ReturnType<typeof pushToJolli>>;
 			try {
 				pushResult = await pushToJolli(
@@ -470,8 +484,8 @@ async function pushAttachmentKinds(
 						commitHash: summary.commitHash,
 						docType: kind.docType,
 						branch: summary.branch,
-						...(storedDocId !== undefined &&
-							canReuseDocId(docUrlOf(kind, item), envKey) && { docId: storedDocId }),
+						...(stored.docId !== undefined &&
+							canReuseDocId(stored.docUrl, envKey) && { docId: stored.docId }),
 						repoUrl: ctx.repoUrl,
 						relativePath: buildBranchRelativePath(summary.branch),
 					},

--- a/vscode/src/views/KnowledgeGraphPanel.test.ts
+++ b/vscode/src/views/KnowledgeGraphPanel.test.ts
@@ -96,10 +96,15 @@ describe("renderGraphHtml", () => {
 		expect(html).not.toContain("<!-- scripts:start -->");
 	});
 
-	it("escapes </script sequences in the embedded graph data", () => {
+	// Behaviour is pinned in the CLI's core/InlineScript.test.ts — this panel
+	// shares that implementation rather than carrying its own copy.
+	it("escapes < in the embedded graph data, including a <!-- comment opener", () => {
 		const html = renderGraphHtml(TEMPLATE, { ...ASSETS, graphJson: '{"x":"</script>BAD"}' });
-		expect(html).toContain("<\\/script");
+		expect(html).toContain("\\u003c/script");
 		expect(html).not.toContain("</script>BAD");
+
+		const commented = renderGraphHtml(TEMPLATE, { ...ASSETS, graphJson: '{"x":"<!--<script>"}' });
+		expect(commented).not.toContain("<!--<script>");
 	});
 
 	it("permits inline styles (style-src 'unsafe-inline') so per-category colors survive", () => {

--- a/vscode/src/views/KnowledgeGraphPanel.ts
+++ b/vscode/src/views/KnowledgeGraphPanel.ts
@@ -17,6 +17,9 @@ import { randomBytes } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import * as vscode from "vscode";
+// Cross-package import resolved at esbuild bundle time (see AGENTS.md): the
+// inline-script escape is a security primitive and must not be a fourth copy.
+import { escapeForInlineScript } from "../../../cli/src/core/InlineScript.js";
 
 const VENDOR_FILES = ["panzoom.min.js", "elk.bundled.js", "marked.min.js"];
 const SCRIPT_FILES = ["data.js", "state.js", "edges.js", "camera.js", "drag.js", "views.js", "panel.js", "main.js"];
@@ -63,18 +66,6 @@ export function renderGraphHtml(template: string, a: GraphHtmlAssets): string {
 	);
 	html = replaceMarker(html, /<!-- scripts:start -->[\s\S]*?<!-- scripts:end -->/, scriptsBlock, "scripts block");
 	return html;
-}
-
-/**
- * Neutralizes inline-script breakout in the embedded graph JSON: the `</script`
- * close sequence (any case) plus the two legacy JS line terminators U+2028/U+2029
- * that JSON.stringify leaves raw (inert on ES2019+ engines, cheap defense in depth).
- */
-function escapeForInlineScript(json: string): string {
-	return json
-		.replace(/<\/script/gi, "<\\/script")
-		.replace(new RegExp(String.fromCharCode(0x2028), "g"), "\\u2028")
-		.replace(new RegExp(String.fromCharCode(0x2029), "g"), "\\u2029");
 }
 
 /** Replaces a single template marker, throwing if it is absent (no silent no-op). */


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Context

- Skills used — 1 skill · 2520.8k tokens

## E2E Test (8)
<details>
<summary><strong>1. No CPU spike after saving a memory</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository already set up with the local database enabled and at least one existing stored memory visible in the sidebar.

**Steps:**
1. Open VS Code with the repository loaded and the Jolli Memory sidebar visible.
2. Open your system's activity monitor or task manager and find the VS Code extension host process.
3. Make a small code change in the repository, then use the "Commit Memory" command to save a new memory.
4. Watch the extension host CPU usage for about 30 seconds after the memory is saved.
5. Return to the sidebar and check that the memory list has refreshed and shows the newly saved memory.

**Expected Results:**
- The extension host CPU usage should spike briefly while saving, then settle back to near zero within a few seconds.
- The sidebar should show the new memory without requiring a manual refresh.
- CPU usage should NOT stay elevated or continue cycling repeatedly after the save completes.

</blockquote>
</details>
<details>
<summary><strong>2. Sidebar and timeline load noticeably faster</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with a meaningful number of stored memories (ideally 50 or more) and the local database enabled.

**Steps:**
1. Open VS Code with the repository loaded and the Jolli Memory sidebar visible.
2. Collapse and re-expand the sidebar panel to trigger a fresh load, and note roughly how long it takes to populate.
3. Open the Jolli Memory dashboard in a browser and navigate to the timeline or history view.
4. Note how quickly the list of memories appears.

**Expected Results:**
- The sidebar should populate within a second or two, feeling noticeably snappier than before this fix.
- The dashboard timeline should load quickly without a visible delay or blank period before entries appear.

</blockquote>
</details>
<details>
<summary><strong>3. Repositories automatically switch to the local database without a manual command</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository that has been set up with Jolli Memory but has not yet been manually migrated to the local database.

**Steps:**
1. Open VS Code with the repository loaded.
2. Run the guided setup flow (open the Jolli Memory panel and follow any first-time setup prompts, or import dashboard history if prompted).
3. After setup completes, make a commit in the repository as normal.
4. Open the Jolli Memory dashboard in a browser and check whether memories and history are visible.

**Expected Results:**
- After completing setup or making a commit, the dashboard should display the repository's memories and history without the user having to run any separate migration or cutover command.
- No error messages or empty states should appear where memory data is expected.

</blockquote>
</details>
<details>
<summary><strong>4. Dashboard stats endpoint does not trigger AI calls from background tabs</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the Jolli Memory dashboard open in a browser tab. Also have a second browser tab open to any unrelated website.

**Steps:**
1. From the unrelated website's tab, open the browser developer tools and attempt to fetch the dashboard stats URL directly (or simply observe normal browsing — no special action needed beyond having the tab open).
2. Return to the Jolli Memory dashboard tab and open the stats or insights section.
3. Check that the stats section loads and displays information normally.

**Expected Results:**
- The stats section in the legitimate dashboard tab should load and display correctly, including any AI-generated summaries.
- No AI-generated content or charges should be triggered by requests coming from other browser tabs or websites — those requests should be silently blocked or return a degraded (non-AI) response.

</blockquote>
</details>
<details>
<summary><strong>5. Saving a memory in a batch with a bad attachment does not lose the memory</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with the local database enabled. This scenario may require a developer to briefly introduce a malformed artifact file alongside a normal memory commit to reproduce the condition, then verify the outcome.

**Steps:**
1. Trigger a commit that includes both a valid memory and a file that cannot be parsed (such as a corrupted plan or topic file attached to the same commit).
2. Open the Jolli Memory dashboard and navigate to the memory list or timeline.
3. Search or scroll to find the memory that was part of the same commit as the bad file.

**Expected Results:**
- The valid memory should appear in the dashboard as normal.
- The bad attachment should be skipped with no visible error shown to the user.
- The rest of the dashboard should continue working normally — no blank screens or crash messages.

</blockquote>
</details>
<details>
<summary><strong>6. IntelliJ panel shows correctly for a repo that was fenced for cutover but never disabled by the user</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the Jolli Memory IntelliJ plugin installed and a repository that has gone through the local database cutover process (fenced state) but where the user never explicitly disabled Jolli Memory for that repo.

**Steps:**
1. Open IntelliJ IDEA with the repository loaded.
2. Locate the Jolli Memory panel or sidebar in the IDE.
3. Check whether the panel shows memory content or displays a "disabled" or empty state.

**Expected Results:**
- The Jolli Memory panel should be active and showing memory content, not a disabled or empty state.
- A repo that was only fenced for the automated cutover — but never turned off by the user — should look and behave exactly like a fully enabled repo in the IntelliJ panel.

</blockquote>
</details>
<details>
<summary><strong>7. Branch information is preserved when a git scan partially fails</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with several commits that already have branch attribution recorded in the Jolli Memory dashboard.

**Steps:**
1. Simulate or wait for a condition where the git branch scan might partially fail (for example, a branch that has been deleted mid-scan, or a network interruption if using a remote). Alternatively, simply make a new commit and let the dashboard update normally.
2. Open the Jolli Memory dashboard and navigate to the commit history or timeline view.
3. Click on a commit that previously showed branch information and check the branch label.

**Expected Results:**
- Commits that already had branch attribution recorded should still show their branch labels — the information should not be wiped or replaced with a blank.
- Only commits where the scan fully succeeded should have their branch data updated; commits touched by a partial failure should retain whatever was previously stored.

</blockquote>
</details>
<details>
<summary><strong>8. Memory rebuild does not archive folders on a freshly enabled repo with no stored memories</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository that was just enabled for Jolli Memory and has gone through a database cutover, but has no memories stored yet (a brand-new setup).

**Steps:**
1. Open VS Code with the freshly enabled repository loaded.
2. Observe the Memory Bank folder in the file explorer — note its current contents (it should be empty or contain only default files).
3. Wait for the extension to finish its activation steps, or trigger a refresh of the Jolli Memory sidebar.
4. Check the Memory Bank folder again and check whether any archiving or migration dialog appeared.

**Expected Results:**
- The Memory Bank folder should remain untouched — no archiving, no migration, and no empty folder replacement should occur.
- No dialog or notification should appear telling the user their memory folders were archived or migrated.
- The sidebar should show an empty or default state appropriate for a repo with no memories yet.

</blockquote>
</details>

---

## Topics (16)
<details>
<summary><strong>01 · Fix infinite refresh loop causing extension host CPU saturation</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After the storage system switched to the local database, clicking "Commit Memory" became extremely slow to respond. The extension host was pegged at high CPU usage continuously, causing user commands to queue up behind a storm of background refresh activity.

**💡 Decisions Behind the Code**

- **Narrow the watch target rather than add suppression heuristics**: The shared-memory file is rewritten by read-only database opens and never by actual data writes, so excluding it from the watch pattern is a precise fix with no false negatives. Broader suppression approaches would have been less reliable and harder to reason about, and the evidence from frozen main-file timestamps during the loop made the root cause unambiguous.
- **Layered defense despite the narrow fix being sufficient**: Even with the shared-memory file excluded, a writable handle checkpointing on close can delete and recreate the write-ahead log, which could re-close the loop. The debounce and echo guard together handle that case: the debounce collapses the burst, and the echo guard stops the cycle if the post-refresh signature matches what the refresh itself produced. Each layer is independently useful, and together they make the fix robust to future storage behavior changes.
- **Sample the echo signature after the refresh settles, not before**: Taking the snapshot before the refresh would miss churn produced by the refresh's own reads, causing legitimate echoes to appear as new writes. Sampling after — made possible by the awaitable refactor — folds the read-induced churn into the baseline, so only a genuine new write from the queue worker produces a signature change that passes the guard.

**✅ What Was Implemented**

- The file watcher in `vscode/src/Extension.ts` was changed from a wildcard pattern covering all database-adjacent files to one that watches only the two files that actually change on a real write. A shared-memory file rewritten on every read-only database open was previously included, causing each refresh to trigger another in an unbounded loop.
- A 300ms debounce timer was added to coalesce burst events (a single stored memory produces several sequential file writes) into one refresh cycle.
- An echo guard was added: after each refresh completes, file signatures are sampled and stored; a subsequent event whose signature matches the post-refresh snapshot is skipped as a self-echo rather than triggering another round.
- `refreshStoredMemory` was extracted as an awaitable async function so the echo guard samples file signatures only after the refresh has fully settled, preventing a race where the guard samples mid-flight and misidentifies a real write as an echo.

**📁 FILES**
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Speed up memory index reads by querying columns instead of parsing bodies</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The dashboard felt sluggish after switching to the local database. Every sidebar refresh, timeline load, and session briefing all read through the same index, and that read was taking around 75ms on a real repository.

**💡 Decisions Behind the Code**

- **Query columns, not bodies, for the index**: The index entry needs only a handful of scalar fields, all of which the database already stores or can extract cheaply. Pulling the full body for every row and parsing it in JavaScript was the dominant cost, and eliminating it produced a 4.7× speedup with no change in output. The trade-off is that adding a new index field now requires a schema column or a cheap extraction expression rather than a free JSON key lookup, which is acceptable given how rarely the index shape changes.
- **Grouped query for topic counts instead of per-root tree assembly**: Assembling each root's subtree to count its topics required loading and parsing every body in that subtree, multiplied by the number of roots. A single aggregation query over the topics table produces the same number at a fraction of the cost. Topics with no title are excluded from the projection table and therefore from the count, but those render as nothing in the UI anyway.

**✅ What Was Implemented**

- `synthIndex` in `cli/src/core/SqliteStorage.ts` was rewritten to fetch eight scalar columns per row rather than pulling the full JSON body of every memory and parsing it in JavaScript. Measured output on a 399-row repository dropped from 75ms to 16ms with byte-identical results across all entries.
- Topic counts for root entries were moved from a per-root tree assembly (which required loading and recursively walking each subtree) to a single grouped database query against the topics projection table, verified equal on all 74 roots in the test repository.
- A module-level `parsedDiffStats` helper was extracted and the now-unused `diffStatsFor` instance method and `countTopics` import were removed, keeping the file consistent with the new column-only approach.

**📁 FILES**
- `cli/src/core/SqliteStorage.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Speed up non-root memory tree reads using targeted subtree traversal</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Reading a single leaf node from a large memory tree was slow because the database fetched the entire tree family — including ancestors and siblings — even though only the node's own subtree was needed to assemble its summary.

**💡 Decisions Behind the Code**

Two separate paths rather than one unified recursive query were chosen after direct measurement. Applying the recursive traversal to root nodes as well made the aggregate read time across all stored summaries worse, not adding per-row join overhead with no rows saved. Roots are also the common case in the sidebar, so protecting their performance was the higher priority. The benchmark result was the deciding factor — the split was kept precisely because it contradicted the initial assumption that a unified approach would be simpler and equally fast.

**✅ What Was Implemented**

- `assembleMemoryTree` in `cli/src/core/SqliteStorage.ts` was split into two code paths based on whether the requested node is a root. Root nodes continue to use a range scan over the shared root identifier. Non-root nodes now use a recursive common table expression that walks only downward from the requested node, fetching only the subtree rather than the whole family.
- Benchmarking on 835 summaries showed the split approach improved the leaf case from 7.45ms to 0.27ms with roots unchanged, while a unified recursive approach regressed roots from 4.81ms to 5.54ms — the split was kept precisely because the benchmark contradicted the initial assumption.
- A test assertion was strengthened in `SqliteStorage.test.ts` to verify that reading a child leaf does not include sibling nodes from the same root.

**📁 FILES**
- `cli/src/core/SqliteStorage.ts`
- `cli/src/core/SqliteStorage.test.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Automatic database cutover triggered without any manual command</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Repositories managed by this tool never actually switched to reading from the local database, because the only way to trigger the cutover was a manual command users had no reason to know about. Every repository stayed in the pre-cutover state indefinitely, leaving the database path permanently unexercised.

**💡 Decisions Behind the Code**

- **Fully automatic with no confirmation prompt**: The switch is scoped entirely to one device and one clone — the fence lives in that clone's local config file and the state row lives in the local database, with nothing pushed to a remote or shared with other machines. With no shared state to corrupt and no other machine to coordinate with, a confirmation prompt has nothing to protect.
- **Two separate trigger points with different throttle rules**: The post-import trigger runs unconditionally because the user is waiting on setup and the database is freshly populated. The post-commit trigger is throttled to once every six hours because the file-comparison step reads every file listed by the frozen branch tip — running that on every commit for a repo that keeps answering "not ready" would be prohibitively slow.
- **Timestamp stamped before the attempt, not after**: If the process is killed or the machine sleeps mid-attempt, the throttle slot must still be consumed. Stamping after a crash would allow a repeatedly-failing comparison to re-run on every single commit. Stamping before means a crashed attempt counts as used and the next try waits for the throttle window.
- **Throttle field excluded from routing logic**: Allowing the attempt timestamp to influence routing would create a third source of truth for a decision that already has two well-defined witnesses (the fence file and the database state row), introducing the possibility of inconsistency. Its only job is to gate the expensive comparison step on the post-commit path.

**✅ What Was Implemented**

- Created `cli/src/dashboard/AutoCutover.ts` with a `maybeAutoCutover` function that invokes the existing cutover engine automatically. It checks the current routing state first, stamps a throttle timestamp before attempting, runs the engine, and returns the resulting state. It never throws and never affects the process exit code.
- Wired the first trigger into `cli/src/commands/DashboardCommand.ts` inside `importDashboardHistory`, which runs at the end of the guided setup flow immediately after the orphan branch history is imported — the highest-probability moment for the switch to succeed. No throttle is applied here.
- Wired the second trigger into `cli/src/hooks/QueueWorker.ts` after the post-commit database write completes, covering repos already enabled before this change. A 6-hour throttle prevents the expensive file-comparison step from running on every commit for repos that repeatedly answer "not ready."
- Added an optional `cutoverAttemptedAtMs` field to the `RepoProfile` interface in `cli/src/core/RepoProfile.ts` to store the epoch millisecond timestamp of the last attempt, explicitly documented as a throttle only with no role in routing decisions.
- Added `readRepoProfile` and `updateRepoProfile` stubs to the `RepoProfile` mock in `cli/src/hooks/QueueWorker.test.ts`, both representing a repo that has never attempted cutover so that test failures are caused by routing state rather than the throttle silently suppressing the attempt.

**📁 FILES**
- `cli/src/dashboard/AutoCutover.ts`
- `cli/src/commands/DashboardCommand.ts`
- `cli/src/hooks/QueueWorker.ts`
- `cli/src/core/RepoProfile.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Fix inline script injection vulnerability across all three page renderers</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Specially crafted text in commit messages or notes could push the browser's HTML parser into a mode where subsequent page scripts were silently discarded, and with the right payload it became an injection primitive.

**💡 Decisions Behind the Code**

- **Escape the character, not the sequence**: Enumerating specific dangerous sequences requires reasoning about every tokenizer state transition and is easy to miss. Escaping `<` universally covers the entire class of breakouts in one rule. The `>` and `&` characters were deliberately left unescaped because neither can move the tokenizer out of script-data state, keeping payload size minimal.
- **Single shared module over three synchronized copies**: Three independent copies of a security primitive meant fixing one and missing two was the default failure mode — which is exactly what happened with the original bug. Centralizing into a zero-dependency module eliminates drift risk entirely. The graph export module re-exports rather than importing directly to avoid breaking its existing callers.

**✅ What Was Implemented**

- Created `cli/src/core/InlineScript.ts` as a single shared escape implementation, replacing three independent copies in the dashboard server, the graph export module, and the VS Code webview panel. The new implementation escapes the `<` character universally rather than enumerating specific breakout sequences, closing all three HTML tokenizer exit paths with one substitution.
- `cli/src/graph/GraphExport.ts` now re-exports the shared function to preserve its existing public API, while `vscode/src/views/KnowledgeGraphPanel.ts` and `cli/src/dashboard/DashboardServer.ts` import from the shared module and delete their private copies.
- Seven regression tests were added in `cli/src/core/InlineScript.test.ts`, including a round-trip JSON parse verification and a specific case for the `<!--<script>` payload that triggered the original bug.

**📁 FILES**
- `cli/src/core/InlineScript.ts`
- `cli/src/graph/GraphExport.ts`
- `vscode/src/views/KnowledgeGraphPanel.ts`
- `cli/src/dashboard/DashboardServer.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Gate AI spending on dashboard stats behind token and browser-origin checks</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The dashboard's stats endpoint could be reached by a background tab on any website, and each request that missed the local cache triggered a real AI call the user never saw, allowing a hostile page to exhaust the cache and run up charges indefinitely.

**💡 Decisions Behind the Code**

- **Answer the request, withhold only the spending**: Returning a 403 for token-free requests would break the documented product promise that opening the URL by hand just works. The gate is applied only to the AI call inside the response — a token-free caller gets the full payload minus the compressed gist, which is the same result a gist failure already produces.
- **Two independent signals rather than one**: The token alone cannot protect page routes, which deliberately accept no credential. The `Sec-Fetch-Site` header alone cannot protect against old browsers that send no fetch-metadata. Each signal covers the gap the other leaves: the header covers page routes and modern browsers, the token covers the API route on older clients.
- **Absent header treated as a command-line tool, not a threat**: When `Sec-Fetch-Site` is missing entirely, the request is trusted as a local invocation. A local process spending the local user's own budget has far easier routes than this endpoint, so blocking it would harm legitimate scripted use without meaningfully reducing risk.

**✅ What Was Implemented**

- Added `allowModelSpend` to the model request type in `cli/src/dashboard/DashboardServer.ts`. The decision-gist function now returns immediately when this flag is false, degrading gracefully to the uncompressed decision text rather than failing.
- Two independent signals determine whether spending is allowed: the `Sec-Fetch-Site` header blocks cross-site requests at both page routes and the API route; the dashboard token additionally gates the API route for browsers that send no fetch-metadata headers.
- The page's polling client in `cli/src/dashboard/assets/js/shell.js` was updated to include the token header on refresh calls.
- Seven new tests cover the combinations: token-free calls answer fully but skip the AI call, cross-site requests with valid tokens are still blocked, and same-origin polls with tokens proceed normally.

**📁 FILES**
- `cli/src/dashboard/DashboardServer.ts`
- `cli/src/dashboard/assets/js/shell.js`

</blockquote>
</details>
<details>
<summary><strong>07 · Fix data corruption when reordering commits arrive in the same batch</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When an amended commit and its predecessor arrived together in a single processing batch, the database could throw a uniqueness violation because child nodes were placed into already-occupied positions before the parent tree had been fully rebuilt.

**💡 Decisions Behind the Code**

- **Keep nodes parked rather than stripping the offset early**: The earlier code stripped the temporary offset immediately on read, putting the node back into the live position space before the parent tree walk had cleared it — exactly the condition that caused the uniqueness collision. Leaving the node parked until the walk assigns a real position is the only safe intermediate state; the walk or the re-ground path always resolves it, so no node can be permanently stranded.
- **Three-branch logic instead of a single strip**: A simpler "always restore" approach would silently corrupt trees where the parent's new child set no longer includes the node. The three-branch check makes each outcome explicit and handles the re-ground case that the old code missed entirely.

**✅ What Was Implemented**

- Rewrote the child-position upsert in `cli/src/dashboard/SotWrite.ts` to use a three-branch strategy: if the current batch is claiming a child node, leave it in the temporary parked offset zone so the parent tree walk can assign the final position; if the batch is not claiming it and its previous slot is now occupied, re-ground it as a root; otherwise restore it to its original mount point.
- Two regression tests were added in `cli/src/dashboard/SotWrite.test.ts` covering the out-of-order three-way reorder case and the re-anchor displacement case.
- `cli/src/dashboard/ZzTmpProbe.test.ts` (a debug probe with no assertions that was breaking the test gate) was deleted; its scenario was absorbed into the new regression tests.

**📁 FILES**
- `cli/src/dashboard/SotWrite.ts`
- `cli/src/dashboard/SotWrite.test.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Fix memory rebuild running destructively on repos with no stored memories</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After a database cutover, the check used to decide whether a repo had stored memories started returning true for every enabled repo — even freshly enabled ones with nothing stored yet — causing the rebuild flow to archive the user's existing Memory Bank folders and then migrate zero memories into a fresh empty folder.

**💡 Decisions Behind the Code**

- **Three states rather than two**: Collapsing a read failure into `"none"` would route it to the destructive branch for a different reason than the intended one. The third state exists specifically to prevent that: a caller that must not act on a guess has a value it can check. Only the two call sites where the answer drives a destructive action were changed; other callers either skip work on a false negative (self-correcting) or genuinely want the initialization question.
- **Read failure absorbed only at the layer where the caller needs a safe answer**: The queue worker deletes an entry only after successful processing, so a thrown exception leaves the entry for retry. Absorbing the exception at the storage layer would cause the worker to proceed against nothing and consume the entry permanently. The new module absorbs the exception only where the caller needs a safe answer, not universally.

**✅ What Was Implemented**

- Added `cli/src/core/StoredMemories.ts` with `detectStoredMemories`, which returns a three-state result: `"some"`, `"none"`, or `"unknown"`. It asks whether the backend is initialized and then lists the summaries directory, treating any read failure as `"unknown"` rather than `"none"`.
- Updated two call sites in `vscode/src/Extension.ts` — the activation-time migration gate and the explicit rebuild command — to treat `"unknown"` the same as `"none"`, so the destructive path never runs on a guess.
- Changed the background watcher's error handler from a modal error dialog to a silent log warning, since the watcher is machine-global and an unrelated repo's write could otherwise pop an error in a window mid-rebase.

**📁 FILES**
- `cli/src/core/StoredMemories.ts`
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · Prevent registry corruption when the repository list file is unreadable</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

If the file storing the list of tracked repositories was corrupted or unreadable for any reason other than simply not existing yet, the application silently treated it as empty and wrote back a registry containing only the one repo being registered, permanently discarding all others.

**💡 Decisions Behind the Code**

- **Two separate read paths rather than one configurable one**: Making the existing reader optionally strict via a parameter would have required auditing every call site to decide which mode it should use, and a wrong default would silently regress. Two named functions make the contract visible at the call site and make it impossible to accidentally use the lenient path in a write context.
- **Shared atomic-write helper extracted to core**: The temp-rename pattern had already been written once with a comment noting the risk; duplicating it a second time would have created two independent places to get the edge cases wrong. Extracting it once means both callers get the same correctness guarantees and future callers inherit them for free.

**✅ What Was Implemented**

- Added a strict read path (`readRepoRegistryStrict`) in `cli/src/dashboard/RepoRegistry.ts` used exclusively by the four write operations (register, list worktree, deregister, stamp instance ID). This path treats a missing file as an empty registry but throws on any other read or parse error; the existing lenient reader remains for read-only consumers.
- A shared `cli/src/core/AtomicJsonFile.ts` helper was introduced implementing PID-plus-nonce temp file and rename for safe atomic writes; both `RepoRegistry` and `cli/src/core/RepoProfile.ts` now use it instead of maintaining separate copies of the same pattern.

**📁 FILES**
- `cli/src/dashboard/RepoRegistry.ts`
- `cli/src/core/AtomicJsonFile.ts`
- `cli/src/core/RepoProfile.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · Fix cutover drift check failing for repositories with multiple clones</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The cutover process that migrates a repository's data into the local database was comparing file-based snapshots against the database using exact byte equality, causing the check to always report drift for repositories with more than one clone and blocking the migration from completing.

**💡 Decisions Behind the Code**

- **Containment rather than equality for union-view files**: Equality was correct for single-clone repositories but structurally wrong for the multi-clone case the cutover is designed to handle. Containment preserves the same safety guarantee — the database cannot be missing entries the source has — while allowing the database to legitimately hold more.
- **Structured return instead of throw for post-fence failures**: The cutover is a resumable operation. If the fence was already written, a subsequent failure leaves the repository in a recoverable state. Throwing discarded that context; returning a structured result with the fence status lets the caller and the user know that a simple re-run is sufficient.

**✅ What Was Implemented**

- Changed the two index-file comparisons in `cli/src/dashboard/CutoverEngine.ts` from exact equality to set containment: every entry present in the source file must appear in the database's union view, but the database is allowed to have additional entries from other clones.
- The post-fence import and compare block was wrapped in a try/catch that returns a structured `not-ready` result instead of throwing; when the repository has already been legacy-fenced, the message tells the user that re-running will complete the migration.
- The drift probe was changed to open the database read-only, eliminating a side-effect where probing could trigger a schema migration, and a schema-version-ahead error is now caught and returned as a human-readable message rather than a stack trace.

**📁 FILES**
- `cli/src/dashboard/CutoverEngine.ts`
- `cli/src/dashboard/CutoverEngine.test.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · Fix pending event count and model-split condition in stats writer</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Two separate correctness issues existed in the component that writes usage statistics: the count of remaining pending events returned after a drain was stale (computed before the drain, not after), and the condition deciding whether to split or carry forward a model's usage record was inconsistent, leaving an event with an empty model list falling through a gap between the two checks.

**💡 Decisions Behind the Code**

- **Re-query rather than decrement**: Decrementing the pre-drain count by the number of rows processed would be wrong whenever a drain is interrupted or rows are added concurrently. A re-query after the drain is the only way to return a number that reflects the actual database state at the moment the caller needs it.
- **Schema migration for failed-event recovery**: Storing the failure reason alongside the event makes recovery automatic on upgrade — the migration can identify which parked events are now processable without requiring any manual intervention or a full re-import. This fulfils the intent already documented in the code but previously unimplemented.

**✅ What Was Implemented**

- Updated the drain path in `cli/src/dashboard/StatsWriter.ts` to re-query the pending count from the database at the end of the drain rather than returning the pre-drain figure; the downstream backfill cursor logic depends on this number to decide whether to advance.
- Unified the two separate boolean conditions controlling carry-forward and split-deletion into a single `hasUsage` variable computed once at the top of the function, eliminating the gap where `models: []` matched neither branch.
- Added a new `failed_kind` column to the stats events table in `cli/src/dashboard/SotSchema.ts` (schema version bumped) so that events that failed due to an unrecognised type can be automatically re-queued when a newer version of the CLI that recognises the type is installed.

**📁 FILES**
- `cli/src/dashboard/StatsWriter.ts`
- `cli/src/dashboard/SotSchema.ts`

</blockquote>
</details>
<details>
<summary><strong>12 · Fix branch attribution being wiped when a git scan partially fails</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When any step of the branch-reachability scan failed, the dashboard emitted an empty branch list for every affected commit, and because the database replaces stored branch data when a new value is present, this silently erased all previously recorded branch attribution in a single pass.

**💡 Decisions Behind the Code**

The distinction between an empty array and an absent field is the load-bearing design. An empty array is a real claim — "no branch currently reaches this commit" — and is the only mechanism that can prune a branch attribution the commit has genuinely left. Omitting the field entirely means "we don't know", which preserves whatever was stored. The previous implementation collapsed these two states into one, making a transient scan failure indistinguishable from a deliberate pruning signal.

**✅ What Was Implemented**

- `cli/src/dashboard/DashboardCollector.ts` now tracks a `branchScanComplete` flag. Any failure in the ref listing or any per-branch reachability check sets it false. When incomplete, the `branches` field is omitted from the event entirely rather than set to an empty array.
- The database writer already treated an absent `branches` field as "leave stored data alone" and a present field (including `[]`) as "replace stored data" — so the fix required only the collector change, not the writer.
- Three new tests distinguish the three cases: ref listing failure (omit), per-branch failure (omit), and clean scan with no reachable branches (emit empty array, which is the meaningful pruning signal).

**📁 FILES**
- `cli/src/dashboard/DashboardCollector.ts`

</blockquote>
</details>
<details>
<summary><strong>13 · Prevent dashboard memory index cursor from advancing after a partial read failure</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

If any single memory failed to read during a sweep — due to a transient file system or git error — the dashboard's index cursor was still advanced, causing every future pass to skip the entire sweep and leaving that memory permanently absent from the dashboard.

**💡 Decisions Behind the Code**

- **Copied the commit tier's existing guard rather than inventing a new mechanism**: The commit sweep already carried a completion flag for exactly this reason. Applying the same pattern to the summary sweep keeps the two tiers consistent and avoids introducing a novel approach that would need its own correctness reasoning.
- **Null summary treated as absent, not a failure**: An index can name a summary that a subsequent prune has removed. Treating that as a read failure would stall the cursor forever on any repo that has ever had a pruned summary. The distinction between "not there" and "failed to read" is meaningful and worth preserving explicitly.

**✅ What Was Implemented**

- `collectSummaryEvents` in `cli/src/dashboard/DashboardCollector.ts` now returns a `{ events, complete }` pair instead of a plain array. Any failure to read a summary sets `complete: false`. A null result (a memory the index references but the store no longer holds) is treated as absent rather than a failure, so repos with pruned summaries do not stall permanently.
- The backfill caller in `cli/src/dashboard/Backfill.ts` was updated to mirror the existing commit-tier guard: the cursor advances only when `complete` is true and no events remained unprojected. A warning is logged with counts when either condition fails.
- `applyBatches` now surfaces the count of events that stayed pending rather than discarding it silently, so the cursor decision has full information about both projection failures and read failures.

**📁 FILES**
- `cli/src/dashboard/DashboardCollector.ts`
- `cli/src/dashboard/Backfill.ts`

</blockquote>
</details>
<details>
<summary><strong>14 · Fix transcript-to-memory links permanently lost when transcript arrives after memory</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a transcript was saved after the memory that referenced it — the order produced by the IDE bridge's transcript-save action — the link between them was logged as dangling and never re-derived, leaving the session-to-commit view permanently broken for those memories.

**💡 Decisions Behind the Code**

The ordering constraint between `landLinks` and the new backfill function is the central design decision. `landLinks` treats the batch's summary data as authoritative and replaces link sets wholesale — running the backfill afterward means it only touches memories whose summaries were not in the current batch, leaving `landLinks`' authority intact. Reversing the order would cause `landLinks` to silently delete the links the backfill just created.

**✅ What Was Implemented**

- Added `backfillLinksForNewTranscripts` in `cli/src/dashboard/SotWrite.ts`, called after `landLinks` completes. For each transcript newly written in the batch, it queries stored memories whose JSON references that transcript ID and inserts the missing link rows.
- A `LIKE` query narrows candidates cheaply before the actual transcript-ID resolution confirms the match, so a pattern metacharacter inside an ID can only widen the candidate set, never produce a false negative.

**📁 FILES**
- `cli/src/dashboard/SotWrite.ts`

</blockquote>
</details>
<details>
<summary><strong>15 · Stop one bad file from rolling back an entire memory batch in the database</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When the dashboard database received a batch of files that included both a memory and an attached artifact, a parse failure on the artifact threw an exception that rolled back the entire database transaction — taking the memory with it.

**💡 Decisions Behind the Code**

- **Skip and warn rather than throw**: The batch is a single database transaction, so throwing on a bad artifact rolls back everything that rode alongside it. The file-based backend stored bytes verbatim and could not fail this way at all, so the throwing behavior was a pure regression. Aligning the writer to the importer's existing skip-with-count behavior means a repo can no longer import cleanly and then fail to re-write what it just imported.
- **Summaries kept as throws**: The memory itself is the primary record; an artifact attached to it is context. A memory without context is still useful, but a memory that fails to write is a data loss event and must surface loudly rather than being silently dropped.

**✅ What Was Implemented**

- Added `dropUnparsable` in `cli/src/dashboard/SotWrite.ts` as a shared helper that logs a warning and continues rather than throwing. Applied to five previously throwing sites: transcript parsing, reference frontmatter parsing, plan-progress parsing, topic page parsing, and the processed-sources set.
- The `summaries/` path was deliberately left as a throw — a memory itself failing to write must still fail loudly.
- The processed-sources case was restructured from an early return to a conditional block so that the unrelated schema-migration state write in the same batch still lands even when the processed set is skipped.
- Tests were updated to assert that the memory in the same batch is present in the database after the bad artifact is skipped.

**📁 FILES**
- `cli/src/dashboard/SotWrite.ts`

</blockquote>
</details>
<details>
<summary><strong>16 · Fix IntelliJ reading a derived disable flag instead of the user's actual setting</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After a database cutover, a field that previously meant "user disabled this repo" was also set when the repo was merely fenced for cutover — a normal automated state. The IntelliJ plugin read the combined field and showed a disabled panel for repos the user had never actually disabled.

**💡 Decisions Behind the Code**

- **Preserve the combined field as a migration fallback, not remove it**: Profiles written by older runtimes only have the combined field. Removing the fallback would cause those repos to appear as neither enabled nor disabled until the profile was rewritten, which could suppress auto-install silently. The fallback is safe as long as it is only reached when the authoritative field is absent.
- **Cannot be verified locally without a JDK**: The Kotlin change was written and tested in code but relies on CI for compilation verification. This was accepted as a known limitation rather than a blocker, since the logic is a straightforward priority reordering with no new branching.

**✅ What Was Implemented**

- Extracted `readUserDisabled` in `intellij/src/main/kotlin/ai/jolli/jollimemory/core/RepoProfileBridge.kt` as a shared helper used by both disk-reading paths. It reads the user-specific field first, falls back to the old combined field only when the user-specific field is absent (for profiles written before the split), and falls back further to the legacy per-worktree marker.
- Three tests were added covering: a fenced repo with `userDisabled=false` must read as not disabled even when the combined field is true; a genuinely disabled repo reads as disabled; a pre-split profile with only the combined field still honours it as a migration fallback.

**📁 FILES**
- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/RepoProfileBridge.kt`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 10, 2026 at 9:39 AM · via Anthropic*
<!-- jollimemory-summary-end -->