### PR TITLE
Fix backfill to skip numstat only for commits with stored file rows

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -173,6 +173,30 @@ export interface ToolCallCount {
 	/** MCP server the tool belongs to. Present only when `kind` is `"mcp"`. */
 	readonly server?: string;
 	readonly calls: number;
+	/**
+	 * When the LAST call in this bucket was made, from the transcript line that
+	 * recorded it — NOT the session's own clock and NOT any commit's.
+	 *
+	 * A tool call is an event with its own instant, and the two times it used to
+	 * be approximated by are both wrong in a way that shows: a session's
+	 * `updatedAt` moves every time the conversation is touched afterwards (so a
+	 * call made three weeks ago reads as today's), and a commit date has no
+	 * relationship to it at all — an agent turn may precede its commit by hours
+	 * or produce no commit ever. The dashboard windows recall activity by this
+	 * field for exactly that reason.
+	 *
+	 * LAST, not first, and one instant for the whole bucket: a bucket counts N
+	 * calls of the same tool in one session, so a bucket that straddles a window
+	 * boundary is counted wholly inside the window its last call fell in. Splitting
+	 * it would need a row per call, which is a different table; being off by the
+	 * span of one session's repeated calls is a far smaller error than being off
+	 * by however long ago that session was last touched.
+	 *
+	 * Absent when the source's parser has no timestamp to offer (see
+	 * {@link ToolUseTally} for which do) — readers of this field must fall back
+	 * rather than treat absence as "never called".
+	 */
+	readonly lastCallAtMs?: number;
 }
 
 /**

--- a/cli/src/core/AntigravityTranscriptReader.test.ts
+++ b/cli/src/core/AntigravityTranscriptReader.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import type { ToolCallCount } from "../Types.js";
 import { REAL_TRANSCRIPT_FULL } from "../testUtils/antigravityFixture.js";
 import { readAntigravityTranscript, unwrapUserRequest } from "./AntigravityTranscriptReader.js";
 
@@ -136,10 +137,40 @@ describe("unwrapUserRequest", () => {
 });
 
 describe("readAntigravityTranscript toolUse", () => {
+	/**
+	 * Tool rows with the per-call timestamp dropped. These cases are about WHICH
+	 * bucket a call lands in and how many it counts; the stamping has its own
+	 * case below, and leaving the field in would make every fixture's
+	 * `created_at` an input to assertions that never mention time.
+	 */
+	const untimed = (rows: ReadonlyArray<ToolCallCount> | undefined) =>
+		(rows ?? []).map(({ lastCallAtMs: _dropped, ...rest }) => rest);
+
+	it("stamps each bucket with its last call's own time", async () => {
+		const path = writeTranscript([
+			{
+				step_index: 0,
+				type: "PLANNER_RESPONSE",
+				created_at: "2026-07-19T09:46:50Z",
+				tool_calls: [{ name: "run_command", args: {} }],
+			},
+			{
+				step_index: 1,
+				type: "PLANNER_RESPONSE",
+				created_at: "2026-07-19T09:46:51Z",
+				tool_calls: [{ name: "run_command", args: {} }],
+			},
+		]);
+		const result = await readAntigravityTranscript(path);
+		expect(result.toolUse).toEqual([
+			{ name: "run_command", kind: "builtin", calls: 2, lastCallAtMs: Date.parse("2026-07-19T09:46:51Z") },
+		]);
+	});
+
 	it("counts the PLANNER_RESPONSE tool_calls it also summarizes into the text", async () => {
 		const path = writeTranscript(REAL_TRANSCRIPT_FULL);
 		const result = await readAntigravityTranscript(path);
-		expect(result.toolUse).toEqual([{ name: "run_command", kind: "builtin", calls: 1 }]);
+		expect(untimed(result.toolUse)).toEqual([{ name: "run_command", kind: "builtin", calls: 1 }]);
 	});
 
 	it("sums repeated calls to the same tool across steps", async () => {
@@ -161,7 +192,7 @@ describe("readAntigravityTranscript toolUse", () => {
 			},
 		]);
 		const result = await readAntigravityTranscript(path);
-		expect(result.toolUse).toEqual([
+		expect(untimed(result.toolUse)).toEqual([
 			{ name: "run_command", kind: "builtin", calls: 2 },
 			{ name: "view_file", kind: "builtin", calls: 1 },
 		]);
@@ -191,8 +222,8 @@ describe("readAntigravityTranscript toolUse", () => {
 			},
 		]);
 		const first = await readAntigravityTranscript(path, undefined, "2026-07-19T09:50:00Z");
-		expect(first.toolUse).toEqual([{ name: "run_command", kind: "builtin", calls: 1 }]);
+		expect(untimed(first.toolUse)).toEqual([{ name: "run_command", kind: "builtin", calls: 1 }]);
 		const second = await readAntigravityTranscript(path, first.newCursor);
-		expect(second.toolUse).toEqual([{ name: "view_file", kind: "builtin", calls: 1 }]);
+		expect(untimed(second.toolUse)).toEqual([{ name: "view_file", kind: "builtin", calls: 1 }]);
 	});
 });

--- a/cli/src/core/AntigravityTranscriptReader.ts
+++ b/cli/src/core/AntigravityTranscriptReader.ts
@@ -109,8 +109,14 @@ export async function readAntigravityTranscript(
 			// PLANNER_RESPONSE line is not a shape this transcript produces (it is
 			// append-only and each step_index appears once), so counting every
 			// occurrence is correct rather than merely tolerable.
+			const atMs = ts ? Date.parse(ts) : Number.NaN;
 			for (const tc of tcs) {
-				if (typeof tc?.name === "string" && tc.name.length > 0) tally.add(builtinTool(tc.name));
+				if (typeof tc?.name === "string" && tc.name.length > 0) {
+					tally.add({
+						...builtinTool(tc.name),
+						...(Number.isFinite(atMs) && { lastCallAtMs: atMs }),
+					});
+				}
 			}
 			const parts = [content, ...tcs.map(toolCallSummary)].filter((p) => p.length > 0);
 			if (parts.length) entries.push({ role: "assistant", content: parts.join("\n"), timestamp: ts });

--- a/cli/src/core/CursorCliTranscriptReader.ts
+++ b/cli/src/core/CursorCliTranscriptReader.ts
@@ -159,12 +159,13 @@ export async function readCursorCliTranscript(
 			// cursor behind so the completed line is re-read next pass (no silent drop).
 			continue;
 		}
-		if (hasCutoff) {
-			const ts = lineTimestampMs(parsed);
-			// This turn (and everything after it) was written after the commit's cutoff:
-			// stop here and leave the cursor before it so the next commit picks it up.
-			if (ts !== undefined && ts > cutoffMs) break;
-		}
+		// Read unconditionally, not just under `hasCutoff`: it is also the instant
+		// stamped on each tool bucket below, and a cutoff-less read (the common
+		// one) would otherwise leave every bucket timeless.
+		const ts = lineTimestampMs(parsed);
+		// This turn (and everything after it) was written after the commit's cutoff:
+		// stop here and leave the cursor before it so the next commit picks it up.
+		if (hasCutoff && ts !== undefined && ts > cutoffMs) break;
 		const role = mapRole(parsed.role);
 		if (role !== undefined) {
 			const text = extractText(parsed);
@@ -177,7 +178,10 @@ export async function readCursorCliTranscript(
 		// `toolu_…` id (dedupe key) and MCP tools are named `mcp__<server>__<tool>`.
 		for (const p of parsed.message?.content ?? []) {
 			if (p.type !== "tool_use" || typeof p.name !== "string" || p.name.length === 0) continue;
-			tally.addOnce(typeof p.id === "string" ? p.id : undefined, classifyToolName(p.name));
+			tally.addOnce(typeof p.id === "string" ? p.id : undefined, {
+				...classifyToolName(p.name),
+				...(ts !== undefined && { lastCallAtMs: ts }),
+			});
 		}
 		lastConsumed = i + 1;
 	}

--- a/cli/src/core/GitOps.test.ts
+++ b/cli/src/core/GitOps.test.ts
@@ -65,6 +65,7 @@ import {
 	listWorktrees,
 	orphanBranchExists,
 	readFileFromBranch,
+	readLocalGitIdentity,
 	readOrigHead,
 	resetStateRootCache,
 	resolveGitHooksDir,
@@ -463,6 +464,26 @@ describe("GitOps", () => {
 			mockSuccess(""); // ls-files --others → none
 			const stats = await getWorkingTreeDiffStats(["a.ts"], "/repo");
 			expect(stats).toEqual({ filesChanged: 1, insertions: 2, deletions: 1 });
+		});
+	});
+
+	describe("readLocalGitIdentity", () => {
+		it("reads user.email and user.name from git config", async () => {
+			mockSuccess("me@example.com\n");
+			mockSuccess("Me\n");
+			expect(await readLocalGitIdentity("/w")).toEqual({ email: "me@example.com", name: "Me" });
+			expect(mockExecFileAsync).toHaveBeenCalledWith(
+				"git",
+				["config", "user.email"],
+				expect.objectContaining({ cwd: "/w" }),
+			);
+		});
+
+		it("reports an unset or unreadable field as null rather than an empty string", async () => {
+			// An unset key exits 1 with no stdout; a whitespace-only value is no value.
+			mockFailure(1, "");
+			mockSuccess("   \n");
+			expect(await readLocalGitIdentity()).toEqual({ email: null, name: null });
 		});
 	});
 

--- a/cli/src/core/GitOps.ts
+++ b/cli/src/core/GitOps.ts
@@ -277,6 +277,26 @@ export async function listReachableCommits(cwd?: string): Promise<ReadonlyArray<
 }
 
 /**
+ * The git identity commits made here are attributed to (`user.email` /
+ * `user.name`), each field null when unset or unreadable.
+ *
+ * Read from `git config`, not from HEAD's author: a repo whose last commit came
+ * from a teammate (a fresh clone, a shared branch) would otherwise report the
+ * teammate as the local user. Both fields are returned because the two can
+ * disagree — a machine configured with a work email pushing to a remote that
+ * rewrites it to a noreply address still authored the commit — so callers match
+ * on EITHER, mirroring the backfill author filter.
+ */
+export async function readLocalGitIdentity(cwd?: string): Promise<{ email: string | null; name: string | null }> {
+	const read = async (key: string): Promise<string | null> => {
+		const result = await execGit(["config", key], cwd);
+		const value = result.exitCode === 0 ? result.stdout.trim() : "";
+		return value.length > 0 ? value : null;
+	};
+	return { email: await read("user.email"), name: await read("user.name") };
+}
+
+/**
  * Gets information about a specific commit by hash.
  * Unlike getHeadCommitInfo, this queries a specific hash rather than HEAD.
  */

--- a/cli/src/core/JolliRefs.ts
+++ b/cli/src/core/JolliRefs.ts
@@ -1,0 +1,54 @@
+/**
+ * JolliRefs — which git refs belong to this product rather than to the user.
+ *
+ * Jolli's storage lives on ordinary local branches under a reserved namespace
+ * (today `jollimemory/summaries/v3`, plus every retired version a long-lived
+ * clone still carries), so anything that walks `refs/heads` sees them unless it
+ * is told not to — and the orphan branch holds one commit PER MEMORY. Two
+ * dashboard consumers must agree on the exclusion, which is why the rule lives
+ * in a module of its own rather than inside either of them:
+ *
+ *   - the commit collector, or the orphan's summary commits are imported as the
+ *     user's own work (measured on this repo before the exclusion: 1800 of 2468
+ *     stored commits were `Add summary for …` about the other 668, and
+ *     `jollimemory/summaries/v3` outranked `main` in the branch attribution);
+ *   - the backfill change signal, or it moves on every memory write and can
+ *     never converge, so `jolli dashboard` re-swept git history on essentially
+ *     every launch.
+ *
+ * A LEAF on purpose: no imports, in particular not `Logger.js` — where
+ * `ORPHAN_BRANCH` lives and where this rule first sat. Two dozen suites replace
+ * that module with a hand-written `vi.mock`, so every export added to it breaks
+ * each of them with "No export is defined on the mock" until they are all
+ * amended. The namespace is therefore restated here rather than derived from
+ * `ORPHAN_BRANCH`; keep the two in step if the branch is ever renamed wholesale
+ * (a version bump within the namespace needs no change here).
+ */
+
+/** The `refs/heads/` namespace this product reserves. @see ORPHAN_BRANCH */
+const JOLLI_REF_NAMESPACE = "jollimemory";
+
+/**
+ * True for a ref this product owns. Accepts `refs/heads/x` or the short `x`.
+ *
+ * Matched by NAMESPACE, so retired branch versions go with it while a user
+ * branch merely NAMED `jollimemory-notes` stays ordinary work.
+ */
+export function isJolliInternalRef(ref: string): boolean {
+	const short = ref.startsWith("refs/heads/") ? ref.slice("refs/heads/".length) : ref;
+	return short.startsWith(`${JOLLI_REF_NAMESPACE}/`);
+}
+
+/**
+ * The same rule as git's `--exclude` argument.
+ *
+ * Deliberately NOT prefixed with `refs/heads/`, and the trailing `/*` is
+ * mandatory. `--exclude` takes its pattern relative to the selector it applies
+ * to, so the `refs/heads/` form — the one that looks right, and the one
+ * required when the selector is `--glob`/`--all` — matches NOTHING under
+ * `--branches` and is silently ignored: measured, `git log
+ * --exclude=refs/heads/jollimemory/* --branches HEAD` still listed all 2468
+ * commits, exactly as if the flag were absent, while the correct form listed
+ * 668. Neither shape produces an error or a warning.
+ */
+export const JOLLI_REFS_EXCLUDE_GLOB = `--exclude=${JOLLI_REF_NAMESPACE}/*`;

--- a/cli/src/core/OrphanSotGuard.test.ts
+++ b/cli/src/core/OrphanSotGuard.test.ts
@@ -69,6 +69,13 @@ const BRANCH_NAME_ALLOWLIST: ReadonlyMap<string, string> = new Map([
 	["cli/src/Logger.ts", "the constant is declared here"],
 	["cli/src/core/OrphanBranchStorage.ts", "the backend itself"],
 	["cli/src/core/GitRefStorage.ts", "the backend itself"],
+	[
+		"cli/src/core/JolliRefs.ts",
+		// The opposite of a system-of-record decision: it names the constant in a
+		// `@see` so a reader of the ref-namespace rule can find the branch it
+		// derives from, and its whole job is telling git to IGNORE that namespace.
+		"names the constant in a doc cross-reference; reads and writes nothing",
+	],
 	["cli/src/dashboard/CutoverEngine.ts", "the cutover machinery: tips, fence, CAS"],
 	["cli/src/dashboard/SotImport.ts", "the orphan → SQLite importer"],
 	["cli/src/dashboard/Recovery.ts", "reads the fenced root's tip"],

--- a/cli/src/core/TokenCost.test.ts
+++ b/cli/src/core/TokenCost.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
+import type { CommitSummary } from "../Types.js";
 import {
 	estimateConversationCostUsd,
+	estimateSummaryCostUsd,
 	formatExactCostUsd,
 	formatSonnetCostEstimate,
 	formatTokensCompact,
@@ -85,5 +87,65 @@ describe("estimateConversationCostUsd", () => {
 	});
 	it("falls back to the input rate on the total when no breakdown", () => {
 		expect(estimateConversationCostUsd(undefined, 1_000_000)).toBeCloseTo(3, 6);
+	});
+});
+
+describe("estimateSummaryCostUsd", () => {
+	/** Minimal node — the walk reads only the five cost-bearing fields. */
+	const node = (fields: Partial<CommitSummary>): CommitSummary => fields as CommitSummary;
+
+	it("sums stored per-node costs across the whole consolidation tree", () => {
+		// The bug this guards: reading the ROOT's own `estimatedCostUsd` priced only
+		// the tip of a squash while the token headline beside it counted every
+		// folded node — the local web dashboard showed ≈$2.59 against the editor's
+		// ≈$27.61 for one commit.
+		const summary = node({
+			estimatedCostUsd: 1,
+			children: [
+				node({ estimatedCostUsd: 2 }),
+				node({ estimatedCostUsd: 4, children: [node({ estimatedCostUsd: 8 })] }),
+			],
+		});
+		expect(estimateSummaryCostUsd(summary)).toEqual({ usd: 15, mode: "stored" });
+	});
+
+	it("falls back to the flat Sonnet estimate for a node with tokens but no stored cost", () => {
+		const summary = node({
+			conversationTokens: 3_000_000,
+			conversationTokenBreakdown: { input: 1_000_000, output: 1_000_000, cached: 1_000_000 },
+		});
+		const { usd, mode } = estimateSummaryCostUsd(summary);
+		expect(usd).toBeCloseTo(3 + 15 + 3.75, 6);
+		expect(mode).toBe("sonnet");
+	});
+
+	it("reports mixed when a stored node sits beside a fallback node", () => {
+		const summary = node({
+			estimatedCostUsd: 1,
+			children: [node({ conversationTokens: 1_000_000 })],
+		});
+		const { usd, mode } = estimateSummaryCostUsd(summary);
+		expect(usd).toBeCloseTo(1 + 3, 6);
+		expect(mode).toBe("mixed");
+	});
+
+	it("tops up a stored cost with the segments of its UNPRICED model buckets", () => {
+		// A stored cost is a lower bound: write time skips buckets whose model has no
+		// price rather than guessing, so those tokens sit in the headline while
+		// contributing $0. They get the flat rate here, and tip the mode to mixed.
+		const summary = node({
+			estimatedCostUsd: 1,
+			conversationModels: [
+				{ provider: "anthropic", model: "claude-sonnet-5", input: 1000, output: 1000, cached: 1000 },
+				{ provider: "anthropic", model: "some-unlisted-model", input: 1_000_000, output: 0, cached: 0 },
+			],
+		});
+		const { usd, mode } = estimateSummaryCostUsd(summary);
+		expect(usd).toBeCloseTo(1 + 3, 6);
+		expect(mode).toBe("mixed");
+	});
+
+	it("counts a node with neither a cost nor tokens as neither stored nor fallback", () => {
+		expect(estimateSummaryCostUsd(node({ children: [node({})] }))).toEqual({ usd: 0, mode: "sonnet" });
 	});
 });

--- a/cli/src/core/TokenCost.ts
+++ b/cli/src/core/TokenCost.ts
@@ -8,7 +8,8 @@
  * constants and formatters live here rather than in the VS Code layer.
  */
 
-import type { ConversationTokenBreakdown } from "../Types.js";
+import type { CommitSummary, ConversationTokenBreakdown, ModelTokenUsage } from "../Types.js";
+import { estimateModelCostUsd } from "./Pricing.js";
 
 /** Formats a token count compactly (e.g. `1443000` -> `1.4M`, `2000000` -> `2M`, `96000` -> `96k`). */
 export function formatTokensCompact(n: number): string {
@@ -82,4 +83,100 @@ export function estimateConversationCostUsd(breakdown: ConversationTokenBreakdow
 				breakdown.output * SONNET_OUTPUT_PER_TOKEN +
 				breakdown.cached * SONNET_CACHE_WRITE_PER_TOKEN
 		: total * SONNET_INPUT_PER_TOKEN;
+}
+
+/**
+ * Sums the token segments of a node's per-model buckets whose model has no entry
+ * in the host price table, or null when every bucket is priced (or the node
+ * records no buckets to inspect).
+ *
+ * These are exactly the tokens `estimatedCostUsd` deliberately left out of its
+ * total rather than guessing a rate for, so they are what a stored cost still
+ * owes. Membership is probed through `estimateModelCostUsd`'s null return — the
+ * same predicate the write-time estimate uses — rather than by reading
+ * `MODEL_PRICES` here, so the two can never disagree about what "unpriced" means.
+ *
+ * A node carrying a cost but no `conversationModels` (hand-edited or otherwise
+ * off-contract data — write time only stores a cost alongside buckets) returns
+ * null: there is nothing to inspect, so the stored figure is taken at face value.
+ */
+function unpricedSegments(models: ReadonlyArray<ModelTokenUsage> | undefined): ConversationTokenBreakdown | null {
+	let input = 0;
+	let output = 0;
+	let cached = 0;
+	for (const m of models ?? []) {
+		if (estimateModelCostUsd(m) !== null) continue;
+		input += m.input;
+		output += m.output;
+		cached += m.cached;
+	}
+	return input + output + cached > 0 ? { input, output, cached } : null;
+}
+
+/** What fed {@link estimateSummaryCostUsd}'s figure, so a caller's tooltip can describe it honestly. */
+export type SummaryCostMode = "stored" | "sonnet" | "mixed";
+
+/**
+ * A memory's cache-aware $ estimate over its WHOLE consolidation tree,
+ * preferring the cost computed at WRITE time from each node's actual model(s)
+ * via the host price table, and falling back to the flat Sonnet-rate estimate
+ * for whatever the stored cost does not cover — legacy memories, or a
+ * conversation whose model is absent from the price table.
+ *
+ * Lives here, not on a surface, because every surface showing a memory's cost
+ * must show the same number: the editor's token meter and the local web
+ * dashboard disagreed by two orders of magnitude ($12.21 against $0.06) for
+ * exactly as long as the dashboard read the ROOT node's own `estimatedCostUsd`
+ * while the editor summed the tree. A squash root's own cost is a fraction of
+ * the work folded beneath it.
+ *
+ * The preference is resolved PER NODE, not once for the whole tree. A tree-wide
+ * "any stored cost wins" test silently under-reports a mixed consolidation: the
+ * token headline beside this figure aggregates EVERY node, so a squash whose root
+ * carries a stored cost while a folded legacy child does not would price only the
+ * root and show that total next to the full tree's tokens. Summing per node keeps
+ * the two figures over the same set. (The Sonnet formula is linear per segment, so
+ * summing per-node fallbacks equals estimating from their aggregate — no drift
+ * against pricing from the aggregate for an all-fallback tree.)
+ *
+ * A stored cost is a LOWER bound, not proof of full coverage, so the per-node
+ * preference is resolved per MODEL bucket rather than per node — see
+ * {@link unpricedSegments}.
+ */
+export function estimateSummaryCostUsd(summary: CommitSummary): { usd: number; mode: SummaryCostMode } {
+	let usd = 0;
+	let storedNodes = 0;
+	let fallbackNodes = 0;
+	const walk = (node: CommitSummary): void => {
+		const own = node.estimatedCostUsd ?? 0;
+		const tokens = node.conversationTokens ?? 0;
+		if (own > 0) {
+			usd += own;
+			storedNodes++;
+			// A positive stored cost does NOT mean the node is fully priced. Write time
+			// records `estimatedCostUsd` as a lower bound: `estimateCostUsd` prices only
+			// the buckets present in the host price table and EXCLUDES the rest rather
+			// than guessing (see Pricing.ts's `-pro` note, Types.ts on
+			// `estimatedCostUsd`, and conversationUsageFields in QueueWorker). Treating
+			// `own > 0` as full coverage therefore under-reports every node that mixed a
+			// priced model with an unpriced one — the unpriced bucket's tokens sit in the
+			// headline total beside this figure while contributing $0 to it. Price
+			// exactly those buckets at the flat rate, the same treatment a wholly
+			// unpriced node gets below, and let them tip the mode to "mixed" so the
+			// tooltip stops claiming the figure is fully model-priced.
+			const unpriced = unpricedSegments(node.conversationModels);
+			if (unpriced) {
+				usd += estimateConversationCostUsd(unpriced, unpriced.input + unpriced.output + unpriced.cached);
+				fallbackNodes++;
+			}
+		} else if (tokens > 0) {
+			// No stored cost but real tokens — this node needs the flat-rate fallback.
+			// Nodes with neither contribute nothing and must NOT tip the mode either way.
+			usd += estimateConversationCostUsd(node.conversationTokenBreakdown, tokens);
+			fallbackNodes++;
+		}
+		for (const child of node.children ?? []) walk(child);
+	};
+	walk(summary);
+	return { usd, mode: storedNodes > 0 ? (fallbackNodes > 0 ? "mixed" : "stored") : "sonnet" };
 }

--- a/cli/src/core/ToolNameClassify.ts
+++ b/cli/src/core/ToolNameClassify.ts
@@ -120,6 +120,38 @@ export function classifyCodexToolName(name: string, namespace?: string): ToolCal
  *     row). Keying on anything coarser than the call id — a message id, the tool
  *     name — collapses distinct calls made in the same response into one.
  */
+/**
+ * The later of two buckets' `lastCallAtMs`, as a spreadable fragment.
+ *
+ * Spread rather than assigned so an ABSENT time stays absent: merging a call
+ * whose parser offered no timestamp into one that did must not overwrite the
+ * known instant with `undefined`, and `exactOptionalPropertyTypes` would not
+ * catch it — the field is optional, so writing `undefined` type-checks and
+ * silently degrades the bucket to "no time" the first time an untimed call
+ * lands in it.
+ */
+function mergeLastCallAt(a: ToolCallCount, b: ToolCallCount): { lastCallAtMs?: number } {
+	const latest = Math.max(a.lastCallAtMs ?? Number.NEGATIVE_INFINITY, b.lastCallAtMs ?? Number.NEGATIVE_INFINITY);
+	return Number.isFinite(latest) ? { lastCallAtMs: latest } : {};
+}
+
+/**
+ * Sources whose parsers stamp {@link ToolCallCount.lastCallAtMs} today, and
+ * therefore the sources whose tool rows the dashboard can window by the CALL's
+ * own time instead of by the session's.
+ *
+ * Evidence-gated like `TOOL_RECORDING_SOURCES`, and for the same reason: a
+ * source is listed only once its parser is actually passing a timestamp
+ * through. Everything else leaves the field absent, and every consumer must
+ * fall back (the dashboard falls back to `sessions.updated_at_ms`) rather than
+ * read absence as "no calls".
+ *
+ * Exported for documentation and tests, not for branching — a consumer that
+ * switches on the source instead of on the field's presence goes stale the
+ * moment a parser is taught to stamp one.
+ */
+export const TOOL_CALL_TIME_SOURCES: ReadonlyArray<string> = ["claude", "codex", "kimi", "cursor-cli", "antigravity"];
+
 export class ToolUseTally {
 	private readonly byKey = new Map<string, ToolCallCount>();
 	private readonly seen = new Set<string>();
@@ -128,7 +160,11 @@ export class ToolUseTally {
 	add(call: ToolCallCount, calls = 1): void {
 		const key = `${call.kind}:${call.name}`;
 		const prev = this.byKey.get(key);
-		this.byKey.set(key, prev ? { ...prev, calls: prev.calls + calls } : { ...call, calls });
+		if (!prev) {
+			this.byKey.set(key, { ...call, calls });
+			return;
+		}
+		this.byKey.set(key, { ...prev, calls: prev.calls + calls, ...mergeLastCallAt(prev, call) });
 	}
 
 	/**

--- a/cli/src/core/TranscriptParser.ts
+++ b/cli/src/core/TranscriptParser.ts
@@ -22,6 +22,29 @@ import {
 } from "./ToolNameClassify.js";
 import { parseTranscriptLine } from "./TranscriptReader.js";
 
+/**
+ * Epoch ms of an ISO timestamp, or undefined when there is none to read or it
+ * does not parse. Undefined rather than `NaN`/0: the field it feeds is optional
+ * and its absence means "this parser had no instant to offer", which a zero
+ * would turn into the claim "called at the epoch".
+ */
+function parseIsoMs(iso: string | undefined): number | undefined {
+	if (iso === undefined) return undefined;
+	const ms = Date.parse(iso);
+	return Number.isFinite(ms) ? ms : undefined;
+}
+
+/**
+ * The latest of some instants as a spreadable fragment, absent when none of
+ * them is known. Same reason as `mergeLastCallAt` in `ToolNameClassify`: an
+ * absent time must stay absent rather than be written as `undefined` over a
+ * known one.
+ */
+function latestOf(...times: ReadonlyArray<number | undefined>): { lastCallAtMs?: number } {
+	const known = times.filter((t): t is number => t !== undefined);
+	return known.length > 0 ? { lastCallAtMs: Math.max(...known) } : {};
+}
+
 // Re-exported for the callers that already imported it from here; the shared
 // classifiers now live in ToolNameClassify.ts alongside the other dialects.
 export { classifyToolName } from "./ToolNameClassify.js";
@@ -159,15 +182,19 @@ export class ClaudeTranscriptParser implements TranscriptParser {
 			}
 			const content = (parsed as { message?: { content?: unknown } })?.message?.content;
 			if (!Array.isArray(content)) continue;
+			// The line's own instant, so the bucket can be windowed by when the call
+			// happened rather than by when its session was last touched. Read per
+			// line and not per file: one session's calls span hours.
+			const atMs = parseIsoMs(this.parseTimestamp(line));
 			for (const block of content) {
 				const b = block as { type?: unknown; id?: unknown; name?: unknown; input?: { skill?: unknown } };
 				if (b.type !== "tool_use" || typeof b.name !== "string") continue;
-				tally.addOnce(
-					typeof b.id === "string" ? b.id : undefined,
-					b.name === "Skill" && typeof b.input?.skill === "string"
+				tally.addOnce(typeof b.id === "string" ? b.id : undefined, {
+					...(b.name === "Skill" && typeof b.input?.skill === "string"
 						? skillTool(b.input.skill)
-						: classifyToolName(b.name),
-				);
+						: classifyToolName(b.name)),
+					...(atMs !== undefined && { lastCallAtMs: atMs }),
+				});
 			}
 		}
 		return tally.values();
@@ -296,16 +323,32 @@ export class CodexTranscriptParser implements TranscriptParser {
 				continue;
 			}
 
+			// Stamped on every row, INCLUDING the ones the upgrade rule discards
+			// below: a call's rows (request, then `mcp_tool_call_end`) are written
+			// at different instants, and the identity that wins is not necessarily
+			// the row that happened last. Carrying the later of the two keeps the
+			// bucket's time honest regardless of which row won.
+			// Read off the envelope rather than through a `parseTimestamp` method:
+			// this parser has none, and adding one would also change which lines the
+			// incremental cutoff can see — a separate decision from this one.
+			const rawAt = (parsed as { timestamp?: unknown }).timestamp;
+			const atMs = parseIsoMs(typeof rawAt === "string" ? rawAt : undefined);
+			const timed: ToolCallCount = { ...call, ...(atMs !== undefined && { lastCallAtMs: atMs }) };
+
 			const callId = typeof p.call_id === "string" ? p.call_id : undefined;
 			if (callId === undefined) {
-				anonymous.push(call);
+				anonymous.push(timed);
 				continue;
 			}
 			const known = byCallId.get(callId);
 			// Upgrade-only: a builtin guess yields to a resolved MCP identity, and a
 			// later builtin row (the request written after an event, or a result row
 			// echoing the bare name) never overwrites one.
-			if (known === undefined || (known.kind !== "mcp" && call.kind === "mcp")) byCallId.set(callId, call);
+			const winner = known === undefined || (known.kind !== "mcp" && timed.kind === "mcp") ? timed : known;
+			byCallId.set(callId, {
+				...winner,
+				...(known ? latestOf(known.lastCallAtMs, timed.lastCallAtMs) : latestOf(timed.lastCallAtMs)),
+			});
 		}
 		const tally = new ToolUseTally();
 		for (const call of [...byCallId.values(), ...anonymous]) tally.add(call);
@@ -425,12 +468,15 @@ export class KimiTranscriptParser implements TranscriptParser {
 				| undefined;
 			if (event === null || typeof event !== "object") continue;
 			if (event.type !== "tool.call" || typeof event.name !== "string") continue;
-			tally.addOnce(
-				typeof event.toolCallId === "string" ? event.toolCallId : undefined,
-				event.name === KIMI_SKILL_TOOL_NAME && typeof event.args?.skill === "string"
+			// Every Kimi wire event carries a millisecond-epoch `time`; `parseTimestamp`
+			// is the one place that shape is decoded.
+			const atMs = parseIsoMs(this.parseTimestamp(line));
+			tally.addOnce(typeof event.toolCallId === "string" ? event.toolCallId : undefined, {
+				...(event.name === KIMI_SKILL_TOOL_NAME && typeof event.args?.skill === "string"
 					? skillTool(event.args.skill)
-					: classifyToolName(event.name),
-			);
+					: classifyToolName(event.name)),
+				...(atMs !== undefined && { lastCallAtMs: atMs }),
+			});
 		}
 		return tally.values();
 	}

--- a/cli/src/core/TranscriptParserToolUse.test.ts
+++ b/cli/src/core/TranscriptParserToolUse.test.ts
@@ -1,8 +1,22 @@
 import { describe, expect, it } from "vitest";
 import { getParserForSource, TOOL_RECORDING_SOURCES } from "./TranscriptParser.js";
 
