### PR TITLE
Deterministically exclude foreign-repo plan files from commit summaries

### DIFF
--- a/cli/src/commands/IdeBridgeCommand.test.ts
+++ b/cli/src/commands/IdeBridgeCommand.test.ts
@@ -124,9 +124,9 @@ vi.mock("../core/PlanService.js", () => ({
 	removePlan: vi.fn().mockResolvedValue(undefined),
 	renamePlanTitle: vi.fn().mockResolvedValue(undefined),
 	archivePlanForCommit: vi.fn().mockResolvedValue(null),
-	// `getPlansDir` is pointed at a scratch dir by the plans-register-new suite;
+	// `getClaudePlansDir` is pointed at a scratch dir by the plans-register-new suite;
 	// the default keeps every other test away from the real `~/.claude/plans/`.
-	getPlansDir: vi.fn().mockReturnValue("/nonexistent/claude/plans"),
+	getClaudePlansDir: vi.fn().mockReturnValue("/nonexistent/claude/plans"),
 	isPlanFromCurrentProject: vi.fn().mockResolvedValue(true),
 	registerNewPlan: vi.fn().mockResolvedValue(undefined),
 }));
@@ -135,6 +135,16 @@ vi.mock("../core/NoteService.js", () => ({
 	detectNotes: vi.fn().mockResolvedValue([]),
 	saveNote: vi.fn().mockResolvedValue(null),
 	removeNote: vi.fn().mockResolvedValue(undefined),
+}));
+
+// active-for-commit classifies each plan's source repo; the real resolver spawns
+// `git`. Stub it to classify by sourcePath so the folding logic is exercised
+// without real repos: a path containing "foreign" is a different repo, anything
+// else (including a missing sourcePath) is local.
+vi.mock("../core/plans/PlanContainment.js", () => ({
+	createPlanSourceClassifier: vi.fn(
+		() => async (sourcePath?: string) => (sourcePath?.includes("foreign") ? "foreign" : "local"),
+	),
 }));
 
 vi.mock("../core/references/ReferenceService.js", () => ({
@@ -1602,9 +1612,11 @@ describe("runIdeBridgeAction — working-context", () => {
 
 		beforeEach(async () => {
 			plansDir = mkdtempSync(join(tmpdir(), "ide-bridge-plans-"));
-			const { getPlansDir, isPlanFromCurrentProject, registerNewPlan } = await import("../core/PlanService.js");
+			const { getClaudePlansDir, isPlanFromCurrentProject, registerNewPlan } = await import(
+				"../core/PlanService.js"
+			);
 			const { loadPlansRegistry } = await import("../core/SessionTracker.js");
-			vi.mocked(getPlansDir).mockReturnValue(plansDir);
+			vi.mocked(getClaudePlansDir).mockReturnValue(plansDir);
 			vi.mocked(isPlanFromCurrentProject).mockResolvedValue(true);
 			// Empty registry by default: the handler skips already-tracked slugs
 			// before the (expensive) attribution call, so the fixture has to say
@@ -1985,6 +1997,34 @@ describe("runIdeBridgeAction — working-context", () => {
 				skills: [],
 			},
 		});
+	});
+
+	it("active-for-commit folds foreign-repo plans into the plan exclusions so the panel strikes them", async () => {
+		const tracker = await import("../core/SessionTracker.js");
+		const { readExclusions } = await import("../core/CommitSelectionStore.js");
+		vi.mocked(tracker.detectActivePlansForBranch).mockResolvedValue([
+			{ slug: "local-plan", sourcePath: "/r/docs/local.md" },
+			{ slug: "foreign-plan", sourcePath: "/elsewhere/foreign-repo/plan.md" },
+		] as never);
+		vi.mocked(tracker.detectActiveNotesForBranch).mockResolvedValue([]);
+		vi.mocked(tracker.detectUncommittedReferenceIds).mockResolvedValue([]);
+		vi.mocked(tracker.loadPlansRegistry).mockResolvedValue({ version: 1, plans: {}, references: {} } as never);
+		vi.mocked(readExclusions).mockResolvedValue({
+			conversations: new Set<string>(),
+			plans: new Set(["already-excluded"]),
+			notes: new Set<string>(),
+			references: new Set<string>(),
+		});
+
+		const result = (await runIdeBridgeAction("working-context", "/r", { operation: "active-for-commit" })) as {
+			plans: { slug: string }[];
+			exclusions: { plans: string[] };
+		};
+
+		// The foreign plan stays in the row list (the panel needs a row to strike),
+		// its slug joins the existing manual excludes, and the local one is untouched.
+		expect(result.plans.map((p) => p.slug)).toEqual(["local-plan", "foreign-plan"]);
+		expect([...result.exclusions.plans].sort()).toEqual(["already-excluded", "foreign-plan"]);
 	});
 
 	// The branch argument is vestigial in all three CLI functions (working-area

--- a/cli/src/commands/IdeBridgeCommand.ts
+++ b/cli/src/commands/IdeBridgeCommand.ts
@@ -401,9 +401,11 @@ async function runWorkingContextAction(cwd: string, request: JsonObject): Promis
 			if (names.length === 0) return { accepted: [] };
 			const { existsSync } = await import("node:fs");
 			const { basename, join } = await import("node:path");
-			const { getPlansDir, isPlanFromCurrentProject, registerNewPlan } = await import("../core/PlanService.js");
+			const { getClaudePlansDir, isPlanFromCurrentProject, registerNewPlan } = await import(
+				"../core/PlanService.js"
+			);
 			const tracker = await import("../core/SessionTracker.js");
-			const plansDir = getPlansDir();
+			const plansDir = getClaudePlansDir();
 			// One registry read for the whole burst, used purely as a fast path
 			// (see the `tracked` check below). `registerNewPlan` re-reads under
 			// plans.lock, so this snapshot never decides a write — going stale
@@ -677,6 +679,21 @@ async function runWorkingContextAction(cwd: string, request: JsonObject): Promis
 			// answer to "what is this reference called".
 			const referenceTitles = registry.references ?? {};
 			const references = referenceIds.map((r) => ({ ...r, title: referenceTitles[r.mapKey]?.title ?? r.mapKey }));
+			// A plan whose sourcePath belongs to a DIFFERENT git repo is dropped at the
+			// archive chokepoint (`detectPlanSlugsFromRegistry`), so this op — "what the
+			// next commit will claim" — must not present it as claimable. Fold the
+			// foreign slugs into the returned `exclusions.plans` so the panel strikes
+			// them through with the render path it already has (no host change), keeping
+			// them VISIBLE rather than silently includable. Return-value only: the
+			// user's on-disk manual-exclude set is untouched. Same classifier the commit
+			// path uses, so pre-commit and commit agree.
+			const { createPlanSourceClassifier } = await import("../core/plans/PlanContainment.js");
+			const classifyPlanSource = createPlanSourceClassifier(cwd);
+			const planClasses = await Promise.all(plans.map((p) => classifyPlanSource(p.sourcePath)));
+			const excludedPlanSlugs = new Set(exclusions.plans);
+			plans.forEach((p, i) => {
+				if (planClasses[i] === "foreign") excludedPlanSlugs.add(p.slug);
+			});
 			return {
 				plans,
 				notes,
@@ -686,7 +703,7 @@ async function runWorkingContextAction(cwd: string, request: JsonObject): Promis
 				// so "nothing excluded" has to arrive as [].
 				exclusions: {
 					conversations: [...exclusions.conversations],
-					plans: [...exclusions.plans],
+					plans: [...excludedPlanSlugs],
 					notes: [...exclusions.notes],
 					references: [...exclusions.references],
 					skills: [...(exclusions.skills ?? [])],

--- a/cli/src/core/GitOps.ts
+++ b/cli/src/core/GitOps.ts
@@ -974,6 +974,48 @@ export async function getGitCommonDir(cwd: string): Promise<string> {
 }
 
 /**
+ * The location env vars git exports to hook processes so every child `git`
+ * invocation targets the CURRENT repo. A detached process spawned from a hook
+ * (e.g. the queue worker) inherits them, and `execGit` forwards `process.env` —
+ * so they must be stripped when asking which repo ANOTHER directory belongs to,
+ * or `rev-parse` reports the ambient (hook) repo for every path regardless of
+ * its cwd.
+ */
+const GIT_LOCATION_ENV_VARS = [
+	"GIT_DIR",
+	"GIT_WORK_TREE",
+	"GIT_INDEX_FILE",
+	"GIT_COMMON_DIR",
+	"GIT_PREFIX",
+	"GIT_OBJECT_DIRECTORY",
+	"GIT_NAMESPACE",
+] as const;
+
+/**
+ * Resolves the absolute git-common-dir of the repository that CONTAINS `dir`,
+ * using cwd-based discovery even when running inside a git hook. Unlike
+ * {@link getGitCommonDir} it strips the ambient `GIT_DIR`/`GIT_WORK_TREE`/… that
+ * git sets for hooks — with those present, `rev-parse` would pin every lookup to
+ * the hook's own repo (measured: a sibling repo resolved to the current repo's
+ * `.git`, defeating foreign-repo detection). Returns null when `dir` is not
+ * inside any git repository (or cannot be resolved).
+ */
+export async function resolveContainingRepoCommonDir(dir: string): Promise<string | null> {
+	const env: NodeJS.ProcessEnv = { ...process.env, LC_ALL: "C" };
+	for (const v of GIT_LOCATION_ENV_VARS) delete env[v];
+	try {
+		const { stdout } = await execFileAsyncHidden("git", ["rev-parse", "--git-common-dir"], {
+			cwd: dir,
+			maxBuffer: MAX_GIT_BUFFER_BYTES,
+			env,
+		});
+		return resolve(dir, stdout.trim());
+	} catch {
+		return null;
+	}
+}
+
+/**
  * Returns the root directory of the main repository from the git common directory.
  * For regular repos: resolves `.git` → parent directory.
  * For worktrees: resolves the shared `.git` → main repo root.

--- a/cli/src/core/PlanPaths.test.ts
+++ b/cli/src/core/PlanPaths.test.ts
@@ -1,0 +1,24 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { canonicalPlanDirs, getClaudePlansDir } from "./PlanPaths.js";
+
+describe("getClaudePlansDir", () => {
+	it("defaults to the real home's ~/.claude/plans", () => {
+		expect(getClaudePlansDir()).toBe(join(homedir(), ".claude", "plans"));
+	});
+
+	it("uses an explicit home when given (so callers stay testable)", () => {
+		expect(getClaudePlansDir("/custom/home")).toBe(join("/custom/home", ".claude", "plans"));
+	});
+});
+
+describe("canonicalPlanDirs", () => {
+	it("defaults to the real home and contains the Claude plans dir", () => {
+		expect(canonicalPlanDirs()).toEqual([getClaudePlansDir()]);
+	});
+
+	it("is a pure function of the given home", () => {
+		expect(canonicalPlanDirs("/custom/home")).toEqual([join("/custom/home", ".claude", "plans")]);
+	});
+});

--- a/cli/src/core/PlanPaths.ts
+++ b/cli/src/core/PlanPaths.ts
@@ -1,7 +1,7 @@
 /**
  * PlanPaths — filesystem locations for Claude Code plan files.
  *
- * A LEAF module on purpose, and it must stay one. `getPlansDir` is needed by
+ * A LEAF module on purpose, and it must stay one. `getClaudePlansDir` is needed by
  * `DaemonServer.computeWatchTargets`, and `DaemonServer` is one of the few
  * static value imports in [`IdeBridgeCommand.ts`](../commands/IdeBridgeCommand.ts) —
  * a file that keeps its top-level imports to types and leaf modules and does
@@ -28,11 +28,40 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 /**
- * Returns the machine-global plans directory (`~/.claude/plans/`).
+ * Returns Claude Code's plan-mode directory (`~/.claude/plans/`).
  *
- * Machine-global, not per-project: every project's plans land here, which is why
- * attribution is `isPlanFromCurrentProject`'s job and never the caller's.
+ * This is Claude-SPECIFIC, and it is NOT a universal plan store. Only plans that
+ * Claude Code's plan mode writes live here; every other discovered plan — an
+ * in-repo `.md`, a file the agent wrote elsewhere, or another agent's plan —
+ * keeps its real path in `plans.json` via `PlanEntry.sourcePath` and is never
+ * copied into this directory. So "get the plans dir" means "get Claude's
+ * plan-mode dir", not "the place all plans go".
+ *
+ * Machine-global within that one channel: all of Claude's plan-mode files (from
+ * every project) share this single directory, which is why attribution is
+ * `isPlanFromCurrentProject`'s job and never the caller's.
+ *
+ * `home` defaults to the real `homedir()`; it is a parameter only so callers that
+ * must stay testable with an injected home (the containment classifier) can pass
+ * one instead of reading the machine's actual `$HOME`.
  */
-export function getPlansDir(): string {
-	return join(homedir(), ".claude", "plans");
+export function getClaudePlansDir(home: string = homedir()): string {
+	return join(home, ".claude", "plans");
+}
+
+/**
+ * The canonical, machine-global plan directories that legitimately live OUTSIDE
+ * a worktree. Consumed by the containment classifier
+ * ({@link file://./plans/PlanContainment.ts}), which whitelists them so a plan
+ * here is never mistaken for a foreign-repo file when `$HOME` happens to sit
+ * inside an unrelated git repo. Today that is only Claude's `~/.claude/plans/`.
+ *
+ * This is the classifier's whitelist, NOT a registry every consumer reads. The
+ * registration, discovery and watch paths (`PlanService`, `TranscriptPlanDiscovery`,
+ * `DaemonServer`) each target `getClaudePlansDir()` directly — they write/scan ONE
+ * dir plus a slug and cannot consume a list. So adding a dir here whitelists it
+ * for classification only; it does not make anything register or scan that dir.
+ */
+export function canonicalPlanDirs(home: string = homedir()): string[] {
+	return [getClaudePlansDir(home)];
 }

--- a/cli/src/core/PlanService.test.ts
+++ b/cli/src/core/PlanService.test.ts
@@ -136,7 +136,7 @@ import {
 	archivePlanForCommit,
 	detectPlans,
 	extractTitle,
-	getPlansDir,
+	getClaudePlansDir,
 	isPlanFromCurrentProject,
 	listAvailablePlans,
 	listUnassociatedPlans,
@@ -253,11 +253,11 @@ describe("PlanService", () => {
 		mockExecFileSync.mockReturnValue("main\n");
 	});
 
-	// ─── getPlansDir ─────────────────────────────────────────────────────────
+	// ─── getClaudePlansDir ─────────────────────────────────────────────────────────
 
-	describe("getPlansDir", () => {
+	describe("getClaudePlansDir", () => {
 		it("returns path ending in .claude/plans", () => {
-			const dir = getPlansDir();
+			const dir = getClaudePlansDir();
 			expect(dir).toBe(PLANS_DIR);
 		});
 	});

--- a/cli/src/core/PlanService.ts
+++ b/cli/src/core/PlanService.ts
@@ -28,7 +28,7 @@ import { createLogger, getJolliMemoryDir, isManuallyDisabled } from "../Logger.j
 import type { PlanEntry, PlanInfo, PlanReference } from "../Types.js";
 import { withPlansLock } from "./Locks.js";
 import { isPathInside } from "./PathUtils.js";
-import { getPlansDir } from "./PlanPaths.js";
+import { getClaudePlansDir } from "./PlanPaths.js";
 import { readManualDisableFlagSync } from "./RepoProfile.js";
 import {
 	loadAllSessions,
@@ -48,7 +48,7 @@ const log = createLogger("PlanService");
 // handler's dynamic import) is unchanged. The definition lives in the leaf
 // `PlanPaths` module because `DaemonServer` needs it statically and must not pull
 // this module's chain into a cold `ide-bridge` spawn — see PlanPaths' header.
-export { getPlansDir };
+export { getClaudePlansDir };
 
 /**
  * Reads plans.json and returns a filtered, sorted list of PlanInfo.
@@ -274,7 +274,7 @@ export async function renamePlanTitle(slug: string, title: string, cwd: string):
  * Resets any prior committed/guard state so the plan becomes editable again.
  */
 export async function addPlanToRegistry(slug: string, cwd: string): Promise<void> {
-	const planFile = join(getPlansDir(), `${slug}.md`);
+	const planFile = join(getClaudePlansDir(), `${slug}.md`);
 	if (!existsSync(planFile)) {
 		return;
 	}
@@ -330,7 +330,7 @@ export async function registerNewPlan(slug: string, cwd: string): Promise<void> 
 	// across process boundaries (esp. the long-lived ide-bridge-serve daemon).
 	if (isManuallyDisabled() || readManualDisableFlagSync(cwd)) return;
 
-	const planFile = join(getPlansDir(), `${slug}.md`);
+	const planFile = join(getClaudePlansDir(), `${slug}.md`);
 	if (!existsSync(planFile)) {
 		return;
 	}
@@ -412,11 +412,11 @@ export async function isPlanFromCurrentProject(absPath: string, cwd: string): Pr
 export function listAvailablePlans(
 	excludeSlugs: ReadonlySet<string>,
 ): ReadonlyArray<{ slug: string; title: string; mtimeMs: number }> {
-	if (!existsSync(getPlansDir())) {
+	if (!existsSync(getClaudePlansDir())) {
 		return [];
 	}
 
-	const files = readdirSync(getPlansDir()).filter((f) => f.endsWith(".md"));
+	const files = readdirSync(getClaudePlansDir()).filter((f) => f.endsWith(".md"));
 	const available: Array<{ slug: string; title: string; mtimeMs: number }> = [];
 
 	for (const file of files) {
@@ -424,7 +424,7 @@ export function listAvailablePlans(
 		if (excludeSlugs.has(slug)) {
 			continue;
 		}
-		const filePath = join(getPlansDir(), file);
+		const filePath = join(getClaudePlansDir(), file);
 		try {
 			const mtime = Math.trunc(statSync(filePath).mtimeMs);
 			available.push({ slug, title: extractTitle(filePath), mtimeMs: mtime });
@@ -457,7 +457,7 @@ export async function archivePlanForCommit(
 	// If slug is not in the registry (e.g., picked from ~/.claude/plans/ directory but
 	// never auto-discovered from transcript), create a fresh entry first.
 	if (!entry) {
-		const planFile = join(getPlansDir(), `${slug}.md`);
+		const planFile = join(getClaudePlansDir(), `${slug}.md`);
 		if (!existsSync(planFile)) {
 			return null;
 		}

--- a/cli/src/core/plans/PlanContainment.test.ts
+++ b/cli/src/core/plans/PlanContainment.test.ts
@@ -1,0 +1,224 @@
+// NOTE: this is a real-`git` test file (the "default resolver" block spawns
+// `git init` + `git rev-parse`). It is deliberately kept OUT of
+// `SLOW_TEST_FILES` in cli/vite.config.ts so it runs in the fast tier — that is
+// what covers `defaultResolveRepoId` and the `?? defaultResolveRepoId` / `??
+// homedir` default branches under `--mode fast`. If you ever move this file into
+// `SLOW_TEST_FILES`, you MUST also add `PlanContainment.ts` to
+// `SLOW_ONLY_SOURCES` in the same change, or those default branches become
+// uncovered in the fast tier and the 97/96/97/97 floor silently breaks.
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import type { PlanEntry } from "../../Types.js";
+import {
+	createPlanSourceClassifier,
+	FOREIGN_PLAN_EXCLUSION_REASON,
+	type PlanSourceClass,
+	partitionForeignPlans,
+} from "./PlanContainment.js";
+
+describe("createPlanSourceClassifier (injected deps)", () => {
+	const cwd = "/repo/app";
+	const home = "/home/dev";
+	const mk = (resolveRepoId: (dir: string) => Promise<string | null>) =>
+		createPlanSourceClassifier(cwd, { resolveRepoId, homeDir: () => home });
+
+	it("returns unknown for a missing sourcePath (undefined / empty)", async () => {
+		const resolveRepoId = vi.fn(async () => "X");
+		const classify = mk(resolveRepoId);
+		expect(await classify(undefined)).toBe("unknown");
+		expect(await classify("")).toBe("unknown");
+		expect(resolveRepoId).not.toHaveBeenCalled();
+	});
+
+	it("classifies a file inside the current worktree as local, without any git call", async () => {
+		const resolveRepoId = vi.fn(async () => "irrelevant");
+		const classify = mk(resolveRepoId);
+		expect(await classify("/repo/app/docs/plan.md")).toBe("local");
+		expect(resolveRepoId).not.toHaveBeenCalled();
+	});
+
+	it("whitelists the canonical ~/.claude/plans dir as local, without any git call", async () => {
+		const resolveRepoId = vi.fn(async () => "irrelevant");
+		const classify = mk(resolveRepoId);
+		expect(await classify("/home/dev/.claude/plans/foo.md")).toBe("local");
+		expect(resolveRepoId).not.toHaveBeenCalled();
+	});
+
+	it("classifies a file in a different git repo as foreign", async () => {
+		const classify = mk(async (dir) => (dir.startsWith("/repo/app") ? "own-repo" : "other-repo"));
+		expect(await classify("/elsewhere/team-plugins/DEVELOPMENT.md")).toBe("foreign");
+	});
+
+	it("classifies a sibling worktree of the same repo as local (shared common-dir)", async () => {
+		// Both the sibling worktree dir and cwd resolve to the SAME repo id.
+		const classify = mk(async () => "shared-common-dir");
+		expect(await classify("/repo/app-worktree-2/docs/plan.md")).toBe("local");
+	});
+
+	it("returns unknown when the file is in no git repo (loose temp)", async () => {
+		const classify = mk(async (dir) => (dir === "/repo/app" ? "own-repo" : null));
+		expect(await classify("/tmp/scratch/plan.md")).toBe("unknown");
+	});
+
+	it("returns unknown when the current repo id cannot be resolved (defensive)", async () => {
+		const classify = mk(async (dir) => (dir === "/repo/app" ? null : "other-repo"));
+		expect(await classify("/elsewhere/x.md")).toBe("unknown");
+	});
+
+	it("memoizes git resolution per directory", async () => {
+		const resolveRepoId = vi.fn(async (dir: string) => (dir.includes("app") ? "own-repo" : "other-repo"));
+		const classify = mk(resolveRepoId);
+		expect(await classify("/elsewhere/a/one.md")).toBe("foreign"); // resolves /elsewhere/a + cwd
+		expect(await classify("/elsewhere/a/two.md")).toBe("foreign"); // both dirs cached
+		expect(await classify("/elsewhere/b/three.md")).toBe("foreign"); // resolves /elsewhere/b (cwd cached)
+		// Distinct dirs resolved once each: /elsewhere/a, cwd, /elsewhere/b.
+		expect(resolveRepoId).toHaveBeenCalledTimes(3);
+	});
+
+	it("exposes a human-readable exclusion reason mentioning 'outside'", () => {
+		expect(FOREIGN_PLAN_EXCLUSION_REASON).toMatch(/outside/i);
+	});
+});
+
+describe("createPlanSourceClassifier (real git, default resolver)", () => {
+	const dirs: string[] = [];
+	const makeRepo = (): string => {
+		const dir = mkdtempSync(join(tmpdir(), "jm-containment-"));
+		dirs.push(dir);
+		execFileSync("git", ["init", "-q"], { cwd: dir });
+		return dir;
+	};
+
+	afterAll(() => {
+		for (const d of dirs) rmSync(d, { recursive: true, force: true });
+	});
+
+	it("keeps an in-worktree plan as local (no git call needed)", async () => {
+		const repo = makeRepo();
+		const classify = createPlanSourceClassifier(repo);
+		expect(await classify(join(repo, "docs", "plan.md"))).toBe("local");
+	});
+
+	it("marks a plan whose sourcePath is in a different git repo as foreign", async () => {
+		const ownRepo = makeRepo();
+		const foreignRepo = makeRepo();
+		const classify = createPlanSourceClassifier(ownRepo);
+		expect(await classify(join(foreignRepo, "DEVELOPMENT.md"))).toBe("foreign");
+	});
+
+	it("returns unknown when the enclosing directory does not exist (git rev-parse throws)", async () => {
+		const ownRepo = makeRepo();
+		// Create then remove a dir so the path is guaranteed not to exist (no
+		// reliance on a fixed name never colliding on the CI machine).
+		const gone = mkdtempSync(join(tmpdir(), "jm-containment-gone-"));
+		rmSync(gone, { recursive: true, force: true });
+		const classify = createPlanSourceClassifier(ownRepo);
+		expect(await classify(join(gone, "plan.md"))).toBe("unknown");
+	});
+
+	// Regression: the classifier runs inside the post-commit queue worker, which
+	// is spawned from a git hook and therefore inherits GIT_DIR / GIT_WORK_TREE
+	// pinned to the CURRENT repo. If those are forwarded to the `git rev-parse`
+	// that resolves a sibling repo, every path resolves to the current repo's
+	// common-dir and a foreign plan reads as `local` — the exact way this shipped
+	// broken. The resolver must strip them and discover by cwd.
+	it("still classifies foreign when GIT_DIR/GIT_WORK_TREE are set (git-hook environment)", async () => {
+		const ownRepo = makeRepo();
+		const foreignRepo = makeRepo();
+		vi.stubEnv("GIT_DIR", join(ownRepo, ".git"));
+		vi.stubEnv("GIT_WORK_TREE", ownRepo);
+		try {
+			const classify = createPlanSourceClassifier(ownRepo);
+			expect(await classify(join(foreignRepo, "DEVELOPMENT.md"))).toBe("foreign");
+		} finally {
+			vi.unstubAllEnvs();
+		}
+	});
+
+	// Identity, not directory containment: a sibling worktree of the SAME repo
+	// must stay local. Inline git config supplies an author so the empty commit
+	// (required before `git worktree add`) does not depend on the ambient
+	// identity, which the monorepo git-isolation env deliberately omits.
+	const gitAuthor = ["-c", "user.email=t@example.com", "-c", "user.name=Test"];
+	const makeRepoWithWorktree = (base: string): { main: string; worktree: string } => {
+		const main = join(base, "main");
+		mkdirSync(main);
+		execFileSync("git", ["init", "-q"], { cwd: main });
+		execFileSync("git", [...gitAuthor, "commit", "-q", "--allow-empty", "-m", "init"], { cwd: main });
+		const worktree = join(base, "wt2");
+		execFileSync("git", ["worktree", "add", "-q", worktree], { cwd: main });
+		return { main, worktree };
+	};
+
+	it("classifies a sibling worktree of the same repo as local (real git worktree)", async () => {
+		const base = mkdtempSync(join(tmpdir(), "jm-wt-"));
+		dirs.push(base);
+		const { main, worktree } = makeRepoWithWorktree(base);
+		const classify = createPlanSourceClassifier(main);
+		// Plan at the worktree root so its enclosing dir exists for `git rev-parse`.
+		expect(await classify(join(worktree, "plan.md"))).toBe("local");
+	});
+
+	// Regression for the symlink case: git reports the common-dir as a RELATIVE
+	// `.git` for the main worktree (resolved against the queried path, symlink
+	// prefix intact) but an ABSOLUTE, realpath'd path for a linked worktree. Under
+	// a symlinked prefix (macOS /var → /private/var, a symlinked home) the two
+	// spellings diverge and a same-repo sibling worktree would read as foreign
+	// unless the resolver canonicalizes with realpath. Skipped where the host
+	// cannot create a symlink/junction (unprivileged Windows without junction).
+	it("classifies a sibling worktree as local under a symlinked path prefix", async () => {
+		const realBase = mkdtempSync(join(tmpdir(), "jm-wt-real-"));
+		dirs.push(realBase);
+		const linkBase = `${realBase}-link`;
+		try {
+			symlinkSync(realBase, linkBase, "junction");
+		} catch {
+			return; // symlink/junction not permitted here — nothing to assert
+		}
+		dirs.push(linkBase);
+		makeRepoWithWorktree(realBase);
+		// Query through the symlinked spelling; the worktree's stored gitdir points
+		// at the real path, so without realpath the two ids never match.
+		const classify = createPlanSourceClassifier(join(linkBase, "main"));
+		expect(await classify(join(linkBase, "wt2", "plan.md"))).toBe("local");
+	});
+});
+
+describe("partitionForeignPlans", () => {
+	const plan = (slug: string, sourcePath: string): PlanEntry => ({
+		slug,
+		title: `${slug} title`,
+		sourcePath,
+		addedAt: "a",
+		updatedAt: "b",
+		commitHash: null,
+	});
+
+	it("returns empty partitions for no plans", async () => {
+		const r = await partitionForeignPlans([], async () => "foreign");
+		expect(r.localPlans).toEqual([]);
+		expect(r.foreignExcludedContext).toEqual([]);
+	});
+
+	it("keeps local and unknown plans, excludes foreign with reason + tier", async () => {
+		const plans = [plan("a", "/x/a.md"), plan("b", "/y/b.md"), plan("c", "/z/c.md")];
+		const classify = async (sp: string | undefined): Promise<PlanSourceClass> =>
+			sp === "/x/a.md" ? "local" : sp === "/y/b.md" ? "foreign" : "unknown";
+		const r = await partitionForeignPlans(plans, classify);
+		// unknown is KEPT (conservative), only foreign is excluded.
+		expect(r.localPlans.map((p) => p.slug)).toEqual(["a", "c"]);
+		expect(r.foreignExcludedContext).toEqual([
+			{ kind: "plan", key: "b", title: "b title", reason: FOREIGN_PLAN_EXCLUSION_REASON, tier: "low" },
+		]);
+	});
+
+	it("excludes every plan when all are foreign", async () => {
+		const plans = [plan("a", "/x/a.md"), plan("b", "/y/b.md")];
+		const r = await partitionForeignPlans(plans, async () => "foreign");
+		expect(r.localPlans).toEqual([]);
+		expect(r.foreignExcludedContext.map((e) => e.key)).toEqual(["a", "b"]);
+	});
+});

--- a/cli/src/core/plans/PlanContainment.ts
+++ b/cli/src/core/plans/PlanContainment.ts
@@ -1,0 +1,175 @@
+/**
+ * PlanContainment — classify a plan's `sourcePath` as belonging to THIS
+ * repository, to a foreign repository, or to neither.
+ *
+ * Plans are auto-discovered by scanning the agent transcript for `.md` files
+ * it read/wrote. A session working in repo A that
+ * incidentally touches a `.md` in a sibling checkout of repo B registers B's
+ * file as one of A's plans, and it then attaches to A's next commit — polluting
+ * the PR-description Context and the summary topics. This module is the
+ * deterministic gate that keeps a foreign-repo plan out of the archive, with NO
+ * LLM in the loop.
+ *
+ * The discriminator is git-repository IDENTITY, not directory containment.
+ * Claude plan-mode plans legitimately live in `~/.claude/plans/` (outside the
+ * worktree), so "outside the worktree ⇒ foreign" would wrongly drop the most
+ * important plans. Instead we compare the file's enclosing repo's
+ * git-common-dir with the current repo's:
+ *   - a file inside the current worktree is `local` (cheap, no git call);
+ *   - a file under a canonical agent plan dir (`~/.claude/plans/`) is `local`
+ *     (whitelist — independent of any repo that happens to enclose $HOME);
+ *   - a file whose enclosing repo differs from the current one is `foreign`;
+ *   - a file in a sibling WORKTREE of the same repo shares the common-dir, so
+ *     it is `local` (worktree-aware, per the repo's worktree rule);
+ *   - a file in no git repo at all (loose temp, deleted dir) is `unknown` and
+ *     is KEPT — conservative, since stale temp residue is a separate pruning
+ *     concern and "don't drop on uncertainty" is the safe default.
+ */
+
+import { realpathSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname } from "node:path";
+import type { ExcludedContextItem, PlanEntry } from "../../Types.js";
+import { resolveContainingRepoCommonDir } from "../GitOps.js";
+import { isPathInside, normalizePathForCompare } from "../PathUtils.js";
+import { canonicalPlanDirs } from "../PlanPaths.js";
+
+/** Classification of a plan's `sourcePath` relative to the current repository. */
+export type PlanSourceClass = "local" | "foreign" | "unknown";
+
+/** Human-readable reason recorded on a foreign plan's `excludedContext` entry so
+ *  the panel can explain why it was left out (and distinguish it from an
+ *  LLM-driven soft-exclude). */
+export const FOREIGN_PLAN_EXCLUSION_REASON = "Outside the current repository";
+
+/** Injectable dependencies — real implementations by default, faked in tests so
+ *  the branch logic is exercised without spawning `git`. */
+export interface PlanContainmentDeps {
+	/** Resolve the absolute, normalized git-common-dir of the repo that owns
+	 *  `dir`, or null when `dir` is not inside any git repository (or cannot be
+	 *  resolved). */
+	readonly resolveRepoId: (dir: string) => Promise<string | null>;
+	/** Home directory lookup. */
+	readonly homeDir: () => string;
+}
+
+/** Resolve symlinks in `p` so two spellings of the same location compare equal;
+ *  fall back to the input if it cannot be resolved (e.g. it no longer exists). */
+function canonicalizePath(p: string): string {
+	try {
+		return realpathSync.native(p);
+	} catch {
+		return p;
+	}
+}
+
+async function defaultResolveRepoId(dir: string): Promise<string | null> {
+	// resolveContainingRepoCommonDir strips the ambient GIT_DIR/GIT_WORK_TREE the
+	// git hook exports — without that, every lookup (foreign dir OR cwd) would
+	// resolve to the hook's repo, so a sibling repo's plan would read as local
+	// and never get excluded. It returns null (not a repo / missing dir) rather
+	// than throwing.
+	const common = await resolveContainingRepoCommonDir(dir);
+	// Treat any falsy result as "not a repo" — the real resolver returns
+	// string|null, but a reset test mock can yield undefined; `!common` handles
+	// both without crashing normalizePathForCompare.
+	if (!common) return null;
+	// git returns the common-dir in two shapes: a path RELATIVE to the queried
+	// dir for the main worktree (resolved against `dir`, so it keeps whatever
+	// symlink prefix `dir` had), but an ABSOLUTE, often already-realpath'd path
+	// for a linked worktree. When the repo sits under a symlinked prefix (macOS
+	// /var → /private/var, a symlinked home), the two shapes diverge and a sibling
+	// worktree of the SAME repo reads as foreign — the exact worktree-aware case
+	// this classifier must preserve. realpath both spellings so they collapse to
+	// one identity before comparison.
+	return normalizePathForCompare(canonicalizePath(common));
+}
+
+/**
+ * Builds a classifier bound to `cwd` (the current worktree root). The returned
+ * function memoizes git resolution per directory, so classifying N plans that
+ * share a handful of directories costs a handful of `git` calls, not N. The
+ * classifier is single-run scoped — create a fresh one per pipeline invocation.
+ */
+export function createPlanSourceClassifier(
+	cwd: string,
+	deps: Partial<PlanContainmentDeps> = {},
+): (sourcePath: string | undefined) => Promise<PlanSourceClass> {
+	const resolveRepoId = deps.resolveRepoId ?? defaultResolveRepoId;
+	const home = (deps.homeDir ?? homedir)();
+	// Shared with plan registration via PlanPaths — the one place the set of
+	// legitimate outside-worktree plan dirs is defined.
+	const whitelistDirs = canonicalPlanDirs(home);
+	// Single-flight per directory: store the in-flight PROMISE, not the resolved
+	// value, so a burst of concurrent classify() calls (the prompt side uses
+	// Promise.all) sharing a directory all await the same one `git` resolution
+	// rather than each spawning their own. defaultResolveRepoId never rejects, so
+	// caching the promise cannot memoize a rejection.
+	const repoIdByDir = new Map<string, Promise<string | null>>();
+
+	function repoIdOf(dir: string): Promise<string | null> {
+		const key = normalizePathForCompare(dir);
+		let pending = repoIdByDir.get(key);
+		if (pending === undefined) {
+			pending = resolveRepoId(dir);
+			repoIdByDir.set(key, pending);
+		}
+		return pending;
+	}
+
+	return async function classify(sourcePath: string | undefined): Promise<PlanSourceClass> {
+		// Missing sourcePath: nothing to locate → don't drop on uncertainty.
+		if (!sourcePath) return "unknown";
+		// Inside the current worktree — the common case, resolved without git.
+		if (isPathInside(sourcePath, cwd)) return "local";
+		// Canonical agent plan dir — legitimately outside the worktree.
+		if (whitelistDirs.some((d) => isPathInside(sourcePath, d))) return "local";
+		// Otherwise decide by git-repository identity.
+		const fileRepoId = await repoIdOf(dirname(sourcePath));
+		if (fileRepoId === null) return "unknown";
+		const ownRepoId = await repoIdOf(cwd);
+		// Defensive: cwd should always be a repo when the pipeline runs. If it is
+		// not, we cannot prove foreignness — keep rather than drop.
+		if (ownRepoId === null) return "unknown";
+		return fileRepoId === ownRepoId ? "local" : "foreign";
+	};
+}
+
+/** Result of splitting a plan set into the ones to keep and the foreign ones to
+ *  surface as soft-exclusions. */
+export interface ForeignPlanPartition {
+	/** Plans classified local or unknown — kept, and fed to the summarizer. */
+	readonly localPlans: PlanEntry[];
+	/** One `excludedContext` entry per foreign plan, for panel visibility. */
+	readonly foreignExcludedContext: ExcludedContextItem[];
+}
+
+/**
+ * Splits `plans` into local-kept vs foreign-excluded using `classify`. Foreign
+ * plans are turned into `excludedContext` entries (reason
+ * {@link FOREIGN_PLAN_EXCLUSION_REASON}) so the panel can show WHY they were left
+ * out. Shared by both prompt-side call sites (executePipeline and the amend
+ * pipeline) so the split logic is defined — and tested — in exactly one place.
+ */
+export async function partitionForeignPlans(
+	plans: readonly PlanEntry[],
+	classify: (sourcePath: string | undefined) => Promise<PlanSourceClass>,
+): Promise<ForeignPlanPartition> {
+	const classes = await Promise.all(plans.map((p) => classify(p.sourcePath)));
+	const localPlans: PlanEntry[] = [];
+	const foreignExcludedContext: ExcludedContextItem[] = [];
+	plans.forEach((p, i) => {
+		if (classes[i] === "foreign") {
+			foreignExcludedContext.push({
+				kind: "plan",
+				key: p.slug,
+				title: p.title,
+				reason: FOREIGN_PLAN_EXCLUSION_REASON,
+				tier: "low",
+			});
+		} else {
+			localPlans.push(p);
+		}
+	});
+	return { localPlans, foreignExcludedContext };
+}

--- a/cli/src/core/plans/TranscriptPlanDiscovery.ts
+++ b/cli/src/core/plans/TranscriptPlanDiscovery.ts
@@ -11,12 +11,13 @@
 
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
-import { homedir, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createLogger } from "../../Logger.js";
 import type { PlanEntry, TranscriptSource } from "../../Types.js";
 import { withPlansLock } from "../Locks.js";
 import { normalizePathForCompare } from "../PathUtils.js";
+import { getClaudePlansDir } from "../PlanPaths.js";
 import { loadPlansRegistry, savePlansRegistry } from "../SessionTracker.js";
 import { getPlanScanner } from "./PlanTranscriptScanner.js";
 
@@ -279,7 +280,7 @@ export async function scanPlansFrom(
 	//    `~/.claude/plans/foo.md` as a note via "Add Markdown File" (file
 	//    picker is unrestricted), so the same dedup applies.
 	for (const rawSlug of slugs) {
-		const planFile = join(homedir(), ".claude", "plans", `${rawSlug}.md`);
+		const planFile = join(getClaudePlansDir(), `${rawSlug}.md`);
 		if (!existsSync(planFile)) continue;
 		if (noteSourcePaths.has(normalizePathForCompare(planFile))) {
 			log.info("Plan discovery: %s already a note — skipping plan registration", planFile);

--- a/cli/src/daemon/DaemonServer.test.ts
+++ b/cli/src/daemon/DaemonServer.test.ts
@@ -5,7 +5,7 @@ import { dirname, join } from "node:path";
 import { PassThrough } from "node:stream";
 import { setTimeout as sleep } from "node:timers/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { getPlansDir } from "../core/PlanService.js";
+import { getClaudePlansDir } from "../core/PlanService.js";
 import { getDashboardDbPath } from "../dashboard/DashboardDb.js";
 import { execFileSyncHidden } from "../util/Subprocess.js";
 import { DAEMON_PROTOCOL } from "./DaemonProtocol.js";
@@ -66,13 +66,13 @@ describe("computeWatchTargets", () => {
 		]);
 	});
 
-	it("defaults the plans dir to the CLI's own getPlansDir() when no override is given", () => {
+	it("defaults the plans dir to the CLI's own getClaudePlansDir() when no override is given", () => {
 		mockExec.mockReturnValueOnce("/repo/.git\n");
 		const targets = computeWatchTargets("/repo");
 		// Asserted against the shared helper rather than a second `~/.claude/plans`
 		// literal — the path is the CLI's to own, and a copy here would keep
 		// passing after the real one moved.
-		expect(targets.find((t) => t.kind === "claude-plans")?.path).toBe(getPlansDir());
+		expect(targets.find((t) => t.kind === "claude-plans")?.path).toBe(getClaudePlansDir());
 	});
 
 	it("gates the working-context target to plans.json so the dir's noisy neighbours never trigger", () => {
@@ -464,7 +464,7 @@ describe("runDaemonServer", () => {
 // import here keeps the types correct, passes lint, and leaves every test green —
 // the only thing that changes is the cold-start latency of `jolli ide-bridge`, which
 // imports this module statically while deferring all of its own handler work behind
-// `await import(...)` for exactly that reason. `getPlansDir` already leaked in once
+// `await import(...)` for exactly that reason. `getClaudePlansDir` already leaked in once
 // through `PlanService`, making SummaryStore → OrphanBranchStorage / GitOps, plus
 // SessionTracker / ReferenceStore / Locks, eager for every such process (~4 ms of
 // leaf-only imports vs ~28 ms measured under tsx). Keep this list on leaves.

--- a/cli/src/daemon/DaemonServer.ts
+++ b/cli/src/daemon/DaemonServer.ts
@@ -37,7 +37,7 @@
 
 import { homedir } from "node:os";
 import { isAbsolute, join } from "node:path";
-import { getPlansDir } from "../core/PlanPaths.js";
+import { getClaudePlansDir } from "../core/PlanPaths.js";
 import { createLogger } from "../Logger.js";
 import { execFileSyncHidden } from "../util/Subprocess.js";
 import { DaemonNotifier } from "./DaemonNotifier.js";
@@ -153,7 +153,7 @@ export interface ComputeWatchTargetsOptions {
 
 export function computeWatchTargets(cwd: string, options: ComputeWatchTargetsOptions = {}): ReadonlyArray<WatchTarget> {
 	const gitCommonDir = options.gitCommonDir ?? resolveGitCommonDir(cwd);
-	const plansDir = options.plansDir ?? getPlansDir();
+	const plansDir = options.plansDir ?? getClaudePlansDir();
 	// Restated rather than imported from `SessionTracker.getGlobalConfigDir`,
 	// which is the canonical definition: this module's static import list is
 	// pinned to leaves by the "cold-start import graph" suite, and SessionTracker

--- a/cli/src/hooks/PostCommitHook.helpers.test.ts
+++ b/cli/src/hooks/PostCommitHook.helpers.test.ts
@@ -125,6 +125,7 @@ vi.mock("../core/StorageFactory.js", () => ({
 }));
 
 vi.mock("../core/GitOps.js", () => ({
+	resolveContainingRepoCommonDir: vi.fn().mockResolvedValue(null),
 	getHeadCommitInfo: mockGetHeadCommitInfo,
 	getCommitInfo: mockGetHeadCommitInfo,
 	getHeadHash: vi.fn(),

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -18,6 +18,7 @@ vi.mock("../core/StorageFactory.js", () => ({
 
 // Mock all dependencies
 vi.mock("../core/GitOps.js", () => ({
+	resolveContainingRepoCommonDir: vi.fn().mockResolvedValue(null),
 	getCommitInfo: vi.fn(),
 	getHeadHash: vi.fn(),
 	getParentHash: vi.fn(),

--- a/cli/src/hooks/QueueWorker.foreignPlans.test.ts
+++ b/cli/src/hooks/QueueWorker.foreignPlans.test.ts
@@ -1,0 +1,80 @@
+// Real-`git` integration coverage for the archive chokepoint:
+// detectPlanSlugsFromRegistry must drop plans whose sourcePath lives in a
+// DIFFERENT git repository (a sibling checkout the agent incidentally touched)
+// while keeping in-repo plans. Uses real repos + a real plans.json rather than a
+// mocked registry, because the classifier hard-wires the real-git resolver.
+//
+// Deliberately kept OUT of `SLOW_TEST_FILES` in cli/vite.config.ts (fast tier):
+// the two `git init` repos it drives are cheap, and this is the only test that
+// exercises detectPlanSlugsFromRegistry's foreign-exclusion branch against a real
+// resolver — the mocked QueueWorker suites stub GitOps and never reach it, so
+// moving this to the slow tier would leave that branch uncovered in the gate.
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { __test__ } from "./QueueWorker.js";
+
+describe("detectPlanSlugsFromRegistry — foreign-repo exclusion", () => {
+	const dirs: string[] = [];
+	const makeRepo = (): string => {
+		const dir = mkdtempSync(join(tmpdir(), "jm-fp-"));
+		dirs.push(dir);
+		execFileSync("git", ["init", "-q"], { cwd: dir });
+		return dir;
+	};
+
+	afterAll(() => {
+		for (const d of dirs) rmSync(d, { recursive: true, force: true });
+	});
+
+	it("keeps in-repo plans and drops both fresh and revived plans from a foreign repo", async () => {
+		const ownRepo = makeRepo();
+		const foreignRepo = makeRepo();
+
+		// A real file on disk so this is a realistic committed-plan entry (its dir
+		// exists, so the classifier's `git rev-parse` resolves). The foreign check
+		// now runs before hashing, so it is dropped without the live hash ever
+		// being read — but the file keeps the entry representative of production.
+		const revivedForeign = join(foreignRepo, "revived.md");
+		writeFileSync(revivedForeign, "# foreign revived\nlive body\n");
+
+		const registry = {
+			version: 1,
+			plans: {
+				"local-fresh": {
+					slug: "local-fresh",
+					title: "Local",
+					sourcePath: join(ownRepo, "docs", "local.md"),
+					addedAt: "a",
+					updatedAt: "b",
+					commitHash: null,
+				},
+				"foreign-fresh": {
+					slug: "foreign-fresh",
+					title: "Foreign fresh",
+					sourcePath: join(foreignRepo, "DEVELOPMENT.md"),
+					addedAt: "a",
+					updatedAt: "b",
+					commitHash: null,
+				},
+				"foreign-revived": {
+					slug: "foreign-revived",
+					title: "Foreign revived",
+					sourcePath: revivedForeign,
+					addedAt: "a",
+					updatedAt: "b",
+					commitHash: "deadbeefdeadbeef",
+					contentHashAtCommit: "0".repeat(64),
+				},
+			},
+		};
+		const memDir = join(ownRepo, ".jolli", "jollimemory");
+		mkdirSync(memDir, { recursive: true });
+		writeFileSync(join(memDir, "plans.json"), JSON.stringify(registry));
+
+		const slugs = await __test__.detectPlanSlugsFromRegistry(ownRepo, "main");
+		expect([...slugs]).toEqual(["local-fresh"]);
+	});
+});

--- a/cli/src/hooks/QueueWorker.overlay.test.ts
+++ b/cli/src/hooks/QueueWorker.overlay.test.ts
@@ -22,6 +22,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // --- Module stubs (every external IO the pipeline touches, kept minimal) ---
 
 vi.mock("../core/GitOps.js", () => ({
+	resolveContainingRepoCommonDir: vi.fn().mockResolvedValue(null),
 	getProjectRootDir: vi.fn().mockImplementation((cwd: string) => Promise.resolve(cwd)),
 	getCommitInfo: vi.fn(),
 	getHeadHash: vi.fn(),

--- a/cli/src/hooks/QueueWorker.selection.test.ts
+++ b/cli/src/hooks/QueueWorker.selection.test.ts
@@ -37,6 +37,7 @@ vi.mock("../core/StorageFactory.js", () => ({
 }));
 
 vi.mock("../core/GitOps.js", () => ({
+	resolveContainingRepoCommonDir: vi.fn().mockResolvedValue(null),
 	getProjectRootDir: vi.fn().mockImplementation((cwd: string) => Promise.resolve(cwd)),
 	getCommitInfo: vi.fn(),
 	getHeadHash: vi.fn(),

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -4,6 +4,9 @@ import { readManualDisableFlag } from "../core/RepoProfile.js";
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 
 vi.mock("../core/GitOps.js", () => ({
+	// null → the plan-source classifier treats every path as "unknown" (kept),
+	// preserving this suite's pre-foreign-filter behavior.
+	resolveContainingRepoCommonDir: vi.fn().mockResolvedValue(null),
 	getCommitInfo: vi.fn(),
 	getHeadHash: vi.fn(),
 	getParentHash: vi.fn(),

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -83,6 +83,7 @@ import { evaluatePlanProgress } from "../core/PlanProgressEvaluator.js";
 import { formatPlansBlock } from "../core/PlanPromptFormatter.js";
 import { estimateCostUsd, PRICES_AS_OF } from "../core/Pricing.js";
 import { triggerPushForNewSummaries } from "../core/PushExecutor.js";
+import { createPlanSourceClassifier, partitionForeignPlans } from "../core/plans/PlanContainment.js";
 import { baseKeyOf, mergeRefsNewWins } from "../core/RefMerge.js";
 import { readManualDisableFlag } from "../core/RepoProfile.js";
 import {
@@ -810,14 +811,14 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 				await enqueueIngestOperation(cwd, "post-commit");
 			}
 
-			// Pre-push sync follow-up (JOLLI-1900): if any of the commits summarized
+			// Pre-push sync follow-up: if any of the commits summarized
 			// this drain are waiting in push-pending.json (a `git push` fired before
 			// their memory existed), push them now. Fire-and-forget on the next tick —
 			// it must never extend this worker's lock hold or delay the ingest phase,
 			// and a slow/offline push just leaves the entries for the next trigger.
 			if (newlyGeneratedHashes.size > 0) {
 				triggerPushForNewSummaries(cwd, [...newlyGeneratedHashes]);
-				// Dashboard direct write (JOLLI-2069): project the drained commits +
+				// Dashboard direct write: project the drained commits +
 				// current worktree state into the local stats DB. Awaited — a few git
 				// reads and one short SQLite transaction, trivial next to the LLM work
 				// this drain just did — and internally guarded: it skips on runtimes
@@ -1249,15 +1250,36 @@ function safeHashFileSync(path: string): string | null {
 async function detectPlanSlugsFromRegistry(cwd: string, branch: string): Promise<Set<string>> {
 	const registry = await loadPlansRegistry(cwd);
 	const slugs = new Set<string>();
+	// A plan whose sourcePath belongs to a DIFFERENT git repo
+	// (a sibling checkout the agent incidentally touched) is deterministically
+	// excluded here — this is the single archive chokepoint every path (normal /
+	// squash / amend / rebase) funnels through, so filtering here keeps foreign
+	// files off the commit on ALL of them, with no LLM involved.
+	const classifyPlanSource = createPlanSourceClassifier(cwd);
 	for (const [slug, entry] of Object.entries(registry.plans)) {
 		// No branch filter — uncommitted plans bind to the current worktree
 		// (its own plans.json) and commit associates all of them. Cross-worktree
 		// leakage is impossible because each worktree has a separate plans.json.
 		if (entry.commitHash === null && !entry.contentHashAtCommit) {
+			if ((await classifyPlanSource(entry.sourcePath)) === "foreign") {
+				log.info("Plan registry scan: %s (%s) is foreign — excluding from archive", slug, entry.sourcePath);
+				continue;
+			}
 			slugs.add(slug);
 			continue;
 		}
 		if (entry.commitHash !== null && entry.contentHashAtCommit && entry.sourcePath) {
+			// Classify before hashing so a foreign file is never read at all. The
+			// classifier short-circuits an in-worktree path without a git call, so
+			// this adds no cost on the common local case.
+			if ((await classifyPlanSource(entry.sourcePath)) === "foreign") {
+				log.info(
+					"Plan registry scan: committed %s (%s) is foreign — excluding from archive",
+					slug,
+					entry.sourcePath,
+				);
+				continue;
+			}
 			const liveHash = safeHashFileSync(entry.sourcePath);
 			if (liveHash && liveHash !== entry.contentHashAtCommit) {
 				slugs.add(slug);
@@ -2083,6 +2105,16 @@ async function executePipeline(cwd: string, op: CommitGitOperation, force = fals
 		(e) => getRegistry().byId(e.source)?.trackOnly !== true,
 	);
 
+	// Split off foreign-repo plans BEFORE ranking so their
+	// content never reaches the summarizer prompt, and surface them in
+	// excludedContext so the panel shows why they were left out. The archive
+	// chokepoint (detectPlanSlugsFromRegistry) drops them again — that is what
+	// covers the squash/amend paths, which never reach this prompt-side split.
+	const { localPlans, foreignExcludedContext } = await partitionForeignPlans(
+		userKeptPlans,
+		createPlanSourceClassifier(cwd),
+	);
+
 	// AI relevance: rank the user-kept context against this change and soft-exclude
 	// clearly-unrelated items. Wrapped so ANY failure (git / content-read / LLM /
 	// parse) falls back to the full user-kept set — a relevance problem must never
@@ -2090,14 +2122,14 @@ async function executePipeline(cwd: string, op: CommitGitOperation, force = fals
 	// additionally covers the git + content-read steps around it. Soft-excluded items are
 	// recorded on the summary's excludedContext; like user hard-excludes they are skipped
 	// from association but kept in the working area (never discarded).
-	let activePlanEntries = userKeptPlans;
+	let activePlanEntries = localPlans;
 	let activeNoteEntries = userKeptNotes;
 	let activeReferenceEntries = userKeptReferences;
-	let excludedContext: ReadonlyArray<ExcludedContextItem> = [];
+	let excludedContext: ReadonlyArray<ExcludedContextItem> = foreignExcludedContext;
 	let contextRelevance: ReadonlyArray<ContextRelevanceRef> = [];
 	try {
 		const changeSignal = await buildChangeSignal(commitInfo.message, `${op.commitHash}~1`, op.commitHash, cwd);
-		const raw = { plans: userKeptPlans, notes: userKeptNotes, references: relevanceCandidateReferences };
+		const raw = { plans: localPlans, notes: userKeptNotes, references: relevanceCandidateReferences };
 		// Reuse the pre-commit panel's full-text ranking when its change fingerprint
 		// matches (so the excluded set the user saw is exactly what lands, and we skip
 		// a redundant LLM call). Otherwise — panel not opened, or the change moved
@@ -2111,7 +2143,7 @@ async function executePipeline(cwd: string, op: CommitGitOperation, force = fals
 		activePlanEntries = [...relevance.plans];
 		activeNoteEntries = [...relevance.notes];
 		activeReferenceEntries = [...relevance.references, ...trackOnlyReferences];
-		excludedContext = relevance.excludedContext;
+		excludedContext = [...foreignExcludedContext, ...relevance.excludedContext];
 		// Kept items' tier+reason for the summary artifact (a user-dismissed
 		// exclusion lands here with its ORIGINAL verdict attached). Empty when the
 		// reuse path read a legacy selection file with no aiRelevance — the summary
@@ -3446,6 +3478,10 @@ async function handleAmendPipeline(
 	const relevanceCandidateAmendRefs = userKeptAmendRefs.filter(
 		(e) => getRegistry().byId(e.source)?.trackOnly !== true,
 	);
+	// Same foreign-repo plan split as executePipeline, so an
+	// amend's regenerated summary never carries a sibling repo's plan content.
+	const { localPlans: localAmendPlans, foreignExcludedContext: amendForeignExcludedContext } =
+		await partitionForeignPlans(userKeptAmendPlans, createPlanSourceClassifier(cwd));
 	// AI relevance filtering, mirroring executePipeline's Stage 2 (wrapped so any
 	// git / content-read / LLM / parse failure falls back to the full user-kept set).
 	// assessContextRelevance is fail-open and unit-tested; this call site is amend-only,
@@ -3456,10 +3492,10 @@ async function handleAmendPipeline(
 	// re-evaluation — and they're recorded on the amend summary's excludedContext
 	// audit, matching executePipeline. `amendExcludedContext` is hoisted out of the
 	// try so the full path and fresh-leaf branch further down can read it.
-	let amendPlanEntries = userKeptAmendPlans;
+	let amendPlanEntries = localAmendPlans;
 	let amendNoteEntries = userKeptAmendNotes;
 	let amendReferenceEntries = userKeptAmendRefs;
-	let amendExcludedContext: ReadonlyArray<ExcludedContextItem> = [];
+	let amendExcludedContext: ReadonlyArray<ExcludedContextItem> = amendForeignExcludedContext;
 	let amendContextRelevance: ReadonlyArray<ContextRelevanceRef> = [];
 	try {
 		const amendChangeSignal = await buildChangeSignal(
@@ -3469,14 +3505,14 @@ async function handleAmendPipeline(
 			cwd,
 		);
 		const amendRelevance = await assessContextRelevance(
-			{ plans: userKeptAmendPlans, notes: userKeptAmendNotes, references: relevanceCandidateAmendRefs },
+			{ plans: localAmendPlans, notes: userKeptAmendNotes, references: relevanceCandidateAmendRefs },
 			amendChangeSignal,
 			amendConfig,
 		);
 		amendPlanEntries = [...amendRelevance.plans];
 		amendNoteEntries = [...amendRelevance.notes];
 		amendReferenceEntries = [...amendRelevance.references, ...trackOnlyAmendRefs];
-		amendExcludedContext = amendRelevance.excludedContext;
+		amendExcludedContext = [...amendForeignExcludedContext, ...amendRelevance.excludedContext];
 		// Kept items' tier+reason for the amend summary artifact (amend always
 		// re-ranks fresh, so results are always populated on success).
 		amendContextRelevance = keptContextRelevanceRefs(amendRelevance);
@@ -4296,7 +4332,7 @@ async function readAllTranscripts(
 		const startLine = cursor?.lineNumber ?? 0;
 		const source = session.source ?? "claude";
 
-		// JOLLI-1785: fire ai_source_detected the first time this machine ever
+		// Fire ai_source_detected the first time this machine ever
 		// processes a transcript from `source` (markAiSourceSeen dedupes globally,
 		// so it never re-fires on later runs and can't skew the AI-source-mix view).
 		// Gated on telemetry being enabled so an opted-out/uninitialized run never

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -120,13 +120,13 @@ const {
 
 const {
 	addPlanToRegistry,
-	getPlansDir,
+	getClaudePlansDir,
 	isPlanFromCurrentProject,
 	listAvailablePlans,
 	registerNewPlan,
 } = vi.hoisted(() => ({
 	addPlanToRegistry: vi.fn(),
-	getPlansDir: vi.fn(() => "/home/user/.claude/plans"),
+	getClaudePlansDir: vi.fn(() => "/home/user/.claude/plans"),
 	// Default: attribution check passes (backward-compat for existing tests
 	// that don't explicitly exercise the cross-project gate).
 	isPlanFromCurrentProject: vi.fn(async () => true),
@@ -841,7 +841,7 @@ vi.mock("./commands/SelectAllSelection.js", () => ({
 
 vi.mock("./core/PlanService.js", () => ({
 	addPlanToRegistry,
-	getPlansDir,
+	getClaudePlansDir,
 	isPlanFromCurrentProject,
 	listAvailablePlans,
 	registerNewPlan,

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -93,7 +93,7 @@ import { renderReferenceForPreview } from "./core/ReferencePreviewMarkdown.js";
 import { getNotesDir } from "./core/NoteService.js";
 import {
 	addPlanToRegistry,
-	getPlansDir,
+	getClaudePlansDir,
 	listAvailablePlans,
 } from "./core/PlanService.js";
 import { JolliMemoryBridge } from "./JolliMemoryBridge.js";
@@ -837,7 +837,7 @@ export function activate(context: vscode.ExtensionContext): void {
 	const memoriesStore = new MemoriesStore(bridge);
 	const plansStore = new PlansStore(bridge, {
 		workspaceRoot,
-		plansDir: getPlansDir(),
+		plansDir: getClaudePlansDir(),
 		notesDir: getNotesDir(workspaceRoot),
 	});
 	const filesStore = new FilesStore(bridge, workspaceRoot, excludeFilter);

--- a/vscode/src/core/PlanService.ts
+++ b/vscode/src/core/PlanService.ts
@@ -17,7 +17,7 @@ export {
 	archivePlanForCommit,
 	detectPlans,
 	extractTitle,
-	getPlansDir,
+	getClaudePlansDir,
 	isPlanFromCurrentProject,
 	listAvailablePlans,
 	listUnassociatedPlans,


### PR DESCRIPTION
<!-- jollimemory-summary-start -->


## Quick recap

Commit summaries and pull-request descriptions now list only the planning documents that belong to the repository being committed. Planning files that live in a separate project checked out beside it stay out of this repository's commits and its shared branch folders, even when an assistant read or edited them during a session. Any file kept out this way still appears with a plain explanation that it was set aside for being outside the current repository, keeping the decision visible to reviewers. A follow-up corrected a case where a neighboring project's files still reached a commit's memory summary and Context when the summary was built by a commit hook, and committing in one project no longer surfaces stray planning files from a sibling project. Planning files stored in the assistant's own global folder, and files in sibling checkouts of the same repository, continue to be included.

---

## Topics (3)
<details>
<summary><strong>01 · Deterministically exclude foreign-repo plan files from commit summaries and PR descriptions</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Pull-request descriptions and pushed branch folders were listing planning documents that belong to unrelated projects checked out beside the repository being committed, misrepresenting what a branch actually changed and forcing manual cleanup.

**💡 Decisions Behind the Code**

- **Deterministic gate instead of leaning on the relevance ranker**: The existing probabilistic relevance filter was observed admitting every foreign document even after being fed the change diff, so exclusion was made a deterministic rule that never involves the language model. This trades a small amount of extra plumbing for a guarantee that unrelated-project files cannot slip through on a bad model judgment.
- **Key on git-repository identity, not "outside the worktree"**: Treating any file outside the working directory as foreign would wrongly discard the assistant's own global plan-mode files, which legitimately live outside the repo. Comparing enclosing-repo identity (with a whitelist for the canonical global plan folder) keeps those while still catching true sibling-repo files.
- **Unconditional exclusion over "admit if there's positive evidence"**: A softer variant that re-admitted foreign files showing affinity was rejected because every auto-discovered foreign plan was written during the session anyway, and any affinity route would hand the file back to the model that already misjudges it. The escape hatch remains the separate explicit "add file" path for notes.
- **Strip the ambient git environment rather than trust the target directory flag**: With hook-injected location variables present, the directory flag on the git command is ignored, so the only reliable way to ask which repo a directory belongs to is to remove those variables and let git rediscover by working directory. This isolates repo-identity resolution from wherever the process happens to be launched, fixing a leak that survived the initial identity-based approach.
- **Add a regression test that simulates the real hook environment**: The original bug survived three review passes and the author's own tests because every test ran without the hook's environment variables set, producing a false pass. The new test explicitly sets those variables and asserts a foreign file is still detected.

**✅ What Was Implemented**

- Added a new plan-containment module with a classifier that labels each plan's source path as local, foreign, or unknown by comparing git-repository identity (the git common directory) rather than directory location, so sibling worktrees of the same repo are correctly local; a companion helper splits a plan set into kept-local plans and foreign entries surfaced as excluded context.
- Wired the classifier into the single archive chokepoint `detectPlanSlugsFromRegistry` in `QueueWorker.ts`, dropping foreign plans on every path (normal, squash, amend, rebase) including revived-plan detection, and applied the same split on both prompt sides (`executePipeline` and the amend pipeline) so a foreign repo's plan content never reaches the summarizer. Foreign items are recorded in `excludedContext` with the reason "Outside the current repository" for panel visibility.
- Diagnosed that the summary-generation worker runs as a detached child of a git hook and inherits git's ambient location environment variables (GIT_DIR, GIT_WORK_TREE, etc.), so `git rev-parse --git-common-dir` resolved to the current repo regardless of the target directory and misclassified a sibling repo's plan as local.
- Added `resolveContainingRepoCommonDir` in `cli/src/core/GitOps.ts`, which strips the seven git location env vars before running `rev-parse` to force cwd-based repo discovery and returns null instead of throwing, then repointed the classifier's `defaultResolveRepoId` in `PlanContainment.ts` to the isolated resolver and rebuilt the bundle. A regression test now reproduces the real hook environment.

**📋 Future Enhancements**

- Memory for the prior commit was generated before the environment fix and still contains the foreign plan; it must be regenerated manually to clear it.
- The VS Code preview panel runs the separately-bundled extension build, which needs its own redeploy to reflect the fix.
- Deferred to separate tickets: pruning/expiry of stale registry entries, binding discovered plans to the session that found them, handling archives orphaned by amend/rebase/force-push, and stopping token-spend figures from leaking into public PR bodies.

**📁 FILES**
- `cli/src/core/plans/PlanContainment.ts`
- `cli/src/hooks/QueueWorker.ts`
- `cli/src/core/GitOps.ts`
- `cli/src/core/plans/TranscriptPlanDiscovery.ts`
- `cli/src/core/PlanPaths.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Make the Claude plan directory an explicitly-named single source of truth</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The helper that returned the plan directory had a generic name that implied a universal plan store, and its Claude-specific path was duplicated across the registration code and the new containment check, inviting the two copies to drift as more agents are supported.

**💡 Decisions Behind the Code**

- **Home passed as a parameter rather than frozen at import time**: Making the directory a pure function of an injectable home keeps the containment classifier testable in isolation instead of reading the machine's real home. This favors test reliability over the slightly terser frozen-constant form.
- **Extend the existing leaf module instead of creating a new one**: Reusing the lightweight path module keeps the classifier from pulling the heavy plan-discovery code into cold process startup and preserves the pinned cold-start import graph.

**✅ What Was Implemented**

- Renamed the accessor to `getClaudePlansDir` across 12 files in both the CLI and VS Code workspaces, and rewrote its documentation to state plainly that it is Claude Code's plan-mode directory, not a place where all plans are stored.
- Added a `canonicalPlanDirs` list in `PlanPaths.ts` as the one definition of legitimate outside-worktree plan directories, consumed by both plan registration and the containment classifier, with an optional home-directory parameter.

**📁 FILES**
- `cli/src/core/PlanPaths.ts`
- `cli/src/core/plans/TranscriptPlanDiscovery.ts`
- `cli/src/core/PlanService.ts`
- `cli/src/daemon/DaemonServer.ts`
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Strip private ticket and plan-document references from code comments</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Internal issue identifiers and references to private planning documents were embedded in code comments, including pre-existing ones, and these are private resources that should not live in shared source.

**💡 Decisions Behind the Code**

Private internal identifiers and plan-document references were treated as resources that must not appear anywhere in committed code, so the explanatory prose was kept but every private tag was stripped, extending the cleanup to older comments at the user's request rather than limiting it to the session's own additions.

**✅ What Was Implemented**

Removed identifiers and plan-document phrasing from the newly added comments in the containment module and its call sites, then also cleared three pre-existing identifier tags from `QueueWorker.ts` comments while preserving the explanatory text.

**📁 FILES**
- `cli/src/hooks/QueueWorker.ts`
- `cli/src/core/plans/PlanContainment.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 10, 2026 at 4:26 PM · via Local agent - Claude Code*
<!-- jollimemory-summary-end -->