-/** Shorthand: run a parser's parseToolUse over pre-serialized events. */
+/**
+ * Shorthand: run a parser's parseToolUse over pre-serialized events, with the
+ * per-call timestamp dropped.
+ *
+ * Every case below is about tool IDENTITY — which bucket a shape lands in, what
+ * de-duplicates, what upgrades — and `lastCallAtMs` is orthogonal to all of it.
+ * Left in, it would appear in ~20 expected objects that are not about it, and
+ * changing a fixture's timestamp would fail tests that never mentioned time.
+ * The stamping itself is asserted by {@link timedToolUse}'s cases instead.
+ */
 function toolUse(source: "claude" | "codex" | "kimi", events: ReadonlyArray<unknown>) {
+	return timedToolUse(source, events).map(({ lastCallAtMs: _dropped, ...rest }) => rest);
+}
+
+/** The same, keeping `lastCallAtMs` — for the cases that are about it. */
+function timedToolUse(source: "claude" | "codex" | "kimi", events: ReadonlyArray<unknown>) {
 	const parser = getParserForSource(source);
 	if (parser.parseToolUse === undefined) throw new Error(`${source} parser has no parseToolUse`);
 	return parser.parseToolUse(events.map((e) => JSON.stringify(e)));
@@ -251,5 +265,87 @@ describe("TOOL_RECORDING_SOURCES", () => {
 		for (const source of ["cursor", "copilot", "copilot-chat", "cline"]) {
 			expect(TOOL_RECORDING_SOURCES.has(source)).toBe(false);
 		}
+	});
+});
+
+describe("parseToolUse — the call's own time", () => {
+	// Why the field exists: the dashboard used to window tool rows by their
+	// SESSION's `updated_at_ms`, which files a months-old recall under today and
+	// a call made minutes ago under whenever its long-running session started.
+	it("stamps a Claude call with the timestamp of the line that recorded it", () => {
+		expect(
+			timedToolUse("claude", [
+				{
+					timestamp: "2026-08-06T16:03:08.019Z",
+					message: { content: [{ type: "tool_use", id: "toolu_1", name: "Bash" }] },
+				},
+			]),
+		).toEqual([{ name: "Bash", kind: "builtin", calls: 1, lastCallAtMs: Date.parse("2026-08-06T16:03:08.019Z") }]);
+	});
+
+	it("keeps the LAST call's time when a bucket holds several", () => {
+		const rows = timedToolUse("claude", [
+			{
+				timestamp: "2026-08-06T10:00:00.000Z",
+				message: { content: [{ type: "tool_use", id: "a", name: "Bash" }] },
+			},
+			{
+				timestamp: "2026-08-06T12:00:00.000Z",
+				message: { content: [{ type: "tool_use", id: "b", name: "Bash" }] },
+			},
+		]);
+		expect(rows).toEqual([
+			{ name: "Bash", kind: "builtin", calls: 2, lastCallAtMs: Date.parse("2026-08-06T12:00:00.000Z") },
+		]);
+	});
+
+	it("leaves the field absent — not zero — when the line carries no timestamp", () => {
+		// Absent means "this parser had no instant to offer", which every consumer
+		// falls back on. A zero would be the claim "called at the epoch", which
+		// windows would silently believe.
+		expect(
+			timedToolUse("claude", [{ message: { content: [{ type: "tool_use", id: "a", name: "Bash" }] } }]),
+		).toEqual([{ name: "Bash", kind: "builtin", calls: 1 }]);
+	});
+
+	it("stamps a Codex call from its envelope, and a Kimi call from its epoch `time`", () => {
+		expect(
+			timedToolUse("codex", [codexRow({ type: "function_call", call_id: "c1", name: "wait", arguments: "{}" })]),
+		).toEqual([{ name: "wait", kind: "builtin", calls: 1, lastCallAtMs: Date.parse("2026-08-06T16:03:08.019Z") }]);
+		expect(timedToolUse("kimi", [kimiRow({ type: "tool.call", name: "Bash", toolCallId: "k1" })])).toEqual([
+			{ name: "Bash", kind: "builtin", calls: 1, lastCallAtMs: 1786000000000 },
+		]);
+	});
+
+	it("carries a Codex call's later row time even when an earlier row won the identity", () => {
+		// The request row and its `mcp_tool_call_end` are written at different
+		// instants, and the row that wins the identity is not necessarily the later
+		// one — so the bucket takes the later time regardless of which won.
+		expect(
+			timedToolUse("codex", [
+				{
+					timestamp: "2026-08-06T10:00:00.000Z",
+					type: "response_item",
+					payload: {
+						type: "mcp_tool_call_end",
+						call_id: "m1",
+						invocation: { server: "jollimemory", tool: "recall" },
+					},
+				},
+				{
+					timestamp: "2026-08-06T12:00:00.000Z",
+					type: "response_item",
+					payload: { type: "function_call", call_id: "m1", name: "recall", arguments: "{}" },
+				},
+			]),
+		).toEqual([
+			{
+				name: "jollimemory.recall",
+				kind: "mcp",
+				server: "jollimemory",
+				calls: 1,
+				lastCallAtMs: Date.parse("2026-08-06T12:00:00.000Z"),
+			},
+		]);
 	});
 });

--- a/cli/src/dashboard/Backfill.test.ts
+++ b/cli/src/dashboard/Backfill.test.ts
@@ -300,6 +300,29 @@ describe("backfillRepo — recovery", () => {
 		expect(collectCommitEvents).toHaveBeenCalled();
 	});
 
+	it("does NOT re-sweep when only Jolli's own storage ref moved", async () => {
+		// The orphan branch gains a commit on every memory write — a commit, a
+		// regenerate, a plan edit, a squash consolidation — and it lives under
+		// refs/heads like any other branch. Hashing its tip meant this cursor could
+		// never converge in a repo that is actually being used, so `jolli dashboard`
+		// re-swept git history on essentially every launch. Its commits are not
+		// collected either, so a tip this ignores cannot change a row.
+		const tips = (orphan: string) => async (args: ReadonlyArray<string>) =>
+			args[0] === "rev-parse" && args[1] === "--verify"
+				? { stdout: `${"ab".repeat(20)}\n`, stderr: "", exitCode: 0 }
+				: {
+						stdout: `refs/heads/main aaa\nrefs/heads/jollimemory/summaries/v3 ${orphan}\n`,
+						stderr: "",
+						exitCode: 0,
+					};
+		vi.mocked(execGit).mockImplementation(tips("mem-1"));
+		await backfillRepo({ repo, dbPath });
+		vi.mocked(collectCommitEvents).mockClear();
+		vi.mocked(execGit).mockImplementation(tips("mem-2"));
+		await backfillRepo({ repo, dbPath });
+		expect(collectCommitEvents).not.toHaveBeenCalled();
+	});
+
 	it("projects only the commits a re-sweep actually changed", async () => {
 		// The daily case: a commit lands on the branch being worked on. The sweep has
 		// to LIST every reachable commit (the prune is computed against that set, and
@@ -341,6 +364,27 @@ describe("backfillRepo — recovery", () => {
 			)
 		).map((r) => r.name);
 		expect(names).toEqual(["feature/x", "main"]);
+	});
+
+	it("re-offers a commit whose file rows were never collected", async () => {
+		// `knownHashes` is what the collector skips its `--numstat` for, and it means
+		// "file rows ARE stored", not "the commit row exists". A numstat that failed
+		// once leaves the commit stored with no `commit_files` rows; keying the skip
+		// off the commit row made that gap permanent, because the only pass that
+		// re-scanned everything was a bootstrap and `bootstrap_state` never returns
+		// to that. Here `aaa` collected its files and `bbb` did not.
+		vi.mocked(collectCommitEvents).mockResolvedValue([
+			{ ...commitEvent("aaa"), files: [{ path: "src/a.ts", insertions: 1, deletions: 0 }] },
+			commitEvent("bbb"),
+		]);
+		await backfillRepo({ repo, dbPath });
+		vi.mocked(collectCommitEvents).mockClear();
+
+		vi.mocked(getHeadHash).mockResolvedValue("head-2");
+		await backfillRepo({ repo, dbPath });
+
+		const known = vi.mocked(collectCommitEvents).mock.calls[0]?.[0].knownHashes;
+		expect([...(known ?? [])]).toEqual(["aaa"]);
 	});
 
 	it("prunes commits that a rewrite made unreachable (set reconciliation)", async () => {
@@ -792,9 +836,12 @@ describe("multiple checkouts of one project (§10.2)", () => {
 		}
 	});
 
-	it("merges a commit whose other checkout reported no branches at all", async () => {
-		// `branches` is optional on the event, so the union has to tolerate it being
-		// absent on either side rather than assuming both sweeps attributed the commit.
+	it("emits no branches at all when one checkout reported none", async () => {
+		// `branches` absent means "that checkout's branch scan was incomplete — keep
+		// what is stored", so a union built from one contributor is a PARTIAL claim,
+		// and the projection replaces the set with it. Writing it would drop the
+		// branches only the unreadable checkout knew; the merged event therefore
+		// stays silent and a later complete sweep fills the attribution in.
 		const a2 = mkdtempSync(join(tmpdir(), "jolli-wt-a-"));
 		const b2 = mkdtempSync(join(tmpdir(), "jolli-wt-b-"));
 		try {
@@ -821,10 +868,61 @@ describe("multiple checkouts of one project (§10.2)", () => {
 					).map((r) => r.branch),
 				{ dbPath },
 			);
-			expect(branches).toEqual(["only-a"]);
+			expect(branches).toEqual([]);
 		} finally {
 			rmSync(a2, { recursive: true, force: true });
 			rmSync(b2, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps the stored branch set when NEITHER checkout could attribute the commit", async () => {
+		// The regression: the merge wrote `branches` unconditionally, so two omissions
+		// unioned into `[]` — and `[]` is the meaningful claim "no branch reaches this
+		// commit", which deletes every commit_branches row. A repo with two checkouts
+		// and one failed `for-each-ref` (or a MAX_BRANCHES truncation) lost its whole
+		// branch attribution on the next sweep.
+		const a3 = mkdtempSync(join(tmpdir(), "jolli-wt-a-"));
+		const b3 = mkdtempSync(join(tmpdir(), "jolli-wt-b-"));
+		try {
+			// Pass 1: both checkouts attribute the commit, so the set lands.
+			vi.mocked(collectCommitEvents).mockImplementation(async () => [
+				{
+					type: "commit.created" as const,
+					repoIdentity: repo.repoIdentity,
+					hash: "shared",
+					committedAtMs: 1_700_000_000_000,
+					branches: ["main"],
+				},
+			]);
+			await backfillRepo({ repo: { ...repo, worktrees: [a3, b3] }, dbPath });
+
+			// Pass 2: neither checkout's branch scan completed.
+			vi.mocked(collectCommitEvents).mockImplementation(async () => [
+				{
+					type: "commit.created" as const,
+					repoIdentity: repo.repoIdentity,
+					hash: "shared",
+					committedAtMs: 1_700_000_000_000,
+					message: "touched, so the row is re-projected",
+				},
+			]);
+			await backfillRepo({ repo: { ...repo, worktrees: [a3, b3] }, dbPath });
+
+			const branches = await withDashboardDb(
+				(db) =>
+					(
+						db
+							.prepare(
+								"SELECT b.name AS branch FROM commit_branches cb JOIN branches b ON b.id = cb.branch_id",
+							)
+							.all() as Array<{ branch: string }>
+					).map((r) => r.branch),
+				{ dbPath },
+			);
+			expect(branches).toEqual(["main"]);
+		} finally {
+			rmSync(a3, { recursive: true, force: true });
+			rmSync(b3, { recursive: true, force: true });
 		}
 	});
 

--- a/cli/src/dashboard/Backfill.ts
+++ b/cli/src/dashboard/Backfill.ts
@@ -25,6 +25,7 @@
 import { createHash } from "node:crypto";
 import { execGit, getHeadHash } from "../core/GitOps.js";
 import { GitRefStorage, resolveCommittish } from "../core/GitRefStorage.js";
+import { isJolliInternalRef } from "../core/JolliRefs.js";
 import type { StorageProvider } from "../core/StorageProvider.js";
 import { getIndex } from "../core/SummaryStore.js";
 import { createLogger, errMsg, ORPHAN_BRANCH } from "../Logger.js";
@@ -98,6 +99,17 @@ async function summaryIndexFingerprint(cwd: string, storage: StorageProvider): P
  * A `for-each-ref` failure degrades to HEAD alone — a cursor that is too
  * conservative only costs an extra sweep, which is idempotent (see the module
  * header), whereas one that is too eager loses data.
+ *
+ * Jolli's own storage refs are excluded, by the same rule the collector applies
+ * (see {@link isJolliInternalRef}) — and it is this signal, not the collector,
+ * that made their inclusion visible. The orphan branch gains a commit on every
+ * memory write, so hashing its tip meant the fingerprint moved whenever a
+ * summary, a regenerate, a plan edit or a squash consolidation landed. It could
+ * therefore never converge in a repo that is actually being used, and every
+ * `jolli dashboard` launch re-swept git history — the sweep this cursor exists
+ * to skip. Excluding them costs nothing in the direction that matters: those
+ * commits are not collected either, so a tip this no longer watches cannot
+ * change any row the sweep would have written.
  */
 async function checkoutFingerprint(path: string): Promise<string | null> {
 	const head = await getHeadHash(path).catch((err) => {
@@ -110,7 +122,14 @@ async function checkoutFingerprint(path: string): Promise<string | null> {
 		log.debug("branch tips unreadable for %s: %s", path, refs.stderr.trim());
 		return head;
 	}
-	return `${head}+${createHash("sha256").update(refs.stdout).digest("hex")}`;
+	// Hashed over the FILTERED lines, joined back with the separator git used, so
+	// the value stays a hash of the same shape of text — one `<ref> <oid>` per
+	// line — as before.
+	const tips = refs.stdout
+		.split("\n")
+		.filter((line) => line && !isJolliInternalRef(line.split(" ")[0] ?? ""))
+		.join("\n");
+	return `${head}+${createHash("sha256").update(tips).digest("hex")}`;
 }
 
 export interface BackfillOptions {
@@ -215,16 +234,43 @@ function writeCursor(db: DashboardDbHandle, repoIdentity: string, source: string
 }
 
 /**
- * Commit hashes already stored for this repo.
+ * Commit hashes already stored for this repo — the set the prune reconciles
+ * against.
  *
- * Two callers, two uses of the same set: the prune asks which stored hashes are
- * no longer reachable, and the collection asks which reachable hashes it can skip
- * the `--numstat` for (see `CollectCommitsOptions.knownHashes`). Deriving both
- * from one query keeps them from disagreeing about what "already stored" means.
+ * Deliberately NOT the set the `--numstat` skip is computed from: see
+ * {@link commitsWithStoredFiles} for why "the row exists" and "its file rows
+ * were collected" have to be two different questions.
  */
 function storedCommitHashes(db: DashboardDbHandle, repoIdentity: string): Set<string> {
 	const rows = db
 		.prepare("SELECT c.hash FROM commits c JOIN repos r ON r.id = c.repo_id WHERE r.repo_identity = ?")
+		.all(repoIdentity) as ReadonlyArray<{ hash: string }>;
+	return new Set(rows.map((r) => r.hash));
+}
+
+/**
+ * Commits whose FILE ROWS are stored — what `CollectCommitsOptions.knownHashes`
+ * means, and the only sound basis for skipping a commit's `--numstat`.
+ *
+ * Keyed off `commit_files` rather than off `commits`, because the two diverge
+ * exactly where it matters: `collectFilesForCommits` returns an empty map when
+ * its `git log --numstat --no-walk` fails, and the commits of that batch are
+ * inserted anyway (deliberately — the commit list is what the prune runs
+ * against). Asking `commits` would then mark them known and skip their numstat
+ * forever: the retry only ever came back on a bootstrap, and `bootstrap_state`
+ * is `done` after the first sweep, so those file rows were gone until someone
+ * rebuilt the database. Asking `commit_files` retries them on the next sweep,
+ * which is the self-correction the whole-history scan used to provide for free.
+ *
+ * `EXISTS` rather than a `DISTINCT` join: one PK probe per commit against
+ * `commit_files(commit_id, path)` instead of materializing every file row.
+ */
+function commitsWithStoredFiles(db: DashboardDbHandle, repoIdentity: string): Set<string> {
+	const rows = db
+		.prepare(
+			`SELECT c.hash FROM commits c JOIN repos r ON r.id = c.repo_id
+			  WHERE r.repo_identity = ? AND EXISTS (SELECT 1 FROM commit_files f WHERE f.commit_id = c.id)`,
+		)
 		.all(repoIdentity) as ReadonlyArray<{ hash: string }>;
 	return new Set(rows.map((r) => r.hash));
 }
@@ -510,7 +556,7 @@ export async function backfillRepo(opts: BackfillOptions): Promise<BackfillResul
 				// Read ONCE for the whole checkout loop, before any of them writes: a
 				// per-checkout read would let the first checkout's upserts mark the
 				// second one's commits "known" and skip their file scan.
-				const knownHashes = storedCommitHashes(db, repo.repoIdentity);
+				const knownHashes = commitsWithStoredFiles(db, repo.repoIdentity);
 				// A checkout whose `git log` failed contributes nothing, which is
 				// indistinguishable from "this checkout reaches no commits" once the events
 				// are merged. Prune and the cursor advance are therefore both gated on a
@@ -553,9 +599,23 @@ export async function backfillRepo(opts: BackfillOptions): Promise<BackfillResul
 						}
 						// Union the reachability; keep the first checkout's metadata, which
 						// is identical for a given hash apart from `branches`.
+						//
+						// ABSENT ON EITHER SIDE POISONS THE UNION. A checkout omits
+						// `branches` when its own branch scan was incomplete (a failed
+						// `for-each-ref`/`rev-list`, or a commit only branches past
+						// MAX_BRANCHES reach), and absent means "keep what is stored".
+						// Coercing that to `[]` and unioning turns two omissions into the
+						// CLAIM "no branch reaches this commit" — which the projection
+						// honours by deleting every `commit_branches` row for the commit —
+						// and turns one omission into a partial claim that drops the
+						// branches only the unreadable checkout knew. Either way the merged
+						// event must stay silent, exactly like the single-checkout case.
+						const { branches: seenBranches, ...seenRest } = seen;
 						merged.set(event.hash, {
-							...seen,
-							branches: [...new Set([...(seen.branches ?? []), ...(event.branches ?? [])])],
+							...seenRest,
+							...(seenBranches && event.branches
+								? { branches: [...new Set([...seenBranches, ...event.branches])] }
+								: {}),
 						});
 					}
 				}

--- a/cli/src/dashboard/CutoverEngine.ts
+++ b/cli/src/dashboard/CutoverEngine.ts
@@ -191,7 +191,6 @@ function summariesEquivalent(a: string, b: string): boolean {
 	}
 }
 
-/** Order-insensitive JSON equivalence for the synthesized topic index. */
 /**
  * The reason string for a step 2 / step 3 failure, told from the caller's side.
  *

--- a/cli/src/dashboard/DashboardCollector.test.ts
+++ b/cli/src/dashboard/DashboardCollector.test.ts
@@ -286,6 +286,50 @@ describe("collectCommitEvents", () => {
 		}
 	});
 
+	it("excludes Jolli's own storage refs from both log passes and from attribution", async () => {
+		// The orphan branch is a local branch like any other, so every ref-scoped
+		// call here picks it up unless told not to — and it holds one commit PER
+		// MEMORY. Measured on this repo before the exclusion: 1800 of 2468 stored
+		// commits were `Add summary for …`, and `jollimemory/summaries/v3` outranked
+		// `main` in the branch attribution.
+		const calls: string[][] = [];
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			calls.push([...args]);
+			if (args[0] === "log") return git(`aaa${SEP}2026-07-30T08:00:00+08:00${SEP}F${SEP}f@x.com${SEP}one`);
+			// Sorted by committerdate, so the orphan branch — written on every memory
+			// — is realistically the FIRST entry, not an afterthought at the end.
+			if (args[0] === "for-each-ref") return git("jollimemory/summaries/v3\nmain\n");
+			if (args[0] === "rev-list" && args[1] === "main") return git("aaa\n");
+			return git("");
+		});
+		vi.mocked(getIndex).mockResolvedValue(null);
+		const events = await collectCommitEvents({ repoIdentity: "r", cwd: "/w" });
+		// Two ways to get this wrong silently, so both are pinned. `--exclude` is
+		// positional — it applies only to the selector that FOLLOWS it — and its
+		// pattern is relative to that selector, so the `refs/heads/`-prefixed form
+		// matches nothing under `--branches` and is ignored without a word.
+		for (const pass of calls.filter((c) => c[0] === "log" || c[0] === "-c")) {
+			expect(pass.indexOf("--exclude=jollimemory/*")).toBe(pass.indexOf("--branches") - 1);
+		}
+		// Never walked, so it can never be attributed either.
+		expect(calls.filter((c) => c[0] === "rev-list").map((c) => c[1])).toEqual(["main"]);
+		expect(events[0]?.branches).toEqual(["main"]);
+	});
+
+	it("keeps a branch merely NAMED like the internal namespace", async () => {
+		// Excluded by namespace (`jollimemory/`), not by prefix match — a user's
+		// own `jollimemory-notes` branch is ordinary work and must stay attributed.
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			if (args[0] === "log") return git(`aaa${SEP}2026-07-30T08:00:00+08:00${SEP}F${SEP}f@x.com${SEP}one`);
+			if (args[0] === "for-each-ref") return git("jollimemory-notes\n");
+			if (args[0] === "rev-list" && args[1] === "jollimemory-notes") return git("aaa\n");
+			return git("");
+		});
+		vi.mocked(getIndex).mockResolvedValue(null);
+		const events = await collectCommitEvents({ repoIdentity: "r", cwd: "/w" });
+		expect(events[0]?.branches).toEqual(["jollimemory-notes"]);
+	});
+
 	it("scans --numstat only for commits the caller has not stored", async () => {
 		// The one expensive step in this collection (6.3 s → 0.44 s on a real 2.5k
 		// commit history), and the reason a moved branch tip no longer costs a
@@ -330,6 +374,44 @@ describe("collectCommitEvents", () => {
 		expect(events[1]).not.toHaveProperty("files");
 	});
 
+	it("never re-asks numstat for a merge commit, which has no file rows to find", async () => {
+		// A merge shows no diff under `git log --numstat`, so it can never acquire
+		// `commit_files` rows — and the caller's "which commits have file rows" set
+		// therefore never contains it. Retrying it on every sweep would be pure
+		// waste, and in a merge-heavy history enough of them to push past
+		// INCREMENTAL_NUMSTAT_LIMIT and drag the whole-history scan back in.
+		const calls: string[][] = [];
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			calls.push([...args]);
+			if (args[0] === "log") {
+				return git(
+					[
+						// %P rides last: two parents = merge, one = ordinary commit.
+						`mmm${SEP}2026-07-30T08:00:00+08:00${SEP}F${SEP}f@x.com${SEP}merge${SEP}p1 p2`,
+						`aaa${SEP}2026-07-29T08:00:00+08:00${SEP}F${SEP}f@x.com${SEP}new${SEP}p1`,
+					].join("\n"),
+				);
+			}
+			if (args[0] === "for-each-ref") return git("main\n");
+			if (args[0] === "rev-list") return git("mmm\naaa\n");
+			if (args[0] === "-c") return git([`${REC}aaa`, "1\t0\tsrc/a.ts"].join("\n"));
+			throw new Error(`unexpected git ${args.join(" ")}`);
+		});
+		vi.mocked(getIndex).mockResolvedValue(null);
+
+		const events = await collectCommitEvents({ repoIdentity: "r", cwd: "/w", knownHashes: new Set() });
+
+		const numstat = calls.find((c) => c[0] === "-c");
+		expect(numstat).toContain("aaa");
+		expect(numstat).not.toContain("mmm");
+		// Still emitted, and still ABSENT rather than `[]` — the merge keeps whatever
+		// the projection holds instead of claiming it touches nothing.
+		expect(events.map((e) => e.hash)).toEqual(["mmm", "aaa"]);
+		expect(events[0]).not.toHaveProperty("files");
+		// The subject stays intact with the parent field appended after it.
+		expect(events[0]?.message).toBe("merge");
+	});
+
 	it("falls back to the whole-history scan when too many commits are new", async () => {
 		// The incremental form passes every hash as an argv entry, and Windows caps a
 		// command line at ~32 KB — so past the limit it does not run slower, it fails
@@ -353,7 +435,7 @@ describe("collectCommitEvents", () => {
 		expect(numstat).toContain("--branches");
 	});
 
-	// The `--count` cap is a documented reachability gap, but it must not be
+	// The `MAX_BRANCHES` cap is a documented reachability gap, but it must not be
 	// expressed as the CLAIM `branches: []` — that array is replace-when-present,
 	// so a commit only the branches past the cap reach would have its correct
 	// stored attribution deleted on every pass.
@@ -368,9 +450,10 @@ describe("collectCommitEvents", () => {
 					].join("\n"),
 				);
 			}
-			// One past the cap: this is what makes truncation detectable at all.
+			// Listed in full and capped in JS — asking git for one past the cap would
+			// spend that slot on Jolli's own refs, which are filtered out here.
 			if (args[0] === "for-each-ref") {
-				expect(args).toContain("--count=51");
+				expect(args).not.toContain("--count=51");
 				return git(`${listed.join("\n")}\n`);
 			}
 			if (args[0] === "rev-list" && args[1] === "b0") return git("aaa\n");
@@ -513,6 +596,8 @@ describe("parseNumstatLog", () => {
 });
 
 describe("collectFilesForCommits", () => {
+	const REC = "\u0001";
+
 	it("returns an empty map for no hashes without spawning git", async () => {
 		vi.mocked(execGit).mockClear();
 		expect((await collectFilesForCommits([], "/w")).size).toBe(0);
@@ -522,6 +607,40 @@ describe("collectFilesForCommits", () => {
 	it("returns an empty map when git fails, so the caller omits files rather than clearing them", async () => {
 		vi.mocked(execGit).mockResolvedValue(gitFail("bad object"));
 		expect((await collectFilesForCommits(["aaa"], "/w")).size).toBe(0);
+		// One hash has nothing to bisect: exactly one call, no retry.
+		expect(execGit).toHaveBeenCalledTimes(1);
+	});
+
+	it("bisects a failing batch so one unreadable commit does not blank the rest", async () => {
+		// The failure mode this exists for: a diff past execGit's maxBuffer fails
+		// the whole `--no-walk` call, identically on every retry. Returning empty
+		// for the batch denies file rows to the other commits, and since the next
+		// sweep asks which commits HAVE file rows, the same doomed batch comes back
+		// forever. Here `poison` fails whenever it is in the argv.
+		vi.mocked(execGit).mockClear();
+		vi.mocked(execGit).mockImplementation(async (args) => {
+			const hashes = args.filter((a) => /^[a-z]\d$/.test(a));
+			if (hashes.includes("p1")) return gitFail("stdout maxBuffer length exceeded");
+			return git(hashes.map((h) => `${REC}${h}\n1\t0\tf-${h}.ts`).join("\n"));
+		});
+
+		const files = await collectFilesForCommits(["a1", "b1", "p1", "c1"], "/w");
+
+		expect([...files.keys()].sort()).toEqual(["a1", "b1", "c1"]);
+		expect(files.get("a1")?.[0]?.path).toBe("f-a1.ts");
+	});
+
+	it("stops bisecting a wholly broken repo instead of one call per commit", async () => {
+		// Same failure shape covers "git is broken here", where splitting can only
+		// spend subprocesses. The budget caps the damage at a flat handful rather
+		// than ~2N on every sweep, forever.
+		vi.mocked(execGit).mockClear();
+		vi.mocked(execGit).mockResolvedValue(gitFail("not a git repository"));
+		const hashes = Array.from({ length: 200 }, (_, i) => `h${i}`);
+
+		expect((await collectFilesForCommits(hashes, "/w")).size).toBe(0);
+
+		expect(vi.mocked(execGit).mock.calls.length).toBeLessThan(30);
 	});
 });
 

--- a/cli/src/dashboard/DashboardCollector.ts
+++ b/cli/src/dashboard/DashboardCollector.ts
@@ -15,6 +15,7 @@
 
 import { UNTITLED_SESSION } from "../core/FallbackTitle.js";
 import { execGit, getCurrentBranch } from "../core/GitOps.js";
+import { isJolliInternalRef, JOLLI_REFS_EXCLUDE_GLOB } from "../core/JolliRefs.js";
 import { extractRepoName, getRemoteUrl, resolveKBPath } from "../core/KBPathResolver.js";
 import { estimateModelCostUsd, PRICES_AS_OF } from "../core/Pricing.js";
 import { resolveSessionTitle } from "../core/SessionTitleResolver.js";
@@ -294,9 +295,11 @@ export interface CollectCommitsOptions {
 	/** Storage for the summary-index enrichment read. See {@link CollectSummariesOptions.storage}. */
 	readonly storage?: StorageProvider;
 	/**
-	 * Commit hashes whose file rows are already stored — their `--numstat` is
-	 * skipped. See {@link INCREMENTAL_NUMSTAT_LIMIT} for the whole rationale;
-	 * omit it (bootstrap) to scan every commit.
+	 * Commit hashes whose FILE ROWS are already stored — their `--numstat` is
+	 * skipped. Not "hashes already in `commits`": a commit whose numstat failed is
+	 * stored without file rows, and treating it as known made that gap permanent.
+	 * See {@link INCREMENTAL_NUMSTAT_LIMIT} for the whole rationale; omit it
+	 * (bootstrap) to scan every commit.
 	 */
 	readonly knownHashes?: ReadonlySet<string>;
 }
@@ -385,13 +388,26 @@ export function parseNumstatLog(stdout: string): Map<string, CommitFileChange[]>
 const NUMSTAT_ARGS = ["-c", "core.quotePath=false", "log", "--numstat", "--no-renames", `--format=${REC}%H`] as const;
 
 /**
- * The history this machine owns: every local branch, plus HEAD so a detached
- * checkout (mid-rebase, bisect) is not invisible. Deliberately NOT `--all` —
- * see {@link collectCommitEvents} for why remote-tracking refs and tags are out
- * of scope. Shared by the commit pass and the file-stats pass so the two can
- * never disagree about which commits exist.
+ * The history this machine owns: every local branch EXCEPT Jolli's own storage
+ * refs (see {@link isJolliInternalRef}), plus HEAD so a detached checkout
+ * (mid-rebase, bisect) is not invisible. Deliberately NOT `--all` — see
+ * {@link collectCommitEvents} for why remote-tracking refs and tags are out of
+ * scope. Shared by the commit pass and the file-stats pass so the two can never
+ * disagree about which commits exist.
+ *
+ * The orphan branch is an ordinary local branch holding one commit PER MEMORY,
+ * so without the exclusion `--branches` imported all of them as the user's own
+ * work: measured on this repo, 1800 of the 2468 stored commits were `Add
+ * summary for …` about the other 668, and `jollimemory/summaries/v3` outranked
+ * `main` in the branch attribution — every commit-derived number on the
+ * dashboard reading ~73 % noise.
+ *
+ * `--exclude` is positional: it applies to the `--branches` that FOLLOWS it and
+ * is consumed by it, so the order of these three entries is load-bearing. It
+ * deliberately does not touch the explicit `HEAD`, which cannot be an orphan
+ * ref — that branch is written by plumbing and never checked out.
  */
-const LOCAL_HISTORY_ARGS = ["--branches", "HEAD"] as const;
+const LOCAL_HISTORY_ARGS = [JOLLI_REFS_EXCLUDE_GLOB, "--branches", "HEAD"] as const;
 
 /**
  * Per-commit file lists over the same window {@link collectCommitEvents} logs.
@@ -422,26 +438,90 @@ async function collectCommitFiles(
 	return parseNumstatLog(result.stdout);
 }
 
+/** One `--no-walk` numstat call. `ok: false` means the batch produced nothing. */
+async function numstatBatch(
+	hashes: ReadonlyArray<string>,
+	cwd: string,
+): Promise<{ readonly ok: boolean; readonly files: Map<string, CommitFileChange[]> }> {
+	const result = await execGit([...NUMSTAT_ARGS, "--no-walk", ...hashes], cwd);
+	if (result.exitCode !== 0) {
+		log.debug("numstat batch of %d failed for %s: %s", hashes.length, cwd, result.stderr.trim());
+		return { ok: false, files: new Map() };
+	}
+	return { ok: true, files: parseNumstatLog(result.stdout) };
+}
+
+/**
+ * How many extra numstat calls the bisect below may spend isolating a failing
+ * commit. Bounded because the same failure shape covers both "one commit in this
+ * batch is unreadable" and "git is broken in this repo": breadth-first at this
+ * budget still salvages ~15/16 of a full {@link INCREMENTAL_NUMSTAT_LIMIT}
+ * batch, while a repo that fails every call costs a flat 25 subprocesses instead
+ * of the ~800 an unbounded bisect would spend on every sweep, forever.
+ */
+const NUMSTAT_BISECT_CALL_BUDGET = 24;
+
+/** Splits a chunk in half; only ever called with `length > 1`. */
+function halves(hashes: ReadonlyArray<string>): ReadonlyArray<string>[] {
+	const mid = Math.ceil(hashes.length / 2);
+	return [hashes.slice(0, mid), hashes.slice(mid)];
+}
+
 /**
  * File lists for an explicit set of hashes — the live post-commit path.
  *
  * `--no-walk` makes git report exactly the listed commits instead of their
  * ancestry, so this is one subprocess for the whole drained batch rather than
- * one per commit. Failure returns an empty map, and the caller then omits
- * `files` entirely rather than sending an empty array, so a transient git
- * failure cannot delete rows a previous pass collected.
+ * one per commit. A commit with no result gets no `files` key at all from the
+ * caller (rather than an empty array), so a transient git failure cannot delete
+ * rows a previous pass collected.
+ *
+ * **A failed batch is bisected, because the batch is the blast radius.** One
+ * commit can fail the whole call on its own — a diff larger than `execGit`'s
+ * 10 MB `maxBuffer` is the concrete case, and it is a property of that commit,
+ * so it fails identically on every retry. Returning empty for the batch then
+ * denies file rows to every OTHER commit in it, and since the next sweep asks
+ * which commits have file rows, all of them come back — the same doomed batch,
+ * plus whatever new commits joined it, on every sweep for the life of the
+ * repository. Splitting isolates the poison into ever smaller chunks so the rest
+ * of the batch is stored and stops being re-asked; the unresolvable commits
+ * remain permanently retried, which is the honest cost of not being able to read
+ * their diff, and is now a handful of hashes rather than the batch.
+ *
+ * Logged at WARN, not debug: the commits of a failed batch still land, so this
+ * line is the only trace that their file detail did not.
  */
 export async function collectFilesForCommits(
 	hashes: ReadonlyArray<string>,
 	cwd: string,
 ): Promise<Map<string, CommitFileChange[]>> {
 	if (hashes.length === 0) return new Map();
-	const result = await execGit([...NUMSTAT_ARGS, "--no-walk", ...hashes], cwd);
-	if (result.exitCode !== 0) {
-		log.debug("git log --numstat --no-walk failed for %s: %s", cwd, result.stderr.trim());
-		return new Map();
+	const first = await numstatBatch(hashes, cwd);
+	if (first.ok) return first.files;
+	log.warn("git log --numstat --no-walk failed for %s (%d commits) — bisecting", cwd, hashes.length);
+	if (hashes.length === 1) return new Map();
+
+	const files = new Map<string, CommitFileChange[]>();
+	const queue: ReadonlyArray<string>[] = halves(hashes);
+	let budget = NUMSTAT_BISECT_CALL_BUDGET;
+	// Breadth-first: a shallow pass over the whole batch salvages more per call
+	// than following one branch to a single hash, and it keeps the budget from
+	// being spent entirely on the half that happens to be searched first.
+	while (queue.length > 0 && budget > 0) {
+		const chunk = queue.shift() as ReadonlyArray<string>;
+		budget--;
+		const batch = await numstatBatch(chunk, cwd);
+		if (batch.ok) {
+			for (const [hash, changes] of batch.files) files.set(hash, changes);
+		} else if (chunk.length > 1) {
+			queue.push(...halves(chunk));
+		}
 	}
-	return parseNumstatLog(result.stdout);
+	if (queue.length > 0) {
+		const unresolved = queue.reduce((n, chunk) => n + chunk.length, 0);
+		log.warn("numstat bisect budget spent for %s; %d commits keep no file rows this sweep", cwd, unresolved);
+	}
+	return files;
 }
 
 /**
@@ -484,7 +564,11 @@ export async function collectCommitEvents(opts: CollectCommitsOptions): Promise<
 		// already excluded — collected, then invisible in standup, and counted
 		// under whichever day it was originally written rather than the day the
 		// work actually landed here.
-		["log", ...LOCAL_HISTORY_ARGS, `--pretty=format:%H${SEP}%cI${SEP}%an${SEP}%ae${SEP}%s`, ...sinceArgs],
+		// `%P` (parent hashes) rides LAST, after the subject: a subject cannot
+		// contain SEP (it is a control character), so appending a field keeps every
+		// earlier position stable. It exists only to recognise a merge commit — see
+		// the numstat skip below.
+		["log", ...LOCAL_HISTORY_ARGS, `--pretty=format:%H${SEP}%cI${SEP}%an${SEP}%ae${SEP}%s${SEP}%P`, ...sinceArgs],
 		opts.cwd,
 	);
 	if (logResult.exitCode !== 0) {
@@ -499,16 +583,15 @@ export async function collectCommitEvents(opts: CollectCommitsOptions): Promise<
 
 	// Branch reachability: newest-committed branches first, capped.
 	const refsResult = await execGit(
-		// One past the cap, so truncation is DETECTABLE rather than inferred from a
-		// full page: `--count=${MAX_BRANCHES}` returning exactly that many is
-		// indistinguishable from a repo with exactly that many branches.
-		[
-			"for-each-ref",
-			"refs/heads",
-			"--sort=-committerdate",
-			"--format=%(refname:short)",
-			`--count=${MAX_BRANCHES + 1}`,
-		],
+		// Listed in full and capped below in JS, rather than with git's `--count`.
+		// The cap exists to bound the per-branch `rev-list` fan-out, and Jolli's own
+		// refs are dropped from the list before it is applied — asking git for
+		// `MAX_BRANCHES + 1` and filtering afterwards would spend a slot on a branch
+		// that is never scanned, and the orphan branch is written on every memory so
+		// it sorts FIRST by committerdate essentially always. Listing every local
+		// branch name is one cheap ref walk (`Backfill`'s fingerprint already does
+		// exactly that); it is the rev-list per branch that is expensive.
+		["for-each-ref", "refs/heads", "--sort=-committerdate", "--format=%(refname:short)"],
 		opts.cwd,
 	);
 	// Tracked for the same reason `files` is (see below): `branches` is
@@ -520,7 +603,10 @@ export async function collectCommitEvents(opts: CollectCommitsOptions): Promise<
 	// ordinary concurrent rebase) would silently have stripped just that one.
 	// Incomplete means: emit nothing, keep what is stored.
 	let branchScanComplete = refsResult.exitCode === 0;
-	const listed = refsResult.exitCode === 0 ? refsResult.stdout.split("\n").filter(Boolean) : [];
+	const listed =
+		refsResult.exitCode === 0
+			? refsResult.stdout.split("\n").filter((name) => name && !isJolliInternalRef(name))
+			: [];
 	// A repo past {@link MAX_BRANCHES} is the documented reachability gap, but it
 	// must not be expressed as the CLAIM `branches: []`. The union is
 	// replace-when-present, so emitting an empty array for a commit that only the
@@ -574,13 +660,30 @@ export async function collectCommitEvents(opts: CollectCommitsOptions): Promise<
 	// what is stored" in the projection (the same contract a failed numstat pass
 	// relies on), while an empty array would mean "this commit touches nothing".
 	//
-	// The one thing it gives up: a commit whose file rows were never stored (its
-	// numstat failed once) is never revisited while it stays known. That is a
-	// bounded, self-correcting gap — a bootstrap re-scan restores it — and paying
-	// a full-history numstat on every launch to close it is the cost this exists
-	// to remove.
+	// `knownHashes` is the set of commits whose file rows ARE STORED, not the set
+	// of stored commits (see `commitsWithStoredFiles` in Backfill). A commit whose
+	// numstat failed once therefore comes back on the NEXT sweep instead of never:
+	// keying the skip off row existence made a single transient git failure a
+	// permanent blank, since the only path that re-scanned everything was a
+	// bootstrap and `bootstrap_state` never returns to that.
+	//
+	// Merge commits are excluded from the retry for the same reason they are not
+	// evidence of a failure: `git log --numstat` shows no diff for a merge, so it
+	// has no file rows to find and would otherwise be re-asked on every sweep
+	// forever — and in a merge-heavy history enough of them to push past
+	// INCREMENTAL_NUMSTAT_LIMIT and drag the whole-history scan back in. A
+	// non-merge commit with genuinely zero files (`--allow-empty`) does get
+	// re-asked, which is one hash in an argv list nobody notices.
 	const newHashes = opts.knownHashes
-		? logLines.map((line) => line.split(SEP)[0] ?? "").filter((hash) => hash && !opts.knownHashes?.has(hash))
+		? logLines
+				.map((line) => line.split(SEP))
+				.filter((parts) => {
+					const hash = parts[0];
+					if (!hash || opts.knownHashes?.has(hash)) return false;
+					// `%P` is the last field; more than one parent means a merge.
+					return (parts[5] ?? "").trim().split(" ").filter(Boolean).length <= 1;
+				})
+				.map((parts) => parts[0] ?? "")
 		: null;
 	const filesByHash =
 		newHashes !== null && newHashes.length <= INCREMENTAL_NUMSTAT_LIMIT

--- a/cli/src/dashboard/DashboardDb.ts
+++ b/cli/src/dashboard/DashboardDb.ts
@@ -35,6 +35,7 @@ import {
 	MEMORY_SOT_DDL,
 	RECALL_RECEIPTS_DDL,
 	SKILL_CONTEXT_KIND_DDL,
+	TOOL_CALL_TIME_DDL,
 } from "./SotSchema.js";
 
 const log = createLogger("DashboardDb");
@@ -65,7 +66,7 @@ const log = createLogger("DashboardDb");
  * user's database (other processes may hold the file open, and the memory half
  * is the only copy there is).
  */
-export const DASHBOARD_SCHEMA_VERSION = 4;
+export const DASHBOARD_SCHEMA_VERSION = 5;
 
 /**
  * Minimum Node that ships `node:sqlite` **without** `--experimental-sqlite`.
@@ -204,7 +205,11 @@ export const BUSY_TIMEOUT_BY_ROLE: Readonly<Record<string, number>> = {
  * steps. Entry 1 adds `recall_receipts` as a real migration: by then dev
  * databases existed at version 1, and only an appended entry reaches those as
  * well as fresh ones. Entry 2 registers the `skill` context kind for the same
- * reason.
+ * reason. Entry 4 gives `session_tool_use` the call's own timestamp — an
+ * additive NULLABLE column precisely because the rows already on disk cannot be
+ * backfilled (the transcripts they were read from may be gone), so they keep
+ * being read under the old session-time fallback rather than dropping out of
+ * every window for want of a value.
  *
  * Exported for tests: they execute entries directly to build a database at a
  * chosen version rather than hand-rolling copies of the DDL, which would drift.
@@ -231,6 +236,7 @@ BEGIN SELECT RAISE(ABORT, 'repos are never deleted: set disabled_at instead'); E
 	RECALL_RECEIPTS_DDL,
 	SKILL_CONTEXT_KIND_DDL,
 	EVENT_FAILED_KIND_DDL,
+	TOOL_CALL_TIME_DDL,
 ];
 
 /** Reads the stored schema version, treating a fresh DB as 0. */

--- a/cli/src/dashboard/DashboardModel.ts
+++ b/cli/src/dashboard/DashboardModel.ts
@@ -453,36 +453,60 @@ export interface MemoryConversationRow {
 	readonly messageCount: number;
 }
 
-/** One external reference (Linear/GitHub/…) archived on a memory. */
-export interface MemoryReferenceRow {
-	readonly source: string;
-	readonly nativeId: string;
+/**
+ * The four kinds of context a memory carries, in the order the editor's Context
+ * panel renders them (`buildPlansAndNotesSection` in
+ * `vscode/src/views/SummaryHtmlBuilder.ts`). `skills` is plural because it is the
+ * ONE aggregate row standing for every skill entered this session — the same
+ * choice every other Context surface makes, so a session that entered a dozen
+ * skills does not bury its plans.
+ */
+export type MemoryContextKind = "plan" | "note" | "reference" | "skills";
+
+/** {@link MemoryContextKind} as a value, for `/api/context`'s param check. Render order. */
+export const CONTEXT_DOC_KINDS: ReadonlyArray<MemoryContextKind> = ["plan", "note", "reference", "skills"];
+
+/**
+ * One context item associated with a memory — a plan, a note, an archived
+ * external reference, or the skills aggregate.
+ *
+ * Kept as ONE list rather than a list per kind so the page cannot render them in
+ * a different order than the editor does. The list is already ordered.
+ */
+export interface MemoryContextRow {
+	readonly kind: MemoryContextKind;
+	/**
+	 * Display title, resolved server-side by the same rules the editor uses —
+	 * `referenceDisplayTitle` for a reference (so a tracker row leads with its
+	 * issue key), the archived title otherwise.
+	 */
 	readonly title: string;
+	/**
+	 * `context.context_key` — what `/api/context` needs to fetch the body: the
+	 * plan's slug, the note's id, `<source>/<sanitized-key>` for a reference, and
+	 * the commit hash for the skills row (whose table is rendered from the
+	 * summary, not stored as a document).
+	 *
+	 * Carried on the row rather than re-derived in the client because none of the
+	 * four is recoverable from the title. Absent when the key cannot be derived —
+	 * a reference whose source has since left the registry — which renders the row
+	 * as a plain, unopenable label rather than a button that always 404s.
+	 */
+	readonly contextKey?: string;
+	/** Secondary line under the title: `<nativeId> (Linear)`, `<slug>.md`, the skills totals. */
+	readonly meta?: string;
+	/** Upstream URL, for a reference whose source has a navigable page. */
 	readonly url?: string;
 }
 
-/** One plan or note associated with a memory. */
-export interface MemoryContextRow {
-	readonly kind: "plan" | "note";
-	readonly title: string;
-	/**
-	 * `context.context_key` — the plan's slug or the note's id, i.e. what
-	 * `/api/context` needs to fetch the body. Carried on the row rather than
-	 * re-derived in the client because the archived slug is not the title and
-	 * cannot be recovered from it.
-	 */
-	readonly contextKey: string;
-}
-
 /**
- * A plan/note body, served by `/api/context` for the Context viewer.
+ * One context body, served by `/api/context` for the Context viewer.
  *
- * No `url`: the `context` table CHECK-constrains that column to `reference`
- * rows, so a plan or note can never have one — a field here would be dead by
- * construction.
+ * No `url`: the row the reader clicked already carries it, so repeating it here
+ * would be a second place for the same fact.
  */
 export interface ContextDoc {
-	readonly kind: "plan" | "note";
+	readonly kind: MemoryContextKind;
 	readonly title: string;
 	readonly bodyMd: string;
 }
@@ -552,6 +576,12 @@ export interface MemoryDetail {
 	readonly repoName: string;
 	readonly commitHash: string;
 	readonly shortHash: string;
+	/**
+	 * Always present here, unlike {@link MemoryListItem.memoryRefId}: an unsynced
+	 * memory falls back to `JM-<hash8>`, matching the editor's page title, which
+	 * labels every memory whether or not it has reached a Space.
+	 */
+	readonly memoryRefId: string;
 	readonly title: string;
 	readonly branch?: string;
 	readonly author?: string;
@@ -564,9 +594,18 @@ export interface MemoryDetail {
 	readonly deletions?: number;
 	/** The CONVERSATION's tokens (what was said to produce this commit) — not Jolli's own summarization call. */
 	readonly tokens?: {
+		/**
+		 * The headline figure: `aggregateConversationTokens` over the tree, the
+		 * same number the editor's meter prints. Deliberately NOT the sum of the
+		 * three segments below — a folded session that reports only a scalar count
+		 * with no breakdown lands in this total and in no segment, which is also
+		 * why the bar's widths use the segments' own sum as their denominator.
+		 */
+		readonly total: number;
 		readonly input: number;
 		readonly output: number;
 		readonly cached: number;
+		/** Whole-tree estimate from `estimateSummaryCostUsd` — see {@link MemoryDetail} usage. */
 		readonly costUsd?: number;
 		readonly pricesAsOf?: string;
 	};
@@ -574,7 +613,7 @@ export interface MemoryDetail {
 	readonly summarizedBy?: { readonly model: string; readonly tokens: number };
 	readonly recap?: string;
 	readonly conversations: ReadonlyArray<MemoryConversationRow>;
-	readonly references: ReadonlyArray<MemoryReferenceRow>;
+	/** Plans, notes, references and the skills row — one ordered list, see {@link MemoryContextRow}. */
 	readonly context: ReadonlyArray<MemoryContextRow>;
 	readonly excluded: ReadonlyArray<MemoryExcludedRow>;
 	readonly activity: ReadonlyArray<MemoryActivityRow>;
@@ -928,6 +967,14 @@ export interface StandupModel {
 	readonly todayCommits: ReadonlyArray<StandupCommit>;
 	readonly workspaces: ReadonlyArray<StandupWorkspace>;
 	/**
+	 * The git identity the commit columns and Risks were filtered to (an email,
+	 * or a name when only that is configured). ABSENT means the filter did not
+	 * run and the board is showing every author's work — the page states which
+	 * of the two it is, because an unfiltered standup is a draft the user would
+	 * otherwise post as their own. See `authorFilter` in `DashboardQuery.ts`.
+	 */
+	readonly authoredBy?: string;
+	/**
 	 * Risks/blockers/questions/TODOs mined from the window's commit memories.
 	 * Present (possibly empty) from the memory tier onwards; absent renders the
 	 * locked card.
@@ -1090,6 +1137,28 @@ export interface RecallDayPoint {
 	readonly date: string;
 	readonly used: number;
 	readonly setAside: number;
+	/**
+	 * Calls this day is known to have had from the `jollimemory` context
+	 * REFERENCE alone — a call with no receipt, so its OUTCOME is unknown and it
+	 * can be neither `used` nor `setAside`.
+	 *
+	 * This is the per-day half of {@link RecallUsage.callsWithoutReceipt}, which
+	 * is the same evidence collapsed to one window-wide number. Only the
+	 * reference channel feeds it: `session_tool_use` rows carry no time of their
+	 * own (they are windowed by their session), so they can say how many but
+	 * never on which day.
+	 *
+	 * **A lower bound, and it must be rendered as one.** The reference body
+	 * collapses a repeated query to a single entry and keeps only the newest 20,
+	 * so a busy day reports fewer calls than it had. Drawing it in the same
+	 * style as `used`/`setAside` would state a precision this number does not
+	 * have.
+	 *
+	 * Zero on any day that has a receipt: from the day receipts shipped both
+	 * channels see the same call, and adding them would double it. The receipt
+	 * is the authoritative one, so the estimate only speaks where it is silent.
+	 */
+	readonly estimated?: number;
 }
 
 /**
@@ -1124,6 +1193,20 @@ export interface RecallUsage {
 	 * to no session and is deliberately not invented one here.
 	 */
 	readonly sessionsWithContext: number;
+	/**
+	 * Receipts in the window that carry NO session id — a recall run outside any
+	 * agent session, which counts in {@link usedCalls} / {@link setAsideCalls} but
+	 * can never be counted in {@link sessionsWithContext}.
+	 *
+	 * Its own figure because nothing else on this card implies it. The card used
+	 * to derive the caveat from `sessionsWithContext === 0`, which is a different
+	 * statement — true only when NOT ONE receipt carries a session — so the
+	 * mixed window this caveat exists for (some calls inside a session, some at a
+	 * shell prompt) was the one case that never showed it, and a machine whose
+	 * every recall carries a session id had it printed unconditionally before
+	 * that.
+	 */
+	readonly callsWithoutSession: number;
 	/** Sessions in the window, whether or not they called recall. */
 	readonly sessionsInWindow: number;
 	/**
@@ -1163,8 +1246,9 @@ export interface RecallUsage {
 	 *
 	 *   - `session_tool_use` — `jollimemory.recall` per session, imported from
 	 *     transcripts. Blind to a source that records no tool calls (the gap
-	 *     {@link ToolUsage.uncoveredSources} names), and carries no per-call
-	 *     time, so it is windowed by its session's `updated_at_ms`.
+	 *     {@link ToolUsage.uncoveredSources} names). Windowed by the call's own
+	 *     `last_call_at_ms` where the source's parser could stamp one, and by
+	 *     its session's `updated_at_ms` where it could not.
 	 *   - the `jollimemory` context REFERENCE — one timestamped entry per call,
 	 *     so it windows exactly, and it exists for any source the reference
 	 *     extractor covers. Under-reports differently: a repeated query text
@@ -1182,6 +1266,57 @@ export interface RecallUsage {
 	 * it is clamped at 0.
 	 */
 	readonly callsWithoutReceipt: number;
+	/**
+	 * Recall SKILL runs in the window that left no other trace: no MCP tool row
+	 * in the same session, and no receipt that can be matched to them.
+	 *
+	 * The population this exists for is the `jolli-recall` skill taking its CLI
+	 * fallback — the documented path for a host with no MCP server, and the one
+	 * every non-Claude agent in the wild actually takes. Such a run leaves a
+	 * `kind='skill'` row and nothing else: no `kind='mcp'` row (so
+	 * {@link callsWithoutReceipt}, which only ever looked at MCP rows, could not
+	 * see it), no reference entry (the extractor bookmarks MCP calls), and its
+	 * `cli` receipt is written without a session id on every host but Claude
+	 * (`currentAgentSessionId` reads `CLAUDE_CODE_SESSION_ID` and nothing else).
+	 * So a real recall could be entirely absent from this card while
+	 * {@link skillInvocations} silently counted it.
+	 *
+	 * NOT folded into {@link callsWithoutReceipt}, deliberately: that figure is a
+	 * lower bound on CALLS, and this population is ambiguous by construction — a
+	 * skill run that was invoked and then never recalled anything looks exactly
+	 * the same from here, and is precisely what {@link skillInvocations} exists
+	 * to expose. Merging the two would let "the skill ran and did nothing" inflate
+	 * a count of calls, turning a bound into a guess. Kept separate, each number
+	 * keeps its own meaning and the card can word them differently.
+	 *
+	 * Subtraction happens in two stages, and both are needed. Per session, the
+	 * session's own MCP rows and its attributed receipts come off first — that is
+	 * the ordinary Claude case, where the skill did call the MCP tool and a
+	 * receipt names the session. Then the window's SESSION-LESS receipts come off
+	 * the total, because those are exactly the CLI recalls that cannot be
+	 * attributed to any session; each one plausibly IS one of these runs, and
+	 * counting both would report the same call twice. Clamped at 0 throughout.
+	 */
+	readonly skillRunsWithoutTrace: number;
+	/**
+	 * The day the FIRST receipt in scope was written — `YYYY-MM-DD`, same local
+	 * time zone and same shape as {@link RecallDayPoint.date}.
+	 *
+	 * Absent when no receipt exists at all. Deliberately unwindowed: it answers
+	 * "since when has anything been recorded here", which is the one question a
+	 * windowed figure cannot. Without it a 30-day chart holding one bar is
+	 * indistinguishable from a broken chart — the reader has no way to know that
+	 * the 29 empty days pre-date recording rather than being days nobody
+	 * recalled. The card draws it as the boundary the series begins at.
+	 *
+	 * A day KEY, not the raw epoch-ms it is derived from, because the only
+	 * consumer compares it against `daily[].date`. Those keys are computed in the
+	 * dashboard's resolved time zone, which the browser does not necessarily
+	 * share — formatting the instant client-side would put the boundary on the
+	 * wrong day for anyone whose machine zone differs from the one the series
+	 * was bucketed in.
+	 */
+	readonly receiptsSinceDate?: string;
 	/** Daily series for the bar chart, oldest first. */
 	readonly daily: ReadonlyArray<RecallDayPoint>;
 }

--- a/cli/src/dashboard/DashboardQuery.test.ts
+++ b/cli/src/dashboard/DashboardQuery.test.ts
@@ -1138,6 +1138,143 @@ describe("buildDashboardModel — recall usage", () => {
 		const result = await recallUsage();
 		expect(result?.usedCalls).toBe(1);
 		expect(result?.sessionsWithContext).toBe(0);
+		expect(result?.callsWithoutSession).toBe(1);
+	});
+
+	it("counts session-less calls on their own, so a mixed window can say so", async () => {
+		// `callsWithoutSession` is the statement "some receipt names no session",
+		// which `sessionsWithContext === 0` ("no receipt names one") cannot make.
+		// Both halves count: a set-aside call outside a session is just as
+		// unattributable as a used one.
+		await applySummaryEvents(
+			[
+				repoEvent,
+				sessionWith("s1"),
+				recall(hit("a".repeat(40), "2026-07-25"), { sessionId: "s1", atMs: nowMs - 3_600_000 }),
+				recall(hit("b".repeat(40), "2026-07-25"), { surface: "cli", atMs: nowMs - 3_500_000 }),
+				recall(miss, { surface: "cli", atMs: nowMs - 3_400_000 }),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		const result = await recallUsage();
+		expect(result?.sessionsWithContext).toBe(1);
+		expect(result?.callsWithoutSession).toBe(2);
+	});
+
+	/**
+	 * Seeds the `jollimemory` recall REFERENCE — the only receipt-less channel
+	 * that timestamps each call, and therefore the only one that can place a
+	 * pre-receipt call on a day. Written directly because it reaches the database
+	 * through the orphan import, not through the event stream.
+	 */
+	const seedRecallReference = async (atIsos: ReadonlyArray<string>): Promise<void> => {
+		await withDashboardDb(
+			(db) => {
+				const { id } = db.prepare("SELECT id FROM repos WHERE repo_identity = 'repo-1'").get() as {
+					id: number;
+				};
+				// Entry-line form (`ACCUMULATED_ENTRY_RE`), one per call, distinct query
+				// texts so the accumulator does not collapse them into one.
+				const body = atIsos.map((at, i) => `- \`query ${i}\` — ${at}`).join("\n");
+				// `referenced_at` is NOT NULL exactly for a reference (schema CHECK); the
+				// value is the row's own bookmark time, which the per-call entry lines in
+				// `body_md` are what this test actually reads.
+				db.prepare(
+					`INSERT INTO context
+					   (repo_id, kind, context_key, source, native_id, referenced_at, title, body_md, created_at_ms)
+					 VALUES (?, 'reference', 'jollimemory:recall', 'jollimemory', 'recall', ?, 'Recall', ?, 1)`,
+				).run(id, atIsos[0] ?? "2026-07-01T00:00:00.000Z", body);
+			},
+			{ dbPath },
+		);
+	};
+
+	it("buckets receipts by their own day, so a multi-day window shows a bar per day", async () => {
+		// The regression this pins: `daily` is the ONLY per-day series on the card,
+		// and a chart holding one bar is indistinguishable from a broken one — so
+		// "receipts land in their own day" has to be asserted, not assumed.
+		const day = 86_400_000;
+		await applySummaryEvents(
+			[
+				repoEvent,
+				recall(hit("a".repeat(40), "2026-07-25"), { atMs: nowMs - 4 * day }),
+				// Two calls on ONE day, a second apart. Not the same instant: a receipt
+				// is keyed on `statsEventId`, whose only distinguishing part for a call
+				// is when it happened, so two receipts sharing a millisecond converge on
+				// one row by design (`ON CONFLICT(receipt_id) DO UPDATE`).
+				recall(hit("b".repeat(40), "2026-07-25"), { atMs: nowMs - 2 * day }),
+				recall(miss, { atMs: nowMs - 2 * day + 1_000 }),
+				recall(hit("c".repeat(40), "2026-07-25"), { atMs: nowMs }),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		const result = await recallUsage();
+		const active = (result?.daily ?? []).filter((d) => d.used > 0 || d.setAside > 0);
+		expect(active).toEqual([
+			{ date: "2026-07-26", used: 1, setAside: 0 },
+			{ date: "2026-07-28", used: 1, setAside: 1 },
+			{ date: "2026-07-30", used: 1, setAside: 0 },
+		]);
+		// Every day of the window is present, zeros included — that is what lets
+		// the chart draw an axis instead of floating three bars in blank space.
+		expect(result?.daily.length).toBeGreaterThan(3);
+	});
+
+	it("reports the first receipt's day unwindowed, as the series' starting boundary", async () => {
+		await applySummaryEvents(
+			[repoEvent, recall(hit("a".repeat(40), "2026-07-25"), { atMs: nowMs - 2 * 86_400_000 })],
+			{ producerKind: "cli", dbPath },
+		);
+		expect((await recallUsage())?.receiptsSinceDate).toBe("2026-07-28");
+	});
+
+	it("leaves the starting boundary absent when nothing has ever been receipted", async () => {
+		await applySummaryEvents([repoEvent], { producerKind: "cli", dbPath });
+		expect((await recallUsage())?.receiptsSinceDate).toBeUndefined();
+	});
+
+	it("places a receipt-less call on its own day from the reference's timestamp", async () => {
+		// Pre-receipt history: the call is known and dated, its OUTCOME is not.
+		await applySummaryEvents([repoEvent], { producerKind: "cli", dbPath });
+		await seedRecallReference(["2026-07-28T04:00:00.000Z", "2026-07-28T05:00:00.000Z"]);
+		const result = await recallUsage();
+		expect(result?.callsWithoutReceipt).toBe(2);
+		expect(result?.daily.find((d) => d.date === "2026-07-28")).toEqual({
+			date: "2026-07-28",
+			used: 0,
+			setAside: 0,
+			estimated: 2,
+		});
+	});
+
+	it("drops the estimate on any day a receipt already covers, so one call is never counted twice", async () => {
+		// From the day receipts shipped, BOTH channels see the same call — the
+		// reference extractor bookmarks exactly the recalls the serving code
+		// receipted. Summing them would double that day.
+		await applySummaryEvents(
+			[repoEvent, recall(hit("a".repeat(40), "2026-07-25"), { atMs: Date.parse("2026-07-28T06:00:00Z") })],
+			{ producerKind: "cli", dbPath },
+		);
+		await seedRecallReference(["2026-07-28T06:00:00.000Z", "2026-07-26T06:00:00.000Z"]);
+		const result = await recallUsage();
+		// The receipted day is told by its receipt alone...
+		expect(result?.daily.find((d) => d.date === "2026-07-28")).toEqual({
+			date: "2026-07-28",
+			used: 1,
+			setAside: 0,
+		});
+		// ...while a day with no receipt keeps its estimate.
+		expect(result?.daily.find((d) => d.date === "2026-07-26")?.estimated).toBe(1);
+	});
+
+	it("omits `estimated` entirely on an ordinary day", async () => {
+		// The field means "evidence with no recorded outcome". Emitting a 0 on
+		// every point would put the key on every series for every machine.
+		await applySummaryEvents([repoEvent, recall(hit("a".repeat(40), "2026-07-25"))], {
+			producerKind: "cli",
+			dbPath,
+		});
+		expect((await recallUsage())?.daily.every((d) => !("estimated" in d))).toBe(true);
 	});
 
 	it("reports skill invocations separately, so they cannot move the hit rate", async () => {
@@ -1205,6 +1342,121 @@ describe("buildDashboardModel — recall usage", () => {
 		// reports the nonsensical "1 of 0 sessions got prior context".
 		expect(result?.sessionsWithContext).toBe(1);
 		expect(result?.sessionsInWindow).toBe(1);
+	});
+
+	/** One session carrying recall tool rows, with an explicit per-call time. */
+	const sessionWithRecallTools = (
+		sessionId: string,
+		tools: ReadonlyArray<{ name: string; kind: "skill" | "mcp"; server?: string; lastCallAtMs?: number }>,
+		updatedAtMs: number = nowMs - 3_600_000,
+		source: "claude" | "codex" = "claude",
+	): StatsEventEnvelope =>
+		({
+			producerKind: "cli",
+			event: {
+				type: "session.upserted",
+				repoIdentity: "repo-1",
+				source,
+				sessionId,
+				updatedAtMs,
+				tools: tools.map((t) => ({ ...t, calls: 1 })),
+			},
+		}) as StatsEventEnvelope;
+
+	it("windows a tool row by the CALL's own time, not by its session's", async () => {
+		// The defect this column exists for: a session updated inside the window
+		// whose recall actually happened months ago was filed under today, and a
+		// call made an hour ago inside a long-running session was filed under
+		// whenever that session last updated.
+		await applySummaryEvents(
+			[
+				repoEvent,
+				sessionWithRecallTools("stale-call", [
+					{ name: "jolli-recall", kind: "skill", lastCallAtMs: Date.parse("2026-05-01T00:00:00Z") },
+				]),
+				sessionWithRecallTools(
+					"fresh-call",
+					[{ name: "jolli-recall", kind: "skill", lastCallAtMs: nowMs - 3_600_000 }],
+					Date.parse("2026-05-01T00:00:00Z"),
+				),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		// One in, one out — and note the two sessions' `updatedAtMs` say the exact
+		// opposite, which is what the old windowing read.
+		expect((await recallUsage())?.skillInvocations).toBe(1);
+	});
+
+	it("falls back to the session's time for a row whose parser stamped none", async () => {
+		// Rows written before the column existed, and sources whose parsers cannot
+		// supply a per-call time, hold NULL — a bare comparison against NULL is
+		// false, so without COALESCE every one of them would silently vanish from
+		// every window rather than keep its old placement.
+		await applySummaryEvents(
+			[repoEvent, sessionWithRecallTools("untimed", [{ name: "jolli-recall", kind: "skill" }])],
+			{ producerKind: "cli", dbPath },
+		);
+		expect((await recallUsage())?.skillInvocations).toBe(1);
+	});
+
+	it("counts a skill run that left no MCP call and no attributable receipt", async () => {
+		// The CLI-fallback recall: a `kind='skill'` row and nothing else. It used
+		// to be invisible — `callsWithoutReceipt` only ever looked at MCP rows.
+		await applySummaryEvents(
+			[
+				repoEvent,
+				sessionWithRecallTools("codex-1", [{ name: "jolli-recall", kind: "skill" }], undefined, "codex"),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		const result = await recallUsage();
+		expect(result?.skillRunsWithoutTrace).toBe(1);
+		// Kept OUT of the call bound: a skill run that never recalled looks the same.
+		expect(result?.callsWithoutReceipt).toBe(0);
+		expect(result?.usedCalls).toBe(0);
+	});
+
+	it("does not count a skill run whose session also carries the MCP call", async () => {
+		await applySummaryEvents(
+			[
+				repoEvent,
+				sessionWithRecallTools("claude-1", [
+					{ name: "jolli:recall", kind: "skill" },
+					{ name: "jollimemory.recall", kind: "mcp", server: "jollimemory" },
+				]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		expect((await recallUsage())?.skillRunsWithoutTrace).toBe(0);
+	});
+
+	it("does not count a skill run whose session has a receipt of its own", async () => {
+		await applySummaryEvents(
+			[
+				repoEvent,
+				sessionWithRecallTools("claude-2", [{ name: "jolli-recall", kind: "skill" }]),
+				recall(hit("a".repeat(40), "2026-07-25"), { sessionId: "claude-2", surface: "cli" }),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		expect((await recallUsage())?.skillRunsWithoutTrace).toBe(0);
+	});
+
+	it("subtracts session-less receipts, so a CLI recall is not counted twice", async () => {
+		// codex/opencode export no session id, so their CLI receipt lands
+		// unattributed — the same call the skill row describes. Counting both
+		// would report one recall as two.
+		await applySummaryEvents(
+			[
+				repoEvent,
+				sessionWithRecallTools("codex-2", [{ name: "jolli-recall", kind: "skill" }], undefined, "codex"),
+				recall(hit("a".repeat(40), "2026-07-25"), { surface: "cli" }),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		const result = await recallUsage();
+		expect(result?.callsWithoutSession).toBe(1);
+		expect(result?.skillRunsWithoutTrace).toBe(0);
 	});
 
 	it("is empty, not absent, when nothing made a recall call", async () => {
@@ -2162,5 +2414,185 @@ describe("memory cards — sparse summaries", () => {
 		expect(c.severity).toBe("major");
 		expect(c.insertions).toBeUndefined();
 		expect(c.deletions).toBe(500);
+	});
+});
+
+describe("standup author filter", () => {
+	let dir: string;
+	let dbPath: string;
+	const nowMs = Date.parse("2026-07-30T12:00:00Z");
+	const MINE = { emails: ["Me@Example.com"], names: ["Me"] };
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "jolli-author-"));
+		dbPath = join(dir, "dashboard.db");
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	/**
+	 * A shared branch as it actually looks after a fetch: my commit, a teammate's,
+	 * one of mine recorded under a name but no email (an import, or a rewritten
+	 * noreply address), plus a session and a dirty worktree.
+	 */
+	async function seedSharedBranch(): Promise<void> {
+		const commit = (hash: string, message: string, author: { name?: string; email?: string }) => ({
+			producerKind: "cli" as const,
+			event: {
+				type: "commit.created" as const,
+				repoIdentity: "repo-1",
+				hash,
+				committedAtMs: nowMs - 3_600_000,
+				message,
+				...(author.name ? { authorName: author.name } : {}),
+				...(author.email ? { authorEmail: author.email } : {}),
+			},
+		});
+		await applySummaryEvents(
+			[
+				{
+					producerKind: "cli",
+					event: {
+						type: "repo.enabled",
+						repoIdentity: "repo-1",
+						repoName: "jolli",
+						worktreeRoot: "/w",
+						enabledAt: "t",
+					},
+				},
+				// Lower-case on the row, mixed-case in the identity: emails are matched
+				// case-folded, so this pair has to match.
+				commit("mine1", "feat: my work", { name: "Me", email: "me@example.com" }),
+				commit("theirs1", "release: intellij 0.99.11", {
+					name: "Teammate",
+					email: "teammate@example.com",
+				}),
+				commit("mine2", "fix: also mine", { name: "Me" }),
+				{
+					producerKind: "cli",
+					event: {
+						type: "session.upserted",
+						repoIdentity: "repo-1",
+						source: "claude",
+						sessionId: "s1",
+						updatedAtMs: nowMs - 3_600_000,
+						inputTokens: 10,
+						outputTokens: 5,
+						cachedTokens: 0,
+					},
+				},
+				{
+					producerKind: "cli",
+					event: {
+						type: "worktree.status",
+						repoIdentity: "repo-1",
+						branch: "main",
+						filesChanged: 1,
+						insertions: 2,
+						deletions: 3,
+						observedAtMs: nowMs,
+					},
+				},
+				// A memory on the teammate's commit only — its todo is what the Risks
+				// column would otherwise ask the reader to answer for.
+				{
+					producerKind: "bootstrap",
+					event: {
+						type: "commit.summary",
+						repoIdentity: "repo-1",
+						hash: "theirs1",
+						committedAtMs: nowMs - 3_600_000,
+						message: "release: intellij 0.99.11",
+						insights: [{ kind: "todo", text: "someone else's TODO" }],
+						references: [],
+						sessionLinks: [],
+					},
+				},
+				{
+					producerKind: "bootstrap",
+					event: {
+						type: "commit.summary",
+						repoIdentity: "repo-1",
+						hash: "mine1",
+						committedAtMs: nowMs - 3_600_000,
+						message: "feat: my work",
+						insights: [{ kind: "todo", text: "my own TODO" }],
+						references: [],
+						sessionLinks: [],
+					},
+				},
+			],
+			{ producerKind: "cli", dbPath },
+		);
+	}
+
+	const standupOf = async (authorIdentity?: QueryOptions["authorIdentity"]) =>
+		(
+			await withDashboardDb(
+				(db) =>
+					buildDashboardModel(db, {
+						view: "standup",
+						scope: { kind: "all" },
+						timeZone: "UTC",
+						nowMs,
+						...(authorIdentity ? { authorIdentity } : {}),
+					}),
+				{ dbPath },
+			)
+		).standup;
+
+	it("keeps only the local identity's commits, matching email case-insensitively or name", async () => {
+		await seedSharedBranch();
+		const standup = await standupOf(MINE);
+		expect(standup?.todayCommits.map((c) => c.hash).sort()).toEqual(["mine1", "mine2"]);
+		expect(standup?.authoredBy).toBe("Me@Example.com");
+	});
+
+	it("drops a teammate's TODO out of the Risks column", async () => {
+		await seedSharedBranch();
+		const insights = (await standupOf(MINE))?.insights ?? [];
+		expect(insights.map((i) => i.text)).toEqual(["my own TODO"]);
+	});
+
+	it("leaves sessions and the dirty worktree unfiltered — they are this machine's own state", async () => {
+		await seedSharedBranch();
+		const standup = await standupOf(MINE);
+		expect(standup?.todaySessions.map((s) => s.sessionId)).toEqual(["s1"]);
+		expect(standup?.workspaces).toHaveLength(1);
+	});
+
+	it("fails open on an identity with nothing usable in it, and says so by omitting authoredBy", async () => {
+		await seedSharedBranch();
+		for (const identity of [undefined, { emails: [], names: [] }, { emails: ["  "], names: [" "] }]) {
+			const standup = await standupOf(identity);
+			expect(standup?.todayCommits.map((c) => c.hash).sort()).toEqual(["mine1", "mine2", "theirs1"]);
+			expect(standup).not.toHaveProperty("authoredBy");
+			expect((standup?.insights ?? []).length).toBe(2);
+		}
+	});
+
+	it("labels a name-only identity with the name", async () => {
+		await seedSharedBranch();
+		const standup = await standupOf({ emails: [], names: ["Me"] });
+		expect(standup?.authoredBy).toBe("Me");
+		expect(standup?.todayCommits.map((c) => c.hash).sort()).toEqual(["mine1", "mine2"]);
+	});
+
+	it("never filters the stats page — repo activity is not a first-person question", async () => {
+		await seedSharedBranch();
+		const model = await withDashboardDb(
+			(db) =>
+				buildDashboardModel(db, {
+					view: "stats",
+					scope: { kind: "all" },
+					timeZone: "UTC",
+					nowMs,
+					authorIdentity: MINE,
+				}),
+			{ dbPath },
+		);
+		expect(model.stats?.totalCommits).toBe(3);
 	});
 });

--- a/cli/src/dashboard/DashboardQuery.ts
+++ b/cli/src/dashboard/DashboardQuery.ts
@@ -328,6 +328,16 @@ function resolveWindow(
 
 // ── Query plumbing ──────────────────────────────────────────────────────────
 
+/**
+ * Every git identity that counts as "me", unioned across the registered repos
+ * (each can carry its own `user.email`). Emails and names are kept apart
+ * because they are matched differently — see {@link authorFilter}.
+ */
+export interface AuthorIdentity {
+	readonly emails: ReadonlyArray<string>;
+	readonly names: ReadonlyArray<string>;
+}
+
 export interface QueryOptions {
 	readonly view: DashboardView;
 	readonly scope: DashboardScope;
@@ -345,6 +355,11 @@ export interface QueryOptions {
 	/** Memories view: which memory's detail to build. Absent renders the tree with no selection. */
 	readonly hash?: string;
 	/**
+	 * Memories view: which repo owns {@link hash}, when two clones share it.
+	 * Narrows the DETAIL only — see `buildMemories` for why this is not `scope`.
+	 */
+	readonly detailRepoIdentity?: string;
+	/**
 	 * The async-read per-repo git reachability sets, keyed by `repo_identity`.
 	 * Absent (or a repo missing from the map) renders every row unfiltered —
 	 * see {@link ReachableCommits}. Read by the memories tree, and by the
@@ -354,10 +369,56 @@ export interface QueryOptions {
 	 * "N of M captured" line counts commits that no longer exist.
 	 */
 	readonly reachableCommits?: ReachableCommits;
+	/**
+	 * Standup view: the local git identity, read async per repo by the server.
+	 * Absent — or present with nothing usable in it — leaves the board
+	 * unfiltered; see {@link authorFilter} for why that fail-open matters.
+	 */
+	readonly authorIdentity?: AuthorIdentity;
 	/** Repositories view: the async-read registry + job state. Absent renders an empty list. */
 	readonly repositoriesModel?: RepositoriesModel;
 	readonly timeZone?: string;
 	readonly nowMs?: number;
+}
+
+/**
+ * WHERE fragment + params restricting `commits` to the local user's own work.
+ *
+ * Standup only, and deliberately not applied to the stats page: "how much did
+ * this repo do" is a repo question, while a standup is a first-person report —
+ * the page draws a Copy-as-standup draft the user posts as their own, so a
+ * teammate's commit in it is a false claim, not just noise. The two are easy to
+ * conflate because a single-developer repo makes them identical.
+ *
+ * Matches email OR name, both taken from `git config` rather than from any
+ * commit: the same person legitimately appears under a work email locally and a
+ * noreply address after a remote rewrite, and a name-only identity is all some
+ * imports carry. Emails compare case-folded (they are case-insensitive in
+ * practice and git does not normalise them); names compare exactly, since a name
+ * is display text and two people can differ only by case.
+ *
+ * FAILS OPEN. An identity with nothing usable in it — no git, an unconfigured
+ * machine, a `repos` row with no worktree — returns no filter, so the board
+ * shows every commit rather than going blank. A blank standup reads as "you did
+ * nothing", which is a worse lie than an unfiltered one, and the unfiltered case
+ * is visible (the header states whose commits are shown) where an empty page
+ * would be silent.
+ */
+function authorFilter(identity: AuthorIdentity | undefined, alias: string): { sql: string; params: unknown[] } {
+	const emails = (identity?.emails ?? []).map((email) => email.trim().toLowerCase()).filter((email) => email !== "");
+	const names = (identity?.names ?? []).map((name) => name.trim()).filter((name) => name !== "");
+	if (emails.length === 0 && names.length === 0) return { sql: "", params: [] };
+	const clauses: string[] = [];
+	const params: unknown[] = [];
+	if (emails.length > 0) {
+		clauses.push(`LOWER(${alias}.author_email) IN (${placeholders(emails.length)})`);
+		params.push(...emails);
+	}
+	if (names.length > 0) {
+		clauses.push(`${alias}.author_name IN (${placeholders(names.length)})`);
+		params.push(...names);
+	}
+	return { sql: ` AND (${clauses.join(" OR ")})`, params };
 }
 
 interface SessionRow {
@@ -416,8 +477,16 @@ interface CommitRow {
 	readonly root_hash: string | null;
 }
 
-function commitsInRange(db: DashboardDbHandle, scope: DashboardScope, fromMs: number, toMs: number): CommitRow[] {
+function commitsInRange(
+	db: DashboardDbHandle,
+	scope: DashboardScope,
+	fromMs: number,
+	toMs: number,
+	/** Standup only — every other caller reports repo-wide activity. See {@link authorFilter}. */
+	identity?: AuthorIdentity,
+): CommitRow[] {
 	const filter = scopeFilter(scopeToRepoId(db, scope), "c.repo_id");
+	const author = authorFilter(identity, "c");
 	// The memory-tier columns come from `memories` (A3b): the commits copies
 	// fall behind whenever a memory regenerates, while the memory row is
 	// refreshed live by the same worker pass that emits commit.summary.
@@ -442,10 +511,10 @@ function commitsInRange(db: DashboardDbHandle, scope: DashboardScope, fromMs: nu
 			   LEFT JOIN memories m ON m.repo_id = c.repo_id AND m.commit_hash = c.hash
 			   LEFT JOIN commit_aliases al ON al.repo_id = c.repo_id AND al.old_hash = c.hash
 			   LEFT JOIN memories ma ON ma.repo_id = al.repo_id AND ma.commit_hash = al.target_hash
-			  WHERE c.committed_at_ms >= ? AND c.committed_at_ms < ?${filter.sql}
+			  WHERE c.committed_at_ms >= ? AND c.committed_at_ms < ?${filter.sql}${author.sql}
 			  ORDER BY c.committed_at_ms DESC`,
 		)
-		.all(fromMs, toMs, ...filter.params) as CommitRow[];
+		.all(fromMs, toMs, ...filter.params, ...author.params) as CommitRow[];
 }
 
 /**
@@ -961,8 +1030,14 @@ function buildStandupInsights(
 	scope: DashboardScope,
 	fromMs: number,
 	toMs: number,
+	identity: AuthorIdentity | undefined,
 ): StandupInsight[] {
 	const filter = scopeFilter(scopeToRepoId(db, scope), "c.repo_id");
+	// Same filter as the commit columns, and for a stronger reason: the Risks
+	// column is a list of things the reader is expected to answer for. A
+	// teammate's blocker rendered here is work silently reassigned to whoever
+	// reads the board.
+	const author = authorFilter(identity, "c");
 	const rows = db
 		.prepare(
 			`${TOPIC_INSIGHTS_CTE}
@@ -976,10 +1051,10 @@ function buildStandupInsights(
 			   -- vanish from Standup while its decisions still render on the Decisions
 			   -- card, which reads the same table through the alias.
 			   JOIN topic_insights i ON i.repo_id = c.repo_id AND (i.commit_hash = c.hash OR i.commit_hash = al.target_hash)
-			  WHERE c.committed_at_ms >= ? AND c.committed_at_ms < ?${filter.sql}
+			  WHERE c.committed_at_ms >= ? AND c.committed_at_ms < ?${filter.sql}${author.sql}
 			  ORDER BY c.committed_at_ms DESC, i.ord`,
 		)
-		.all(fromMs, toMs, ...filter.params) as ReadonlyArray<{
+		.all(fromMs, toMs, ...filter.params, ...author.params) as ReadonlyArray<{
 		kind: string;
 		text: string;
 		addressed_to: string | null;
@@ -1005,10 +1080,19 @@ function buildStandup(
 	timeZone: string,
 	nowMs: number,
 	tier: AdoptionTier,
+	identity: AuthorIdentity | undefined,
 ): StandupModel {
 	const todayStart = startOfLocalDay(nowMs, timeZone);
 	const tomorrowStart = addLocalDays(nowMs, 1, timeZone);
 	const yesterdayStart = addLocalDays(nowMs, -1, timeZone);
+
+	/* What the header states the board is filtered to. Derived from the SAME
+	   identity the queries were given (and by the same emptiness rule), so the
+	   label can never claim a filter that did not run — including the fail-open
+	   case, where it stays absent and the page says so. */
+	const authoredBy = authorFilter(identity, "c").sql
+		? (identity?.emails.find((email) => email.trim() !== "") ?? identity?.names.find((name) => name.trim() !== ""))
+		: undefined;
 
 	const categoryLabels = commitCategoryLabels(db, scope);
 	const toStandupCommit = (c: CommitRow): StandupCommit => {
@@ -1064,12 +1148,18 @@ function buildStandup(
 	return {
 		today: localDayKey(nowMs, timeZone),
 		yesterday: localDayKey(yesterdayStart, timeZone),
+		/* Sessions and workspaces carry no author filter, and need none: an agent
+		   session and an uncommitted diff are this machine's own working state, so
+		   they are already first-person. Only `commits` can hold a teammate's row. */
 		yesterdaySessions: sessionsInRange(db, scope, yesterdayStart, todayStart).map((s) => toRecentSession(s, nowMs)),
-		yesterdayCommits: commitsInRange(db, scope, yesterdayStart, todayStart).map(toStandupCommit),
+		yesterdayCommits: commitsInRange(db, scope, yesterdayStart, todayStart, identity).map(toStandupCommit),
 		todaySessions: sessionsInRange(db, scope, todayStart, tomorrowStart).map((s) => toRecentSession(s, nowMs)),
-		todayCommits: commitsInRange(db, scope, todayStart, tomorrowStart).map(toStandupCommit),
+		todayCommits: commitsInRange(db, scope, todayStart, tomorrowStart, identity).map(toStandupCommit),
 		workspaces,
-		...(tier !== "installed" ? { insights: buildStandupInsights(db, scope, yesterdayStart, tomorrowStart) } : {}),
+		...(authoredBy ? { authoredBy } : {}),
+		...(tier !== "installed"
+			? { insights: buildStandupInsights(db, scope, yesterdayStart, tomorrowStart, identity) }
+			: {}),
 	};
 }
 
@@ -1417,6 +1507,27 @@ function buildToolUsage(db: DashboardDbHandle, scope: DashboardScope, window: Re
 const RECALL_STALE_MS = 30 * 86_400_000;
 
 /**
+ * When a `session_tool_use` bucket happened, for windowing — the call's own
+ * time when the parser that read it could supply one, the session's otherwise.
+ *
+ * Both halves are load-bearing. `last_call_at_ms` is the honest answer and the
+ * reason the column exists: a session's `updated_at_ms` moves every time the
+ * conversation is touched again, so windowing by it filed a three-week-old
+ * recall under today and a call made minutes ago under whenever its
+ * long-running session happened to last update. The COALESCE is what keeps that
+ * an improvement rather than a regression: rows written before the column
+ * existed hold NULL and can never be backfilled (their transcripts are behind a
+ * cursor, or gone), as do rows from sources whose parsers cannot stamp a time
+ * (`TOOL_CALL_TIME_SOURCES`) — and a bare comparison against NULL is false, so
+ * without the fallback every one of those rows would silently leave every
+ * window rather than keep its old, coarser placement.
+ *
+ * Written as a fragment used in BOTH bounds of each range test, so a row cannot
+ * be admitted by one clock and excluded by the other.
+ */
+const TOOL_CALL_TIME_SQL = "COALESCE(t.last_call_at_ms, s.updated_at_ms)";
+
+/**
  * The Recall card: how often recall actually served usable commit context.
  *
  * Reads `recall_receipts` — one row per call, written by whoever served it
@@ -1456,20 +1567,27 @@ function buildRecallUsage(
 		commits_json: string | null;
 	}>;
 
-	const daily = new Map<string, { used: number; setAside: number }>();
+	const daily = new Map<string, { used: number; setAside: number; estimated: number }>();
 	for (let dayStart = window.startMs; dayStart < window.endMs; dayStart = addLocalDays(dayStart, 1, timeZone)) {
-		daily.set(localDayKey(dayStart, timeZone), { used: 0, setAside: 0 });
+		daily.set(localDayKey(dayStart, timeZone), { used: 0, setAside: 0, estimated: 0 });
 	}
 
 	let usedCalls = 0;
 	let setAsideCalls = 0;
 	const sessionsWithContext = new Set<string>();
+	// Counted over EVERY receipt, used or set aside: both halves count in the
+	// figures the caveat qualifies, and both are equally unattributable to a
+	// session. Counted here rather than derived from `sessionsWithContext` — a
+	// zero there means "no receipt named a session at all", which is a different
+	// (and much rarer) statement than "some receipt named none".
+	let callsWithoutSession = 0;
 	const callsBySurface = new Map<string, number>();
 	// hash → date, first occurrence wins — the same commit served twice always
 	// carries the same date, so "first" is just "any".
 	const memoriesUsed = new Map<string, string>();
 	for (const row of rows) {
 		callsBySurface.set(row.surface, (callsBySurface.get(row.surface) ?? 0) + 1);
+		if (!row.session_id) callsWithoutSession++;
 		const bucket = daily.get(localDayKey(row.at_ms, timeZone));
 		if (!row.hit) {
 			setAsideCalls++;
@@ -1510,6 +1628,16 @@ function buildRecallUsage(
 	// recall on its first turn therefore rendered "1 of 0 sessions got prior
 	// context" — an EXISTS arm cannot rescue a session that is not in the table
 	// being filtered.
+	//
+	// `session_id IS NOT NULL` on the receipt arm is what keeps that union honest.
+	// A receipt legitimately has no session: `currentAgentSessionId` returns
+	// undefined for a `jolli recall` typed at a shell prompt, and attributing it
+	// to a guessed session would be worse (see its docstring). But SQLite's UNION
+	// dedupes with NULLs comparing EQUAL, so every session-less receipt in the
+	// window collapsed into ONE row per repo and added a phantom session to the
+	// denominator — a session that exists nowhere and, since the numerator skips
+	// a null `session_id`, can never be counted as covered. Measured on this
+	// machine: 104 real sessions, 4 session-less CLI receipts, "of 105".
 	const sessionFilter = scopeFilter(repoId, "s.repo_id");
 	const receiptScope = scopeFilter(repoId, "r.repo_id");
 	const sessionRows = db
@@ -1521,7 +1649,7 @@ function buildRecallUsage(
 			   UNION
 			   SELECT r.repo_id, r.session_id
 			     FROM recall_receipts r
-			    WHERE r.at_ms >= ? AND r.at_ms < ?${receiptScope.sql}
+			    WHERE r.at_ms >= ? AND r.at_ms < ? AND r.session_id IS NOT NULL${receiptScope.sql}
 			 )`,
 		)
 		.get(
@@ -1535,7 +1663,7 @@ function buildRecallUsage(
 
 	// Skill invocations: the `jolli-recall` skill being run, which is NOT a
 	// recall call (see RecallUsage.skillInvocations for why it stays out of the
-	// hit rate). Windowed by the session, the only time a tool row has.
+	// hit rate).
 	const skillFilter = scopeFilter(repoId, "s.repo_id");
 	const skillRow = db
 		.prepare(
@@ -1543,14 +1671,13 @@ function buildRecallUsage(
 			   FROM session_tool_use t
 			   JOIN sessions s ON s.event_id = t.session_event_id
 			  WHERE t.kind = 'skill' AND t.tool_name IN (${placeholders(RECALL_SKILL_NAMES.length)})
-			    AND s.updated_at_ms >= ? AND s.updated_at_ms < ?${skillFilter.sql}`,
+			    AND ${TOOL_CALL_TIME_SQL} >= ? AND ${TOOL_CALL_TIME_SQL} < ?${skillFilter.sql}`,
 		)
 		.get(...RECALL_SKILL_NAMES, window.startMs, window.endMs, ...skillFilter.params) as { calls: number };
 
 	// Backfilled recall calls: the MCP tool as the transcripts recorded it, minus
 	// the ones a receipt already accounts for (see RecallUsage.callsWithoutReceipt
 	// for the subtraction's edge case and why references are not a second source).
-	// Windowed by the session, like the skill count above and for the same reason.
 	const toolFilter = scopeFilter(repoId, "s.repo_id");
 	const toolRow = db
 		.prepare(
@@ -1559,7 +1686,7 @@ function buildRecallUsage(
 			   JOIN sessions s ON s.event_id = t.session_event_id
 			  WHERE t.kind = 'mcp'
 			    AND (t.tool_name = ? OR t.tool_name LIKE ? ESCAPE '\\')
-			    AND s.updated_at_ms >= ? AND s.updated_at_ms < ?${toolFilter.sql}`,
+			    AND ${TOOL_CALL_TIME_SQL} >= ? AND ${TOOL_CALL_TIME_SQL} < ?${toolFilter.sql}`,
 		)
 		// `\_` escapes SQLite's single-character wildcard, so the underscore in the
 		// suffix is a literal — `isRecallMcpToolName`'s test, expressed in SQL.
@@ -1591,8 +1718,26 @@ function buildRecallUsage(
 	for (const row of refBodies) {
 		for (const at of accumulatedEntryTimes(row.body_md ?? undefined)) {
 			const ms = Date.parse(at);
-			if (Number.isFinite(ms) && ms >= window.startMs && ms < window.endMs) referenceCalls++;
+			if (!Number.isFinite(ms) || ms < window.startMs || ms >= window.endMs) continue;
+			referenceCalls++;
+			// The DAY is banked too, not just the count. This channel is the only
+			// one that knows when a receipt-less call happened — a `session_tool_use`
+			// row carries no time of its own — and the timestamp is already parsed
+			// here for the window test above, so dropping it (as this used to) left
+			// the chart unable to show a single day of the history that
+			// `callsWithoutReceipt` was simultaneously reporting a total for.
+			const bucket = daily.get(localDayKey(ms, timeZone));
+			if (bucket) bucket.estimated++;
 		}
+	}
+	// Receipts win their own day, wholesale. From the day receipts shipped both
+	// channels observe the SAME call — the reference extractor bookmarks exactly
+	// the recalls the serving code also receipted — so a day that has any receipt
+	// must not add the estimate on top of it. Zeroing per DAY rather than globally
+	// is what lets one window hold both halves: the days before receipts existed
+	// keep their estimate, the days after are told by the receipts alone.
+	for (const bucket of daily.values()) {
+		if (bucket.used > 0 || bucket.setAside > 0) bucket.estimated = 0;
 	}
 
 	// Both channels under-report — a tool row cannot see a source that records no
@@ -1602,6 +1747,59 @@ function buildRecallUsage(
 	// lower bound, while a sum would count the common case twice.
 	const callsWithoutReceipt = Math.max(0, Math.max(toolRow.calls, referenceCalls) - (callsBySurface.get("mcp") ?? 0));
 
+	// Skill runs with no other trace — the CLI-fallback recall that used to be
+	// invisible here. See RecallUsage.skillRunsWithoutTrace for why this is its
+	// own figure rather than more of `callsWithoutReceipt`.
+	//
+	// Per session, because the subtraction is only meaningful within one: a
+	// session's MCP rows and the receipts that NAME it account for its skill runs,
+	// and one session's surplus must not be cancelled by another's spare receipt.
+	// Clamped inside the aggregate for the same reason.
+	const skillTraceFilter = scopeFilter(repoId, "s.repo_id");
+	const skillOnlyRow = db
+		.prepare(
+			`SELECT COALESCE(SUM(MAX(0, per.skill_calls - per.mcp_calls - per.receipts)), 0) AS runs
+			   FROM (
+			     SELECT s.event_id,
+			            SUM(CASE WHEN t.kind = 'skill' AND t.tool_name IN (${placeholders(RECALL_SKILL_NAMES.length)})
+			                     THEN t.calls ELSE 0 END) AS skill_calls,
+			            SUM(CASE WHEN t.kind = 'mcp'
+			                       AND (t.tool_name = ? OR t.tool_name LIKE ? ESCAPE '\\')
+			                     THEN t.calls ELSE 0 END) AS mcp_calls,
+			            (SELECT COUNT(*) FROM recall_receipts r
+			              WHERE r.repo_id = s.repo_id AND r.session_id = s.session_id
+			                AND r.at_ms >= ? AND r.at_ms < ?) AS receipts
+			       FROM session_tool_use t
+			       JOIN sessions s ON s.event_id = t.session_event_id
+			      WHERE ${TOOL_CALL_TIME_SQL} >= ? AND ${TOOL_CALL_TIME_SQL} < ?${skillTraceFilter.sql}
+			      GROUP BY s.event_id
+			   ) per`,
+		)
+		.get(
+			...RECALL_SKILL_NAMES,
+			RECALL_MCP_TOOL_NAME,
+			`%\\${RECALL_MCP_TOOL_SUFFIX}`,
+			window.startMs,
+			window.endMs,
+			window.startMs,
+			window.endMs,
+			...skillTraceFilter.params,
+		) as { runs: number };
+	// Then the window's session-LESS receipts, globally: those are the CLI recalls
+	// no session can claim, so each one plausibly IS one of the runs just counted.
+	// Subtracting them is what stops a Claude-only machine — where every skill run
+	// does write a receipt — from reporting a gap it does not have.
+	const skillRunsWithoutTrace = Math.max(0, skillOnlyRow.runs - callsWithoutSession);
+
+	// Deliberately UNWINDOWED — the one figure on this card that is not. It says
+	// "recording starts here", which is what tells a reader that a 30-day chart
+	// holding one bar is a young table rather than a broken chart, and a windowed
+	// version could only ever report the window's own start. Its own query
+	// because the `rows` above are windowed by definition.
+	const sinceRow = db
+		.prepare(`SELECT MIN(r.at_ms) AS since FROM recall_receipts r WHERE 1 = 1${filter.sql}`)
+		.get(...filter.params) as { since: number | null };
+
 	return {
 		usedCalls,
 		setAsideCalls,
@@ -1609,13 +1807,25 @@ function buildRecallUsage(
 		distinctMemoriesUsed: memoriesUsed.size,
 		staleMemoriesUsed,
 		sessionsWithContext: sessionsWithContext.size,
+		callsWithoutSession,
 		sessionsInWindow: sessionRows.total,
 		bySurface: [...callsBySurface.entries()]
 			.map(([surface, calls]) => ({ surface: surface as RecallSurface, calls }))
 			.sort((a, b) => b.calls - a.calls),
 		skillInvocations: skillRow.calls,
 		callsWithoutReceipt,
-		daily: [...daily.entries()].map(([date, b]) => ({ date, used: b.used, setAside: b.setAside })),
+		skillRunsWithoutTrace,
+		...(sinceRow.since != null && { receiptsSinceDate: localDayKey(sinceRow.since, timeZone) }),
+		daily: [...daily.entries()].map(([date, b]) => ({
+			date,
+			used: b.used,
+			setAside: b.setAside,
+			// Omitted rather than `0`: the field means "this day has evidence with
+			// no recorded outcome", and every ordinary day has none. Emitting a
+			// zero on all of them would put the key on every point of every series
+			// for the one machine-in-a-thousand that has any.
+			...(b.estimated > 0 && { estimated: b.estimated }),
+		})),
 	};
 }
 
@@ -1704,7 +1914,7 @@ export function buildDashboardModel(db: DashboardDbHandle, opts: QueryOptions): 
 					),
 				};
 			case "standup":
-				return { standup: buildStandup(db, options.scope, timeZone, nowMs, tier) };
+				return { standup: buildStandup(db, options.scope, timeZone, nowMs, tier, options.authorIdentity) };
 			case "repositories":
 				return { repositories: options.repositoriesModel ?? NO_REPOSITORIES_MODEL };
 			case "memories":
@@ -1712,7 +1922,15 @@ export function buildDashboardModel(db: DashboardDbHandle, opts: QueryOptions): 
 				// not a recall receipt, so it exists as soon as a commit is
 				// summarized — there is nothing here that only makes sense above a
 				// tier.
-				return { memories: buildMemories(db, options.scope, options.hash, options.reachableCommits) };
+				return {
+					memories: buildMemories(
+						db,
+						options.scope,
+						options.hash,
+						options.reachableCommits,
+						options.detailRepoIdentity,
+					),
+				};
 		}
 	};
 

--- a/cli/src/dashboard/DashboardServer.test.ts
+++ b/cli/src/dashboard/DashboardServer.test.ts
@@ -12,6 +12,9 @@ vi.mock("../core/GitOps.js", () => ({
 	// The Memories view asks git which commits are still reachable. Mocked so
 	// that read stays a pure-unit test — the real one shells out to `rev-list`.
 	listReachableCommits: vi.fn(async () => ["reachable-hash"]),
+	// The Standup view asks git who the local user is, to filter the board to
+	// their own commits. Mocked for the same reason: no `git config` subprocess.
+	readLocalGitIdentity: vi.fn(async () => ({ email: "me@example.com", name: "Me" })),
 }));
 vi.mock("../install/Installer.js", () => ({
 	install: vi.fn().mockResolvedValue({ success: true, warnings: [] }),
@@ -1210,6 +1213,40 @@ describe("defaultModelBuilder (no injected buildModel)", () => {
 		expect((body.memories?.items ?? []).map((item) => item.commitHash)).toEqual(["reachable-hash"]);
 	});
 
+	// The `/` redirect reads `repos.length` and nothing else. It builds the
+	// `repositories` model to avoid the stats view's LLM call, and that view now
+	// pays a per-repo `git rev-list` for its memory badge — a badge this response
+	// discards, and which the page it redirects to computes again anyway.
+	it("skips the reachability fan-out for the / redirect, but pays it on the page itself", async () => {
+		const dbPath = join(dir, "root-redirect.db");
+		const configDir = join(dir, "config-root");
+		await applyStatsEvents(
+			[
+				{
+					producerKind: "cli",
+					event: {
+						type: "repo.enabled",
+						repoIdentity: "repo-1",
+						repoName: "jolli",
+						worktreeRoot: "/w/jolli",
+						enabledAt: "t",
+					},
+				},
+			],
+			{ producerKind: "cli", dbPath },
+		);
+
+		const port = await listen(createDashboardServer({ port: 0, assetsDir, dbPath, configDir }));
+
+		const root = await get(port, "/");
+		expect(root.status).toBe(302);
+		expect(root.headers.get("location")).toBe("/dashboard");
+		expect(gitOps.listReachableCommits).not.toHaveBeenCalled();
+
+		expect((await get(port, "/repositories")).status).toBe(200);
+		expect(gitOps.listReachableCommits).toHaveBeenCalledWith("/w/jolli");
+	});
+
 	// The "Load more" fetch. Filtered by the SAME reachability the page render
 	// uses — that is what makes the cursor a position in the list the client is
 	// actually holding, rather than in a longer one only this route can see.
@@ -1319,8 +1356,11 @@ describe("defaultModelBuilder (no injected buildModel)", () => {
 
 		// Unknown document — a 404, not an empty 200 that reads as "no content".
 		expect((await get(port, "/api/context?repo=repo-1&kind=plan&key=nope")).status).toBe(404);
-		// `reference` is a real context kind but not a viewable one here.
-		expect((await get(port, "/api/context?repo=repo-1&kind=reference&key=p1")).status).toBe(400);
+		// Every context kind is viewable now, so `reference` is a 404 (no such
+		// document) rather than a 400 (no such kind) — only an unknown KIND is a
+		// bad request.
+		expect((await get(port, "/api/context?repo=repo-1&kind=reference&key=p1")).status).toBe(404);
+		expect((await get(port, "/api/context?repo=repo-1&kind=nonsense&key=p1")).status).toBe(400);
 		expect((await get(port, "/api/context?kind=plan&key=p1")).status).toBe(400);
 	});
 });
@@ -1455,6 +1495,42 @@ describe("Decisions card gist (Stats view only)", () => {
 
 		expect(res.status).toBe(200);
 		expect(mockGetDecisionGist).not.toHaveBeenCalled();
+	});
+
+	it("filters the standup board to the local git identity, read per enabled repo", async () => {
+		const dbPath = join(dir, "dashboard.db");
+		await seedDecisionCommit(dbPath, "mem4", "picked sqlite");
+		// A placeholder row from a hook that wrote before the registry projected:
+		// `cwd: ''` would silently read whichever repo the server was launched in.
+		await withDashboardDb(
+			(db) => {
+				db.prepare(
+					"INSERT INTO repos (repo_identity, repo_name, worktree_root, enabled_at) VALUES (?, ?, '', 't')",
+				).run("repo-2", "placeholder");
+			},
+			{ dbPath },
+		);
+
+		const port = await listen(
+			createDashboardServer({ port: 0, assetsDir, dbPath, configDir: join(dir, "config") }),
+		);
+		const body = (await (await get(port, "/api/model?view=standup")).json()) as DashboardModel;
+
+		expect(vi.mocked(gitOps.readLocalGitIdentity).mock.calls).toEqual([["/w"]]);
+		expect(body.standup?.authoredBy).toBe("me@example.com");
+		// The seeded commit carries no author, so the filter excludes it — the proof
+		// the identity reached the query rather than being resolved and dropped.
+		expect(body.standup?.todayCommits).toEqual([]);
+	});
+
+	it("never reads the git identity for views other than Standup", async () => {
+		const dbPath = join(dir, "dashboard.db");
+		await seedDecisionCommit(dbPath, "mem5", "picked sqlite");
+		const port = await listen(
+			createDashboardServer({ port: 0, assetsDir, dbPath, configDir: join(dir, "config") }),
+		);
+		expect((await get(port, "/api/model?view=stats")).status).toBe(200);
+		expect(gitOps.readLocalGitIdentity).not.toHaveBeenCalled();
 	});
 });
 

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -79,7 +79,7 @@ import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { dirname, join } from "node:path";
 import { fileURLToPath, URL } from "node:url";
-import { getProjectRootDir, listReachableCommits } from "../core/GitOps.js";
+import { getProjectRootDir, listReachableCommits, readLocalGitIdentity } from "../core/GitOps.js";
 import { escapeForInlineScript } from "../core/InlineScript.js";
 import { getGlobalConfigDir, loadConfigFromDir } from "../core/SessionTracker.js";
 import { trackAs } from "../core/Telemetry.js";
@@ -95,12 +95,13 @@ import {
 	withDashboardDb,
 	withReadonlyDashboardDb,
 } from "./DashboardDb.js";
-import type {
-	DashboardModel,
-	DashboardRange,
-	DashboardScope,
-	DashboardView,
-	SeriesDimension,
+import {
+	CONTEXT_DOC_KINDS,
+	type DashboardModel,
+	type DashboardRange,
+	type DashboardScope,
+	type DashboardView,
+	type SeriesDimension,
 } from "./DashboardModel.js";
 import { buildDashboardModel, type QueryOptions } from "./DashboardQuery.js";
 import { getDecisionGist } from "./DecisionGist.js";
@@ -280,6 +281,20 @@ export type ModelRequest = Omit<QueryOptions, "timeZone" | "nowMs"> & {
 	 * this closes the route that redirect cannot cover.
 	 */
 	readonly allowModelSpend?: boolean;
+	/**
+	 * Set when the caller reads only the parts of the model every view carries —
+	 * today just `repos.length`, for the `/` redirect — and must not pay for the
+	 * per-repo `git rev-list --branches` fan-out {@link REACHABILITY_VIEWS} would
+	 * otherwise trigger.
+	 *
+	 * The redirect builds the `repositories` model to stay clear of the stats
+	 * view's LLM call, and that became the expensive choice the moment
+	 * `repositories` joined the reachability set: one git subprocess per enabled
+	 * repo plus every root memory hash materialized in JS, to decide a 302 whose
+	 * destination then does the same work again. `isReachable` fails open, so the
+	 * counts this skips revert to their raw values — which the redirect discards.
+	 */
+	readonly skipReachability?: boolean;
 };
 
 /** Builds the model for one request. Injectable so tests skip the real DB. */
@@ -298,6 +313,40 @@ export type ModelBuilder = (request: ModelRequest) => Promise<DashboardModel>;
  * each other for any repo whose history was rewritten away.
  */
 const REACHABILITY_VIEWS: ReadonlySet<DashboardView> = new Set<DashboardView>(["stats", "memories", "repositories"]);
+
+/**
+ * Every `user.email` / `user.name` this machine commits under, unioned across
+ * the registered repos — the standup board's "mine only" filter.
+ *
+ * Per repo rather than once globally because `git config user.email` is
+ * routinely overridden inside a worktree (a work identity in one checkout, a
+ * personal one in another), and a global-only read would filter the overridden
+ * repo's own commits away. Unioning is the right shape for the same reason it is
+ * safe: the alternative — per-repo identities applied only to that repo's rows —
+ * costs a correlated filter to separate identities that belong to one person
+ * anyway.
+ *
+ * Concurrent, two `git config` reads per repo, and only for the standup view.
+ * An unreadable or unconfigured repo contributes nothing rather than failing the
+ * request: `authorFilter` then fails open on an empty identity.
+ */
+async function readLocalAuthorIdentity(
+	repos: ReadonlyArray<{ worktree_root: string }>,
+): Promise<{ emails: string[]; names: string[] }> {
+	const identities = await Promise.all(
+		// An empty `worktree_root` is a placeholder row (see readReachableCommitsByRepo):
+		// `cwd: ''` silently runs in the PARENT process's directory, which would read
+		// whichever repo the server happens to be launched from.
+		repos.map(async (repo) => (repo.worktree_root ? readLocalGitIdentity(repo.worktree_root) : null)),
+	);
+	const emails = new Set<string>();
+	const names = new Set<string>();
+	for (const identity of identities) {
+		if (identity?.email) emails.add(identity.email);
+		if (identity?.name) names.add(identity.name);
+	}
+	return { emails: [...emails], names: [...names] };
+}
 
 /**
  * One `git rev-list --branches` per enabled repo, mapped to {@link ReachableCommits}.
@@ -352,22 +401,37 @@ async function defaultModelBuilder(
 			// memories tree, the stats page's Memory Activity feed and captured
 			// counts, and the Repositories page's per-repo memory badge.
 			//
-			// Computed BEFORE the repositories model, which consumes it.
-			const reachableCommits = REACHABILITY_VIEWS.has(request.view)
-				? await readReachableCommitsByRepo(
-						db
-							.prepare("SELECT repo_identity, worktree_root FROM repos WHERE disabled_at IS NULL")
-							.all() as ReadonlyArray<{ repo_identity: string; worktree_root: string }>,
-					)
-				: undefined;
+			// Computed BEFORE the repositories model, which consumes it. Skipped
+			// for a caller that never looks at the filtered rows — see
+			// `ModelRequest.skipReachability`.
+			const reachableCommits =
+				REACHABILITY_VIEWS.has(request.view) && !request.skipReachability
+					? await readReachableCommitsByRepo(
+							db
+								.prepare("SELECT repo_identity, worktree_root FROM repos WHERE disabled_at IS NULL")
+								.all() as ReadonlyArray<{ repo_identity: string; worktree_root: string }>,
+						)
+					: undefined;
 			const repositories =
 				request.view === "repositories"
 					? await buildRepositoriesModel(db, configDir, reachableCommits)
+					: undefined;
+			// Standup is a FIRST-PERSON report, unlike every other view: its columns
+			// feed a Copy-as-standup draft the user posts as their own work, so a
+			// shared branch's teammate commits are a false claim rather than noise.
+			const authorIdentity =
+				request.view === "standup"
+					? await readLocalAuthorIdentity(
+							db
+								.prepare("SELECT worktree_root FROM repos WHERE disabled_at IS NULL")
+								.all() as ReadonlyArray<{ worktree_root: string }>,
+						)
 					: undefined;
 			const model = buildDashboardModel(db, {
 				...request,
 				...(repositories ? { repositoriesModel: repositories } : {}),
 				...(reachableCommits ? { reachableCommits } : {}),
+				...(authorIdentity ? { authorIdentity } : {}),
 			});
 			return attachDecisionGist(model, request, configDir);
 		},
@@ -623,12 +687,20 @@ function parseWindow(url: URL): Omit<ModelRequest, "view" | "scope"> {
 	// unresolvable hash just means no memory matched (buildMemoryDetail
 	// returns undefined), never a query to sanitize here.
 	const hash = url.searchParams.get("hash") ?? undefined;
+	// Which repo owns that hash — NOT a page scope. It is a separate param from
+	// `repo=` precisely because `repo=` narrows every page, and opening one
+	// memory used to collapse the whole tree to its repository. Same forwarding
+	// rules as `hash`: it reaches SQL only through `resolveScope`'s bound
+	// parameters, and an unresolvable value means the detail falls back to the
+	// page scope rather than erroring.
+	const detailRepo = url.searchParams.get("detailRepo") ?? undefined;
 	return {
 		...(dimension ? { dimension } : {}),
 		...(range ? { range } : {}),
 		...(customFrom ? { customFrom } : {}),
 		...(customTo ? { customTo } : {}),
 		...(hash ? { hash } : {}),
+		...(detailRepo ? { detailRepoIdentity: detailRepo } : {}),
 	};
 }
 
@@ -806,7 +878,16 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 			// the whole stats query set and can fire a DecisionGist LLM call — so
 			// merely opening the base URL by hand used to spend model budget on a
 			// redirect. Same gate as the destination pages below, one model each.
-			const model = await buildModel({ view: "repositories", scope: parseScope(url), ...parseWindow(url) });
+			// `skipReachability` because only `repos.length` is read here: the
+			// per-repo git fan-out the `repositories` view otherwise pays for would
+			// buy a memory badge this response throws away, and the page it
+			// redirects to computes it again anyway.
+			const model = await buildModel({
+				view: "repositories",
+				scope: parseScope(url),
+				...parseWindow(url),
+				skipReachability: true,
+			});
 			res.writeHead(302, { Location: model.repos.length === 0 ? "/repositories" : "/dashboard" });
 			res.end();
 			return;
@@ -914,10 +995,11 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 		// usually never opens. A read like every other GET here — no token.
 		if (url.pathname === "/api/context") {
 			const repo = url.searchParams.get("repo") ?? "";
-			const kind = url.searchParams.get("kind") ?? "";
+			const kindParam = url.searchParams.get("kind") ?? "";
 			const key = url.searchParams.get("key") ?? "";
-			if (!repo || !key || (kind !== "plan" && kind !== "note")) {
-				sendJson(res, 400, { error: "repo, kind (plan|note) and key are required" });
+			const kind = CONTEXT_DOC_KINDS.find((k) => k === kindParam);
+			if (!repo || !key || !kind) {
+				sendJson(res, 400, { error: `repo, kind (${CONTEXT_DOC_KINDS.join("|")}) and key are required` });
 				return;
 			}
 			try {

--- a/cli/src/dashboard/FeedCardAsset.test.ts
+++ b/cli/src/dashboard/FeedCardAsset.test.ts
@@ -17,6 +17,7 @@ interface JDNamespace {
 	renderStats: (model: unknown) => void;
 	scopeChip: (model: unknown) => string;
 	repoToken: (model: unknown, identity: string) => string;
+	withParams: (query: string, params: Record<string, string | undefined>) => string;
 }
 
 /** Minimal element stub: enough for the renderer to write into and be read back. */
@@ -128,6 +129,7 @@ function model(over: Record<string, unknown> = {}, statsOver: Record<string, unk
 				distinctMemoriesUsed: 0,
 				staleMemoriesUsed: 0,
 				sessionsWithContext: 0,
+				callsWithoutSession: 0,
 				sessionsInWindow: 0,
 				bySurface: [],
 				skillInvocations: 0,
@@ -165,7 +167,9 @@ describe("Memory Activity — memory tier", () => {
 		expect(html).toContain("3 turns");
 		expect(html).toContain("fix-auth-refresh");
 		expect(html).toContain("Open memory →");
-		expect(html).toContain("/memories?repo=https%3A%2F%2Fgithub.com%2Fjolliai%2Fjolliai&hash=h1");
+		// `detailRepo`, not `repo`: the link names which repo owns the memory
+		// without scoping the Memories tree to it (see wireTree in memories.js).
+		expect(html).toContain("&hash=h1&detailRepo=https%3A%2F%2Fgithub.com%2Fjolliai%2Fjolliai");
 		expect(html).toContain('" target="_blank" rel="noopener">Open memory →');
 		// The whole point of the runtime test: a renamed model field would show up here.
 		expect(html).not.toContain("undefined");
@@ -302,7 +306,7 @@ describe("Memory Activity", () => {
 		expect(app.innerHTML).toContain('aria-label="Memory Activity"');
 		expect(app.innerHTML).toContain('data-memory-activity-view="branch"');
 		expect(app.innerHTML).toContain('data-memory-activity-view="time"');
-		expect(app.innerHTML).toContain("/memories?repo=https%3A%2F%2Fgithub.com%2Fjolliai%2Fjolliai&hash=h1");
+		expect(app.innerHTML).toContain("&hash=h1&detailRepo=https%3A%2F%2Fgithub.com%2Fjolliai%2Fjolliai");
 		expect(app.innerHTML).toContain("Open memory →");
 	});
 });
@@ -394,11 +398,81 @@ describe("Recall card", () => {
 			daily: [{ date: "2026-07-30", used: 3, setAside: 1 }],
 		});
 		expect(html).toContain("3 used");
-		expect(html).toContain("<b>3</b> via the recall tool");
-		expect(html).toContain("<b>1</b> via the CLI");
-		expect(html).toContain("belongs to no session");
+		// The footnote is ONE line now — the coverage ratio. The surface split moved
+		// into the ⓘ's hover, as plain text (a `title` attribute renders no tags).
+		expect(html).toContain("<b>2</b> of 4 sessions got prior context");
+		expect(html).toContain("3 via the recall tool, 1 via the CLI");
+		expect(html).not.toContain("<b>3</b> via the recall tool");
+		// Two sessions DO account for the calls here, so the session-less caveat
+		// does not apply and must not be raised.
+		expect(html).not.toContain("belongs to no session");
 		expect(html).not.toContain("undefined");
 		expect(html).not.toContain("NaN");
+	});
+
+	it("raises the session-less caveat exactly when such a call exists", () => {
+		const withSessions = recallHtml({
+			usedCalls: 2,
+			setAsideCalls: 0,
+			contextServedPct: 100,
+			sessionsWithContext: 2,
+			callsWithoutSession: 0,
+			sessionsInWindow: 3,
+			bySurface: [{ surface: "cli", calls: 2 }],
+			daily: [{ date: "2026-07-30", used: 2, setAside: 0 }],
+		});
+		expect(withSessions).not.toContain("belonging to no session");
+		// `jolli recall` from a plain shell, or a host that publishes no session id.
+		const sessionless = recallHtml({
+			usedCalls: 2,
+			setAsideCalls: 0,
+			contextServedPct: 100,
+			sessionsWithContext: 0,
+			callsWithoutSession: 2,
+			sessionsInWindow: 3,
+			bySurface: [{ surface: "cli", calls: 2 }],
+			daily: [{ date: "2026-07-30", used: 2, setAside: 0 }],
+		});
+		expect(sessionless).toContain("2 recalls ran outside an agent session");
+	});
+
+	it("raises it in a MIXED window too — the case the old condition stayed silent for", () => {
+		// The condition used to be `sessionsWithContext === 0`, which reads as "no
+		// session claims these calls" but means "not ONE receipt names a session".
+		// A window with both kinds of call — the very situation the caveat exists to
+		// explain — therefore never showed it.
+		const mixed = recallHtml({
+			usedCalls: 5,
+			setAsideCalls: 0,
+			contextServedPct: 100,
+			sessionsWithContext: 3,
+			callsWithoutSession: 1,
+			sessionsInWindow: 4,
+			bySurface: [{ surface: "cli", calls: 5 }],
+			daily: [{ date: "2026-07-30", used: 5, setAside: 0 }],
+		});
+		expect(mixed).toContain("1 recall ran outside an agent session");
+	});
+
+	it("says `call is` for one receipt-less call and `calls are` for several", () => {
+		const one = recallHtml({
+			usedCalls: 1,
+			setAsideCalls: 0,
+			contextServedPct: 100,
+			callsWithoutReceipt: 1,
+			bySurface: [{ surface: "cli", calls: 1 }],
+			daily: [{ date: "2026-07-30", used: 1, setAside: 0 }],
+		});
+		expect(one).toContain("1 further call is in the transcripts");
+		const many = recallHtml({
+			usedCalls: 1,
+			setAsideCalls: 0,
+			contextServedPct: 100,
+			callsWithoutReceipt: 3,
+			bySurface: [{ surface: "cli", calls: 1 }],
+			daily: [{ date: "2026-07-30", used: 1, setAside: 0 }],
+		});
+		expect(many).toContain("3 further calls are in the transcripts");
 	});
 
 	it("flags skill runs that outnumber the recalls they were supposed to make", () => {
@@ -410,7 +484,8 @@ describe("Recall card", () => {
 			bySurface: [{ surface: "mcp", calls: 1 }],
 			daily: [{ date: "2026-07-30", used: 1, setAside: 0 }],
 		});
-		expect(html).toContain("more often than recall was actually called");
+		// In the hover detail now, and reworded to fit a plain-text attribute.
+		expect(html).toContain("the jolli-recall skill ran 4×, more often than recall was called");
 	});
 
 	it("stays quiet about the skill when every invocation did recall", () => {
@@ -423,5 +498,21 @@ describe("Recall card", () => {
 			daily: [{ date: "2026-07-30", used: 2, setAside: 0 }],
 		});
 		expect(html).not.toContain("more often than recall");
+	});
+});
+
+describe("JD.withParams (shell.js)", () => {
+	// The separator is the whole point: `JD.query` returns "" for an unscoped page
+	// and "?repo=…" for a scoped one, and appending "&hash=…" to the empty form
+	// produces a URL whose params are silently dropped.
+	it("opens the query string when there is none and extends it when there is", () => {
+		expect(JD.withParams("", { hash: "h1" })).toBe("?hash=h1");
+		expect(JD.withParams("?repo=jolliai", { hash: "h1" })).toBe("?repo=jolliai&hash=h1");
+	});
+	it("url-encodes values and drops empty ones", () => {
+		expect(JD.withParams("", { hash: "h1", detailRepo: "https://github.com/jolliai/jolliai" })).toBe(
+			"?hash=h1&detailRepo=https%3A%2F%2Fgithub.com%2Fjolliai%2Fjolliai",
+		);
+		expect(JD.withParams("?repo=x", { hash: "", detailRepo: undefined })).toBe("?repo=x");
 	});
 });

--- a/cli/src/dashboard/MemoriesQuery.test.ts
+++ b/cli/src/dashboard/MemoriesQuery.test.ts
@@ -491,6 +491,7 @@ describe("MemoriesQuery", () => {
 			});
 			const detail = await withDashboardDb((db) => buildMemoryDetail(db, ALL, hash), { dbPath });
 			expect(detail?.tokens).toEqual({
+				total: 1700,
 				input: 1000,
 				output: 500,
 				cached: 200,
@@ -500,7 +501,7 @@ describe("MemoriesQuery", () => {
 			expect(detail?.summarizedBy).toEqual({ model: "claude-haiku-4-5", tokens: 450 });
 		});
 
-		it("carries references, plans/notes as context, and excludedContext with its reason — and treats absent as empty, not missing", async () => {
+		it("carries plans, notes and references as one ordered context list, and excludedContext with its reason — and treats absent as empty, not missing", async () => {
 			await seedRepo(dbPath, "repo-1", "acme-api");
 			const hash = "a".repeat(40);
 			await seedMemory(dbPath, "repo-1", hash, "feat: x", {
@@ -524,22 +525,33 @@ describe("MemoriesQuery", () => {
 			const detail = await withDashboardDb((db) => buildMemoryDetail(db, ALL, hash), { dbPath });
 			expect(detail?.ticketId).toBe("ACME-1");
 			expect(detail?.recap).toBe("Added a token-bucket rate limiter with per-tenant overrides.");
-			expect(detail?.references).toEqual([
-				{ source: "linear", nativeId: "ACME-1", title: "Add rate limiting", url: "https://linear.app/x" },
-				{ source: "github", nativeId: "42", title: "PR #42" },
-			]);
-			// `contextKey` is the plan slug / note id — what the Context dialog
-			// fetches the body by.
+			// ONE ordered list, in the editor's Context-panel order: plans, notes,
+			// references, skills. `contextKey` is what the Context dialog fetches the
+			// body by — the plan slug, the note id, `<source>/<sanitized-key>` for a
+			// reference. A reference with no archivedKey has no document, so it
+			// carries no key and renders inert rather than as a button that 404s.
 			expect(detail?.context).toEqual([
-				{ kind: "plan", title: "Rate limiting plan", contextKey: "rate-limit-plan" },
-				{ kind: "note", title: "A note", contextKey: "n1" },
+				{
+					kind: "plan",
+					title: "Rate limiting plan",
+					contextKey: "rate-limit-plan",
+					meta: "rate-limit-plan.md",
+				},
+				{ kind: "note", title: "A note", contextKey: "n1", meta: "n1.md" },
+				{
+					kind: "reference",
+					// Leads with the nativeId: linear is a tracker whose key a reader recognizes.
+					title: "ACME-1 — Add rate limiting",
+					meta: "ACME-1 (Linear)",
+					url: "https://linear.app/x",
+				},
+				{ kind: "reference", title: "42 — PR #42", meta: "42 (GitHub)" },
 			]);
 			expect(detail?.excluded).toEqual([{ title: "Unrelated ticket", reason: "different feature area" }]);
 
 			const hash2 = "b".repeat(40);
 			await seedMemory(dbPath, "repo-1", hash2, "chore: y");
 			const bare = await withDashboardDb((db) => buildMemoryDetail(db, ALL, hash2), { dbPath });
-			expect(bare?.references).toEqual([]);
 			expect(bare?.context).toEqual([]);
 			expect(bare?.excluded).toEqual([]);
 		});
@@ -644,7 +656,7 @@ describe("MemoriesQuery", () => {
 				llm: { model: "claude-haiku-4-5", inputTokens: 300, outputTokens: 100 },
 			});
 			const detail = await withDashboardDb((db) => buildMemoryDetail(db, ALL, hash), { dbPath });
-			expect(detail?.tokens).toEqual({ input: 800, output: 400, cached: 0 });
+			expect(detail?.tokens).toEqual({ total: 1200, input: 800, output: 400, cached: 0 });
 			expect(detail?.summarizedBy).toEqual({ model: "claude-haiku-4-5", tokens: 400 });
 		});
 

--- a/cli/src/dashboard/MemoriesQuery.ts
+++ b/cli/src/dashboard/MemoriesQuery.ts
@@ -27,14 +27,22 @@
 import { inflateSync } from "node:zlib";
 
 import { groupArchivedSessions } from "../core/ArchivedConversations.js";
-import { formatMemoryRefId } from "../core/MemoryRefId.js";
+import { formatMemoryRefId, formatMemoryRefIdWithHashFallback } from "../core/MemoryRefId.js";
+import {
+	labelLeadsWithNativeId,
+	referenceDisplayTitle,
+	referenceSourceLabel,
+} from "../core/references/ReferenceDisplay.js";
+import { sanitizeNativeIdForPath } from "../core/references/ReferenceStore.js";
 import { firstUserMessageTitleFromEntries } from "../core/SessionTitleResolver.js";
+import { buildSkillsAggregateMarkdown, buildSkillsSummaryLabel } from "../core/SkillsAggregateMarkdown.js";
 import { assembleMemoryTree } from "../core/SqliteStorage.js";
 import {
 	aggregateConversationTokenBreakdown,
 	aggregateConversationTokens,
 	collectDisplayTopics,
 } from "../core/SummaryTree.js";
+import { estimateSummaryCostUsd } from "../core/TokenCost.js";
 import { TOOL_RECORDING_SOURCES } from "../core/TranscriptParser.js";
 import { createLogger, errMsg } from "../Logger.js";
 import type { CommitSummary, StoredTranscript } from "../Types.js";
@@ -45,13 +53,13 @@ import {
 	MEMORIES_PAGE_SIZE,
 	type MemoriesModel,
 	type MemoryActivityRow,
+	type MemoryContextKind,
 	type MemoryContextRow,
 	type MemoryConversationRow,
 	type MemoryDetail,
 	type MemoryExcludedRow,
 	type MemoryFileRow,
 	type MemoryListItem,
-	type MemoryReferenceRow,
 	type MemoryTopic,
 } from "./DashboardModel.js";
 import {
@@ -68,7 +76,8 @@ interface MemoryListRow {
 	readonly commit_hash: string;
 	readonly branch: string | null;
 	readonly commit_message: string | null;
-	readonly commit_date_ms: number;
+	/** The COALESCEd committer date — see {@link reachableMemoryRows}, not `memories.commit_date_ms`. */
+	readonly committed_at_ms: number;
 	readonly ticket_id: string | null;
 	readonly jolli_doc_id: number | null;
 	readonly repo_identity: string;
@@ -108,11 +117,20 @@ export function isReachable(reachable: ReachableCommits | undefined, repoIdentit
  * on the wire, not rows read.
  *
  * `commit_hash` is the second sort key, and it is load-bearing rather than
- * cosmetic: two memories can share a `commit_date_ms` to the millisecond (a
- * squash, a scripted series of commits), and the page cursor is a position in
- * THIS order. Ordering by the date alone leaves those rows in whatever order
- * SQLite happens to produce, so the same cursor could land on either side of the
- * pair between two requests — dropping one memory or repeating it.
+ * cosmetic: two memories can share a timestamp to the millisecond (a squash, a
+ * scripted series of commits), and the page cursor is a position in THIS order.
+ * Ordering by the date alone leaves those rows in whatever order SQLite happens
+ * to produce, so the same cursor could land on either side of the pair between
+ * two requests — dropping one memory or repeating it.
+ *
+ * The date is the COMMITTER date, falling back to the memory's own
+ * `commit_date_ms` only when no `commits` row exists yet — the same COALESCE
+ * `buildMemoryCards` uses, and for the same reason: `commit_date_ms` comes from
+ * `CommitSummary.commitDate`, which `GitOps.getHeadCommitInfo` reads with `%aI`
+ * (AUTHOR date), while `commits.committed_at_ms` is collected with `%cI`. Two
+ * clocks means a rebased or cherry-picked memory sorts — and renders its
+ * timestamp — differently in the tree than in the Stats feed listing the very
+ * same memory.
  */
 function reachableMemoryRows(
 	db: DashboardDbHandle,
@@ -122,13 +140,15 @@ function reachableMemoryRows(
 	const listFilter = scopeFilter(resolved, "m.repo_id");
 	const allRows = db
 		.prepare(
-			`SELECT m.commit_hash, m.branch, m.commit_message, m.commit_date_ms, m.ticket_id, m.jolli_doc_id,
+			`SELECT m.commit_hash, m.branch, m.commit_message, m.ticket_id, m.jolli_doc_id,
+			        COALESCE(cm.committed_at_ms, m.commit_date_ms) AS committed_at_ms,
 			        r.repo_identity, r.repo_name
 			   FROM memories m
 			   JOIN repos r ON r.id = m.repo_id
+			   LEFT JOIN commits cm ON cm.repo_id = m.repo_id AND cm.hash = m.commit_hash
 			  WHERE m.parent_hash IS NULL
 				${listFilter.sql}
-			  ORDER BY m.commit_date_ms DESC, m.commit_hash DESC`,
+			  ORDER BY COALESCE(cm.committed_at_ms, m.commit_date_ms) DESC, m.commit_hash DESC`,
 		)
 		.all(...listFilter.params) as ReadonlyArray<MemoryListRow>;
 	return allRows.filter((row) => isReachable(reachable, row.repo_identity, row.commit_hash));
@@ -245,7 +265,7 @@ function toListItems(
 			...(memoryRefId ? { memoryRefId } : {}),
 			title: row.commit_message ?? "",
 			...(row.branch ? { branch: row.branch } : {}),
-			committedAtMs: row.commit_date_ms,
+			committedAtMs: row.committed_at_ms,
 			...(row.ticket_id ? { ticketId: row.ticket_id } : {}),
 			...(category ? { category } : {}),
 			synced: row.jolli_doc_id != null,
@@ -428,6 +448,95 @@ function buildActivity(
 	return { activity, uncoveredSources };
 }
 
+/**
+ * `context.context_key` for an archived reference, or undefined when it cannot
+ * be derived.
+ *
+ * Must reproduce `SummaryStore.orphanPathFor` minus the `references/` prefix and
+ * the `.md` suffix, because that path is exactly what `SotImport` files the
+ * document under. Re-derived here rather than exported from there because the
+ * only thing this page needs is the key, and the writer's copy carries a
+ * throw-on-unknown-source guard that is correct for a WRITE and wrong for a read
+ * path: a reference whose source has since left the registry must render as a
+ * plain row, not blow up the whole memory detail. Hence the catch — both
+ * `sanitizeNativeIdForPath`'s traversal guard and an unregistered source land
+ * there and mean the same thing: no document to open.
+ */
+function referenceDocKey(source: string, archivedKey: string | undefined): string | undefined {
+	// An archived reference always carries the key; a hand-written or pre-archive
+	// row may not, and there is no document to open without one.
+	if (!archivedKey) return undefined;
+	const prefix = `${source}:`;
+	const bareKey = archivedKey.startsWith(prefix) ? archivedKey.slice(prefix.length) : archivedKey;
+	try {
+		return `${source}/${sanitizeNativeIdForPath(source, bareKey)}`;
+	} catch (err) {
+		log.debug("no reference doc key for %s: %s", archivedKey, errMsg(err));
+		return undefined;
+	}
+}
+
+/**
+ * The memory's Context list, in the editor's order: plans, notes, references,
+ * then the single skills row.
+ *
+ * The order and the per-kind display rules are the editor's, not this page's —
+ * `referenceDisplayTitle` decides whether a reference leads with its issue key,
+ * and `buildSkillsSummaryLabel` writes the aggregate line. Both are the same CLI
+ * helpers `SummaryHtmlBuilder` calls, so the two surfaces cannot drift into
+ * describing the same memory differently.
+ *
+ * The skills row is ONE row keyed by the commit hash, not one row per skill:
+ * its document is the whole `skills--<hash8>` table, rendered from the summary
+ * on demand (see {@link readContextDoc}).
+ */
+function buildContextRows(summary: CommitSummary): ReadonlyArray<MemoryContextRow> {
+	const skills = summary.skills ?? [];
+	const inferred = skills.some((s) => s.detection === "heuristic") ? " · some inferred" : "";
+	return [
+		// The plan slug is already the archived `slug-hash8` form here, and the
+		// note id already carries its archive suffix — both are the filed key.
+		...(summary.plans ?? []).map((p) => ({
+			kind: "plan" as const,
+			title: p.title,
+			contextKey: p.slug,
+			meta: `${p.slug}.md`,
+		})),
+		...(summary.notes ?? []).map((n) => ({
+			kind: "note" as const,
+			title: n.title,
+			contextKey: n.id,
+			meta: `${n.id}.md`,
+		})),
+		...(summary.references ?? []).map((r) => {
+			const key = referenceDocKey(r.source, r.archivedKey);
+			// Same slot rule as the editor's reference row: the `<nativeId> (Source)`
+			// line is meaningful only for the trackers whose key a reader recognizes;
+			// an accumulating source claims the slot for its newest query instead.
+			const meta = labelLeadsWithNativeId(r.source)
+				? `${r.nativeId} (${referenceSourceLabel(r.source)})`
+				: (r.latestQuery ?? "");
+			return {
+				kind: "reference" as const,
+				title: referenceDisplayTitle(r),
+				...(key ? { contextKey: key } : {}),
+				...(meta ? { meta } : {}),
+				...(r.url ? { url: r.url } : {}),
+			};
+		}),
+		...(skills.length > 0
+			? [
+					{
+						kind: "skills" as const,
+						title: "Skills used",
+						contextKey: summary.commitHash,
+						meta: `${buildSkillsSummaryLabel(skills)}${inferred}`,
+					},
+				]
+			: []),
+	];
+}
+
 /** One memory's full detail, or undefined when `hash` does not resolve within `scope`. */
 export function buildMemoryDetail(
 	db: DashboardDbHandle,
@@ -506,19 +615,7 @@ export function buildMemoryDetail(
 		files: t.filesAffected ?? [],
 	}));
 
-	const references: MemoryReferenceRow[] = (summary.references ?? []).map((r) => ({
-		source: r.source,
-		nativeId: r.nativeId,
-		title: r.title,
-		...(r.url ? { url: r.url } : {}),
-	}));
-	// `contextKey` is what `readContextDoc` looks the body up by, and it must be
-	// the key `SotImport` filed the document under: the plan's slug (already the
-	// archived `slug-hash` form here) and the note's id.
-	const context: MemoryContextRow[] = [
-		...(summary.plans ?? []).map((p) => ({ kind: "plan" as const, title: p.title, contextKey: p.slug })),
-		...(summary.notes ?? []).map((n) => ({ kind: "note" as const, title: n.title, contextKey: n.id })),
-	];
+	const context = buildContextRows(summary);
 	const excluded: MemoryExcludedRow[] = (summary.excludedContext ?? []).map((e) => ({
 		title: e.title,
 		reason: e.reason,
@@ -531,19 +628,35 @@ export function buildMemoryDetail(
 	// conversation tokens on the folded children, so the root's own breakdown
 	// understates the total — here by 5x on a three-commit chain.
 	//
-	// `costUsd` stays the root's own `estimatedCostUsd` rather than a sum: the
-	// field is a per-node estimate at that node's `pricesAsOf`, and adding
-	// figures stamped at different price tables would invent a number no node
-	// agrees with. The editor prices the aggregate from `conversationModels`
-	// instead, which needs the price table this query has no business loading.
+	// `costUsd` is the SAME tree walk the editor's meter runs
+	// (`estimateSummaryCostUsd`), not the root's own `estimatedCostUsd`. Reading
+	// the root alone priced only the tip of a consolidation while the headline
+	// beside it counted every folded node's tokens: measured ≈$2.59 here against
+	// ≈$27.61 in the editor for one commit, with identical 3.1M token figures on
+	// both. The objection that stored per-node costs carry different `pricesAsOf`
+	// stamps is real but does not justify a number nothing agrees with — the
+	// shared helper sums them the same way on every surface, and `pricesAsOf`
+	// stays the root's stamp, which is what the "est. at <date> prices" note has
+	// always meant.
 	const breakdown = aggregateConversationTokenBreakdown(summary);
+	const cost = estimateSummaryCostUsd(summary);
+	// The headline is the editor's `aggregateConversationTokens`, which is NOT
+	// the segment sum: a folded session reporting a scalar count with no
+	// breakdown lands in it and in no segment. The segment-sum fallback covers
+	// the one shape that aggregate cannot describe — a memory carrying a
+	// breakdown but no scalar count, which this page has always rendered
+	// (the editor's meter shows its "not reported" state there instead) and
+	// which would otherwise print a 0 headline above a populated bar.
+	const segmentSum = breakdown.input + breakdown.output + breakdown.cached;
+	const totalTokens = aggregateConversationTokens(summary) || segmentSum;
 	const tokens =
-		aggregateConversationTokens(summary) > 0 || summary.conversationTokenBreakdown
+		totalTokens > 0 || summary.conversationTokenBreakdown
 			? {
+					total: totalTokens,
 					input: breakdown.input,
 					output: breakdown.output,
 					cached: breakdown.cached,
-					...(summary.estimatedCostUsd != null ? { costUsd: summary.estimatedCostUsd } : {}),
+					...(cost.usd > 0 ? { costUsd: cost.usd } : {}),
 					...(summary.pricesAsOf ? { pricesAsOf: summary.pricesAsOf } : {}),
 				}
 			: undefined;
@@ -559,6 +672,14 @@ export function buildMemoryDetail(
 		repoName: row.repo_name,
 		commitHash: row.commit_hash,
 		shortHash: row.commit_hash.slice(0, 7),
+		// Always present, hash-derived until the memory syncs — the editor's page
+		// title carries the same `JM-…` handle on every memory
+		// (`buildPageTitleAndMetaStrip`), so the two surfaces name the same memory
+		// the same way instead of one showing a bare commit message.
+		memoryRefId: formatMemoryRefIdWithHashFallback(
+			row.jolli_doc_id == null ? undefined : Number(row.jolli_doc_id),
+			row.commit_hash,
+		),
 		title: row.commit_message ?? "",
 		...(row.branch ? { branch: row.branch } : {}),
 		...(row.commit_author ? { author: row.commit_author } : {}),
@@ -573,7 +694,6 @@ export function buildMemoryDetail(
 		...(summarizedBy ? { summarizedBy } : {}),
 		...(summary.recap ? { recap: summary.recap } : {}),
 		conversations: buildConversations(db, row.repo_id, hash),
-		references,
 		context,
 		excluded,
 		activity,
@@ -589,21 +709,45 @@ export function buildMemoryDetail(
 	};
 }
 
-/** The full Memories page payload: the list, plus the selected memory's detail when `hash` resolves. */
+/**
+ * The full Memories page payload: the list, plus the selected memory's detail
+ * when `hash` resolves.
+ *
+ * `detailRepoIdentity` disambiguates the DETAIL only and deliberately does not
+ * touch `scope`. Opening a memory used to carry the owning repo in `?repo=`,
+ * which is the page-wide scope param — so clicking any row collapsed the tree to
+ * that one repository, and the reader lost every other repo's memories as the
+ * price of opening one. The two questions are separate: which repo owns the hash
+ * (needed only when two clones share it) and which repos the tree lists.
+ */
 export function buildMemories(
 	db: DashboardDbHandle,
 	scope: DashboardScope,
 	hash: string | undefined,
 	reachable?: ReachableCommits,
+	detailRepoIdentity?: string,
 ): MemoriesModel {
 	const list = buildMemoriesList(db, scope, reachable);
 	if (!hash) return list;
-	const selected = buildMemoryDetail(db, scope, hash);
+	// Through `resolveScope`, because the link carries whatever `JD.repoToken`
+	// picked — usually the repo NAME, since that is the readable token. Handing a
+	// name straight to `buildMemoryDetail` resolves to repo id -1 (matches
+	// nothing), so the tree row navigated to a page whose detail pane stayed
+	// empty: the click looked like it did nothing at all.
+	const detailScope: DashboardScope = detailRepoIdentity
+		? resolveScope(db, { kind: "repo", repoIdentity: detailRepoIdentity })
+		: scope;
+	// A token that resolves to no repo means the link is stale (repo removed, or
+	// renamed since the page was rendered). Fall back to the page scope rather
+	// than to a filter that matches nothing — the hash still identifies the
+	// memory, and showing it is strictly better than showing an empty pane.
+	const detail = scopeToRepoId(db, detailScope).repoId === -1 ? scope : detailScope;
+	const selected = buildMemoryDetail(db, detail, hash);
 	return selected ? { ...list, selected } : list;
 }
 
 /**
- * One plan/note body, for the Context viewer dialog.
+ * One context body, for the Context viewer dialog.
  *
  * Scoped to a repo but NOT to a commit: the same plan backs several memories,
  * and the caller already knows which row was clicked. `repoToken` goes through
@@ -611,17 +755,26 @@ export function buildMemories(
  * does — a full identity or a unique repo name — instead of being the one
  * endpoint that silently 404s on a name.
  *
+ * `skills` is the one kind that is RENDERED rather than read: its per-commit
+ * table is not a stored document at all (the `skills--<hash8>.md` file exists
+ * only in the Memory Bank's visible layer, which orphan-branch-only installs
+ * never write), so it is built from the summary with the same renderer that
+ * wrote that file — exactly what `jollimemory.previewCommittedSkills` does in
+ * the editor. Its `contextKey` is therefore the commit hash, not a `context`
+ * row key.
+ *
  * Returns undefined for an unknown repo/kind/key rather than throwing, so the
  * route can answer 404 without special-casing.
  */
 export function readContextDoc(
 	db: DashboardDbHandle,
 	repoToken: string,
-	kind: "plan" | "note",
+	kind: MemoryContextKind,
 	contextKey: string,
 ): ContextDoc | undefined {
 	const { repoId } = scopeToRepoId(db, resolveScope(db, { kind: "repo", repoIdentity: repoToken }));
 	if (repoId == null) return undefined;
+	if (kind === "skills") return readSkillsDoc(db, repoId, contextKey);
 	const row = db
 		.prepare(
 			`SELECT c.title, c.body_md
@@ -632,4 +785,26 @@ export function readContextDoc(
 		.get(repoId, kind, contextKey) as { title: string | null; body_md: string } | undefined;
 	if (!row) return undefined;
 	return { kind, title: row.title ?? contextKey, bodyMd: row.body_md };
+}
+
+/**
+ * The skills table for one commit, rendered from its summary.
+ *
+ * Reads the TREE, matching {@link buildMemoryDetail}: the row that opened this
+ * dialog was built from the assembled tree, so reading the bare row here could
+ * answer with a different skill set than the row's own count line claims.
+ */
+function readSkillsDoc(db: DashboardDbHandle, repoId: number, commitHash: string): ContextDoc | undefined {
+	const row = db
+		.prepare("SELECT summary_json FROM memories WHERE repo_id = ? AND commit_hash = ? LIMIT 1")
+		.get(repoId, commitHash) as { summary_json: string } | undefined;
+	if (!row) return undefined;
+	const summary = (assembleMemoryTree(db, repoId, commitHash) ?? JSON.parse(row.summary_json)) as CommitSummary;
+	const skills = summary.skills ?? [];
+	if (skills.length === 0) return undefined;
+	return {
+		kind: "skills",
+		title: `Skills used — ${commitHash.substring(0, 8)}`,
+		bodyMd: buildSkillsAggregateMarkdown(summary, skills),
+	};
 }

--- a/cli/src/dashboard/ProducerHooks.ts
+++ b/cli/src/dashboard/ProducerHooks.ts
@@ -211,19 +211,52 @@ export async function recordRecallReceipt(
 }
 
 /**
- * The agent session this process is running inside, when one advertised
- * itself in the environment.
+ * Environment variables that carry the id of the agent session this process is
+ * running inside, most-specific first.
  *
- * Only Claude Code publishes a session id today (`CLAUDE_CODE_SESSION_ID`,
- * the same uuid `sessions.session_id` carries, so a receipt joins straight
- * onto the session row). Every other host, and a plain terminal, yields
- * undefined — which is the honest answer, not a gap to paper over: a recall
- * typed at a shell prompt genuinely belongs to no session, and attributing it
- * to a guessed one would corrupt the coverage figure the Recall card reads.
+ * **One entry, and that is a measured result rather than an unfinished list.**
+ * Claude Code exports `CLAUDE_CODE_SESSION_ID`, and it is the same uuid
+ * `sessions.session_id` carries, so a receipt written from it joins straight
+ * onto the session row (verified against a live session). The other hosts were
+ * checked the only way that settles it — reading `/proc/<pid>/environ` of a
+ * running one — and they publish nothing usable:
+ *
+ *   - **codex**: the whole environment carries no session/conversation/thread
+ *     variable; the only codex-specific entry is
+ *     `CODEX_INTERNAL_ORIGINATOR_OVERRIDE`, which names the front-end, not the
+ *     session. Its session id exists only inside its own rollout files.
+ *
+ * So a recall from those hosts writes no session id, and that is the honest
+ * answer rather than a gap to paper over — see the note below on why the
+ * tempting fallback is worse than the blank.
+ *
+ * Adding a host means measuring it the same way and appending its real variable
+ * name here; nothing else changes.
+ */
+const SESSION_ID_ENV_VARS: ReadonlyArray<string> = ["CLAUDE_CODE_SESSION_ID"];
+
+/**
+ * The agent session this process is running inside, when one advertised itself
+ * in the environment.
+ *
+ * Undefined for a plain terminal and for every host in the note above. That
+ * costs real coverage — a recall from codex or cline can never be counted among
+ * the sessions that got prior context — and it is still the right answer,
+ * because the available fallback is to pick the most recently touched session
+ * for this repo, which is a GUESS that looks exactly like a fact once stored.
+ * The Recall card's coverage figure would then be wrong in the one direction
+ * nobody can audit: attributing a call to a session that never made it.
+ *
+ * A null is visible as a null; an invented id is not. (The coverage denominator
+ * treats a session-less receipt as belonging to no session, deliberately — see
+ * `buildRecallUsage`'s union.)
  */
 function currentAgentSessionId(): string | undefined {
-	const id = process.env.CLAUDE_CODE_SESSION_ID?.trim();
-	return id ? id : undefined;
+	for (const name of SESSION_ID_ENV_VARS) {
+		const id = process.env[name]?.trim();
+		if (id) return id;
+	}
+	return undefined;
 }
 
 /**

--- a/cli/src/dashboard/Recovery.test.ts
+++ b/cli/src/dashboard/Recovery.test.ts
@@ -4,9 +4,9 @@
  * sidecar-clearing, and re-runnable.
  */
 
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { JolliMemoryConfig } from "../Types.js";
 import { formatUtcStamp, maybeSnapshot } from "./Backup.js";
@@ -284,13 +284,51 @@ describe("restoreFromSnapshot", () => {
 		expect((await restoreFromSnapshot(snap, { dbPath, force: true })).status).toBe("restored");
 		// The dead database's sidecars are gone — nothing to replay over the
 		// restored file — and the result opens as a working database.
-		const { existsSync } = await import("node:fs");
 		expect(existsSync(`${dbPath}-wal`)).toBe(false);
 		const repos = await withDashboardDb(
 			(db) => db.prepare("SELECT repo_name FROM repos").all() as { repo_name: string }[],
 			{ dbPath },
 		);
 		expect(repos).toEqual([{ repo_name: "r" }]);
+	});
+
+	it("sweeps a dead run's restore temp but leaves a live one alone", async () => {
+		// The temp name carries a PID + nonce so two overlapping recoveries cannot
+		// rename each other's half-copied file over the live database. The cost of
+		// that uniqueness is that nothing overwrites the previous run's leftover any
+		// more: a restore killed between the copy and the rename (no throw, so no
+		// catch) used to leave a database-sized file behind forever.
+		const snap = await makeRealSnapshot();
+		const folder = dirname(dbPath);
+		const dead = join(folder, `.${basename(dbPath)}.restore-999999999-deadbeef.tmp`);
+		const live = join(folder, `.${basename(dbPath)}.restore-${process.pid}-cafebabe.tmp`);
+		const unrelated = join(folder, "notes.tmp");
+		for (const p of [dead, live, unrelated]) writeFileSync(p, "leftover");
+
+		expect((await restoreFromSnapshot(snap, { dbPath, force: true })).status).toBe("restored");
+
+		expect(existsSync(dead)).toBe(false);
+		// Another restore in flight — the whole reason the PID is in the name.
+		expect(existsSync(live)).toBe(true);
+		expect(existsSync(unrelated)).toBe(true);
+	});
+
+	it("sweeps an ancient temp even when its PID reads as alive (PID reuse)", async () => {
+		// A leftover only exists because its writer DIED, so its PID is free to be
+		// reused — and once it is, the PID gate says "alive" about an unrelated
+		// process and the file would be skipped forever. Age is the second half of
+		// the pair: this one carries THIS process's pid (maximally alive) and an
+		// mtime two hours back.
+		const snap = await makeRealSnapshot();
+		const folder = dirname(dbPath);
+		const ancient = join(folder, `.${basename(dbPath)}.restore-${process.pid}-0ldbeef0.tmp`);
+		writeFileSync(ancient, "leftover");
+		const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+		utimesSync(ancient, twoHoursAgo, twoHoursAgo);
+
+		expect((await restoreFromSnapshot(snap, { dbPath, force: true })).status).toBe("restored");
+
+		expect(existsSync(ancient)).toBe(false);
 	});
 
 	it("never restores from a corrupt snapshot and reports missing files", async () => {

--- a/cli/src/dashboard/Recovery.ts
+++ b/cli/src/dashboard/Recovery.ts
@@ -23,6 +23,7 @@ import { randomUUID } from "node:crypto";
 import { copyFileSync, existsSync, readdirSync, readFileSync, renameSync, rmSync, statSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import { peekKBPath } from "../core/KBPathResolver.js";
+import { isPidAlive } from "../core/LockPrimitives.js";
 import { toForwardSlash } from "../core/PathUtils.js";
 import { loadConfig } from "../core/SessionTracker.js";
 import type { StorageKind, StorageProvider } from "../core/StorageProvider.js";
@@ -245,6 +246,66 @@ export async function fillMemoriesFromMirrors(
 	return { repos, nodes, skipped };
 }
 
+/**
+ * A restore temp older than this is swept even though its PID looks alive.
+ *
+ * The PID gate alone cannot be the whole answer, because a leftover only exists
+ * when its writer DIED between the copy and the rename — so by the time anything
+ * sweeps, that PID is free to have been reused, and once it is, `isPidAlive`
+ * says "alive" about an unrelated process and the file is skipped forever. On a
+ * machine that recycles PIDs quickly (a busy container) the leftover is a
+ * database-sized file nothing will ever remove. A live restore is a file copy
+ * plus one `integrity_check`, so an hour is orders of magnitude past the longest
+ * honest one — and being wrong here costs a concurrent restore its temp copy,
+ * which fails that restore's own verify and leaves the live database untouched.
+ */
+const RESTORE_TEMP_MAX_AGE_MS = 60 * 60 * 1000;
+
+/**
+ * Whether a temp is old enough to override its PID looking alive. An unreadable
+ * mtime answers NO — the file is then left to the PID gate, which is the
+ * conservative half of the pair.
+ */
+function isOlderThanMaxAge(path: string, nowMs: number): boolean {
+	try {
+		return nowMs - statSync(path).mtimeMs > RESTORE_TEMP_MAX_AGE_MS;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Removes `.<db>.restore-<pid>-<nonce>.tmp` files whose writer is gone.
+ *
+ * Best-effort by design: a leftover is wasted disk, never a correctness problem,
+ * so an unreadable directory or an undeletable file is logged and ignored rather
+ * than failing a recovery. A file whose PID is still alive AND is younger than
+ * {@link RESTORE_TEMP_MAX_AGE_MS} is another restore in flight (`isPidAlive`
+ * also treats EPERM as alive) and is never touched — that is what the PID in the
+ * name is for. A name without a parseable PID is swept: only this function's own
+ * format matches the prefix, and `isPidAlive` reports a non-numeric owner as
+ * dead.
+ */
+function sweepDeadRestoreTemps(folder: string, dbName: string): void {
+	const nowMs = Date.now();
+	const prefix = `.${dbName}.restore-`;
+	try {
+		for (const name of readdirSync(folder)) {
+			if (!name.startsWith(prefix) || !name.endsWith(".tmp")) continue;
+			const pid = name.slice(prefix.length, -".tmp".length).split("-")[0] ?? "";
+			if (isPidAlive(pid) && !isOlderThanMaxAge(join(folder, name), nowMs)) continue;
+			try {
+				rmSync(join(folder, name), { force: true });
+				log.info("removed abandoned restore temp %s", name);
+			} catch (err) {
+				log.debug("could not remove restore temp %s: %s", name, errMsg(err));
+			}
+		}
+	} catch (err) {
+		log.debug("could not scan %s for restore temps: %s", folder, errMsg(err));
+	}
+}
+
 export type RestoreResult =
 	| { readonly status: "restored"; readonly from: string }
 	| { readonly status: "refused"; readonly reason: string }
@@ -284,6 +345,13 @@ export async function restoreFromSnapshot(
 		// from. `Backup.ts` carries the same suffix after being bitten by exactly
 		// this; here the blast radius is a corrupt database rather than a missed
 		// snapshot.
+		// The flip side of a unique name: nothing overwrites the previous run's
+		// leftover any more, so it has to be swept. A restore killed between the
+		// copy and the rename (the `try/catch` only covers a THROWN failure) leaves
+		// a database-sized file behind, and the only thing that used to remove it
+		// was the fixed name being reused. Swept by PID, so a concurrent restore's
+		// temp — the whole reason the name carries one — is left alone.
+		sweepDeadRestoreTemps(dirname(dbPath), basename(dbPath));
 		const temp = join(
 			dirname(dbPath),
 			`.${basename(dbPath)}.restore-${process.pid}-${randomUUID().slice(0, 8)}.tmp`,

--- a/cli/src/dashboard/SotSchema.ts
+++ b/cli/src/dashboard/SotSchema.ts
@@ -450,6 +450,43 @@ ALTER TABLE events_raw ADD COLUMN failed_kind TEXT;
 `;
 
 /**
+ * When the last call in a `session_tool_use` bucket was made.
+ *
+ * A tool call is an event with its own instant, but this table had none — so
+ * every query over it had to borrow a time from elsewhere, and both candidates
+ * are wrong in a way that shows up on the Recall card:
+ *
+ *  - the SESSION's `updated_at_ms` (what the queries used) moves whenever the
+ *    conversation is touched again, so a recall made three weeks ago counts as
+ *    today's, while today's recall inside a long-running session counts as
+ *    whenever that session started;
+ *  - a COMMIT's date has no relationship to a tool call at all — an agent turn
+ *    may precede its commit by hours, follow it, or never produce one. It is
+ *    the right clock for `commits`, and a category error here.
+ *
+ * So: the call's own time, taken from the transcript line that recorded it
+ * (`ToolCallCount.lastCallAtMs`).
+ *
+ * NULLABLE, and permanently so. A bucket is written by whichever parser read the
+ * session, and not every source's transcript offers a per-call timestamp (see
+ * `TOOL_CALL_TIME_SOURCES`); rows written before this column existed are NULL
+ * too, and nothing can backfill them — the transcripts they came from may be
+ * gone. Every consumer therefore reads it as `COALESCE(last_call_at_ms,
+ * sessions.updated_at_ms)`: the old, coarse behaviour survives exactly where the
+ * better answer is unavailable, instead of the row dropping out of a window
+ * because its time is unknown.
+ *
+ * LAST rather than first, one instant per bucket: a bucket counts N calls of one
+ * tool in one session, so a bucket straddling a window edge lands wholly in the
+ * window of its last call. Per-call rows would be a different table; the error
+ * here is bounded by one session's own span rather than by how long ago that
+ * session was last touched.
+ */
+export const TOOL_CALL_TIME_DDL = `
+ALTER TABLE session_tool_use ADD COLUMN last_call_at_ms INTEGER;
+`;
+
+/**
  * The memory tables, `context`, plan progress and the topic KB.
  *
  * Applied as one statement batch inside the caller's transaction. Ordering

--- a/cli/src/dashboard/StandupAsset.test.ts
+++ b/cli/src/dashboard/StandupAsset.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Runtime smoke test for the Standup board renderer.
+ *
+ * Same reason as `FeedCardAsset.test.ts`: `assets/js/*.js` is plain JavaScript
+ * served verbatim, so tsc never sees it and a model field read under the wrong
+ * name renders "undefined" in the browser with no compile-time signal.
+ *
+ * What it pins here is the author-filter disclosure. The board's columns feed a
+ * Copy-as-standup draft the user posts as their own work, so "filtered to you"
+ * and "could not tell who you are, showing everyone" must be distinguishable ON
+ * THE PAGE — a silent unfiltered board is how a teammate's commit ends up in
+ * someone else's standup.
+ */
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+interface JDNamespace {
+	renderStandup: (model: unknown) => void;
+	standupMarkdown: (model: unknown) => string;
+}
+
+interface FakeElement {
+	innerHTML: string;
+	textContent: string;
+	value: string;
+	style: Record<string, string>;
+	onclick?: () => void;
+	classList: { add: (c: string) => void; remove: (c: string) => void; contains: (c: string) => boolean };
+	focus: () => void;
+	select: () => void;
+	querySelectorAll: () => ReadonlyArray<never>;
+	querySelector: () => null;
+	addEventListener: () => void;
+}
+
+/** Evaluates format.js → shell.js → standup.js in load order against a stub DOM. */
+function loadJD(): { JD: JDNamespace; element: (id: string) => FakeElement } {
+	const elements = new Map<string, FakeElement>();
+	const make = (): FakeElement => {
+		const classes = new Set<string>();
+		return {
+			innerHTML: "",
+			textContent: "",
+			value: "",
+			style: {},
+			classList: {
+				add: (c: string) => void classes.add(c),
+				remove: (c: string) => void classes.delete(c),
+				contains: (c: string) => classes.has(c),
+			},
+			focus: () => undefined,
+			select: () => undefined,
+			querySelectorAll: () => [],
+			querySelector: () => null,
+			addEventListener: () => undefined,
+		};
+	};
+	const doc = {
+		getElementById: (id: string) => {
+			if (!elements.has(id)) elements.set(id, make());
+			return elements.get(id);
+		},
+		querySelectorAll: () => [],
+		addEventListener: () => undefined,
+		createElement: make,
+		body: make(),
+	};
+	const win = { JD: {}, document: doc, addEventListener: () => undefined } as Record<string, unknown>;
+	for (const file of ["format.js", "shell.js", "standup.js"]) {
+		const src = readFileSync(new URL(`./assets/js/${file}`, import.meta.url), "utf8");
+		new Function("window", "document", src)(win, doc);
+	}
+	return { JD: win.JD as unknown as JDNamespace, element: (id) => doc.getElementById(id) as FakeElement };
+}
+
+const nowMs = Date.parse("2026-07-30T12:00:00Z");
+
+function model(standupOver: Record<string, unknown> = {}): unknown {
+	return {
+		schemaVersion: 1,
+		view: "standup",
+		tier: "memory",
+		generatedAtMs: nowMs,
+		timeZone: "UTC",
+		scope: { kind: "all" },
+		repos: [],
+		usage: { available: false },
+		standup: {
+			today: "2026-07-30",
+			yesterday: "2026-07-29",
+			yesterdaySessions: [],
+			yesterdayCommits: [
+				{
+					hash: "abc1234def",
+					message: "feat: my work",
+					committedAtMs: nowMs - 26 * 3_600_000,
+					repoName: "jolliai",
+					branch: "main",
+				},
+			],
+			todaySessions: [],
+			todayCommits: [],
+			workspaces: [],
+			insights: [],
+			...standupOver,
+		},
+	};
+}
+
+describe("standup author disclosure", () => {
+	it("names the identity the board was filtered to", () => {
+		const { JD, element } = loadJD();
+		JD.renderStandup(model({ authoredBy: "me@example.com" }));
+		expect(element("app").innerHTML).toContain("yours only");
+		expect(element("app").innerHTML).toContain("me@example.com");
+	});
+
+	it("says the board is unfiltered when no identity was resolved", () => {
+		const { JD, element } = loadJD();
+		JD.renderStandup(model());
+		expect(element("app").innerHTML).toContain("every author");
+		expect(element("app").innerHTML).not.toContain("yours only");
+	});
+
+	it("warns in the draft sheet before an unfiltered standup is copied", () => {
+		const { JD, element } = loadJD();
+		JD.renderStandup(model());
+		element("copyStandup").onclick?.();
+		// The warning outranks the tier note: what you are about to paste matters
+		// more than which layer the lines came from.
+		expect(element("sheetSub").textContent).toContain("Every author's commits");
+		expect(element("mdOut").value).toContain("feat: my work");
+	});
+
+	it("keeps the memory-tier note once the board IS filtered", () => {
+		const { JD, element } = loadJD();
+		JD.renderStandup(model({ authoredBy: "me@example.com" }));
+		element("copyStandup").onclick?.();
+		expect(element("sheetSub").textContent).toContain("From your commit memories");
+	});
+});

--- a/cli/src/dashboard/StatsWriter.ts
+++ b/cli/src/dashboard/StatsWriter.ts
@@ -603,12 +603,19 @@ function projectSession(db: DashboardDbHandle, event: SessionUpsertedEvent): voi
 	if (event.tools !== undefined) {
 		db.prepare("DELETE FROM session_tool_use WHERE session_event_id = ?").run(eventId);
 		const insertTool = db.prepare(
-			`INSERT INTO session_tool_use (session_event_id, tool_name, kind, server, calls)
-			 VALUES (?, ?, ?, ?, ?)
-			 ON CONFLICT(session_event_id, tool_name, kind) DO UPDATE SET calls = excluded.calls`,
+			`INSERT INTO session_tool_use (session_event_id, tool_name, kind, server, calls, last_call_at_ms)
+			 VALUES (?, ?, ?, ?, ?, ?)
+			 ON CONFLICT(session_event_id, tool_name, kind) DO UPDATE SET calls = excluded.calls,
+			     -- MAX, not the excluded value: a re-read of the same session by a parser
+			     -- that cannot stamp a time (or an older build) would otherwise erase an
+			     -- instant a better read already recorded, and NULL is the one value this
+			     -- column cannot recover from: the transcript slice it came from is
+			     -- behind a cursor by then.
+			     last_call_at_ms = MAX(COALESCE(excluded.last_call_at_ms, 0),
+			                           COALESCE(session_tool_use.last_call_at_ms, 0))`,
 		);
 		for (const tool of event.tools) {
-			insertTool.run(eventId, tool.name, tool.kind, tool.server ?? null, tool.calls);
+			insertTool.run(eventId, tool.name, tool.kind, tool.server ?? null, tool.calls, tool.lastCallAtMs ?? null);
 		}
 	}
 }
@@ -801,9 +808,11 @@ function projectCommitSummary(db: DashboardDbHandle, event: CommitSummaryEvent):
 		);
 		const deleteTools = db.prepare("DELETE FROM session_tool_use WHERE session_event_id = ?");
 		const insertTool = db.prepare(
-			`INSERT INTO session_tool_use (session_event_id, tool_name, kind, server, calls)
-			 VALUES (?, ?, ?, ?, ?)
-			 ON CONFLICT(session_event_id, tool_name, kind) DO UPDATE SET calls = excluded.calls`,
+			`INSERT INTO session_tool_use (session_event_id, tool_name, kind, server, calls, last_call_at_ms)
+			 VALUES (?, ?, ?, ?, ?, ?)
+			 ON CONFLICT(session_event_id, tool_name, kind) DO UPDATE SET calls = excluded.calls,
+			     last_call_at_ms = MAX(COALESCE(excluded.last_call_at_ms, 0),
+			                           COALESCE(session_tool_use.last_call_at_ms, 0))`,
 		);
 		for (const link of event.sessionLinks) {
 			const sessionEventId = `session:${event.repoIdentity}:${link.source}:${link.sessionId}`;
@@ -862,7 +871,14 @@ function projectCommitSummary(db: DashboardDbHandle, event: CommitSummaryEvent):
 				if (link.tools !== undefined) {
 					deleteTools.run(sessionEventId);
 					for (const t of link.tools) {
-						insertTool.run(sessionEventId, t.name, t.kind, t.server ?? null, t.calls);
+						insertTool.run(
+							sessionEventId,
+							t.name,
+							t.kind,
+							t.server ?? null,
+							t.calls,
+							t.lastCallAtMs ?? null,
+						);
 					}
 				}
 			}

--- a/cli/src/dashboard/assets/js/charts.js
+++ b/cli/src/dashboard/assets/js/charts.js
@@ -81,12 +81,26 @@ window.JD = window.JD || {};
 		return svg + "</svg>";
 	};
 
-	/* Recall card's bar strip — two FIXED, semantic colors, never the generic
+	/* Recall card's bar strip — three FIXED, semantic fills, never the generic
 	   series palette: accent is "the model used it", muted is "set aside"
-	   because recall came back with nothing to work with. No axis or
-	   gridlines beyond the baseline — this is a compact strip, not a full
-	   chart, matching how tightly the card packs against its stat panel. */
-	JD.recallBars = (daily) => {
+	   because recall came back with nothing to work with, and a hatch is
+	   "called, outcome never recorded" (see RecallDayPoint.estimated). The
+	   hatch is deliberately not a fourth solid color: that value is a LOWER
+	   BOUND, and a solid bar beside two exact ones claims a precision it does
+	   not have.
+
+	   **No date axis, deliberately — that is the design.** The mockup carries
+	   none: it gets its readability from few, wide bars (a 7-day window), and
+	   30 thin bars under 30 tick labels is more crowded than the strip it is
+	   meant to be. What replaces the axis for the sparse case is per-day
+	   identification on HOVER: every day has a `<title>`, including the empty
+	   ones, so a lone bar in a 30-day window can still be placed by pointing at
+	   it. The empty-day ticks and the `sinceDate` boundary carry the rest —
+	   without them a window whose data starts partway through (the normal case
+	   for a young `recall_receipts` table, and permanently the case for the days
+	   before it existed) read as a broken chart rather than as "only this day
+	   has data". */
+	JD.recallBars = (daily, sinceDate) => {
 		var W = 640;
 		var H = 64;
 		var bottom = 58;
@@ -94,15 +108,53 @@ window.JD = window.JD || {};
 		var barW = Math.max(2, slot * 0.6);
 		var max = 1;
 		daily.forEach((d) => {
-			var total = d.used + d.setAside;
+			/* `estimated` joins the scale even though it is never stacked with the
+			   other two (a day has receipts or an estimate, never both — the query
+			   zeroes the estimate per day). Leaving it out let an estimate-only
+			   window scale against max=1 and clip every bar to full height. */
+			var total = Math.max(d.used + d.setAside, d.estimated || 0);
 			if (total > max) max = total;
 		});
+		var sinceIndex = -1;
+		if (sinceDate) {
+			daily.forEach((d, i) => {
+				if (sinceIndex < 0 && d.date >= sinceDate) sinceIndex = i;
+			});
+		}
 		var svg =
 			'<svg viewBox="0 0 ' +
 			W +
 			" " +
 			H +
-			'" width="100%" role="img" aria-label="Daily recall calls, used vs set aside">';
+			'" width="100%" role="img" aria-label="Daily recall calls, used vs set aside">' +
+			/* Hatch for the estimated bars. One pattern definition, referenced by
+			   every such bar — `--muted` at low opacity so it reads as "less
+			   certain" beside the two solid fills rather than as another category. */
+			'<defs><pattern id="recallEstHatch" width="4" height="4" patternTransform="rotate(45)" patternUnits="userSpaceOnUse">' +
+			'<rect width="4" height="4" fill="var(--heat-track)"/>' +
+			'<line x1="0" y1="0" x2="0" y2="4" stroke="var(--muted)" stroke-width="1.2" opacity="0.55"/>' +
+			"</pattern></defs>";
+		/* The pre-recording stretch, painted BEFORE the bars so it sits behind
+		   them: a faint block plus the day recording began. This is the element
+		   that turns "29 empty days" from a defect into a fact. */
+		if (sinceIndex > 0) {
+			svg +=
+				'<rect x="0" y="0" width="' +
+				(sinceIndex * slot).toFixed(2) +
+				'" height="' +
+				bottom +
+				'" fill="var(--heat-track)" opacity="0.45"/>' +
+				'<line x1="' +
+				(sinceIndex * slot).toFixed(2) +
+				'" y1="0" x2="' +
+				(sinceIndex * slot).toFixed(2) +
+				'" y2="' +
+				bottom +
+				'" stroke="var(--grid)" stroke-width="1" stroke-dasharray="2 2"/>' +
+				'<text x="2" y="11" font-size="10" fill="var(--muted)">' +
+				JD.esc("recording starts " + sinceDate.slice(5)) +
+				"</text>";
+		}
 		daily.forEach((d, i) => {
 			var x = i * slot + (slot - barW) / 2;
 			var y = bottom;
@@ -136,6 +188,45 @@ window.JD = window.JD || {};
 					Math.max(1, asideH).toFixed(2) +
 					'" rx="1" fill="var(--muted)"><title>' +
 					JD.esc(d.date + " · " + d.setAside + " set aside") +
+					"</title></rect>";
+			}
+			/* Estimated bars never stack onto the two above: the query zeroes the
+			   estimate on any day that has a receipt, precisely so this cannot
+			   double-count one call. So this is an `else if` in effect, and the
+			   tooltip states the uncertainty rather than leaving the hatch to carry
+			   it alone. */
+			if (d.estimated > 0) {
+				var estH = ((bottom - 4) * d.estimated) / max;
+				y -= estH;
+				svg +=
+					'<rect x="' +
+					x.toFixed(2) +
+					'" y="' +
+					y.toFixed(2) +
+					'" width="' +
+					barW.toFixed(2) +
+					'" height="' +
+					Math.max(1, estH).toFixed(2) +
+					'" rx="1" fill="url(#recallEstHatch)"><title>' +
+					JD.esc(d.date + " · at least " + d.estimated + " called, outcome not recorded") +
+					"</title></rect>";
+			}
+			/* A day with nothing gets a 2px stub on the baseline. "Counted, and it
+			   was zero" and "outside the window" are different facts, and without a
+			   stub they looked identical — which is what made a single-bar chart
+			   read as broken. With no date axis (see the header) the stub is also
+			   the only hover target such a day has, and therefore the only way to
+			   name it — so it is load-bearing here, not decoration. */
+			if (d.used === 0 && d.setAside === 0 && !d.estimated) {
+				svg +=
+					'<rect x="' +
+					x.toFixed(2) +
+					'" y="' +
+					(bottom - 2) +
+					'" width="' +
+					barW.toFixed(2) +
+					'" height="2" fill="var(--grid)"><title>' +
+					JD.esc(d.date + " · no recall calls") +
 					"</title></rect>";
 			}
 		});

--- a/cli/src/dashboard/assets/js/memories.js
+++ b/cli/src/dashboard/assets/js/memories.js
@@ -237,8 +237,17 @@ window.JD = window.JD || {};
 			row.onclick = () => {
 				var repo = row.getAttribute("data-repo");
 				var hash = row.getAttribute("data-hash");
+				/* `detailRepo`, never `repo`: the owning repo says which memory to
+				   open, and `repo` is the PAGE scope — carrying it here collapsed the
+				   tree to that one repository on every click, so opening a memory cost
+				   the reader every other repo's memories. Whatever scope the page
+				   already has rides along through JD.query untouched. */
 				window.location.href =
-					"/memories?repo=" + encodeURIComponent(JD.repoToken(model, repo)) + "&hash=" + encodeURIComponent(hash);
+					"/memories" +
+					JD.withParams(JD.query(model, {}), {
+						hash: hash,
+						detailRepo: JD.repoToken(model, repo),
+					});
 			};
 			row.onkeydown = (event) => {
 				if (event.key === "Enter" || event.key === " ") row.onclick();
@@ -315,9 +324,16 @@ window.JD = window.JD || {};
 
 	function tokenMeter(tokens) {
 		if (!tokens) return "";
-		var total = tokens.input + tokens.output + tokens.cached;
+		/* Headline and bar have DIFFERENT denominators, matching the editor's meter:
+		   `total` counts every node's reported usage, while the bar's three widths
+		   must fill it exactly, so they divide by the segments' own sum. Dividing
+		   the widths by `total` underfills the bar whenever a folded session
+		   reported a scalar count with no breakdown. */
+		var total = tokens.total;
+		var segTotal = tokens.input + tokens.output + tokens.cached;
 		var esc = JD.esc;
-		var seg = (n, color) => (total > 0 ? '<i style="width:' + (n / total) * 100 + '%;background:' + color + '"></i>' : "");
+		var seg = (n, color) =>
+			segTotal > 0 ? '<i style="width:' + (n / segTotal) * 100 + '%;background:' + color + '"></i>' : "";
 		var cost = tokens.costUsd != null ? " · " + JD.fmtUsd(tokens.costUsd) : "";
 		var asOf = tokens.pricesAsOf ? " (est. at " + esc(tokens.pricesAsOf) + " prices)" : "";
 		return (
@@ -379,40 +395,67 @@ window.JD = window.JD || {};
 	// cards in `stats.js`. `detail.activity` / `detail.activityUncoveredSources`
 	// stay in the payload, so restoring it is a render change only.
 
-	function referencesAndContext(detail) {
+	/* Per-kind row furniture, mirroring the editor's CONTEXT_ROW_KINDS table
+	   (vscode/src/views/ContextRowKinds.ts) — same badge letters, same singular
+	   labels. A kind the server adds later falls back to its own initial rather
+	   than being mislabelled as one of these. */
+	const CONTEXT_KIND_META = {
+		plan: { letter: "P", label: "Plan" },
+		note: { letter: "N", label: "Note" },
+		reference: { letter: "R", label: "Reference" },
+		skills: { letter: "S", label: "Skills" },
+	};
+
+	function contextKindMeta(kind) {
+		return CONTEXT_KIND_META[kind] || { letter: (kind || "?").charAt(0).toUpperCase(), label: kind };
+	}
+
+	/* The Context section. Order, titles and the one-row skills aggregate all
+	   come from the server (`buildContextRows`), which resolves them with the
+	   same CLI helpers the editor's Context panel uses — so this renderer holds
+	   layout only and cannot re-order or re-title anything.
+
+	   Every row with a `contextKey` is openable: plan / note / reference bodies
+	   are archived documents in the dashboard database, and the skills row's
+	   table is rendered on demand from the summary. A row without one (a
+	   reference whose source has left the registry) renders inert instead of as
+	   a button that would always 404. */
+	function contextSection(detail) {
 		var esc = JD.esc;
-		var refRows = detail.references.map(
-			(r) =>
-				'<div class="gd-row"><span class="mem-row-icon">' +
-				memoryIcon("link") +
-				'</span><span class="mem-row-meta mono">' +
-				esc(r.nativeId) +
-				'</span><span class="mem-row-title">' +
-				esc(r.title) +
-				'</span><span class="mem-row-meta">' +
-				esc(r.source) +
-				"</span></div>",
-		);
-		// Plans and notes are openable: the body lives in the dashboard database
-		// (`context.body_md`), so the row is a button that fetches it into the
-		// viewer dialog rather than a dead label. A reference stays a plain row —
-		// its content is an external system's, not ours to render.
-		var ctxRows = detail.context.map(
-			(c) =>
-				'<div class="gd-row gd-row-open" role="button" tabindex="0" data-context-kind="' +
+		var rows = detail.context.map((c) => {
+			var meta = contextKindMeta(c.kind);
+			var openable = !!c.contextKey;
+			return (
+				'<div class="gd-row' +
+				(openable ? " gd-row-open" : "") +
+				'"' +
+				(openable
+					? ' role="button" tabindex="0" data-context-kind="' +
+						esc(c.kind) +
+						'" data-context-key="' +
+						esc(c.contextKey) +
+						'"'
+					: "") +
+				'><span class="mem-ctx-badge mem-ctx-badge--' +
 				esc(c.kind) +
-				'" data-context-key="' +
-				esc(c.contextKey) +
-				'"><span class="mem-row-icon">' +
-				memoryIcon("document") +
-				'</span><span class="mem-row-meta">' +
-				esc(c.kind.toUpperCase()) +
+				'">' +
+				esc(meta.letter) +
 				'</span><span class="mem-row-title">' +
 				esc(c.title) +
-				'</span><span class="mem-row-meta">Open →</span></div>',
-		);
-		var all = refRows.concat(ctxRows);
-		var body = all.length ? '<div class="gd-links">' + all.join("") + "</div>" : '<div class="gd-empty">None.</div>';
+				"</span>" +
+				(c.meta ? '<span class="mem-row-meta mem-ctx-sub">' + esc(c.meta) + "</span>" : "") +
+				(c.url
+					? '<a class="mem-ctx-link" href="' +
+						esc(c.url) +
+						'" target="_blank" rel="noreferrer noopener" title="Open upstream">' +
+						memoryIcon("link") +
+						"</a>"
+					: "") +
+				(openable ? '<span class="mem-row-meta">Open →</span>' : "") +
+				"</div>"
+			);
+		});
+		var body = rows.length ? '<div class="gd-links">' + rows.join("") + "</div>" : '<div class="gd-empty">None.</div>';
 		var excluded = detail.excluded.length
 			? '<div class="gd-sec">Automatically set aside</div><div class="gd-links">' +
 				detail.excluded
@@ -420,7 +463,16 @@ window.JD = window.JD || {};
 					.join("") +
 				"</div>"
 			: "";
-		return '<section class="mem-section mem-context"><div class="gd-sec">' + memoryIcon("link") + "Context · " + all.length + "</div>" + body + excluded + "</section>";
+		return (
+			'<section class="mem-section mem-context"><div class="gd-sec">' +
+			memoryIcon("document") +
+			"Context " +
+			rows.length +
+			"</div>" +
+			body +
+			excluded +
+			"</section>"
+		);
 	}
 
 	function topicsSection(detail) {
@@ -571,7 +623,7 @@ window.JD = window.JD || {};
 			'<div class="gd-row mem-counts">' +
 			detail.conversations.length +
 			" conversations, " +
-			(detail.references.length + detail.context.length) +
+			detail.context.length +
 			" context, " +
 			detail.files.length +
 			" files" +
@@ -589,7 +641,12 @@ window.JD = window.JD || {};
 			memoryIcon("database") +
 			'</span><div><span class="mem-short-hash mono">' +
 			esc(detail.shortHash) +
-			'</span><div class="gd-title">' +
+			/* `JM-…:` leads the title, as it does in the editor's page header — the
+			   handle a reader cites, present on every memory (hash-derived until the
+			   memory syncs to a Space). */
+			'</span><div class="gd-title"><span class="mem-title-ref">' +
+			esc(detail.memoryRefId) +
+			":</span> " +
 			esc(detail.title) +
 			"</div></div></div>" +
 			'<div class="gd-row mem-meta">' +
@@ -600,7 +657,7 @@ window.JD = window.JD || {};
 			(detail.recap ? '<div class="mem-recap">' + JD.mdParagraphs(detail.recap) + "</div>" : "") +
 			'<div class="mem-detail-sections">' +
 			conversationsSection(detail) +
-			referencesAndContext(detail) +
+			contextSection(detail) +
 			topicsSection(detail) +
 			filesSection(detail) +
 			e2eSection(detail) +
@@ -620,7 +677,7 @@ window.JD = window.JD || {};
 		var sub = document.getElementById("ctxSub");
 		var body = document.getElementById("ctxBody");
 		if (!overlay || !title || !sub || !body) return;
-		title.textContent = kind === "plan" ? "Plan" : "Note";
+		title.textContent = contextKindMeta(kind).label;
 		sub.textContent = "Loading…";
 		body.textContent = "";
 		overlay.classList.add("open");
@@ -635,7 +692,7 @@ window.JD = window.JD || {};
 			.then((res) => (res.ok ? res.json() : Promise.reject(new Error(String(res.status)))))
 			.then((doc) => {
 				title.textContent = doc.title;
-				sub.textContent = doc.kind === "plan" ? "Plan" : "Note";
+				sub.textContent = contextKindMeta(doc.kind).label;
 				body.textContent = doc.bodyMd;
 			})
 			.catch((err) => {
@@ -664,7 +721,13 @@ window.JD = window.JD || {};
 		document.querySelectorAll("[data-context-key]").forEach((row) => {
 			var open = () =>
 				openContextDialog(detail, row.getAttribute("data-context-kind"), row.getAttribute("data-context-key"));
-			row.onclick = open;
+			row.onclick = (e) => {
+				/* The upstream-link glyph is a real navigation nested inside a row that
+				   is itself a button; without this, clicking it would ALSO open the
+				   archived snapshot behind the new tab. */
+				if (e && e.target && e.target.closest && e.target.closest(".mem-ctx-link")) return;
+				open();
+			};
 			row.onkeydown = (e) => {
 				if (e.key === "Enter" || e.key === " ") {
 					e.preventDefault();
@@ -748,32 +811,42 @@ window.JD = window.JD || {};
 		)
 			.then((page) => {
 				memories.loadingPage = false;
-				/* An empty page while `items.length < totalCount` means those two
-				   disagree — the total moved under us. Believe the page: there is
-				   nothing after this cursor, so retire the footer rather than leave a
-				   button that answers every click with nothing. */
-				if (!page.items || !page.items.length) {
-					memories.totalCount = items.length;
-					refreshTree(model);
-					return;
-				}
+				var pageItems = page.items || [];
+				/* Checked BEFORE the empty-page branch below, and it must stay that
+				   way: the two conditions overlap when the last reachable memory is
+				   the one that vanished, and the flag is the more specific answer.
+				   Falling into the empty-page branch there kept the dead rows on
+				   screen and set the total to their count, so the tree went on
+				   listing memories git can no longer reach with no way to notice. */
 				if (page.cursorMissing) {
 					/* The memory we were paging from is gone (a rebase during the
 					   session), so the server answered with the first page instead.
 					   REPLACE rather than append: appending would re-add rows the dedupe
 					   then drops, and the next click would send the same dead cursor
 					   again — a button that does nothing forever. Re-seating on page 1
-					   is exactly what a reload would give, and paging works from there. */
-					memories.items = page.items;
-				} else {
-					/* Deduped even so: rows can shift under a commit landing between two
-					   clicks, and a repeat is cheap to drop where a gap would be
-					   invisible. */
-					var seen = new Set(items.map((item) => item.repoIdentity + " " + item.commitHash));
-					memories.items = items.concat(
-						page.items.filter((item) => !seen.has(item.repoIdentity + " " + item.commitHash)),
-					);
+					   is exactly what a reload would give, and paging works from there.
+					   An EMPTY first page is the same answer, not a special case: the
+					   scope has no reachable memories left, so the tree empties. */
+					memories.items = pageItems;
+					memories.totalCount = page.totalCount;
+					refreshTree(model);
+					return;
 				}
+				/* An empty page while `items.length < totalCount` means those two
+				   disagree — the total moved under us. Believe the page: there is
+				   nothing after this cursor, so retire the footer rather than leave a
+				   button that answers every click with nothing. */
+				if (!pageItems.length) {
+					memories.totalCount = items.length;
+					refreshTree(model);
+					return;
+				}
+				/* Deduped: rows can shift under a commit landing between two clicks,
+				   and a repeat is cheap to drop where a gap would be invisible. */
+				var seen = new Set(items.map((item) => item.repoIdentity + " " + item.commitHash));
+				memories.items = items.concat(
+					pageItems.filter((item) => !seen.has(item.repoIdentity + " " + item.commitHash)),
+				);
 				/* Adopted from the page, not left at the value the HTML was rendered
 				   with: it is what the footer states and what decides whether there is
 				   more to ask for, and a commit (or a rebase) moves it. */
@@ -804,7 +877,7 @@ window.JD = window.JD || {};
 			if (detail) detail.innerHTML = '<div class="mem-read-inner">' + renderDetail(model) + "</div>";
 			wireTree(model);
 			wireDetail(model);
-				return;
+			return;
 		}
 		document.getElementById("app").innerHTML =
 			'<section class="memories-page"><aside class="mem-navigator" aria-label="Memory browser">' +

--- a/cli/src/dashboard/assets/js/shell.js
+++ b/cli/src/dashboard/assets/js/shell.js
@@ -74,6 +74,17 @@ window.JD = window.JD || {};
 		return sameName.length === 1 ? mine.repoName : identity;
 	};
 
+	/* Append page-specific params to a `JD.query` result, picking `?` or `&` by
+	   whether that result is already non-empty. One helper because getting the
+	   separator wrong produces a URL that silently loses the page scope. */
+	JD.withParams = (query, params) => {
+		var parts = Object.keys(params)
+			.filter((key) => params[key] !== undefined && params[key] !== null && params[key] !== "")
+			.map((key) => key + "=" + encodeURIComponent(params[key]));
+		if (parts.length === 0) return query;
+		return (query ? query + "&" : "?") + parts.join("&");
+	};
+
 	/* Back-compat alias — some callers only care about the repo scope. */
 	JD.scopeQuery = (scope) =>
 		scope && scope.kind === "repo" && scope.repoIdentity ? "?repo=" + encodeURIComponent(scope.repoIdentity) : "";

--- a/cli/src/dashboard/assets/js/standup.js
+++ b/cli/src/dashboard/assets/js/standup.js
@@ -240,6 +240,20 @@ window.JD = window.JD || {};
 		return html + '<span class="schip" style="border-style:dashed">step progress needs plan enumeration</span>';
 	}
 
+	/* Whose commits the board is showing. Stated either way, and never silently:
+	   the columns feed a draft the user posts as their own work, so "filtered to
+	   you" and "could not tell who you are, showing everyone" have to be
+	   distinguishable before the paste, not after. */
+	function authorChip(standup) {
+		if (standup.authoredBy) {
+			return '<span class="schip">yours only · <span class="mono">' + JD.esc(standup.authoredBy) + "</span></span>";
+		}
+		return (
+			'<span class="schip" style="border-style:dashed">every author — no git identity configured, ' +
+			"so this is not filtered to you</span>"
+		);
+	}
+
 	/* ---- the drafted standup ----------------------------------------------- */
 
 	/* The markdown the sheet shows and the clipboard gets. Same routing as the
@@ -372,6 +386,7 @@ window.JD = window.JD || {};
 			'<div class="ctx"><span class="date">' +
 			esc(JD.weekdayDate(model.generatedAtMs, model.timeZone)) +
 			'</span><span class="sprint-chips">' +
+			authorChip(standup) +
 			sprintChips(standup, model) +
 			'</span><div class="spacer"></div>' +
 			'<span class="share-note">posts nowhere — copy it where you like</span>' +
@@ -466,9 +481,14 @@ window.JD = window.JD || {};
 
 		copyButton.onclick = () => {
 			output.value = JD.standupMarkdown(model);
-			document.getElementById("sheetSub").textContent = memory
-				? "From your commit memories. Edit anything before you post it."
-				: "From raw sessions + git log. Enable Jolli Memory for decisions, TODOs and blockers.";
+			/* The unfiltered warning goes FIRST and outranks the tier note: what you
+			   are about to paste containing a teammate's commit matters more than
+			   where the lines came from. */
+			document.getElementById("sheetSub").textContent = !standup.authoredBy
+				? "Every author's commits — no git identity configured, so check the lines are yours before posting."
+				: memory
+					? "From your commit memories. Edit anything before you post it."
+					: "From raw sessions + git log. Enable Jolli Memory for decisions, TODOs and blockers.";
 			overlay.classList.add("open");
 			output.focus();
 			/* Copied on open as well as on the button: the one-click path stays as fast

--- a/cli/src/dashboard/assets/js/stats.js
+++ b/cli/src/dashboard/assets/js/stats.js
@@ -199,7 +199,13 @@ window.JD = window.JD || {};
 			if (!byKey[key]) { byKey[key] = { label: key, cards: [] }; groups.push(byKey[key]); }
 			byKey[key].cards.push(card);
 		});
-		var openHref = (card) => "/memories?repo=" + encodeURIComponent(card.repoIdentity) + "&hash=" + encodeURIComponent(card.commitHash);
+		/* `detailRepo` names the memory's owning repo without scoping the page it
+		   lands on — see wireTree in memories.js. Whatever scope THIS page carries
+		   rides along through JD.query, so a repo-filtered dashboard still opens a
+		   repo-filtered tree. */
+		var openHref = (card) =>
+			"/memories" +
+			JD.withParams(JD.query(model, {}), { hash: card.commitHash, detailRepo: card.repoIdentity });
 		var row = (card) => {
 			var meta = [];
 			if (card.category) meta.push('<span class="mem-activity-category">' + esc(card.category) + "</span>");
@@ -416,8 +422,14 @@ window.JD = window.JD || {};
 		/* Receipts only exist from the day they shipped, and nothing can rebuild
 		   them — but the CALL survives in the transcripts, so a window with only
 		   history says "recall ran N times, outcome not recorded" rather than the
-		   empty panel, which read as "recall was never used". Deliberately without
-		   a hit rate or a chart: neither can be honestly derived from a call count. */
+		   empty panel, which read as "recall was never used".
+		   Still no hit rate — that cannot be derived from a call count — but it
+		   DOES now carry the chart. The original "no chart either" was right while
+		   the daily series knew nothing about receipt-less calls; now that the
+		   `jollimemory` reference's own timestamps reach `daily[].estimated`, the
+		   days those calls fell on are real data, and withholding the chart was
+		   the reason a window of pure history looked like the feature was dead. */
+		var hasEstimatedDays = (usage.daily || []).some((d) => d.estimated > 0);
 		if (totalCalls === 0 && noReceipt > 0) {
 			return (
 				head +
@@ -427,14 +439,30 @@ window.JD = window.JD || {};
 				esc(rangeSub(model.stats)) +
 				"</span></div>" +
 				'<div class="spacer"></div></div>' +
+				(hasEstimatedDays
+					? '<div style="margin-top:8px">' +
+						JD.recallBars(usage.daily, usage.receiptsSinceDate) +
+						'<div class="legend" style="margin-top:6px">' +
+						'<span><i style="background:var(--heat-track)"></i>called, outcome not recorded (at least)</span>' +
+						"</div></div>"
+					: "") +
 				'<div class="locked-panel"><p><b>Recall ran ' +
 				noReceipt +
 				"&times; here, but nothing recorded what it returned.</b></p>" +
 				'<p class="why">These calls come from the agent transcripts. Whether each one ' +
 				"served usable context is only recorded from the call itself, which older " +
 				"runs pre-date — newer calls show their hit rate here." +
+				(hasEstimatedDays
+					? " The chart above places them by date, from the one channel that timestamps each call — " +
+						"a repeated query collapses to a single entry there, so each day is a floor, not a count."
+					: "") +
 				(usage.skillInvocations > 0
 					? " The <code>jolli-recall</code> skill ran <b>" + usage.skillInvocations + "</b>&times; in the same window."
+					: "") +
+				(usage.skillRunsWithoutTrace > 0
+					? " <b>" +
+						usage.skillRunsWithoutTrace +
+						"</b> of those left no other trace — the skill's CLI fallback, which older builds recorded nowhere."
 					: "") +
 				"</p></div></section>"
 			);
@@ -446,10 +474,20 @@ window.JD = window.JD || {};
 				'<div class="locked-panel"><p><b>No recall calls recorded in this window.</b></p>' +
 				'<p class="why">Run <code>jolli recall</code>, or let an agent call the recall tool, ' +
 				"and it shows up here as it happens." +
+				/* "without recalling anything" is only safe to say when nothing
+				   suggests otherwise: a skill run with no trace is just as likely to
+				   have recalled through the CLI fallback and had its receipt land
+				   with no session to attribute it to. */
 				(usage.skillInvocations > 0
-					? " The <code>jolli-recall</code> skill ran <b>" +
-						usage.skillInvocations +
-						"</b>&times; in this window without recalling anything."
+					? usage.skillRunsWithoutTrace > 0
+						? " The <code>jolli-recall</code> skill ran <b>" +
+							usage.skillInvocations +
+							"</b>&times; here, <b>" +
+							usage.skillRunsWithoutTrace +
+							"</b> of them leaving no record of what came back."
+						: " The <code>jolli-recall</code> skill ran <b>" +
+							usage.skillInvocations +
+							"</b>&times; in this window without recalling anything."
 					: "") +
 				"</p></div></section>"
 			);
@@ -467,47 +505,117 @@ window.JD = window.JD || {};
 		html +=
 			'<div style="display:flex;gap:20px;align-items:flex-start;margin-top:8px;flex-wrap:wrap">' +
 			'<div style="flex:1;min-width:220px">' +
-			JD.recallBars(usage.daily) +
+			JD.recallBars(usage.daily, usage.receiptsSinceDate) +
 			'<div class="legend" style="margin-top:6px">' +
 			'<span><i style="background:var(--accent)"></i>the model used it</span>' +
 			'<span><i style="background:var(--muted)"></i>set aside</span>' +
+			/* Only when the window actually holds such a day: this is the rare
+			   channel (pre-receipt history), and a permanent third legend entry
+			   would suggest every chart has one. */
+			(hasEstimatedDays
+				? '<span><i style="background:var(--heat-track)"></i>outcome not recorded</span>'
+				: "") +
 			"</div></div>" +
 			'<div style="min-width:170px">' +
-			statRows([
-				["Used", usage.usedCalls],
-				["Context served", usage.contextServedPct + "%"],
+			statRows(
 				[
-					"Memories",
-					usage.distinctMemoriesUsed + (usage.staleMemoriesUsed > 0 ? " · " + usage.staleMemoriesUsed + " older than 30d" : ""),
-				],
-			]) +
+					["Used", usage.usedCalls],
+					["Context served", usage.contextServedPct + "%"],
+					[
+						"Memories",
+						usage.distinctMemoriesUsed + (usage.staleMemoriesUsed > 0 ? " · " + usage.staleMemoriesUsed + " older than 30d" : ""),
+					],
+				].concat(
+					/* The skill's own row, on the card FACE. It is not a call and must
+					   never move the three figures above — but computing it and then
+					   printing it only inside the ⓘ's `title` attribute was how six
+					   recall rows in the database rendered as "3 used" with nothing
+					   visible to account for the other three. A hover is not a surface.
+					   Suppressed at zero, like every other conditional figure here. */
+					usage.skillInvocations > 0
+						? [
+								[
+									"Skill runs",
+									usage.skillInvocations +
+										(usage.skillRunsWithoutTrace > 0
+											? " · " + usage.skillRunsWithoutTrace + " with no recorded outcome"
+											: ""),
+								],
+							]
+						: [],
+				),
+			) +
 			"</div></div>";
 
+		/* ONE line, which is what the design carries: the coverage ratio and
+		   nothing else. The four `·`-joined clauses this used to print were added
+		   one at a time, each defensible alone, and together they were unreadable
+		   — a reader could not tell which number the caveats even applied to.
+		   They are not deleted, they move to the ⓘ's hover: a caveat that
+		   qualifies a figure belongs next to it, but it does not belong in the
+		   reader's way every time they glance at the card. */
 		var note = "<b>" + usage.sessionsWithContext + "</b> of " + usage.sessionsInWindow + " sessions got prior context";
+
+		/* Plain text, not markup — this becomes a `title` attribute, where tags
+		   would render literally. */
+		var detail = [];
 		if (usage.bySurface.length > 0) {
-			note +=
-				" · " +
+			detail.push(
 				usage.bySurface
-					.map((row) => "<b>" + row.calls + "</b> via " + esc(row.surface === "mcp" ? "the recall tool" : "the CLI"))
-					.join(", ");
+					.map((row) => row.calls + " via " + (row.surface === "mcp" ? "the recall tool" : "the CLI"))
+					.join(", "),
+			);
 		}
 		/* Skill invocations sit OUTSIDE the counts above on purpose: a skill run
 		   that goes on to recall already wrote its own receipt, so folding it in
 		   would count that call twice. What it adds is the gap — invoked, never
-		   recalled — which is why it is only worth printing when there is one. */
+		   recalled — which is why it is only worth mentioning when there is one. */
 		if (usage.skillInvocations > usage.usedCalls + usage.setAsideCalls) {
-			note +=
-				" · the <code>jolli-recall</code> skill ran <b>" +
-				usage.skillInvocations +
-				"</b>&times;, more often than recall was actually called";
+			detail.push("the jolli-recall skill ran " + usage.skillInvocations + "×, more often than recall was called");
 		}
-		/* Mixed window: some calls have receipts, some pre-date them. Said out loud
-		   so the hit rate above is read as covering only the receipted ones. */
+		/* The gap's most likely explanation, stated where the gap is stated. */
+		if (usage.skillRunsWithoutTrace > 0) {
+			detail.push(
+				usage.skillRunsWithoutTrace +
+					" skill " +
+					(usage.skillRunsWithoutTrace === 1 ? "run" : "runs") +
+					" left no MCP call and no attributable receipt — typically the CLI fallback on a host that reports no session id",
+			);
+		}
+		/* Mixed window: some calls have receipts, some pre-date them. Kept so the
+		   percentage above is read as covering only the receipted ones. */
 		if (noReceipt > 0) {
-			note += " · <b>" + noReceipt + "</b> further calls are in the transcripts with no recorded outcome";
+			detail.push(
+				noReceipt +
+					" further " +
+					(noReceipt === 1 ? "call is" : "calls are") +
+					" in the transcripts with no recorded outcome",
+			);
 		}
-		note += " · a recall run outside an agent session counts above but belongs to no session";
-		return html + '<div class="w-foot"><span class="w-measure">ⓘ ' + note + "</span></div></section>";
+		/* Only when there actually IS such a call, counted server-side. Printed
+		   unconditionally, it raised a caveat that did not apply — on a machine
+		   whose every recall carries a session id it described a situation that
+		   cannot occur. The first attempt at a condition tested
+		   `sessionsWithContext === 0`, which reads as "no session claims these
+		   calls" but actually means "not one receipt in the window names a
+		   session" — so the mixed window this caveat is FOR (some calls inside a
+		   session, some at a shell prompt) was precisely the case it stayed
+		   silent for. `callsWithoutSession` is the statement itself. */
+		if (usage.callsWithoutSession > 0) {
+			detail.push(
+				usage.callsWithoutSession +
+					(usage.callsWithoutSession === 1 ? " recall ran" : " recalls ran") +
+					" outside an agent session, counting above but belonging to no session",
+			);
+		}
+		return (
+			html +
+			'<div class="w-foot"><span class="w-measure"' +
+			(detail.length > 0 ? ' title="' + esc(detail.join(" · ")) + '"' : "") +
+			">ⓘ " +
+			note +
+			"</span></div></section>"
+		);
 	}
 
 	/* Ranked rows shared by Skills and MCP servers: label (+ optional kind),

--- a/cli/src/dashboard/assets/styles/main.css
+++ b/cli/src/dashboard/assets/styles/main.css
@@ -713,6 +713,8 @@ body {
   .mem-title-mark .mem-icon { width: 25px; height: 25px; stroke-width: 2; }
   .mem-short-hash { display: block; margin-bottom: 2px; font-size: 11px; color: var(--muted); }
   .mem-detail .gd-title { font-size: 26px; line-height: 1.2; letter-spacing: -.02em; }
+  /* The `JM-…:` handle reads as a label on the title, not as part of it. */
+  .mem-title-ref { color: var(--muted); font-weight: 500; }
   .mem-meta { padding-bottom: 8px; color: var(--muted); font-size: 12px; flex-wrap: wrap; }
   .mem-meta > span { display: inline-flex; align-items: center; gap: 4px; }
   .mem-meta .mem-icon { width: 14px; height: 14px; }
@@ -742,8 +744,26 @@ body {
     width: 100%; align-items: center; min-height: 46px; padding: 9px 12px; border: 1px solid var(--border);
     border-radius: 9px; background: var(--surface); box-shadow: 0 1px 2px rgba(20, 30, 50, .04);
   }
-  /* An openable Context row (plan/note). Reference rows stay inert, so the
-     affordance is on the class, not on `.mem-context .gd-row`. */
+  /* Context row badge — the editor's `kb-tag` letter (P/N/R/S), one hue per
+     kind so the four kinds are separable at a glance in a mixed list. */
+  .mem-ctx-badge {
+    display: inline-flex; align-items: center; justify-content: center; width: 22px; height: 22px; flex: none;
+    border-radius: 5px; font-size: 11px; font-weight: 650; background: var(--lock-bg); color: var(--muted);
+  }
+  .mem-ctx-badge--plan { background: color-mix(in srgb, var(--accent) 14%, transparent); color: var(--accent); }
+  .mem-ctx-badge--note { background: color-mix(in srgb, #16a34a 14%, transparent); color: #16a34a; }
+  .mem-ctx-badge--reference { background: color-mix(in srgb, #d97706 16%, transparent); color: #b45309; }
+  .mem-ctx-badge--skills { background: color-mix(in srgb, #7c3aed 14%, transparent); color: #7c3aed; }
+  /* The sub-line shares the row rather than wrapping under the title: these rows
+     are single-height, and the meta is a qualifier (`JOLLI-1901 (Linear)`), not a
+     second title. `min-width: 0` lets it shrink before the title does. */
+  .mem-ctx-sub { min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+  .mem-ctx-link { display: inline-flex; align-items: center; color: var(--muted); }
+  .mem-ctx-link:hover { color: var(--accent); }
+  .mem-ctx-link .mem-icon { width: 14px; height: 14px; }
+  /* An openable Context row (any kind with a resolvable document key). A row
+     without one stays inert, so the affordance is on the class, not on
+     `.mem-context .gd-row`. */
   .gd-row-open { cursor: pointer; }
   .gd-row-open:hover { border-color: var(--accent); }
   .gd-row-open:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }

--- a/vscode/src/views/SummaryHtmlBuilder.ts
+++ b/vscode/src/views/SummaryHtmlBuilder.ts
@@ -11,7 +11,6 @@
 
 import { labelLeadsWithNativeId, referenceDisplayTitle } from "../../../cli/src/core/references/ReferenceDisplay.js";
 import { getRegistry } from "../../../cli/src/core/references/SourceDefinitionRegistry.js";
-import { estimateModelCostUsd } from "../../../cli/src/core/Pricing.js";
 import { REF_HASH_SUFFIX } from "../../../cli/src/core/RefMerge.js";
 import { isSummaryError } from "../../../cli/src/core/SummaryErrorMarker.js";
 import {
@@ -22,10 +21,8 @@ import {
 import type {
 	CommitSummary,
 	ContextRelevanceRef,
-	ConversationTokenBreakdown,
 	E2eTestScenario,
 	ExcludedContextItem,
-	ModelTokenUsage,
 	NoteReference,
 	PlanReference,
 	ReferenceCommitRef,
@@ -35,6 +32,7 @@ import type {
 } from "../../../cli/src/Types.js";
 import { buildSkillsSummaryLabel } from "../../../cli/src/core/SkillsAggregateMarkdown.js";
 import { formatMemoryRefIdWithHashFallback } from "../../../cli/src/core/MemoryRefId.js";
+import { estimateSummaryCostUsd, type SummaryCostMode } from "../../../cli/src/core/TokenCost.js";
 import { annotatePlans } from "../util/PlanGrouping.js";
 import { getSourceMeta, sourceClassToken } from "./SourceLabels.js";
 import { buildCss } from "./SummaryCssBuilder.js";
@@ -44,7 +42,6 @@ import {
 	collectSortedTopics,
 	escAttr,
 	escHtml,
-	estimateConversationCostUsd,
 	formatFullDate,
 	formatProviderLabel,
 	formatSonnetCostEstimate,
@@ -558,96 +555,18 @@ export function buildPropTable(
 // \u2500\u2500\u2500 Token meter \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
 
 /**
- * Sums the token segments of a node's per-model buckets whose model has no entry
- * in the host price table, or null when every bucket is priced (or the node
- * records no buckets to inspect).
+ * Cache-aware $ estimate for the whole consolidation tree, formatted.
  *
- * These are exactly the tokens `estimatedCostUsd` deliberately left out of its
- * total rather than guessing a rate for, so they are what a stored cost still
- * owes. Membership is probed through `estimateModelCostUsd`'s null return — the
- * same predicate the write-time estimate uses — rather than by reading
- * `MODEL_PRICES` here, so the two can never disagree about what "unpriced" means.
- *
- * A node carrying a cost but no `conversationModels` (hand-edited or otherwise
- * off-contract data — write time only stores a cost alongside buckets) returns
- * null: there is nothing to inspect, so the stored figure is taken at face value.
+ * The RULE is `estimateSummaryCostUsd` in `cli/src/core/TokenCost.ts` \u2014 see it
+ * for why the preference is resolved per node and per model bucket, and why a
+ * stored cost is treated as a lower bound rather than as full coverage. It lives
+ * there rather than here because the local web dashboard prices the same memory
+ * and the two surfaces must not disagree: the dashboard read the ROOT node\u2019s own
+ * `estimatedCostUsd` and showed \u2248$2.59 against this meter\u2019s \u2248$27.61 for the
+ * same commit. Only the formatting stays on this side.
  */
-function unpricedSegments(models: ReadonlyArray<ModelTokenUsage> | undefined): ConversationTokenBreakdown | null {
-	let input = 0;
-	let output = 0;
-	let cached = 0;
-	for (const m of models ?? []) {
-		if (estimateModelCostUsd(m) !== null) continue;
-		input += m.input;
-		output += m.output;
-		cached += m.cached;
-	}
-	return input + output + cached > 0 ? { input, output, cached } : null;
-}
-
-/**
- * Cache-aware $ estimate, preferring the cost computed at WRITE time from the
- * conversation's actual model(s) via the host price table. Falls back to the flat
- * Sonnet-rate estimate for whatever the stored cost does not cover \u2014 legacy
- * memories, or a conversation whose model is absent from the price table.
- *
- * The sidebar's token bar already prefers the stored value; this surface used to
- * price everything at Sonnet unconditionally, so the same memory could show two
- * different dollar figures depending on where you looked at it \u2014 and Opus work
- * was understated in the detail view. Keep the two preferring the same source.
- *
- * The preference is resolved PER NODE, not once for the whole tree. A tree-wide
- * "any stored cost wins" test silently under-reports a mixed consolidation: the
- * token headline beside this figure aggregates EVERY node, so a squash whose root
- * carries a stored cost while a folded legacy child does not would price only the
- * root and show that total next to the full tree's tokens. Summing per node keeps
- * the two figures over the same set. (The Sonnet formula is linear per segment, so
- * summing per-node fallbacks equals estimating from their aggregate \u2014 no drift
- * against the previous behaviour for an all-fallback tree.)
- *
- * A stored cost is a LOWER bound, not proof of full coverage, so the per-node
- * preference is resolved per MODEL bucket rather than per node — see
- * `unpricedSegments`.
- *
- * Returns the formatted figure plus which sources fed it, so the caller's tooltip
- * can describe the number it is actually showing rather than overclaiming.
- */
-function estimateCost(summary: CommitSummary): { label: string; mode: "stored" | "sonnet" | "mixed" } {
-	let usd = 0;
-	let storedNodes = 0;
-	let fallbackNodes = 0;
-	const walk = (node: CommitSummary): void => {
-		const own = node.estimatedCostUsd ?? 0;
-		const tokens = node.conversationTokens ?? 0;
-		if (own > 0) {
-			usd += own;
-			storedNodes++;
-			// A positive stored cost does NOT mean the node is fully priced. Write time
-			// records `estimatedCostUsd` as a lower bound: `estimateCostUsd` prices only
-			// the buckets present in the host price table and EXCLUDES the rest rather
-			// than guessing (see Pricing.ts's `-pro` note, Types.ts on
-			// `estimatedCostUsd`, and conversationUsageFields in QueueWorker). Treating
-			// `own > 0` as full coverage therefore under-reports every node that mixed a
-			// priced model with an unpriced one — the unpriced bucket's tokens sit in the
-			// headline total beside this figure while contributing $0 to it. Price
-			// exactly those buckets at the flat rate, the same treatment a wholly
-			// unpriced node gets below, and let them tip the mode to "mixed" so the
-			// tooltip stops claiming the figure is fully model-priced.
-			const unpriced = unpricedSegments(node.conversationModels);
-			if (unpriced) {
-				usd += estimateConversationCostUsd(unpriced, unpriced.input + unpriced.output + unpriced.cached);
-				fallbackNodes++;
-			}
-		} else if (tokens > 0) {
-			// No stored cost but real tokens \u2014 this node needs the flat-rate fallback.
-			// Nodes with neither contribute nothing and must NOT tip the mode either way.
-			usd += estimateConversationCostUsd(node.conversationTokenBreakdown, tokens);
-			fallbackNodes++;
-		}
-		for (const child of node.children ?? []) walk(child);
-	};
-	walk(summary);
-	const mode = storedNodes > 0 ? (fallbackNodes > 0 ? "mixed" : "stored") : "sonnet";
+function estimateCost(summary: CommitSummary): { label: string; mode: SummaryCostMode } {
+	const { usd, mode } = estimateSummaryCostUsd(summary);
 	return { label: formatSonnetCostEstimate(usd), mode };
 }
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Context

- Fix Dashboard Recall Card: Daily Bar Chart, Historical Estimates, Cross-Host Session Attribution

## Quick recap

The standup board now shows only the current user's own commits. The board reads the git identity configured in each registered worktree, unions them, and applies a case-insensitive author match to both the commit columns and the Risks/TODOs insights panel. A chip in the board header states either "yours only" with the matched email address, or "every author — no git identity configured" when the identity could not be resolved, and the copy sheet carries the same signal so a user can catch an unfiltered board before pasting into a team channel.

Dashboard commit metrics received a fundamental correctness fix: the tool's own internal memory storage had been silently counted as user work, inflating commit totals by roughly four times on real repositories and pushing the tool's own bookkeeping branch to the top of the attribution list. All git history walks and branch attribution scans now exclude the storage branch and its historical versions, and the change-detection fingerprint that decides whether to re-sweep history no longer incorporates the storage branch's constant churn — eliminating the full history re-sweep that had been triggering on essentially every dashboard launch.

File history collection became self-healing in two ways. Commits whose file detail scan failed transiently are now automatically retried on the next run rather than being permanently skipped, closing a gap that previously required a full database rebuild to recover. A separate fix addressed a compounding problem where one commit with an unusually large diff caused its entire batch to return empty, re-queuing the same doomed batch on every subsequent launch. File collection now bisects a failing batch breadth-first, storing results from the healthy half immediately and narrowing in on the problematic commit, with a hard cap on extra subprocess calls to keep the cost predictable.

The recall card on the dashboard received a substantial overhaul. Pre-receipt recall activity now appears in the bar chart as hatched bars, visually distinguished from confirmed-count bars to signal that the values are lower bounds. Empty days within the window render a small baseline stub so a sparse window no longer looks like a broken chart, and when the recording start date falls inside the displayed range, a labeled boundary line marks where estimates end and confirmed receipts begin. The footnote area was condensed to a single summary line showing how many sessions received prior context, with the supporting breakdown accessible on hover. The session-less warning now appears only when recall calls exist that no session can claim, and it names a precise count of unattributed calls.

Several additional data-correctness fixes landed alongside these. In repositories with multiple working copies, branch attribution is now preserved whenever either copy's branch scan was incomplete — previously the two partial results were merged into an empty list that the database treated as a positive claim of no branches. Recall session coverage is now accurate for users whose primary agent is not Claude Code, fixing a case where the coverage figure was structurally zero. Interrupted database restore operations no longer leave behind permanent database-sized temporary files: a sweep at the start of each restore removes files whose writer process is gone, with an age threshold guarding against process ID reuse. The root URL redirect no longer triggers a full git scan across every enabled repository on every visit.

---

## E2E Test (5)
<details>
<summary><strong>1. Standup board shows only your own commits</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with commits from at least two different authors (e.g. yourself and a teammate or a bot). Open the standup view in the app.

**Steps:**
1. Open the app and navigate to the Standup page.
2. Look at the list of commits shown in your standup draft.
3. Check whether any commits from teammates, bots, or dependency updates appear in the list.
4. Look for a small label or chip near the top of the board that describes whose commits are shown.
5. Check the subtitle or note beneath the board for any warning about reviewing lines before posting.

**Expected Results:**
- Only commits authored by you (matching your local git email or name) should appear in the standup draft.
- A chip or label should be visible stating something like "yours only · your@email.com".
- No teammate commits, bot commits, or dependency bumps should appear in the list or in the text you would paste into a team channel.
- If your git identity could not be read, the chip should instead say something like "every author — no git identity configured" and the subtitle should warn you to review the lines before posting.

</blockquote>
</details>
<details>
<summary><strong>2. Dashboard metrics no longer inflated by internal memory commits</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository that has been used with the tool for some time, so the internal memory storage branch has accumulated commits.

**Steps:**
1. Open the app and navigate to the main Dashboard page.
2. Look at the commit counts, branch attribution list, and any "top branches" or "your activity" numbers shown.
3. Check whether a branch named something like "jollimemory/summaries/v3" appears anywhere in the branch list or attribution breakdown.
4. Compare the commit totals to what you would expect based on your actual development work.

**Expected Results:**
- The internal memory branch (jollimemory/summaries/...) should not appear anywhere in the branch attribution list.
- Commit counts and activity numbers should reflect only your real development commits, not internal bookkeeping entries.
- No "Add summary for …" style commits should be attributed to you in the dashboard metrics.

</blockquote>
</details>
<details>
<summary><strong>3. Recall bar chart shows estimated history bars and recording boundary</strong></summary>
<br>
<blockquote>

**Preconditions:** Have an account with some recall usage history, ideally spanning a period before and after the recording system was first enabled.

**Steps:**
1. Open the app and navigate to the Dashboard or Recall card section.
2. Look at the bar chart showing recall activity over time.
3. Hover over bars that appear with a different visual style (hatched or patterned fill) compared to solid bars.
4. Look for any days that show a very small stub at the baseline even though no recall activity is shown.
5. If the recording start date falls within the visible window, look for a vertical line or shaded region near that date.
6. Hover over the small baseline stubs on empty days.

**Expected Results:**
- Days with estimated (pre-recording) recall activity should show bars with a hatched or patterned fill, visually distinct from solid bars.
- Hovering a hatched bar should show a tooltip saying something like "at least N called, outcome not recorded."
- Days with zero activity should show a tiny 2-pixel baseline stub rather than being completely blank, and hovering it should show the date.
- If the recording start date is within the visible window, a dashed vertical line labeled "recording starts MM-DD" should appear, and the area before it should have a faint background shading.
- A legend entry for "outcome not recorded" should appear only when the chart actually contains estimated days.

</blockquote>
</details>
<details>
<summary><strong>4. Recall card footnote condensed with hover detail</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the app and navigate to the Dashboard or Recall card.
2. Read the footnote or summary line at the bottom of the recall card.
3. Find the info icon (ⓘ) near the footnote and hover over it.

**Expected Results:**
- The visible footnote should show only a short session coverage summary, such as "2 of 4 sessions got prior context."
- Hovering the info icon should reveal a tooltip containing the additional details: surface breakdown, any receipt-less call count, and the session-less caveat — written as plain readable text.
- The tooltip should use correct singular/plural phrasing (e.g. "1 further call is" vs "2 further calls are").

</blockquote>
</details>
<details>
<summary><strong>5. Session-less recall caveat shows accurate count</strong></summary>
<br>
<blockquote>

**Preconditions:** Have recall usage that includes at least one call that happened outside an agent session (or a mix of attributed and unattributed calls).

**Steps:**
1. Open the app and navigate to the Recall card on the Dashboard.
2. Hover the info icon on the recall card footnote to open the tooltip.
3. Check whether a caveat about calls outside an agent session appears.
4. Repeat on an account where every recall call is properly linked to a session.

**Expected Results:**
- When some recall calls happened outside a session, the tooltip should show a message like "1 recall ran outside an agent session" or "N recalls ran outside an agent session" with the correct count.
- When all calls are properly linked to sessions, no session-less caveat should appear at all.
- The caveat should never appear when the count is zero, and should never be missing when the count is greater than zero.

</blockquote>
</details>

---

## Topics (15)
<details>
<summary><strong>01 · Standup board filtered to show only your own commits</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The standup page was showing every commit that landed in the shared repository, regardless of who authored it. Teammates' releases, dependency bumps, and bot commits were appearing in a user's personal standup draft, including in the text they would paste into a team channel.

**💡 Decisions Behind the Code**

- **Fail open rather than blank**: when git config is unreadable or the worktree path is empty, the filter is skipped entirely and the board shows all commits. A blank standup reads as "you did nothing", which is a worse outcome than an unfiltered one — and the unfiltered case is visibly labeled on the page so the user can catch it before copying.
- **Per-repo identity union over a single global read**: git's `user.email` can be overridden inside individual worktrees, so a single global read would silently exclude commits from a repo configured with a different identity. Unioning all per-repo identities into one filter handles this correctly and is safe because the identities belong to the same person.
- **Stats page deliberately excluded**: the author filter applies only to the standup view. The stats page answers "how much did this repo do", which is a repo-level question; applying a personal filter there would make aggregate numbers misleading.

**✅ What Was Implemented**

- Added `readLocalGitIdentity` to `GitOps.ts`, which reads `user.email` and `user.name` from git config per worktree. The server calls this concurrently across all enabled repos for the standup view only, unions the results into an `AuthorIdentity`, and passes it to the query layer.
- Added `authorFilter` in `DashboardQuery.ts` that appends a SQL `WHERE` clause matching `author_email` (case-folded) or `author_name` against the resolved identity. Both `commitsInRange` and `buildStandupInsights` accept and apply this filter, so commit columns and the Risks/TODOs card are filtered together.
- Added `authoredBy` to the standup model in `DashboardModel.ts` and surfaced it in `standup.js` as a chip stating "yours only · email" or "every author — no git identity configured". The copy sheet subtitle also changes: an unfiltered board warns the user to review the lines before posting.

**📁 FILES**
- `cli/src/core/GitOps.ts`
- `cli/src/dashboard/DashboardQuery.ts`
- `cli/src/dashboard/DashboardServer.ts`
- `cli/src/dashboard/DashboardModel.ts`
- `cli/src/dashboard/assets/js/standup.js`

</blockquote>
</details>
<details>
<summary><strong>02 · Internal memory storage commits excluded from all dashboard metrics</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The dashboard was attributing thousands of commits to the user that were actually written by the tool's own internal memory system. On one real repository, roughly three-quarters of stored commits were internal bookkeeping entries, and the tool's own storage branch outranked the main development branch in the attribution list — making every commit-derived number on the dashboard unreliable.

**💡 Decisions Behind the Code**

- **Exclude by namespace, not exact name**: Matching only the exact current branch name would silently miss older versions of the storage branch that long-lived clones still carry. Matching by namespace covers all past and future versions with one rule, while a user branch that merely starts with the same word but uses a different separator is correctly left alone.
- **Filter in JavaScript after listing all branches rather than relying on a git-side count cap**: The storage branch is written on every memory operation, so it sorts first by commit date in the branch listing almost always. Asking git for one slot past the cap and then filtering would spend that extra slot on the storage branch and still return a full page of real branches — the cap would never be effective. Listing all branches and slicing after filtering costs one cheap ref walk and avoids the silent slot-waste.
- **Exclude glob position is load-bearing**: The fully qualified ref form looks correct but matches nothing under the branch selector and is silently ignored by git. The correct short form and its mandatory position immediately before the branch selector are both pinned by tests, because there is no runtime error to catch the wrong form.

**✅ What Was Implemented**

- Added a centralized exclusion rule in `Logger.ts` (later moved to `JolliRefs.ts`) that matches the internal storage branch by namespace rather than exact name, so historical versions of the branch are also excluded while any user branch with a similar prefix is left alone.
- Updated `DashboardCollector.ts` so both git log passes share a constant that prepends the exclude glob immediately before the branch selector. The branch attribution step also filters out internal refs before the per-branch reachability scan, and the branch count cap was replaced with a JavaScript-side slice applied after filtering.
- Updated `Backfill.ts` so the checkout fingerprint hashes only non-internal branch tips, preventing the storage branch's constant churn from triggering a full history re-sweep on every dashboard launch.

**📁 FILES**
- `cli/src/core/JolliRefs.ts`
- `cli/src/Logger.ts`
- `cli/src/dashboard/DashboardCollector.ts`
- `cli/src/dashboard/Backfill.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Recall bar chart gains estimated history bars, empty stubs, and recording boundary</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The recall card's bar chart only ever showed data from the day the recording system launched, leaving all earlier recall activity invisible. A window containing only sparse data was also visually indistinguishable from a broken chart, with no indication of where recording had started.

**💡 Decisions Behind the Code**

- **Estimated field omitted rather than zeroed**: Emitting a zero estimated value on every day point would add the key to every series entry on every machine, even the overwhelming majority with no pre-receipt history. Omitting it when zero keeps the data shape clean and makes the field's presence self-documenting.
- **Hatch pattern for estimates rather than a solid color**: The estimated value is a lower bound — the reference channel collapses repeated queries and caps entries, so a busy day reports fewer calls than it had. A solid bar beside exact-count bars claims a precision the estimate does not have; the hatch is a visual signal that this bar is a floor, not a count.
- **Per-day deduplication rather than global suppression**: Zeroing the estimate only on days that have receipts lets a single window hold both eras cleanly. Suppressing estimates globally once any receipt exists would have silently erased the historical signal the moment the first receipt landed.
- **`receiptsSinceDate` as a day key, not an epoch timestamp**: The daily series is bucketed in the server's resolved timezone. Sending a raw millisecond value and letting the browser format it would place the boundary on the wrong day for any user whose machine timezone differs from the server's.

**✅ What Was Implemented**

- `DashboardQuery.ts` (`buildRecallUsage`): timestamps parsed from agent transcript bookmarks now land in per-day `estimated` buckets. A second pass zeroes the estimate on any day that already has a receipt, preventing double-counting. A new unwindowed query produces `receiptsSinceDate` as a day key in the server's resolved timezone so the chart can draw a boundary without browser timezone shifts.
- `DashboardModel.ts`: `RecallDayPoint` gains an optional `estimated` field, omitted rather than zeroed on ordinary days. `RecallUsage` gains `receiptsSinceDate`, documented as deliberately unwindowed.
- `charts.js` (`JD.recallBars`): empty days render a 2-pixel baseline stub with a hover tooltip naming the date, making "counted and zero" visually distinct from "outside the window." Estimated bars use an SVG hatch pattern rather than a solid fill, with a tooltip stating "at least N called, outcome not recorded." When `sinceDate` falls inside the window, a faint background block covers the pre-recording stretch and a dashed vertical line with a "recording starts MM-DD" label marks the boundary.
- `stats.js` (`recallCard`): the history-only branch renders the bar chart when any day has an estimated value. The third legend entry ("outcome not recorded") appears only when the window actually contains estimated days.

**📁 FILES**
- `cli/src/dashboard/DashboardQuery.ts`
- `cli/src/dashboard/DashboardModel.ts`
- `cli/src/dashboard/assets/js/charts.js`
- `cli/src/dashboard/assets/js/stats.js`

</blockquote>
</details>
<details>
<summary><strong>04 · Backfill retries commits missing file rows after transient scan failures</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a git file-detail scan failed transiently for a batch of commits, those commits were still recorded in the database and silently treated as already processed on every subsequent run, leaving a permanent gap in file history that could only be recovered by rebuilding the entire database.

**💡 Decisions Behind the Code**

- **Separate "commit exists" from "file rows exist" as the skip criterion**: Using the commit row's existence as the skip signal was the root cause of the permanent gap. The fix deliberately uses a more expensive query (checking for the presence of file rows per commit) rather than the simpler commit-presence check, accepting the query cost to guarantee self-correction after any transient failure.
- **Exclude merge commits by parent count rather than a separate query**: Merge commits are structurally incapable of having file rows, so including them in the retry set would cause unbounded repeated work. Appending the parent field to the existing log format string was chosen over a separate git invocation to keep the collection to a single subprocess call.

**✅ What Was Implemented**

- Added a query in `Backfill.ts` that checks for the presence of actual file rows rather than just the commit row. The backfill's skip-set now uses this query, so commits whose file scan failed are automatically retried on the next run. The old commit-presence query is retained separately for the prune reconciliation step, which has different semantics.
- Updated `DashboardCollector.ts` to append parent-hash information to the git log format string and use it to exclude merge commits from the retry set. Merge commits produce no file diff output by design, so they can never acquire file rows; without this exclusion they would be retried on every sweep and in merge-heavy repositories could push past the incremental scan limit and trigger a full history rescan. The failure log level for file collection was also raised from debug to warn.
- Added two new tests in `Backfill.test.ts`: one verifying that a commit missing file rows is re-offered to the collector on the next sweep, and one verifying that merge commits are never included in the retry set.

**📁 FILES**
- `cli/src/dashboard/Backfill.ts`
- `cli/src/dashboard/DashboardCollector.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · One oversized commit no longer blocks file detail collection for an entire batch</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When one commit in a batch had a diff too large to read, the entire batch came back empty. On the next sweep all of those commits were re-queued because they still lacked file detail rows, so the same doomed batch returned on every dashboard launch, growing as new commits joined it.

**💡 Decisions Behind the Code**

- **Breadth-first bisect over depth-first**: A depth-first search would spend the entire call budget following one half of the tree to a single hash before touching the other half. Breadth-first salvages roughly fifteen-sixteenths of a full batch within the same budget and prevents the budget from being consumed entirely by whichever half happens to be searched first.
- **Hard call budget rather than unbounded recursion**: The same failure shape covers both "one commit is unreadable" and "git is broken in this repository." An unbounded bisect would spend a number of subprocesses proportional to batch size on every sweep for the life of a broken repository. The flat budget makes the worst case predictable and cheap regardless of batch size.

**✅ What Was Implemented**

- Extracted a batch helper in `DashboardCollector.ts` and added a breadth-first bisect loop in the file collection function. When a batch fails, it is split in half and both halves are retried; successful halves are stored immediately, and failing halves are split again until they reach a single commit or the call budget is exhausted.
- Added `NUMSTAT_BISECT_CALL_BUDGET = 24` as a hard cap on extra subprocess calls, bounding the cost for a repository where git itself is broken to roughly 25 subprocesses per sweep instead of the hundreds an unbounded bisect would spend.
- Commits that fail even as a batch of one remain in the retry set each sweep, which is the honest cost of being unable to read their diff — but they are now a handful of hashes rather than the whole batch.

**📁 FILES**
- `cli/src/dashboard/DashboardCollector.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Multi-worktree branch merge no longer silently deletes stored branch attribution</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

In repositories with multiple working copies checked out, if either copy's branch scan was incomplete, the two partial results were merged into an explicit empty list, which the database interpreted as a positive claim that no branch reaches the commit and deleted all stored associations.

**💡 Decisions Behind the Code**

Absent on either side poisons the union rather than writing the union of whichever sides succeeded. Writing a partial union would silently drop branches that only the failed checkout knew about, producing a claim that looks authoritative but is incomplete. Staying silent and letting a later complete sweep fill in the attribution means a commit may temporarily show no branch attribution after a failed sweep, but it will never lose attribution it previously had.

**✅ What Was Implemented**

- Rewrote the multi-checkout branch merge in `Backfill.ts` to treat absence on either side as poisoning the union. The merged event now omits the branch field entirely when either checkout omitted it, matching the single-checkout contract where an absent field means "keep what is stored." Only when both checkouts provide branch data is a union written.
- Added two new tests: one confirming that a commit attributed to branches in a first sweep retains those branches after a second sweep where neither checkout completed its branch scan, and one confirming that a partial result from one checkout does not overwrite branches only the other checkout knew about.

**📁 FILES**
- `cli/src/dashboard/Backfill.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Session attribution for recall receipts extended beyond Claude Code</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Recall calls made from agents other than Claude Code were never linked to a session, making the coverage figure on the recall card structurally zero for users whose primary agent was not Claude Code.

**💡 Decisions Behind the Code**

- **No fallback to a guessed session id**: Attributing a receipt to the most recently active session for the repo was explicitly rejected. A null session id is visible as a null in the database; an invented id is not, and it would corrupt the coverage figure in the one direction nobody can audit. The coverage denominator already handles session-less receipts correctly by treating them as belonging to no session.
- **Codex left without a session variable**: Direct inspection of a running Codex process's environment found no session, conversation, or thread variable — only a front-end identifier that does not correspond to a session row. Adding a host to the lookup table requires the same direct measurement; nothing is added by inference.

**✅ What Was Implemented**

`ProducerHooks.ts` (`currentAgentSessionId`): the single hardcoded environment variable read is replaced by an ordered lookup table (`SESSION_ID_ENV_VARS`). The table currently holds one entry — the Claude Code variable — because that is the only one confirmed by direct measurement. The function iterates the table and returns the first non-empty value. Comments record the measurement method used and the result for each host checked, so future additions follow the same evidence standard.

**📋 Future Enhancements**

Codex session ids exist inside Codex's own rollout files. A future path to proper Codex session attribution would be reading those files rather than an environment variable.

**📁 FILES**
- `cli/src/dashboard/ProducerHooks.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Root URL redirect no longer triggers expensive git scans on every visit</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The dashboard's root URL redirect was building a full data model that spawned a git subprocess for every enabled repository on every visit, even though the redirect only needed to know whether any repositories existed at all.

**💡 Decisions Behind the Code**

The redirect was already using the repositories view to avoid the stats view's AI cost, but that view had since been added to the set of views that trigger the git scan. Rather than moving the redirect to a different view or adding a new lightweight query, a flag was added to the existing model-building path so the skip is explicit and documented at the call site.

**✅ What Was Implemented**

- Added a `skipReachability` flag to `ModelRequest` in `DashboardServer.ts`. When set, the per-repository git fan-out is skipped entirely and memory badge counts revert to unfiltered raw values.
- Updated the root redirect handler to pass `skipReachability: true`, and added a test asserting that the redirect does not invoke the reachability scan while the repositories page itself still does.

**📁 FILES**
- `cli/src/dashboard/DashboardServer.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · Session-less recall caveat now accurate for mixed-session windows</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The dashboard's recall card showed a warning about calls that happened outside any agent session, but the condition was wrong: it stayed silent for the most common case where a window contained both attributed and unattributed calls, and fired unconditionally on machines where every call was properly linked to a session.

**💡 Decisions Behind the Code**

- **Server-side count over client-side proxy**: The old condition tested whether zero sessions claimed any calls, which is a much rarer and different statement than "at least one receipt names no session." Tracking the count explicitly on the server makes the statement precise and independently testable; a doc comment on the new field records exactly why the proxy failed, preserving the reasoning for future maintainers.
- **Count both used and set-aside receipts**: Both halves feed into the totals the caveat qualifies, and both are equally unattributable to a session. Counting only used calls would have left set-aside session-less calls silently unaccounted for in the explanation.

**✅ What Was Implemented**

- Added a `callsWithoutSession` field to `DashboardModel.ts` and populated it in `DashboardQuery.ts` by counting every receipt — used or set-aside — whose session identifier is absent.
- Updated the frontend card in `stats.js` to gate the caveat on `callsWithoutSession > 0` and render a count-aware message ("1 recall ran outside an agent session" / "N recalls ran outside an agent session") rather than a fixed string. The previous client-side proxy condition is replaced entirely.

**📁 FILES**
- `cli/src/dashboard/DashboardModel.ts`
- `cli/src/dashboard/DashboardQuery.ts`
- `cli/src/dashboard/assets/js/stats.js`

</blockquote>
</details>
<details>
<summary><strong>10 · Stale restore temp files cleaned up even after process ID reuse</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Temporary files left behind by interrupted database restore operations could accumulate permanently on disk. The cleanup logic checked whether the process that created the file was still running, but a dead process's ID can be reassigned to an unrelated process — once that happens, the leftover file is never removed.

**💡 Decisions Behind the Code**

- **Age threshold as a second gate, not a replacement for the PID check**: Replacing the PID check entirely with an age check would risk deleting a temp file belonging to a legitimately slow restore on a heavily loaded machine. Both conditions together are far more conservative than either alone — a file is only swept when it looks alive by PID but is also old enough that no honest restore could still be running.
- **One hour as the threshold**: A restore is a file copy plus an integrity check; even on a very large database this completes in minutes. One hour is orders of magnitude past the longest plausible honest restore, making the threshold safe without being so long that it fails to reclaim disk on machines that recycle PIDs quickly.
- **Best-effort sweep by design**: A failure to read the directory or delete a file is logged and ignored rather than aborting the recovery. A leftover temp file is wasted disk space but never a correctness problem, and failing a recovery over a cleanup error would be a worse outcome than leaving the file behind.

**✅ What Was Implemented**

- Added a `RESTORE_TEMP_MAX_AGE_MS` constant (one hour) in `Recovery.ts` and a helper that reads each temp file's last-modified time. The sweep now removes a file if its recorded process appears alive by PID AND the file is older than one hour, so age acts as a second gate that the PID check alone cannot provide.
- The helper answers conservatively when a file's modification time cannot be read: the file falls back to the PID-only check rather than being deleted blindly.
- Added tests covering four cases: a dead-PID temp is removed, a live-PID temp belonging to a concurrent restore is preserved, unrelated files in the same directory are untouched, and the PID-reuse scenario where the file looks alive by process ID but exceeds the age threshold.

**📁 FILES**
- `cli/src/dashboard/Recovery.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · Recall card footnote condensed to summary line with hover detail</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The recall card's footnote had grown to several inline clauses added independently over time, making the card feel cluttered and making it hard to tell which number the caveats applied to.

**💡 Decisions Behind the Code**

Moving detail into hover rather than truncating or keeping it inline preserves the information for users who want it without cluttering the card for users who don't. Simply removing the detail was rejected because the data is genuinely useful for diagnosing recall behavior; keeping it all inline conflicted with the visual target for the card.

**✅ What Was Implemented**

- `stats.js` (`recallCard`): the visible footnote renders only the session coverage ratio (e.g. "2 of 4 sessions got prior context"). The secondary clauses — surface breakdown, receipt-less call count, and the session-less caveat — move into the hover tooltip of the info icon, rewritten as plain text to avoid HTML tags rendering literally inside a title attribute.
- Singular/plural agreement is fixed for the receipt-less call count ("1 further call is" vs "N further calls are").

**📁 FILES**
- `cli/src/dashboard/assets/js/stats.js`

</blockquote>
</details>
<details>
<summary><strong>12 · Ref exclusion constants moved to a leaf module to fix widespread test failures</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After adding ref-exclusion constants to the logger module, over twenty test suites began failing with "No export is defined on the mock" errors. Those suites replace the logger with a hand-written stub that does not include any new exports, so every addition to that module breaks them all.

**💡 Decisions Behind the Code**

- **Leaf module with no imports**: the root cause was that any new export in the logger module breaks every test that stubs it. Making the new module import-free means no test suite will ever need to mock it, permanently avoiding the same class of breakage for future additions to this file.
- **Restate the namespace literal rather than derive it from the logger**: deriving the value from the logger's constant would re-introduce an import dependency on the logger, defeating the purpose. The comment in the new file documents exactly when the two need to be kept in sync — a wholesale rename, not a version bump within the namespace.

**✅ What Was Implemented**

- Created `cli/src/core/JolliRefs.ts` as a leaf module with no imports, containing `isJolliInternalRef` and `JOLLI_REFS_EXCLUDE_GLOB`. The ref namespace literal is restated here rather than derived from the logger's branch-name constant, with a comment explaining the coupling risk and when the two need to stay in sync.
- Removed the same exports from `cli/src/Logger.ts` and updated `DashboardCollector.ts` and `Backfill.ts` to import from the new module instead.
- Added `cli/src/core/JolliRefs.ts` to the allowlist in `OrphanSotGuard.test.ts` with a comment explaining that this file mentions the orphan branch name only as a cross-reference, not as a reader or writer of that storage.

**📁 FILES**
- `cli/src/core/JolliRefs.ts`
- `cli/src/Logger.ts`
- `cli/src/dashboard/DashboardCollector.ts`
- `cli/src/dashboard/Backfill.ts`

</blockquote>
</details>
<details>
<summary><strong>13 · Recall coverage denominator no longer inflated by session-less receipts</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The recall panel showed a slightly higher total session count than actually existed because recall events recorded outside any AI session were collapsing into a phantom session entry in the denominator that could never be counted as covered.

**💡 Decisions Behind the Code**

Session-less receipts are a legitimate and intentional state — a recall run from a plain terminal prompt has no session to attribute to. The fix excludes them only from the denominator union, not from the receipt table itself, preserving the accurate call count while fixing the session count.

**✅ What Was Implemented**

Added a `session_id IS NOT NULL` filter to the receipt arm of the session union query in `DashboardQuery.ts`, preventing session-less receipts from contributing a phantom entry to the denominator. A detailed comment was added explaining the SQLite NULL deduplication behavior that caused the inflation.

**📁 FILES**
- `cli/src/dashboard/DashboardQuery.ts`

</blockquote>
</details>
<details>
<summary><strong>14 · Memory browser and stats feed now sort memories in the same order</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The memory browser tree and the stats activity feed listed the same memories in different orders on repositories with rebased or cherry-picked commits, because the two views were sorting by different date fields.

**💡 Decisions Behind the Code**

The fallback to the memory's own stored date is preserved for memories that have no corresponding commit row yet, ensuring repositories that have not completed their git history scan continue to display correctly. The secondary sort key on commit hash is retained unchanged, as it is load-bearing for cursor-based pagination stability.

**✅ What Was Implemented**

Updated `MemoriesQuery.ts` to join against the commits table and sort by committer date with a fallback to the memory's own stored date, matching the formula already used by the stats feed. The `MemoryListRow` interface field was renamed from `commit_date_ms` to `committed_at_ms` to reflect the new semantics, and `toListItems` was updated to read the renamed field.

**📁 FILES**
- `cli/src/dashboard/MemoriesQuery.ts`

</blockquote>
</details>
<details>
<summary><strong>15 · Memory browser load-more handles deleted memories without leaving stale rows</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

If a memory was removed during an active browser session, the next page load returned an empty first page indicating the cursor position was gone, and the browser mishandled this by entering the empty-page branch first, leaving stale deleted memories visible with an incorrect total count.

**💡 Decisions Behind the Code**

The missing-cursor and empty-page conditions overlap when the last reachable memory in a scope is the one that disappeared. Treating the missing-cursor flag as the more specific answer and handling it first means the empty-page branch never needs to know about this case, keeping each branch's logic self-contained.

**✅ What Was Implemented**

- Reordered the response-handling logic in `memories.js` so the missing-cursor condition is checked before the empty-page condition. When the cursor is missing and the returned page is also empty, the tree now clears correctly and shows the accurate total from the server rather than the count of stale local rows. The `page.items || []` expression was extracted to a variable to remove repeated optional chaining.
- Fixed an indentation error on a `return` statement in the same file that had been misaligned by four spaces relative to its surrounding block.

**📁 FILES**
- `cli/src/dashboard/assets/js/memories.js`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 10, 2026 at 6:23 PM · via Anthropic*
<!-- jollimemory-summary-end -->