### PR TITLE
Skip dead worktrees in backfill and align the dashboard's two clocks

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -258,6 +258,22 @@ export interface StoredSession {
 	readonly source?: TranscriptSource;
 	/** Original JSONL file path, preserved for re-summarize (future) */
 	readonly transcriptPath?: string;
+	/**
+	 * The session's display title as of this commit, resolved by
+	 * `resolveArchivedTitle` when the memory was written.
+	 *
+	 * The answer, deliberately, rather than leaving every reader to re-derive it
+	 * from {@link transcriptPath}. That path is machine-local and the file behind
+	 * it is pruned on the agent's own schedule, so re-derivation fails exactly
+	 * where it matters most: an old memory, and every memory on a machine that
+	 * did not write it. This archive is the only artifact that travels.
+	 *
+	 * Forward-only, like {@link usage} and {@link toolUse}: absent on memories
+	 * written before this field existed, and absent when no title could be
+	 * resolved at all. Readers must treat absence as "not recorded" and fall back
+	 * to whatever they used before, never as "this session has no title".
+	 */
+	readonly title?: string;
 	readonly entries: ReadonlyArray<TranscriptEntry>;
 	/**
 	 * This session's own share of the commit's conversation tokens — the
@@ -1490,6 +1506,13 @@ export interface CommitInfo {
 	readonly message: string;
 	readonly author: string;
 	readonly date: string;
+	/**
+	 * Author email (`%ae`), absent when git reported none. Optional because
+	 * `getHeadCommitInfo` does not ask for it — only the dashboard's live
+	 * producer needs it, to match the author filter's email clause against
+	 * commits made since the last backfill sweep.
+	 */
+	readonly authorEmail?: string;
 }
 
 /** Result of a git command execution */

--- a/cli/src/backfill/BackfillEngine.ts
+++ b/cli/src/backfill/BackfillEngine.ts
@@ -17,6 +17,7 @@
 import { execGit, getCommitInfo, getDiffContent, getDiffStats } from "../core/GitOps.js";
 import { enqueueIngestOperation } from "../core/IngestTrigger.js";
 import { hasLlmCredentials } from "../core/LlmCredentials.js";
+import { resolveArchivedTitle } from "../core/SessionTitleResolver.js";
 import { loadConfig } from "../core/SessionTracker.js";
 import { createStorage } from "../core/StorageFactory.js";
 import type { StorageProvider } from "../core/StorageProvider.js";
@@ -149,13 +150,24 @@ async function worktreeRoots(cwd: string): Promise<string[]> {
 // hasLlmCredentials is imported from ../core/LlmCredentials.js (single source of
 // truth shared with SessionStartHook, the summarizer, and compile).
 
-/** Converts an attributed commit's sessions into the orphan-branch transcript artifact. */
-function toStoredTranscript(attr: AttributedCommit): StoredTranscript {
+/**
+ * Converts an attributed commit's sessions into the orphan-branch transcript artifact.
+ *
+ * Titles are resolved here for the same reason the live writer resolves them
+ * (see `resolveArchivedTitle`), with one difference worth knowing: backfill runs
+ * long after the commit, so a transcript pruned in the meantime yields no
+ * `ai-title` and the archived first user message stands instead. That is the
+ * honest answer — and still strictly better than archiving nothing, which leaves
+ * every future reader deriving it from a path that is already gone.
+ */
+async function toStoredTranscript(attr: AttributedCommit): Promise<StoredTranscript> {
+	const titles = await Promise.all(attr.sessions.map((s) => resolveArchivedTitle(s)));
 	return {
-		sessions: attr.sessions.map((s) => ({
+		sessions: attr.sessions.map((s, i) => ({
 			sessionId: s.sessionId,
 			source: s.source,
 			transcriptPath: s.transcriptPath,
+			...(titles[i] ? { title: titles[i] } : {}),
 			entries: [...s.entries],
 		})),
 	};
@@ -223,7 +235,7 @@ async function generateAndStore(
 
 	// Only attach a transcript artifact when a conversation was attributed.
 	const artifacts =
-		attr && transcriptId ? { transcript: { id: transcriptId, data: toStoredTranscript(attr) } } : undefined;
+		attr && transcriptId ? { transcript: { id: transcriptId, data: await toStoredTranscript(attr) } } : undefined;
 	await storeSummary(summary, cwd, false, artifacts, storage);
 	return result.topics.length;
 }

--- a/cli/src/commands/DashboardCommand.test.ts
+++ b/cli/src/commands/DashboardCommand.test.ts
@@ -3,13 +3,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { BackfillProgress } from "../dashboard/Backfill.js";
 import type { DashboardServerState } from "../dashboard/DashboardServer.js";
 import { writeDashboardState } from "../dashboard/DashboardServer.js";
+import type { DbBackfillProgress } from "../dashboard/DbBackfill.js";
 import type { RegisteredRepo } from "../dashboard/RepoRegistry.js";
 
-vi.mock("../dashboard/Backfill.js", () => ({
-	backfillRepos: vi.fn(async () => [{ mode: "bootstrapped", eventsApplied: 3 }]),
+vi.mock("../dashboard/DbBackfill.js", () => ({
+	dbBackfillRepos: vi.fn(async () => [{ mode: "bootstrapped", eventsApplied: 3 }]),
 }));
 // executeDashboard takes the daily backup snapshot (moved here off the
 // read-only server); unmocked it would open the real machine database and
@@ -41,9 +41,9 @@ vi.mock("../dashboard/DashboardDb.js", async (importOriginal) => {
 });
 
 import { maybeAutoCutover } from "../dashboard/AutoCutover.js";
-import { backfillRepos } from "../dashboard/Backfill.js";
 import { opportunisticSnapshot } from "../dashboard/Backup.js";
 import { canUseDashboardDb } from "../dashboard/DashboardDb.js";
+import { dbBackfillRepos } from "../dashboard/DbBackfill.js";
 import { listActiveRepos, registerRepo } from "../dashboard/RepoRegistry.js";
 import {
 	acquireSpawnLock,
@@ -102,7 +102,7 @@ beforeEach(() => {
 		worktreeRoot: "/w",
 		enabledAt: "t",
 	});
-	vi.mocked(backfillRepos).mockResolvedValue([{ mode: "bootstrapped", eventsApplied: 3, repoName: "jolli" }]);
+	vi.mocked(dbBackfillRepos).mockResolvedValue([{ mode: "bootstrapped", eventsApplied: 3, repoName: "jolli" }]);
 	vi.mocked(listActiveRepos).mockResolvedValue([]);
 	vi.spyOn(console, "log").mockImplementation(() => {});
 	vi.spyOn(console, "error").mockImplementation(() => {});
@@ -265,7 +265,7 @@ describe("importDashboardHistory", () => {
 		const d = deps();
 		await importDashboardHistory("/w", d);
 		expect(registerRepo).toHaveBeenCalledWith(expect.objectContaining({ cwd: "/w" }));
-		expect(backfillRepos).toHaveBeenCalledTimes(1);
+		expect(dbBackfillRepos).toHaveBeenCalledTimes(1);
 		// The whole point of the split: enable must not bind a port or open a browser.
 		expect(d.spawned).toEqual([]);
 		expect(d.opened).toEqual([]);
@@ -275,18 +275,105 @@ describe("importDashboardHistory", () => {
 		vi.mocked(canUseDashboardDb).mockReturnValueOnce(false);
 		await importDashboardHistory("/w", deps());
 		expect(registerRepo).not.toHaveBeenCalled();
-		expect(backfillRepos).not.toHaveBeenCalled();
+		expect(dbBackfillRepos).not.toHaveBeenCalled();
 	});
 
 	it("imports anyway when the cwd is not a repo", async () => {
 		vi.mocked(registerRepo).mockRejectedValueOnce(new Error("not a git repo"));
 		await importDashboardHistory("/w", deps());
-		expect(backfillRepos).toHaveBeenCalledTimes(1);
+		expect(dbBackfillRepos).toHaveBeenCalledTimes(1);
 	});
 
 	it("never throws when the import fails", async () => {
-		vi.mocked(backfillRepos).mockRejectedValueOnce(new Error("db locked"));
+		vi.mocked(dbBackfillRepos).mockRejectedValueOnce(new Error("db locked"));
 		await expect(importDashboardHistory("/w", deps())).resolves.toBeUndefined();
+	});
+
+	it("says nothing when every registered repo was skipped as dead", async () => {
+		// A repo whose every recorded worktree is gone is dropped before the sweep
+		// and returns no result, so there is nothing this report may claim about it.
+		// Counting the registry instead printed "✓ All 0 memories already migrated."
+		vi.mocked(listActiveRepos).mockResolvedValue([
+			{ repoIdentity: "r", repoName: "jolli", worktreeRoot: "/gone", enabledAt: "t" },
+		]);
+		vi.mocked(dbBackfillRepos).mockResolvedValue([]);
+		await importDashboardHistory("/w", deps());
+		expect(vi.mocked(console.log).mock.calls.flat().join("\n")).not.toMatch(/migrated/i);
+	});
+
+	it("counts the repos that were swept, not the ones that were registered", async () => {
+		vi.mocked(listActiveRepos).mockResolvedValue([
+			{ repoIdentity: "r1", repoName: "a", worktreeRoot: "/a", enabledAt: "t" },
+			{ repoIdentity: "r2", repoName: "b", worktreeRoot: "/b", enabledAt: "t" },
+			{ repoIdentity: "r3", repoName: "gone", worktreeRoot: "/gone", enabledAt: "t" },
+		]);
+		vi.mocked(dbBackfillRepos).mockResolvedValue([
+			{ mode: "updated", eventsApplied: 1, repoName: "a", sotImport: { nodes: 2, updated: 2 } },
+			{ mode: "updated", eventsApplied: 1, repoName: "b", sotImport: { nodes: 1, updated: 1 } },
+		] as unknown as Awaited<ReturnType<typeof dbBackfillRepos>>);
+		await importDashboardHistory("/w", deps());
+		expect(vi.mocked(console.log).mock.calls.flat().join("\n")).toContain("across 2 repo(s)");
+	});
+
+	it("names the repos with no checkout on disk, once, without calling it a failure", async () => {
+		// The only place this reaches the user: the backfill's own log line is at
+		// `debug`, which CLI mode keeps off the terminal, so an unmounted share
+		// silently stopped importing. It is NOT a migration failure — that wording
+		// belongs to `skipped`, and this repo may be back on the next launch.
+		vi.mocked(listActiveRepos).mockResolvedValue([
+			{ repoIdentity: "r1", repoName: "a", worktreeRoot: "/a", enabledAt: "t" },
+			{ repoIdentity: "r2", repoName: "on-a-nas", worktreeRoot: "/mnt/nas/x", enabledAt: "t" },
+		]);
+		vi.mocked(dbBackfillRepos).mockResolvedValue([
+			{ mode: "updated", eventsApplied: 1, repoName: "a", sotImport: { nodes: 2, updated: 0 } },
+			{ mode: "unavailable", eventsApplied: 0, repoName: "on-a-nas" },
+		] as unknown as Awaited<ReturnType<typeof dbBackfillRepos>>);
+		await importDashboardHistory("/w", deps());
+		const out = vi.mocked(console.log).mock.calls.flat().join("\n");
+		expect(out).toContain("Skipped 1 repo(s) with no checkout on disk (on-a-nas)");
+		expect(out).not.toMatch(/migration failed/i);
+		// Counted out of the migration report too — it was never swept, so it is not
+		// one of the repos the "already migrated" line is speaking for.
+		expect(out).not.toContain("across");
+	});
+
+	it("samples distinct names instead of printing the whole dead-entry list", async () => {
+		// Measured on a real registry: 132 unavailable entries, most named `repo`
+		// (test fixtures from before the isolatedHome fix). Printed in full they
+		// buried the result line under them, and "repo, repo, repo" identifies
+		// nothing anyway. Nothing prunes that file, so the count only grows.
+		vi.mocked(listActiveRepos).mockResolvedValue([
+			{ repoIdentity: "r1", repoName: "a", worktreeRoot: "/a", enabledAt: "t" },
+		]);
+		const dead = ["repo", "repo", "repo", "frepo", "bare-fenced", "trepo"].map((repoName, i) => ({
+			mode: "unavailable",
+			eventsApplied: 0,
+			repoName,
+			id: i,
+		}));
+		vi.mocked(dbBackfillRepos).mockResolvedValue([
+			{ mode: "updated", eventsApplied: 1, repoName: "a", sotImport: { nodes: 1, updated: 0 } },
+			...dead,
+		] as unknown as Awaited<ReturnType<typeof dbBackfillRepos>>);
+		await importDashboardHistory("/w", deps());
+		const out = vi.mocked(console.log).mock.calls.flat().join("\n");
+		// The COUNT is every entry; the sample is distinct names, capped at three.
+		expect(out).toContain("Skipped 6 repo(s) with no checkout on disk (repo, frepo, bare-fenced, +1 more)");
+	});
+
+	it("stays silent about migration when every registered repo is unavailable", async () => {
+		// `results` is no longer empty in this case, so the quiet rule has to read
+		// past the unavailable rows or it prints "✓ All 0 memories already migrated."
+		vi.mocked(listActiveRepos).mockResolvedValue([
+			{ repoIdentity: "r1", repoName: "gone", worktreeRoot: "/gone", enabledAt: "t" },
+		]);
+		vi.mocked(dbBackfillRepos).mockResolvedValue([
+			{ mode: "unavailable", eventsApplied: 0, repoName: "gone" },
+		] as unknown as Awaited<ReturnType<typeof dbBackfillRepos>>);
+		await importDashboardHistory("/w", deps());
+		const out = vi.mocked(console.log).mock.calls.flat().join("\n");
+		expect(out).toContain("Skipped 1 repo(s)");
+		expect(out).not.toMatch(/migrated/i);
 	});
 });
 
@@ -308,7 +395,7 @@ describe("executeDashboard", () => {
 		expect(d.opened).toHaveLength(1);
 		// No `?t=` — the URL is hand-openable, which is why the token was dropped.
 		expect(d.opened[0]).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/dashboard\/standup$/);
-		expect(backfillRepos).toHaveBeenCalledTimes(1);
+		expect(dbBackfillRepos).toHaveBeenCalledTimes(1);
 	});
 
 	it("attempts a THROTTLED auto-cutover after the import", async () => {
@@ -318,7 +405,7 @@ describe("executeDashboard", () => {
 		const d = deps();
 		await executeDashboard("stats", { cwd: "/w" }, d);
 		expect(maybeAutoCutover).toHaveBeenCalledWith("/w", expect.objectContaining({ throttle: true }));
-		expect(vi.mocked(backfillRepos).mock.invocationCallOrder[0]).toBeLessThan(
+		expect(vi.mocked(dbBackfillRepos).mock.invocationCallOrder[0]).toBeLessThan(
 			vi.mocked(maybeAutoCutover).mock.invocationCallOrder[0] as number,
 		);
 	});
@@ -363,7 +450,7 @@ describe("executeDashboard", () => {
 	});
 
 	it("a backfill failure warns but does not fail the command", async () => {
-		vi.mocked(backfillRepos).mockRejectedValueOnce(new Error("db locked"));
+		vi.mocked(dbBackfillRepos).mockRejectedValueOnce(new Error("db locked"));
 		await expect(executeDashboard("stats", {}, deps())).resolves.toBe(true);
 	});
 
@@ -456,7 +543,7 @@ describe("registerDashboardCommand", () => {
 });
 
 describe("createProgressPrinter", () => {
-	const event = (over: Partial<BackfillProgress>): BackfillProgress => ({
+	const event = (over: Partial<DbBackfillProgress>): DbBackfillProgress => ({
 		repoName: "jolliai",
 		kind: "memories",
 		done: 1,
@@ -467,7 +554,7 @@ describe("createProgressPrinter", () => {
 	});
 
 	/** Drives `done` from 1..total, returning every line the printer emitted. */
-	function drive(total: number, over: Partial<BackfillProgress> = {}, from = 1): string[] {
+	function drive(total: number, over: Partial<DbBackfillProgress> = {}, from = 1): string[] {
 		const lines: string[] = [];
 		const printer = createProgressPrinter({ log: (line) => lines.push(line) });
 		for (let done = from; done <= total; done++) printer.onProgress(event({ done, total, ...over }));

--- a/cli/src/commands/DashboardCommand.ts
+++ b/cli/src/commands/DashboardCommand.ts
@@ -28,10 +28,10 @@ import type { Command } from "commander";
 import { getProjectRootDir } from "../core/GitOps.js";
 import { getGlobalConfigDir } from "../core/SessionTracker.js";
 import { maybeAutoCutover } from "../dashboard/AutoCutover.js";
-import { type BackfillProgress, backfillRepos } from "../dashboard/Backfill.js";
 import { opportunisticSnapshot } from "../dashboard/Backup.js";
 import { canUseDashboardDb, DASHBOARD_SQLITE_MIN_VERSION, ensureDashboardDbExists } from "../dashboard/DashboardDb.js";
 import { clearDashboardState, type DashboardServerState, readDashboardState } from "../dashboard/DashboardServer.js";
+import { type DbBackfillProgress, dbBackfillRepos } from "../dashboard/DbBackfill.js";
 import { listActiveRepos, registerRepo } from "../dashboard/RepoRegistry.js";
 import { createLogger, errMsg } from "../Logger.js";
 import { spawnHidden } from "../util/Subprocess.js";
@@ -369,7 +369,7 @@ async function stopServer(deps: DashboardDeps): Promise<void> {
  *
  * Split out of {@link executeDashboard} because the import is the only part of
  * the launcher `jolli enable` and the guided front door actually need.
- * `backfillRepos` is the sole production caller of the SOT import, so memories
+ * `dbBackfillRepos` is the sole production caller of the SOT import, so memories
  * just written would otherwise sit outside the database until someone ran
  * `jolli dashboard` by hand — but wanting that import is no reason to bind a
  * port, spawn a detached server and take over the user's browser at enable
@@ -393,12 +393,12 @@ async function runHistoryImport(deps: DashboardDeps): Promise<void> {
 		const repos = await listActiveRepos(deps.configDir);
 		// Zero registered repos stays completely silent, header included: there is
 		// no work, and announcing none is worse than saying nothing. The call still
-		// happens — `backfillRepos([])` is a no-op, and skipping it would make this
+		// happens — `dbBackfillRepos([])` is a no-op, and skipping it would make this
 		// function's contract depend on the registry, which callers rely on not
 		// doing.
 		const quiet = repos.length === 0;
 		// Held, not printed: on a steady-state pass the whole block is noise. The
-		// import itself is cursor-gated (see Backfill's `sot-import`), so a converged
+		// import itself is cursor-gated (see DbBackfill's `sot-import`), so a converged
 		// run does no memory work at all — but the phase markers still fire for the
 		// tiers that DO run every time (sessions), and a header announcing a
 		// migration that will not happen is exactly what made this look like it
@@ -407,7 +407,7 @@ async function runHistoryImport(deps: DashboardDeps): Promise<void> {
 		// honest report and prints either way.
 		const out = createDeferredWriter();
 		const printer = createProgressPrinter({ log: out.write });
-		const results = await backfillRepos(repos, {
+		const results = await dbBackfillRepos(repos, {
 			...(deps.dbPath ? { dbPath: deps.dbPath } : {}),
 			...(deps.now ? { now: deps.now } : {}),
 			// THE reveal rule: only the two tiers that are cursor-gated may put this
@@ -433,12 +433,50 @@ async function runHistoryImport(deps: DashboardDeps): Promise<void> {
 				printer.onProgress(progress);
 			},
 		});
-		if (quiet) return;
+		// A repo whose every registered worktree is gone is not counted with the
+		// ones that were imported: it was never swept, so `results` — never
+		// `repos` — is what this report may count, minus the entries that only say
+		// "not here". Unfiltered it printed "✓ All 0 memories already migrated."
+		const worked = results.filter((r) => r.mode !== "unavailable");
+		const missing = results.filter((r) => r.mode === "unavailable");
+		// ONE line for the whole run, naming the repos. The three warnings per repo
+		// per pass this replaced were the reason it went silent, but silence is not
+		// the fix: "no checkout on disk" is also what a network share or an
+		// external drive looks like while it is unmounted, and in that case the
+		// user is still expecting these memories to arrive. The wording says what
+		// was observed and what follows from it — not "failed", which is what a
+		// `skipped` row below means.
+		//
+		// Printed directly rather than through the deferred writer, and WITHOUT
+		// revealing a header: nothing was migrated for these repos, so putting
+		// "Migrating your memories…" on screen because one of them is unmounted
+		// would re-introduce, in the block that exists to avoid it, exactly the
+		// claim the reveal rule is there to prevent.
+		if (missing.length > 0) {
+			// A SAMPLE of distinct names, never the whole list. Measured on a real
+			// registry: 132 dead entries, most of them named `repo` — test fixtures
+			// that predate the `isolatedHome` fix in this same change — printed as
+			// one 132-item line that buried the ✓ result under it. Nothing prunes
+			// this file, so the count only grows. Distinct because a list reading
+			// "repo, repo, repo" identifies nothing; the count carries the scale and
+			// the sample carries "which kind of thing is this".
+			const distinct = [...new Set(missing.map((r) => r.repoName))];
+			const sample = distinct.slice(0, 3).join(", ");
+			const rest = distinct.length > 3 ? `, +${distinct.length - 3} more` : "";
+			console.log(
+				`\n  ⚠ Skipped ${missing.length} repo(s) with no checkout on disk (${sample}${rest})` +
+					" — deleted, or on a drive that is not mounted. Still registered; they resume on their own.",
+			);
+		}
+		// With every entry dead that leaves nothing more to say, and the
+		// zero-registered-repos rule applies for the same reason: announcing work
+		// on repos that were not touched is worse than silence.
+		if (quiet || worked.length === 0) return;
 		// A failure has to be shown in context — which repo, under which header.
-		if (results.some((r) => r.mode === "skipped")) out.reveal(MIGRATION_HEADER);
+		if (worked.some((r) => r.mode === "skipped")) out.reveal(MIGRATION_HEADER);
 		// A repo that threw used to reach `log.error` and nothing else, so on
 		// screen it was indistinguishable from a repo with nothing to do.
-		for (const failed of results.filter((r) => r.mode === "skipped")) {
+		for (const failed of worked.filter((r) => r.mode === "skipped")) {
 			console.log(`  ⚠ ${failed.repoName} — migration failed: ${failed.error ?? "unknown error"}`);
 		}
 		// Report what actually happened, not what was re-projected. A steady-state
@@ -449,10 +487,10 @@ async function runHistoryImport(deps: DashboardDeps): Promise<void> {
 		//
 		// The counts are MEMORIES, not events: events are the activity tier, and
 		// this whole line is about the thing the user was told was migrating.
-		const migrated = results.reduce((sum, r) => sum + (r.sotImport?.nodes ?? 0), 0);
-		const bootstrapped = results.filter((r) => r.mode === "bootstrapped").length;
-		const newMemories = results.reduce((sum, r) => sum + (r.sotImport?.updated ?? 0), 0);
-		const across = repos.length > 1 ? ` across ${bootstrapped || repos.length} repo(s)` : "";
+		const migrated = worked.reduce((sum, r) => sum + (r.sotImport?.nodes ?? 0), 0);
+		const bootstrapped = worked.filter((r) => r.mode === "bootstrapped").length;
+		const newMemories = worked.reduce((sum, r) => sum + (r.sotImport?.updated ?? 0), 0);
+		const across = worked.length > 1 ? ` across ${bootstrapped || worked.length} repo(s)` : "";
 		if (bootstrapped > 0 || newMemories > 0) {
 			// Something landed, so the progress that produced it belongs on screen —
 			// including the runs too fast to have tripped the elapsed-time reveal.
@@ -529,7 +567,7 @@ export function createDeferredWriter(): {
  * rewritten line is invisible in a piped log.
  */
 export function createProgressPrinter(deps: { readonly log?: (line: string) => void } = {}): {
-	onProgress: (progress: BackfillProgress) => void;
+	onProgress: (progress: DbBackfillProgress) => void;
 } {
 	const write = deps.log ?? ((line: string) => console.log(line));
 	let lastQuarter = 0;

--- a/cli/src/commands/DoctorCommand.test.ts
+++ b/cli/src/commands/DoctorCommand.test.ts
@@ -74,6 +74,7 @@ vi.mock("./CliUtils.js", async (importOriginal) => {
 	return { ...actual, resolveProjectDir: h.resolveProjectDir };
 });
 
+import { setIsolatedHome } from "../testUtils/isolatedHome.js";
 import { registerDoctorCommand } from "./DoctorCommand.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -277,8 +278,7 @@ describe("doctor --recover", () => {
 		const { join } = await import("node:path");
 		const { runRecover } = await import("./DoctorCommand.js");
 		const home = mkdtempSync(join(tmpdir(), "jolli-doctor-recover-"));
-		const realHome = process.env.HOME;
-		process.env.HOME = home;
+		const restoreHome = setIsolatedHome(home);
 		// This file mocks SessionTracker wholesale; point the two functions the
 		// recovery path uses at the fake HOME.
 		const st = await import("../core/SessionTracker.js");
@@ -331,7 +331,7 @@ describe("doctor --recover", () => {
 			process.exitCode = 0;
 			logSpy.mockRestore();
 			errSpy.mockRestore();
-			process.env.HOME = realHome;
+			restoreHome();
 			rmSync(home, { recursive: true, force: true });
 		}
 	});

--- a/cli/src/commands/GuidedFrontDoor.ts
+++ b/cli/src/commands/GuidedFrontDoor.ts
@@ -273,7 +273,7 @@ export async function runGuidedFrontDoor(): Promise<void> {
  * browser on it — one `executeDashboard` call, which is exactly what `jolli
  * dashboard` runs.
  *
- * Placed AFTER the back-fill step on purpose. `backfillRepos` (which the import
+ * Placed AFTER the back-fill step on purpose. `dbBackfillRepos` (which the import
  * half wraps) is the ONLY production caller of the source-of-truth import:
  * memories the back-fill just wrote would otherwise sit outside the dashboard
  * database until the user happened to run `jolli dashboard` by hand.

--- a/cli/src/core/ClaudeAiTitleReader.test.ts
+++ b/cli/src/core/ClaudeAiTitleReader.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { readClaudeAiTitle } from "./ClaudeAiTitleReader.js";
+import { readClaudeAiTitle, TAIL_SCAN_BYTES } from "./ClaudeAiTitleReader.js";
 
 describe("readClaudeAiTitle", () => {
 	let dir: string;
@@ -126,6 +126,33 @@ describe("readClaudeAiTitle", () => {
 		);
 		const result = await readClaudeAiTitle(file);
 		expect(result).toBe("OK");
+	});
+
+	it("scans only the tail of a transcript larger than the budget, dropping the partial first line", async () => {
+		// The read is on the dashboard's request path against a file that is being
+		// appended to, so a growing multi-MB transcript is re-scanned on every 30 s
+		// poll. The tail is where the answer is: only the LAST ai-title is wanted.
+		const file = join(dir, "huge.jsonl");
+		const filler = `${JSON.stringify({ type: "user", content: "x".repeat(4096) })}\n`;
+		const early = `${JSON.stringify({ type: "ai-title", sessionId: "s", aiTitle: "before the cut" })}\n`;
+		const late = `${JSON.stringify({ type: "ai-title", sessionId: "s", aiTitle: "after the cut" })}\n`;
+		writeFileSync(file, early + filler.repeat(Math.ceil(TAIL_SCAN_BYTES / filler.length) + 8) + late);
+
+		expect(await readClaudeAiTitle(file)).toBe("after the cut");
+	});
+
+	it("gives up a title that sits entirely before the cut, rather than reporting a wrong one", async () => {
+		// The documented trade-off, pinned so it is a decision and not a surprise: a
+		// transcript that grew past the budget with every `ai-title` behind the cut
+		// reports none, and the caller falls back to its own title source. Claude
+		// re-emits the title as the conversation continues, so this is the shape a
+		// real transcript does not have.
+		const file = join(dir, "title-before-cut.jsonl");
+		const filler = `${JSON.stringify({ type: "user", content: "x".repeat(4096) })}\n`;
+		const early = `${JSON.stringify({ type: "ai-title", sessionId: "s", aiTitle: "before the cut" })}\n`;
+		writeFileSync(file, early + filler.repeat(Math.ceil(TAIL_SCAN_BYTES / filler.length) + 8));
+
+		expect(await readClaudeAiTitle(file)).toBeUndefined();
 	});
 
 	it("returns undefined and does not throw when readlines is given a path it cannot open as a regular file", async () => {

--- a/cli/src/core/ClaudeAiTitleReader.ts
+++ b/cli/src/core/ClaudeAiTitleReader.ts
@@ -5,13 +5,14 @@
  * new line of `{ type: "ai-title", aiTitle: "...", sessionId: "..." }`
  * every time. The last such line is the current title.
  *
- * Strategy: forward stream once, remember the most recent `aiTitle`.
- * For multi-MB transcripts this remains acceptable in practice; if
- * profiling later shows it's a bottleneck, reverse-chunk reads are an
- * obvious optimization (out of scope for MVP).
+ * Strategy: stream once, remember the most recent `aiTitle` — over the whole
+ * file when it is small, over its last {@link TAIL_SCAN_BYTES} when it is not.
+ * See {@link TAIL_SCAN_BYTES} for why the tail is the right slice and what it
+ * gives up.
  */
 
 import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
 import { createInterface } from "node:readline";
 import { createLogger, errMsg, isEnoent } from "../Logger.js";
 
@@ -19,14 +20,55 @@ const log = createLogger("ClaudeAiTitleReader");
 
 const AI_TITLE_FRAGMENT = '"type":"ai-title"';
 
+/**
+ * Above this size the scan starts here-many bytes from the end instead of at
+ * byte 0.
+ *
+ * The read is on a request path — the dashboard resolves a memory's
+ * conversation titles while building `/api/model`, which a browsing user
+ * re-polls every 30 s — and a transcript that is being appended to right now
+ * invalidates its own `(mtimeMs, size)` cache entry on every one of those ticks.
+ * So the common case is not "scan a big file once", it is "re-scan the same
+ * growing multi-MB file twice a minute for as long as the tab is open", which is
+ * exactly the session a user browses right after committing.
+ *
+ * The tail is sound because of what the title IS: Claude re-emits `ai-title` as
+ * the conversation continues, and only the LAST one is wanted — so the answer
+ * lives at the end of the file, and everything before it is read to be thrown
+ * away. What this gives up is the pathological case of a transcript that grew
+ * past the budget with all of its `ai-title` lines before the cut; that session
+ * falls back to the caller's own title source (the archived first user message)
+ * rather than showing a wrong title. 4 MiB is far more than the span between two
+ * consecutive re-titlings in any capture we have.
+ */
+export const TAIL_SCAN_BYTES = 4 * 1024 * 1024;
+
 export async function readClaudeAiTitle(transcriptPath: string): Promise<string | undefined> {
 	let latest: string | undefined;
 	let parseSkipped = 0;
+	// A failed stat falls through to a whole-file scan: it is the behaviour that
+	// was always correct, and the size is an optimisation input, not a
+	// precondition. `createReadStream` reports the real error a moment later.
+	const size = await stat(transcriptPath).then(
+		(s) => s.size,
+		() => 0,
+	);
+	const start = size > TAIL_SCAN_BYTES ? size - TAIL_SCAN_BYTES : 0;
 	try {
-		const stream = createReadStream(transcriptPath, { encoding: "utf8" });
+		const stream = createReadStream(transcriptPath, { encoding: "utf8", start });
 		const rl = createInterface({ input: stream, crlfDelay: Infinity });
 		try {
+			// Byte `start` lands mid-line (and possibly mid-codepoint) in the general
+			// case, so the first line of a tail read is a fragment: it cannot be
+			// parsed and, worse, a fragment of a NON-title line can carry a title
+			// line's fragment shape. Dropping it costs one line and is the only way
+			// to keep every line this loop sees a whole one.
+			let dropPartial = start > 0;
 			for await (const line of rl) {
+				if (dropPartial) {
+					dropPartial = false;
+					continue;
+				}
 				// Pre-filter: skip lines that can't possibly be ai-title rows.
 				// The literal substring `"type":"ai-title"` (including the
 				// trailing closing quote) is exactly what Claude Code writes,

--- a/cli/src/core/GitOps.test.ts
+++ b/cli/src/core/GitOps.test.ts
@@ -498,6 +498,20 @@ describe("GitOps", () => {
 			expect(info.date).toBe("2026-02-19T10:00:00+08:00");
 		});
 
+		it("should parse the author email when git reports one", async () => {
+			mockSuccess("abc123\x00Fix\x00John Doe\x002026-02-19T10:00:00+08:00\x00john@example.com");
+
+			expect((await getCommitInfo("abc123")).authorEmail).toBe("john@example.com");
+		});
+
+		// The field is appended last precisely so a 4-field line stays valid — the
+		// dashboard's author filter then falls back to matching on the name.
+		it("should omit the author email when the line carries none", async () => {
+			mockSuccess("abc123\x00Fix\x00John Doe\x002026-02-19T10:00:00+08:00");
+
+			expect((await getCommitInfo("abc123")).authorEmail).toBeUndefined();
+		});
+
 		it("should pass the given hash as an argument to git log", async () => {
 			mockSuccess("abc123def456\x00Fix bug\x00John\x002026-02-19T10:00:00+08:00");
 

--- a/cli/src/core/GitOps.ts
+++ b/cli/src/core/GitOps.ts
@@ -299,9 +299,13 @@ export async function readLocalGitIdentity(cwd?: string): Promise<{ email: strin
 /**
  * Gets information about a specific commit by hash.
  * Unlike getHeadCommitInfo, this queries a specific hash rather than HEAD.
+ *
+ * `%ae` is appended LAST so the four historical field positions are untouched:
+ * a caller (or a test) that still sees a 4-field line keeps working and simply
+ * reports no email.
  */
 export async function getCommitInfo(hash: string, cwd?: string): Promise<CommitInfo> {
-	const logResult = await execGit(["log", "-1", "--pretty=format:%H%x00%s%x00%an%x00%aI", hash], cwd);
+	const logResult = await execGit(["log", "-1", "--pretty=format:%H%x00%s%x00%an%x00%aI%x00%ae", hash], cwd);
 	if (logResult.exitCode !== 0) {
 		throw new Error(`Failed to get commit info for ${hash}: ${logResult.stderr}`);
 	}
@@ -311,11 +315,13 @@ export async function getCommitInfo(hash: string, cwd?: string): Promise<CommitI
 		throw new Error(`Unexpected git log format for ${hash}: ${logResult.stdout}`);
 	}
 
+	const authorEmail = parts[4]?.trim();
 	const info: CommitInfo = {
 		hash: parts[0],
 		message: parts[1],
 		author: parts[2],
 		date: parts[3],
+		...(authorEmail ? { authorEmail } : {}),
 	};
 	log.info("Commit %s: %s", info.hash.substring(0, 8), info.message.substring(0, 60));
 	return info;

--- a/cli/src/core/OrphanSotGuard.test.ts
+++ b/cli/src/core/OrphanSotGuard.test.ts
@@ -79,7 +79,7 @@ const BRANCH_NAME_ALLOWLIST: ReadonlyMap<string, string> = new Map([
 	["cli/src/dashboard/CutoverEngine.ts", "the cutover machinery: tips, fence, CAS"],
 	["cli/src/dashboard/SotImport.ts", "the orphan → SQLite importer"],
 	["cli/src/dashboard/Recovery.ts", "reads the fenced root's tip"],
-	["cli/src/dashboard/Backfill.ts", "reads the orphan tip"],
+	["cli/src/dashboard/DbBackfill.ts", "reads the orphan tip"],
 	["cli/src/backfill/CommitTargetIndex.ts", "`--not` excludes the summaries branch's own commits; unrelated to SoT"],
 	["cli/src/core/SchemaV5Migration.ts", "captures the rollback SHA only while the branch IS the system of record"],
 	["cli/src/core/SummaryMigration.ts", "the v1-era raw branch writes, refused by route on any non-uncutover repo"],

--- a/cli/src/core/SessionTitleResolver.ts
+++ b/cli/src/core/SessionTitleResolver.ts
@@ -109,6 +109,61 @@ export function firstUserMessageTitleFromEntries(entries: ReadonlyArray<Transcri
 	return UNTITLED_SESSION;
 }
 
+/**
+ * The title to ARCHIVE with a session, resolved at the moment the memory is
+ * written — the answer, not a pointer to where the answer could be recomputed.
+ *
+ * Every reader used to re-derive this, and each derived it differently: the
+ * editor ran the full ladder against the live file, the dashboard joined its
+ * `sessions` table and then re-read the file again, and the collector wrote a
+ * third answer into that table. Those agree only as long as someone keeps them
+ * agreeing. Archiving the string makes them agree by construction.
+ *
+ * Commit time is the only moment where this is both cheap and correct: the live
+ * transcript was just read (its entries are the argument below), so step 2 has
+ * the file it needs and step 3 needs no second pass. Every later moment is worse
+ * — the file is pruned on the agent's own schedule, the `sessions` row is pruned
+ * with `sessions.json`, and on a teammate's machine neither ever existed. The
+ * archive is the only artifact that travels, and it carried a machine-local
+ * absolute path where it should have carried this.
+ *
+ * `mergedEntries` is the ARCHIVED slice on purpose: step 3 then describes the
+ * turns this memory actually owns, rather than the live file's first turn, which
+ * for an amend chain belongs to a different commit.
+ *
+ * Structural parameter rather than `SessionTranscript` so this module does not
+ * import the transcript reader (both archive writers pass one).
+ *
+ * Returns undefined for {@link UNTITLED_SESSION} so the field stays absent
+ * rather than storing a sentinel: "no title" is a fact each surface renders its
+ * own way, and an absent field is what lets an older archive fall back.
+ */
+export async function resolveArchivedTitle(session: {
+	readonly sessionId: string;
+	readonly source?: TranscriptSource;
+	readonly transcriptPath?: string;
+	readonly entries: ReadonlyArray<TranscriptEntry>;
+}): Promise<string | undefined> {
+	try {
+		const title = await resolveSessionTitle(
+			{
+				sessionId: session.sessionId,
+				transcriptPath: session.transcriptPath ?? "",
+				updatedAt: "",
+				...(session.source ? { source: session.source } : {}),
+			},
+			session.entries,
+		);
+		return title && title !== UNTITLED_SESSION ? title : undefined;
+	} catch (err) {
+		// A title is never worth failing an archive write for — the memory itself
+		// is what must land. Readers fall back exactly as they do for an archive
+		// written before this field existed.
+		log.debug("resolveArchivedTitle failed for %s: %s", session.sessionId, errMsg(err));
+		return undefined;
+	}
+}
+
 // --- per-source line parsers ---
 
 function parseClaudeUserLine(line: string): string | undefined {

--- a/cli/src/dashboard/AutoCutover.test.ts
+++ b/cli/src/dashboard/AutoCutover.test.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { readRepoProfile, updateRepoProfile } from "../core/RepoProfile.js";
 import { ORPHAN_BRANCH } from "../Logger.js";
+import { type RestoreHome, setIsolatedHome } from "../testUtils/isolatedHome.js";
 import { AUTO_CUTOVER_RETRY_MS, maybeAutoCutover } from "./AutoCutover.js";
 import { resolveCutoverRoute } from "./CutoverRouter.js";
 import { registerRepo } from "./RepoRegistry.js";
@@ -19,7 +20,7 @@ import { registerRepo } from "./RepoRegistry.js";
 let dir: string;
 let cwd: string;
 let dbPath: string;
-let realHome: string | undefined;
+let restoreHome: RestoreHome;
 
 const HASH = "a".repeat(40);
 
@@ -54,10 +55,11 @@ async function writeOrphanSummary(hash: string): Promise<void> {
 
 beforeEach(async () => {
 	dir = mkdtempSync(join(tmpdir(), "jolli-autocut-"));
+	// Isolated HOME: `registerRepo` below writes the machine-global registry.
+	// The helper also covers Windows, where `os.homedir()` ignores `HOME`.
 	const home = join(dir, "home");
 	mkdirSync(home, { recursive: true });
-	realHome = process.env.HOME;
-	process.env.HOME = home;
+	restoreHome = setIsolatedHome(home);
 	cwd = join(dir, "repo");
 	mkdirSync(cwd, { recursive: true });
 	execSync("git init -q", { cwd });
@@ -68,7 +70,7 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-	process.env.HOME = realHome;
+	restoreHome();
 	rmSync(dir, { recursive: true, force: true });
 });
 

--- a/cli/src/dashboard/Backup.test.ts
+++ b/cli/src/dashboard/Backup.test.ts
@@ -29,6 +29,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { JolliMemoryConfig } from "../Types.js";
+import { setIsolatedHome } from "../testUtils/isolatedHome.js";
 import {
 	backupHealthCheck,
 	defaultBackupFolder,
@@ -184,14 +185,13 @@ describe("folder rules", () => {
 		// default-folder arm runs without touching the real home.
 		const fakeHome = join(dir, "home");
 		mkdirSync(fakeHome, { recursive: true });
-		const realHome = process.env.HOME;
-		process.env.HOME = fakeHome;
+		const restoreHome = setIsolatedHome(fakeHome);
 		try {
 			const result = await snapshot({ config: {} as JolliMemoryConfig });
 			expect(result.status).toBe("created");
 			expect((result as { path: string }).path.startsWith(join(fakeHome, "jolli_back"))).toBe(true);
 		} finally {
-			process.env.HOME = realHome;
+			restoreHome();
 		}
 	});
 
@@ -204,14 +204,13 @@ describe("folder rules", () => {
 		const fakeHome = join(dir, "dotfiles-home");
 		mkdirSync(fakeHome, { recursive: true });
 		await execFileAsync("git", ["init"], { cwd: fakeHome });
-		const realHome = process.env.HOME;
-		process.env.HOME = fakeHome;
+		const restoreHome = setIsolatedHome(fakeHome);
 		try {
 			const result = await snapshot({ config: {} as JolliMemoryConfig });
 			expect(result).toMatchObject({ status: "failed", reason: expect.stringContaining("git clean -xdf") });
 			expect(existsSync(join(fakeHome, "jolli_back"))).toBe(false);
 		} finally {
-			process.env.HOME = realHome;
+			restoreHome();
 		}
 	});
 
@@ -269,8 +268,7 @@ describe("mirror witness", () => {
 		// A real mirror carries its identity; without it peekKBPath treats the
 		// folder as foreign and resolves to a fresh slot.
 		writeFileSync(join(kb, "app", ".jolli", "config.json"), JSON.stringify({ repoName: "app" }));
-		const realHome = process.env.HOME;
-		process.env.HOME = home;
+		const restoreHome = setIsolatedHome(home);
 		try {
 			const { stampRegistryInstanceId } = await import("./RepoRegistry.js");
 			await stampRegistryInstanceId("unused-here");
@@ -294,7 +292,7 @@ describe("mirror witness", () => {
 			// The mirror-less repo gained nothing: no folder was created.
 			expect(existsSync(join(kb, "ghost"))).toBe(false);
 		} finally {
-			process.env.HOME = realHome;
+			restoreHome();
 		}
 	});
 });
@@ -339,12 +337,11 @@ describe("save-time validation", () => {
 		// No dbPath: the machine default fills in (fake HOME keeps it in the fixture).
 		const fakeHome = join(dir, "vhome");
 		mkdirSync(fakeHome, { recursive: true });
-		const realHome = process.env.HOME;
-		process.env.HOME = fakeHome;
+		const restoreHome = setIsolatedHome(fakeHome);
 		try {
 			expect(await validateBackupFolder(join(dir, "ok-target"), {})).toBeNull();
 		} finally {
-			process.env.HOME = realHome;
+			restoreHome();
 		}
 	});
 
@@ -389,8 +386,7 @@ describe("opportunisticSnapshot", () => {
 		// in the fixture instead of the real ~/jolli_back.
 		const fakeHome = join(dir, "op-home");
 		mkdirSync(fakeHome, { recursive: true });
-		const realHome = process.env.HOME;
-		process.env.HOME = fakeHome;
+		const restoreHome = setIsolatedHome(fakeHome);
 		try {
 			const result = await opportunisticSnapshot(dbPath);
 			expect(result.status).toBe("created");
@@ -405,7 +401,7 @@ describe("opportunisticSnapshot", () => {
 			const bad = await opportunisticSnapshot(join(dir, "not-a-dir", "x.db"));
 			expect(bad.status).toBe("failed");
 		} finally {
-			process.env.HOME = realHome;
+			restoreHome();
 		}
 	});
 });

--- a/cli/src/dashboard/CutoverEngine.test.ts
+++ b/cli/src/dashboard/CutoverEngine.test.ts
@@ -14,6 +14,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { resolveCommittish } from "../core/GitRefStorage.js";
 import { readCutoverFence, writeCutoverFence } from "../core/RepoProfile.js";
 import { ORPHAN_BRANCH } from "../Logger.js";
+import { type RestoreHome, setIsolatedHome } from "../testUtils/isolatedHome.js";
 import { probeCutoverDrift, runCutover } from "./CutoverEngine.js";
 import { resolveCutoverRoute } from "./CutoverRouter.js";
 import { withDashboardDb } from "./DashboardDb.js";
@@ -22,7 +23,8 @@ import { readRepoRegistry, registerRepo } from "./RepoRegistry.js";
 let dir: string;
 let cwd: string;
 let dbPath: string;
-let realHome: string | undefined;
+let home: string;
+let restoreHome: RestoreHome;
 
 const HASH = "a".repeat(40);
 
@@ -80,11 +82,12 @@ async function writeOrphanSummary(hash: string, message: string): Promise<void> 
 
 beforeEach(async () => {
 	dir = mkdtempSync(join(tmpdir(), "jolli-cutover-"));
-	// Isolated HOME: the registry and profile paths are machine-global.
-	const home = join(dir, "home");
+	// Isolated HOME: the registry and profile paths are machine-global. Must go
+	// through the helper — setting `HOME` alone leaves the real home in place on
+	// Windows, where `os.homedir()` reads `USERPROFILE`.
+	home = join(dir, "home");
 	mkdirSync(home, { recursive: true });
-	realHome = process.env.HOME;
-	process.env.HOME = home;
+	restoreHome = setIsolatedHome(home);
 	cwd = join(dir, "repo");
 	mkdirSync(cwd, { recursive: true });
 	execSync("git init -q", { cwd });
@@ -97,7 +100,7 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
-	process.env.HOME = realHome;
+	restoreHome();
 	rmSync(dir, { recursive: true, force: true });
 });
 
@@ -652,7 +655,7 @@ describe("runCutover", () => {
 		await writeOrphanSummary(HASH, "seed");
 		// dist-paths records what is INSTALLED here; an old surface would keep
 		// writing the frozen branch, so the cutover must not begin.
-		const distDir = join(process.env.HOME as string, ".jolli", "jollimemory", "dist-paths");
+		const distDir = join(home, ".jolli", "jollimemory", "dist-paths");
 		mkdirSync(distDir, { recursive: true });
 		const { writeFileSync } = await import("node:fs");
 		// The dist dir must EXIST: admission only counts entries whose directory

--- a/cli/src/dashboard/DashboardCollector.ts
+++ b/cli/src/dashboard/DashboardCollector.ts
@@ -589,7 +589,7 @@ export async function collectCommitEvents(opts: CollectCommitsOptions): Promise<
 		// `MAX_BRANCHES + 1` and filtering afterwards would spend a slot on a branch
 		// that is never scanned, and the orphan branch is written on every memory so
 		// it sorts FIRST by committerdate essentially always. Listing every local
-		// branch name is one cheap ref walk (`Backfill`'s fingerprint already does
+		// branch name is one cheap ref walk (`DbBackfill`'s fingerprint already does
 		// exactly that); it is the rev-list per branch that is expensive.
 		["for-each-ref", "refs/heads", "--sort=-committerdate", "--format=%(refname:short)"],
 		opts.cwd,
@@ -661,7 +661,7 @@ export async function collectCommitEvents(opts: CollectCommitsOptions): Promise<
 	// relies on), while an empty array would mean "this commit touches nothing".
 	//
 	// `knownHashes` is the set of commits whose file rows ARE STORED, not the set
-	// of stored commits (see `commitsWithStoredFiles` in Backfill). A commit whose
+	// of stored commits (see `commitsWithStoredFiles` in DbBackfill). A commit whose
 	// numstat failed once therefore comes back on the NEXT sweep instead of never:
 	// keying the skip off row existence made a single transient git failure a
 	// permanent blank, since the only path that re-scanned everything was a

--- a/cli/src/dashboard/DashboardDb.test.ts
+++ b/cli/src/dashboard/DashboardDb.test.ts
@@ -412,7 +412,7 @@ describe("schema creation", () => {
 	it("supports the repos DML shapes the writers use — UPSERT, UPDATE, child FK", async () => {
 		await withDashboardDb(
 			(db) => {
-				// The three shapes StatsWriter/Backfill actually use, replayed verbatim
+				// The three shapes StatsWriter/DbBackfill actually use, replayed verbatim
 				// against the surrogate-key repos table.
 				db.prepare(
 					`INSERT INTO repos (repo_identity, repo_name, worktree_root, remote_url, enabled_at, disabled_at)

--- a/cli/src/dashboard/DashboardDb.ts
+++ b/cli/src/dashboard/DashboardDb.ts
@@ -48,10 +48,26 @@ const log = createLogger("DashboardDb");
  * able to `SELECT` the columns it knows about after a newer build has migrated
  * up.
  *
- * It is 4. Entry 0 is the whole schema as it first landed; entry 1 adds
- * `recall_receipts`; entry 2 registers `skill` as the fourth `context` kind;
- * entry 3 adds `events_raw.failed_kind` so an event parked by an older build
- * that did not know its type can be un-parked by one that does.
+ * It is 5, one per entry in {@link MIGRATIONS}. Entry 0 is the whole schema as
+ * it first landed; entry 1 adds `recall_receipts`; entry 2 registers `skill` as
+ * the fourth `context` kind; entry 3 adds `events_raw.failed_kind` so an event
+ * parked by an older build that did not know its type can be un-parked by one
+ * that does; entry 4 adds `session_tool_use.last_call_at_ms`.
+ *
+ * Bumping this is a CROSS-SURFACE event, not a local edit — that is the reason
+ * the number is worth stating here rather than left to be read off the array.
+ * Every surface that opens this database refuses one stamped ahead of its own
+ * build ({@link DashboardSchemaAheadError}, `CutoverRouter`'s `unavailable`, the
+ * server's skipped registry projection), so the first surface to migrate locks
+ * every older one out of the machine-global file until it is upgraded too. The
+ * cost is paid per bump, not per entry: an entry that rides an already-planned
+ * bump is free, and one that forces its own has to be worth a forced upgrade on
+ * its own. A sixth entry — one `UPDATE` normalising a value the writers can no
+ * longer produce — was added and then taken back out for exactly that test; see
+ * the note where it used to live in `SotSchema.ts`, and prefer a defensive READ
+ * over a migration whenever the choice exists (a read is permanent, a migration
+ * runs once).
+ *
  * Nothing has shipped yet, so entry 0 could in principle
  * have absorbed the new table — it deliberately does not, because dev
  * databases (including the one every developer on this repo is using) are
@@ -210,6 +226,12 @@ export const BUSY_TIMEOUT_BY_ROLE: Readonly<Record<string, number>> = {
  * backfilled (the transcripts they were read from may be gone), so they keep
  * being read under the old session-time fallback rather than dropping out of
  * every window for want of a value.
+ *
+ * There is no entry normalising a stored `0` in that column, and that absence is
+ * a decision: the writers cannot produce one, and the reader treats one as
+ * absent (`TOOL_CALL_TIME_SQL`'s `NULLIF`), which is both permanent and free
+ * where a sixth entry would have been neither. See the note in `SotSchema.ts`
+ * where that entry used to be.
  *
  * Exported for tests: they execute entries directly to build a database at a
  * chosen version rather than hand-rolling copies of the DDL, which would drift.
@@ -423,8 +445,8 @@ async function openDb(readOnly: boolean, opts: OpenDashboardDbOptions): Promise<
  *
  * Keep `fn` short. It holds a connection that may take SQLite's single writer
  * lock, and every other producer on the machine — hooks, the extension host,
- * `jolli enable` — is contending for it. Backfill opens one handle per repo
- * and runs many short transactions inside it (see `Backfill.applyBatches`) —
+ * `jolli enable` — is contending for it. DbBackfill opens one handle per repo
+ * and runs many short transactions inside it (see `DbBackfill.applyBatches`) —
  * the lock is held per-transaction, not for the whole callback.
  */
 export async function withDashboardDb<T>(
@@ -452,7 +474,7 @@ export async function withDashboardDb<T>(
  *
  * Exists because "no writer has run yet" is a REACHABLE first-run state, not a
  * theoretical one: a `jolli dashboard` in a directory with nothing registered
- * never opens a writable handle anywhere (`backfillRepos([])` returns without
+ * never opens a writable handle anywhere (`dbBackfillRepos([])` returns without
  * touching the file), so every read-only open below fails and the whole
  * dashboard answers 500. A reader cannot fix that for itself — `readOnly:
  * true` is exactly the mode that must not create a schema — so the one caller

--- a/cli/src/dashboard/DashboardModel.ts
+++ b/cli/src/dashboard/DashboardModel.ts
@@ -446,11 +446,37 @@ export interface MemoryListItem {
 	readonly synced: boolean;
 }
 
-/** One conversation that fed a memory — {@link MemoryDetail.conversations}. */
+/**
+ * One conversation that fed a memory — {@link MemoryDetail.conversations}.
+ *
+ * Exactly the four fields the page renders, and no server-side ones. The whole
+ * model is `JSON.stringify`d into the served HTML, so a field here is a field in
+ * the payload; the rule is that nothing lands in this type which the client does
+ * not use. `transcriptPath` and a `nativeTitle` flag were briefly on it to drive
+ * a server-side `ai-title` read, defended by a strip on the way out — a
+ * convention the type system could not enforce, shipping an absolute path under
+ * the user's home for nothing. The title is now resolved once at archive time
+ * (`StoredSession.title`), so there is no private data to carry and nothing to
+ * strip.
+ */
 export interface MemoryConversationRow {
 	readonly title: string;
 	readonly source: string;
 	readonly messageCount: number;
+	/**
+	 * Rendered as the row's tooltip (`conversationsSection` in `memories.js`) —
+	 * which is the only reason it is allowed here, by the rule above. It earns
+	 * that: the other three fields do not distinguish two conversations from the
+	 * same source, and a title that fell back to the first user message can make
+	 * two rows near-identical, so a memory fed by three Claude sessions was
+	 * unreadable and could not be matched against `sessions.json` or a log line.
+	 *
+	 * Safe to serve for the reason `transcriptPath` was not: it is an opaque id
+	 * the agent chose, not a fact about this machine's filesystem. It is also the
+	 * editor's own row identity — `SummaryScriptBuilder` keys its conversation
+	 * rows on `(source, sessionId)` — so the two surfaces name a row the same way.
+	 */
+	readonly sessionId: string;
 }
 
 /**

--- a/cli/src/dashboard/DashboardQuery.test.ts
+++ b/cli/src/dashboard/DashboardQuery.test.ts
@@ -968,6 +968,83 @@ describe("buildDashboardModel — tool usage", () => {
 		expect(result?.sessionsInWindow).toBe(2);
 	});
 
+	it("counts a session whose CALL is in the window but whose own time is not", async () => {
+		// The ranked rows are windowed by call time; the coverage denominator is
+		// windowed by the session's own. A long-running session that last updated
+		// weeks ago but called a tool an hour ago is in one and not the other, so
+		// the page printed "1 session" for the tool directly above "from 0 of 0
+		// sessions in this window".
+		await applySummaryEvents(
+			[
+				repoEvent,
+				{
+					producerKind: "cli",
+					event: {
+						type: "session.upserted",
+						repoIdentity: "repo-1",
+						source: "claude",
+						sessionId: "long-running",
+						updatedAtMs: nowMs - 90 * 86_400_000,
+						tools: [{ name: "code-review", kind: "skill", calls: 4, lastCallAtMs: nowMs - 3_600_000 }],
+					},
+				},
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		const result = await usage();
+		expect(result?.skills).toEqual([{ name: "code-review", kind: "skill", sessions: 1, calls: 4 }]);
+		expect(result?.sessionsInWindow).toBe(1);
+		expect(result?.sessionsWithTools).toBe(1);
+	});
+
+	it("does not count a session whose own time is in the window but whose calls are not", async () => {
+		// The mirror of the case above, and the other way the caveat can contradict
+		// the table it sits under. A session touched an hour ago whose only tool call
+		// was four months back is in the denominator (its own clock puts it here) but
+		// its call is in no ranked row — both rankings window by call time. Counting
+		// it as "with tools" printed "1 of 1 sessions" above an empty table.
+		await applySummaryEvents(
+			[
+				repoEvent,
+				{
+					producerKind: "cli",
+					event: {
+						type: "session.upserted",
+						repoIdentity: "repo-1",
+						source: "claude",
+						sessionId: "touched-today",
+						updatedAtMs: nowMs - 3_600_000,
+						tools: [{ name: "old-skill", kind: "skill", calls: 2, lastCallAtMs: nowMs - 120 * 86_400_000 }],
+					},
+				},
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		const result = await usage();
+		expect(result?.skills).toEqual([]);
+		expect(result?.sessionsInWindow).toBe(1);
+		expect(result?.sessionsWithTools).toBe(0);
+	});
+
+	it("treats a stored 0 as no time at all, falling back to the session's own", async () => {
+		// 0 is the one value a bare COALESCE cannot survive: it is not NULL, so the
+		// row resolves to epoch 0 and leaves every window — while meaning exactly
+		// what NULL means, "this parser could not stamp a time". Neither writer can
+		// store one (both wrap their MAX in NULLIF), so the row below is written by
+		// hand: the point of handling it at the READ is that it also covers a writer
+		// that does not yet exist, which the migration this replaced could not.
+		await applySummaryEvents([repoEvent, sessionWith("zeroed", [{ name: "Bash", kind: "builtin", calls: 3 }])], {
+			producerKind: "cli",
+			dbPath,
+		});
+		await withDashboardDb((db) => db.exec("UPDATE session_tool_use SET last_call_at_ms = 0"), { dbPath });
+
+		const result = await usage();
+		// Windowed by the session's `updated_at_ms` (an hour ago), not by epoch 0.
+		expect(result?.sessionsInWindow).toBe(1);
+		expect(result?.sessionsWithTools).toBe(1);
+	});
+
 	it("is empty, not absent, when nothing recorded a tool call", async () => {
 		await applySummaryEvents([repoEvent, sessionWith("s1", undefined, "codex")], { producerKind: "cli", dbPath });
 		expect(await usage()).toMatchObject({
@@ -1362,6 +1439,29 @@ describe("buildDashboardModel — recall usage", () => {
 				tools: tools.map((t) => ({ ...t, calls: 1 })),
 			},
 		}) as StatsEventEnvelope;
+
+	it("ranks the Skills panel by the call's own time too, matching the Recall card", async () => {
+		// Same rows, same table, two panels: a bucket that lands in the window for
+		// one and outside it for the other is a contradiction with no resolution
+		// available to the reader.
+		await applySummaryEvents(
+			[
+				repoEvent,
+				sessionWithRecallTools(
+					"fresh-call",
+					[{ name: "jolli-recall", kind: "skill", lastCallAtMs: nowMs - 3_600_000 }],
+					Date.parse("2026-05-01T00:00:00Z"),
+				),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		const model = await withDashboardDb(
+			(db) => buildDashboardModel(db, { view: "stats", scope: { kind: "all" }, timeZone: "UTC", nowMs }),
+			{ dbPath },
+		);
+		expect(model.stats?.toolUsage.skills).toEqual([{ name: "jolli-recall", kind: "skill", sessions: 1, calls: 1 }]);
+		expect(model.stats?.recallUsage.skillInvocations).toBe(1);
+	});
 
 	it("windows a tool row by the CALL's own time, not by its session's", async () => {
 		// The defect this column exists for: a session updated inside the window

--- a/cli/src/dashboard/DashboardQuery.ts
+++ b/cli/src/dashboard/DashboardQuery.ts
@@ -1369,12 +1369,16 @@ function buildToolUsage(db: DashboardDbHandle, scope: DashboardScope, window: Re
 	const filter = scopeFilter(scopeToRepoId(db, scope), "s.repo_id");
 	const rows = db
 		.prepare(
+			// Windowed by the CALL, like the Recall card — see TOOL_CALL_TIME_SQL. The
+			// two panels report the same rows from the same table, so a `jolli-recall`
+			// bucket landing on one day here and another day there is a contradiction
+			// the reader has no way to resolve.
 			`SELECT t.tool_name, t.kind, t.server,
 			        COUNT(DISTINCT t.session_event_id) AS session_count,
 			        COALESCE(SUM(t.calls), 0) AS call_count
 			   FROM session_tool_use t
 			   JOIN sessions s ON s.event_id = t.session_event_id
-			  WHERE s.updated_at_ms >= ? AND s.updated_at_ms < ?${filter.sql}
+			  WHERE ${TOOL_CALL_TIME_SQL} >= ? AND ${TOOL_CALL_TIME_SQL} < ?${filter.sql}
 			  GROUP BY t.kind, t.tool_name, t.server`,
 		)
 		.all(window.startMs, window.endMs, ...filter.params) as ReadonlyArray<{
@@ -1442,7 +1446,7 @@ function buildToolUsage(db: DashboardDbHandle, scope: DashboardScope, window: Re
 			        COUNT(DISTINCT t.tool_name) AS tool_count
 			   FROM session_tool_use t
 			   JOIN sessions s ON s.event_id = t.session_event_id
-			  WHERE s.updated_at_ms >= ? AND s.updated_at_ms < ?${filter.sql}
+			  WHERE ${TOOL_CALL_TIME_SQL} >= ? AND ${TOOL_CALL_TIME_SQL} < ?${filter.sql}
 			    AND t.kind = 'mcp' AND t.server IS NOT NULL
 			  GROUP BY t.server`,
 		)
@@ -1456,18 +1460,53 @@ function buildToolUsage(db: DashboardDbHandle, scope: DashboardScope, window: Re
 	const byAdoption = <T extends { sessions: number; calls: number }>(a: T, b: T) =>
 		b.sessions - a.sessions || b.calls - a.calls;
 
-	// Coverage from the FULL session population, never from the join above.
+	// Coverage from the FULL session population, never from the join above — and
+	// windowed by the SESSION's own time OR by any call it made, which is the
+	// union of the two clocks and not either one alone. Both halves are needed
+	// and for opposite reasons. Session time alone drops nothing that the caveat
+	// is about but cannot see a session whose calls landed in this window while
+	// its own `updated_at_ms` did not — and since the two queries above moved to
+	// call time, that session's tool row is IN the ranking, so the page printed
+	// "1 session" directly above "from 0 of 0 sessions in this window". Call time
+	// alone is the failure the old comment named: a session that made no tool
+	// call has no call to be windowed by and would vanish from the denominator
+	// the caveat is built on. The union admits a session if EITHER clock puts it
+	// here, so every ranked row is backed by a session it counts.
+	//
+	// The NUMERATOR carries the same window as the rankings, and for the reason
+	// the denominator carries the union: unwindowed, a session admitted by its own
+	// `updated_at_ms` counted as "with tools" on the strength of calls made weeks
+	// earlier — calls that are in no ranked row on the page, because both queries
+	// above window by call time. That is the same contradiction in the other
+	// direction: "3 of 4 sessions" above a table whose rows account for one of
+	// them. Windowed, the fraction says what the caveat claims it says — sessions
+	// whose tool use is what the page is showing.
 	const sessionFilter = scopeFilter(scopeToRepoId(db, scope), "s.repo_id");
 	const sessionRows = db
 		.prepare(
 			`SELECT s.source,
 			        COUNT(*) AS total,
-			        COALESCE(SUM(EXISTS (SELECT 1 FROM session_tool_use t WHERE t.session_event_id = s.event_id)), 0) AS with_tools
+			        COALESCE(SUM(EXISTS (SELECT 1 FROM session_tool_use t
+			                              WHERE t.session_event_id = s.event_id
+			                                AND ${TOOL_CALL_TIME_SQL} >= ? AND ${TOOL_CALL_TIME_SQL} < ?)), 0) AS with_tools
 			   FROM sessions s
-			  WHERE s.updated_at_ms >= ? AND s.updated_at_ms < ?${sessionFilter.sql}
+			  WHERE ((s.updated_at_ms >= ? AND s.updated_at_ms < ?)
+			         OR EXISTS (SELECT 1 FROM session_tool_use t
+			                     WHERE t.session_event_id = s.event_id
+			                       AND ${TOOL_CALL_TIME_SQL} >= ? AND ${TOOL_CALL_TIME_SQL} < ?))${sessionFilter.sql}
 			  GROUP BY s.source`,
 		)
-		.all(window.startMs, window.endMs, ...sessionFilter.params) as ReadonlyArray<{
+		// Six bounds, not four: the SELECT list's `?`s bind ahead of the WHERE's,
+		// and all three range tests are the same window.
+		.all(
+			window.startMs,
+			window.endMs,
+			window.startMs,
+			window.endMs,
+			window.startMs,
+			window.endMs,
+			...sessionFilter.params,
+		) as ReadonlyArray<{
 		source: string;
 		total: number;
 		with_tools: number;
@@ -1524,8 +1563,21 @@ const RECALL_STALE_MS = 30 * 86_400_000;
  *
  * Written as a fragment used in BOTH bounds of each range test, so a row cannot
  * be admitted by one clock and excluded by the other.
+ *
+ * The `NULLIF` is what makes the fallback total. 0 is the one stored value that
+ * defeats a bare COALESCE — 0 is not NULL, so the row resolves to epoch 0 and
+ * leaves every window instead of keeping its session's placement — and it is
+ * indistinguishable from "no time known", which is precisely the case the
+ * fallback exists for. Both writers already refuse to store one (their
+ * `MAX(COALESCE(…,0), COALESCE(…,0))` is wrapped in `NULLIF` too), so this is
+ * the belt to those braces; it lives HERE, and not in a migration, because a
+ * migration runs once and a third writer added later would store its first 0
+ * long after every database had passed that step. Neutralising it at the read
+ * costs nothing, covers rows that already exist and rows not yet written, and
+ * needs no schema version — which is a cross-surface event, since every surface
+ * refuses a database stamped ahead of its own build.
  */
-const TOOL_CALL_TIME_SQL = "COALESCE(t.last_call_at_ms, s.updated_at_ms)";
+const TOOL_CALL_TIME_SQL = "COALESCE(NULLIF(t.last_call_at_ms, 0), s.updated_at_ms)";
 
 /**
  * The Recall card: how often recall actually served usable commit context.

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -25,7 +25,7 @@
  * Both halves of the no-daemon backup schedule now live in processes that
  * already write: `executeDashboard` and the post-commit `QueueWorker`.
  *
- * Backfill is deliberately NOT part of that write surface. Generating memories
+ * DbBackfill is deliberately NOT part of that write surface. Generating memories
  * for existing commits is an explicit CLI action (`jolli backfill`), and the
  * import sweep that fills the database from summaries already written is
  * `jolli dashboard`'s own startup step, run in the command process. A second
@@ -86,7 +86,6 @@ import { trackAs } from "../core/Telemetry.js";
 import { isTelemetryEventName, type TelemetryEventName } from "../core/TelemetryEvents.js";
 import { install, uninstall } from "../install/Installer.js";
 import { createLogger, errMsg, isEnoent } from "../Logger.js";
-import { projectRepoRegistryState } from "./Backfill.js";
 import { BrowseError, browseDirectory, defaultBrowsePath } from "./Browse.js";
 import {
 	DASHBOARD_SCHEMA_VERSION,
@@ -104,6 +103,7 @@ import {
 	type SeriesDimension,
 } from "./DashboardModel.js";
 import { buildDashboardModel, type QueryOptions } from "./DashboardQuery.js";
+import { projectRepoRegistryState } from "./DbBackfill.js";
 import { getDecisionGist } from "./DecisionGist.js";
 import { buildMemoriesPage, type ReachableCommits, readContextDoc } from "./MemoriesQuery.js";
 import { probeRepo } from "./RepoProbe.js";
@@ -315,6 +315,21 @@ export type ModelBuilder = (request: ModelRequest) => Promise<DashboardModel>;
 const REACHABILITY_VIEWS: ReadonlySet<DashboardView> = new Set<DashboardView>(["stats", "memories", "repositories"]);
 
 /**
+ * How long one worktree's git identity is trusted. Minutes, not hours: the value
+ * only changes when the user reconfigures git, and a stale identity shows the
+ * wrong person's commits as their own.
+ */
+const IDENTITY_CACHE_TTL_MS = 5 * 60_000;
+
+/**
+ * Per-worktree git identity, remembered for the life of ONE server (created in
+ * `createDashboardServer`, never module-global). Process-scoped state is what a
+ * cache of a machine-local git config should be, and it also keeps a test's
+ * observations of the git calls from depending on what an earlier test cached.
+ */
+type IdentityCache = Map<string, { identity: { email: string | null; name: string | null }; atMs: number }>;
+
+/**
  * Every `user.email` / `user.name` this machine commits under, unioned across
  * the registered repos — the standup board's "mine only" filter.
  *
@@ -326,18 +341,36 @@ const REACHABILITY_VIEWS: ReadonlySet<DashboardView> = new Set<DashboardView>(["
  * costs a correlated filter to separate identities that belong to one person
  * anyway.
  *
- * Concurrent, two `git config` reads per repo, and only for the standup view.
+ * Concurrent, two `git config` reads per repo, and only for the standup view —
+ * and each worktree's answer is then cached for {@link IDENTITY_CACHE_TTL_MS}.
+ * The page re-polls `/api/model` every 30 s for as long as it is open, so an
+ * uncached read means two subprocesses per repo forever, to re-learn a value
+ * that changes when the user edits `.git/config` by hand. The TTL, rather than a
+ * permanent memo, is what lets such an edit take effect without a restart.
+ *
  * An unreadable or unconfigured repo contributes nothing rather than failing the
- * request: `authorFilter` then fails open on an empty identity.
+ * request: `authorFilter` then fails open on an empty identity. Those are cached
+ * too — a repo with no `user.email` would otherwise pay the subprocesses on
+ * every poll precisely because it has nothing to remember.
  */
 async function readLocalAuthorIdentity(
 	repos: ReadonlyArray<{ worktree_root: string }>,
+	cache: IdentityCache,
+	now: () => number,
 ): Promise<{ emails: string[]; names: string[] }> {
+	const nowMs = now();
 	const identities = await Promise.all(
 		// An empty `worktree_root` is a placeholder row (see readReachableCommitsByRepo):
 		// `cwd: ''` silently runs in the PARENT process's directory, which would read
 		// whichever repo the server happens to be launched from.
-		repos.map(async (repo) => (repo.worktree_root ? readLocalGitIdentity(repo.worktree_root) : null)),
+		repos.map(async (repo) => {
+			if (!repo.worktree_root) return null;
+			const hit = cache.get(repo.worktree_root);
+			if (hit && nowMs - hit.atMs < IDENTITY_CACHE_TTL_MS) return hit.identity;
+			const identity = await readLocalGitIdentity(repo.worktree_root);
+			cache.set(repo.worktree_root, { identity, atMs: nowMs });
+			return identity;
+		}),
 	);
 	const emails = new Set<string>();
 	const names = new Set<string>();
@@ -383,6 +416,8 @@ async function defaultModelBuilder(
 	request: ModelRequest,
 	configDir: string | undefined,
 	dbPath: string | undefined,
+	identityCache: IdentityCache,
+	now: () => number,
 ): Promise<DashboardModel> {
 	// The launcher creates the file before this process starts, so this only
 	// covers the case where it disappears under a running server (a wiped
@@ -425,15 +460,17 @@ async function defaultModelBuilder(
 							db
 								.prepare("SELECT worktree_root FROM repos WHERE disabled_at IS NULL")
 								.all() as ReadonlyArray<{ worktree_root: string }>,
+							identityCache,
+							now,
 						)
 					: undefined;
-			const model = buildDashboardModel(db, {
+			const built = buildDashboardModel(db, {
 				...request,
 				...(repositories ? { repositoriesModel: repositories } : {}),
 				...(reachableCommits ? { reachableCommits } : {}),
 				...(authorIdentity ? { authorIdentity } : {}),
 			});
-			return attachDecisionGist(model, request, configDir);
+			return attachDecisionGist(built, request, configDir);
 		},
 		{ dbPath },
 	);
@@ -768,8 +805,11 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 	/** The idle poll, armed on `listening` and cleared on `close`. See `armIdlePoll`. */
 	let idlePoll: ReturnType<typeof setInterval> | undefined;
 	let boundPort = options.port;
+	/** Lives as long as this server; see {@link IdentityCache}. */
+	const identityCache: IdentityCache = new Map();
 	const buildModel =
-		options.buildModel ?? ((request: ModelRequest) => defaultModelBuilder(request, configDir, options.dbPath));
+		options.buildModel ??
+		((request: ModelRequest) => defaultModelBuilder(request, configDir, options.dbPath, identityCache, now));
 
 	const server = createServer(async (req, res) => {
 		lastRequestMs = now();

--- a/cli/src/dashboard/DbBackfill.test.ts
+++ b/cli/src/dashboard/DbBackfill.test.ts
@@ -47,7 +47,6 @@ vi.mock("./SotImport.js", async (importOriginal) => ({
 import { execGit, getHeadHash, listFilesInBranch } from "../core/GitOps.js";
 import { readCutoverFence } from "../core/RepoProfile.js";
 import { getIndex } from "../core/SummaryStore.js";
-import { backfillRepo, backfillRepos, pruneUnreachableCommits } from "./Backfill.js";
 import {
 	collectCommitEvents,
 	collectRepoGraph,
@@ -55,6 +54,7 @@ import {
 	collectSummaryEvents,
 	collectWorktreeEvent,
 } from "./DashboardCollector.js";
+import { dbBackfillRepo, dbBackfillRepos, pruneUnreachableCommits } from "./DbBackfill.js";
 import { importRepoMemory } from "./SotImport.js";
 
 let dir: string;
@@ -63,7 +63,11 @@ let dbPath: string;
 const repo: RegisteredRepo = {
 	repoIdentity: "https://github.com/jolliai/jolliai",
 	repoName: "jolliai",
-	worktreeRoot: "/home/dev/jolli",
+	// Must be a directory that EXISTS: `dbBackfillRepos` drops a repo whose every
+	// recorded checkout is gone (see its own describe block), so a fixture on a
+	// made-up path would silently be skipped instead of swept. Nothing is read
+	// from it — the collectors are mocked.
+	worktreeRoot: tmpdir(),
 	remoteUrl: "https://github.com/jolliai/jolliai",
 	enabledAt: "2026-01-01T00:00:00.000Z",
 };
@@ -145,9 +149,9 @@ async function query<T>(sql: string, ...params: unknown[]): Promise<T[]> {
 	return withDashboardDb((db) => db.prepare(sql).all(...params) as T[], { dbPath });
 }
 
-describe("backfillRepo — bootstrap", () => {
+describe("dbBackfillRepo — bootstrap", () => {
 	it("imports commits, sessions and worktree state, then marks the repo done", async () => {
-		const result = await backfillRepo({ repo, dbPath });
+		const result = await dbBackfillRepo({ repo, dbPath });
 		expect(result.mode).toBe("bootstrapped");
 		expect(result.eventsApplied).toBe(5); // repo.enabled + 2 commits + session + worktree
 
@@ -161,7 +165,7 @@ describe("backfillRepo — bootstrap", () => {
 	});
 
 	it("records cursors: HEAD for commits, max updatedAt for sessions", async () => {
-		await backfillRepo({ repo, dbPath, now: () => 42 });
+		await dbBackfillRepo({ repo, dbPath, now: () => 42 });
 		const cursors = await query<{ source: string; cursor: string }>(
 			"SELECT source, cursor FROM ingest_cursors ORDER BY source",
 		);
@@ -170,12 +174,15 @@ describe("backfillRepo — bootstrap", () => {
 			// sorted) so a commit landing in a second clone — or a branch moving
 			// without HEAD moving — cannot read as "nothing changed". Matched by shape
 			// rather than a pinned digest of the fixture's empty ref output.
-			{ source: "git-commits", cursor: expect.stringMatching(/^\/home\/dev\/jolli@head-1\+[0-9a-f]{64}$/) },
+			// The path prefix is the fixture's own root (an existing directory — see
+			// the fixture), asserted below rather than inlined into the pattern.
+			{ source: "git-commits", cursor: expect.stringMatching(/@head-1\+[0-9a-f]{64}$/) },
 			{ source: "sessions", cursor: String(sessionEvent.updatedAtMs) },
 			// The memory import's own signal: the orphan tip (a hash of everything it
 			// reads) plus the mode, since seed and catch-up do not write the same rows.
 			{ source: "sot-import", cursor: `${"ab".repeat(20)}#seed` },
 		]);
+		expect(cursors[0].cursor.startsWith(`${repo.worktreeRoot}@`)).toBe(true);
 	});
 
 	// PARKED with `repo_graphs` and Backfill's call site (see SotSchema): the
@@ -197,7 +204,7 @@ describe("backfillRepo — bootstrap", () => {
 	// edges: [{ from: "u1", to: "u2" }],
 	// coChangeTopicEdges: [],
 	// } as unknown as KnowledgeGraph);
-	// await backfillRepo({ repo, dbPath });
+	// await dbBackfillRepo({ repo, dbPath });
 	// const row = await withDashboardDb(
 	// (db) =>
 	// db
@@ -218,9 +225,9 @@ describe("backfillRepo — bootstrap", () => {
 	// });
 
 	it("is idempotent — running twice does not duplicate rows", async () => {
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		vi.mocked(getHeadHash).mockResolvedValue("head-2"); // force a re-collect
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		expect((await query("SELECT hash FROM commits")).length).toBe(2);
 	});
 
@@ -243,7 +250,7 @@ describe("backfillRepo — bootstrap", () => {
 		);
 		expect((await query("SELECT event_id FROM events_raw WHERE event_id = 'stale'")).length).toBe(1);
 
-		await backfillRepo({ repo, dbPath, now: () => Date.parse("2026-08-09T00:00:00Z") });
+		await dbBackfillRepo({ repo, dbPath, now: () => Date.parse("2026-08-09T00:00:00Z") });
 
 		expect((await query("SELECT event_id FROM events_raw WHERE event_id = 'stale'")).length).toBe(0);
 	});
@@ -265,7 +272,7 @@ describe("backfillRepo — bootstrap", () => {
 			{ dbPath },
 		);
 
-		await backfillRepo({ repo, dbPath, now: () => Date.parse("2026-08-09T00:00:00Z") });
+		await dbBackfillRepo({ repo, dbPath, now: () => Date.parse("2026-08-09T00:00:00Z") });
 
 		const kept = await query<{ event_id: string }>(
 			"SELECT event_id FROM events_raw WHERE event_id IN ('pending','failed') ORDER BY event_id",
@@ -274,11 +281,11 @@ describe("backfillRepo — bootstrap", () => {
 	});
 });
 
-describe("backfillRepo — recovery", () => {
+describe("dbBackfillRepo — recovery", () => {
 	it("skips the git sweep when HEAD matches the cursor", async () => {
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		vi.mocked(collectCommitEvents).mockClear();
-		const result = await backfillRepo({ repo, dbPath });
+		const result = await dbBackfillRepo({ repo, dbPath });
 		expect(collectCommitEvents).not.toHaveBeenCalled();
 		// Sessions and worktree are still re-projected (idempotent, cheap).
 		expect(collectSessionEvents).toHaveBeenCalledTimes(2);
@@ -286,7 +293,7 @@ describe("backfillRepo — recovery", () => {
 	});
 
 	it("re-sweeps when a branch tip moves without HEAD moving", async () => {
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		vi.mocked(collectCommitEvents).mockClear();
 		// Same HEAD, different branch tips — a branch that is not the checked-out one
 		// was deleted, rebased or gained a commit. A HEAD-only cursor read this as
@@ -296,7 +303,7 @@ describe("backfillRepo — recovery", () => {
 			stderr: "",
 			exitCode: 0,
 		});
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		expect(collectCommitEvents).toHaveBeenCalled();
 	});
 
@@ -316,10 +323,10 @@ describe("backfillRepo — recovery", () => {
 						exitCode: 0,
 					};
 		vi.mocked(execGit).mockImplementation(tips("mem-1"));
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		vi.mocked(collectCommitEvents).mockClear();
 		vi.mocked(execGit).mockImplementation(tips("mem-2"));
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		expect(collectCommitEvents).not.toHaveBeenCalled();
 	});
 
@@ -330,13 +337,13 @@ describe("backfillRepo — recovery", () => {
 		// projecting the unchanged ones re-ran an UPSERT + DELETE + re-INSERT per
 		// commit to arrive at the bytes already there. Measured on a real 2.5k-commit
 		// repo: one new commit went from 2457 projections to 1.
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		// A pass with nothing to do still re-projects the always-on tiers, so THAT is
 		// the baseline to compare against rather than a hard-coded count.
-		const idle = await backfillRepo({ repo, dbPath });
+		const idle = await dbBackfillRepo({ repo, dbPath });
 		vi.mocked(getHeadHash).mockResolvedValue("head-2");
 		vi.mocked(collectCommitEvents).mockResolvedValue([commitEvent("aaa"), commitEvent("bbb"), commitEvent("ccc")]);
-		const result = await backfillRepo({ repo, dbPath });
+		const result = await dbBackfillRepo({ repo, dbPath });
 		// Exactly one more: `ccc`. `aaa` and `bbb` are listed by the sweep and used
 		// for the prune, but neither reaches the projection.
 		expect(result.eventsApplied).toBe(idle.eventsApplied + 1);
@@ -348,13 +355,13 @@ describe("backfillRepo — recovery", () => {
 		// `branches` is replace-when-present, so a stale set is a wrong answer to
 		// "group by branch" — this is the one field that legitimately changes for an
 		// OLD commit, and skipping it is what a naive "already stored" test would do.
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		vi.mocked(getHeadHash).mockResolvedValue("head-2");
 		vi.mocked(collectCommitEvents).mockResolvedValue([
 			{ ...commitEvent("aaa"), branches: ["main", "feature/x"] },
 			commitEvent("bbb"),
 		]);
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		const names = (
 			await query<{ name: string }>(
 				`SELECT b.name FROM commit_branches cb
@@ -377,22 +384,22 @@ describe("backfillRepo — recovery", () => {
 			{ ...commitEvent("aaa"), files: [{ path: "src/a.ts", insertions: 1, deletions: 0 }] },
 			commitEvent("bbb"),
 		]);
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		vi.mocked(collectCommitEvents).mockClear();
 
 		vi.mocked(getHeadHash).mockResolvedValue("head-2");
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 
 		const known = vi.mocked(collectCommitEvents).mock.calls[0]?.[0].knownHashes;
 		expect([...(known ?? [])]).toEqual(["aaa"]);
 	});
 
 	it("prunes commits that a rewrite made unreachable (set reconciliation)", async () => {
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		// Rebase: bbb rewritten to ccc, HEAD moved.
 		vi.mocked(getHeadHash).mockResolvedValue("head-2");
 		vi.mocked(collectCommitEvents).mockResolvedValue([commitEvent("aaa"), commitEvent("ccc")]);
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		const hashes = (await query<{ hash: string }>("SELECT hash FROM commits ORDER BY hash")).map((r) => r.hash);
 		expect(hashes).toEqual(["aaa", "ccc"]);
 	});
@@ -403,13 +410,13 @@ describe("backfillRepo — recovery", () => {
 		// commits", so the prune wiped the commit layer (with its CASCADEs) — and then
 		// advanced the cursor, so the next pass skipped collection entirely and the
 		// blank persisted until some unrelated ref moved.
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		const before = await query<{ hash: string }>("SELECT hash FROM commits ORDER BY hash");
 		const cursorBefore = await query<{ cursor: string }>("SELECT cursor FROM ingest_cursors WHERE source = 'git'");
 
 		vi.mocked(getHeadHash).mockResolvedValue("head-2");
 		vi.mocked(collectCommitEvents).mockRejectedValue(new Error("git log failed: stdout limit exceeded"));
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 
 		expect(await query<{ hash: string }>("SELECT hash FROM commits ORDER BY hash")).toEqual(before);
 		// Cursor unmoved, so the next pass re-collects instead of trusting the gap.
@@ -420,7 +427,7 @@ describe("backfillRepo — recovery", () => {
 
 	it("still recovers sessions when HEAD is unreadable (worktree gone mid-run)", async () => {
 		vi.mocked(getHeadHash).mockRejectedValue(new Error("not a repo"));
-		const result = await backfillRepo({ repo, dbPath });
+		const result = await dbBackfillRepo({ repo, dbPath });
 		expect(result.mode).toBe("bootstrapped");
 		expect((await query("SELECT event_id FROM sessions")).length).toBe(1);
 		// No commit cursor written without a HEAD to anchor it. The memory import's
@@ -432,14 +439,14 @@ describe("backfillRepo — recovery", () => {
 
 	it("skips the worktree event when the collector returns null", async () => {
 		vi.mocked(collectWorktreeEvent).mockResolvedValue(null);
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		expect(await query("SELECT branch FROM worktree_status")).toEqual([]);
 	});
 });
 
 describe("pruneUnreachableCommits", () => {
 	it("returns 0 and writes nothing when everything is reachable", async () => {
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		const pruned = await withDashboardDb(
 			(db) => pruneUnreachableCommits(db, repo.repoIdentity, new Set(["aaa", "bbb"])),
 			{ dbPath },
@@ -448,7 +455,7 @@ describe("pruneUnreachableCommits", () => {
 	});
 
 	it("cascades: pruning a commit removes its branch links", async () => {
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		const pruned = await withDashboardDb((db) => pruneUnreachableCommits(db, repo.repoIdentity, new Set(["aaa"])), {
 			dbPath,
 		});
@@ -460,19 +467,20 @@ describe("pruneUnreachableCommits", () => {
 	});
 });
 
-describe("backfillRepos", () => {
+describe("dbBackfillRepos", () => {
 	it("continues past a repo whose backfill throws", async () => {
+		// Live path on purpose: this is the "the sweep threw" case, distinct from
+		// the "the checkout is gone" case below, which never reaches the sweep.
 		const broken: RegisteredRepo = {
 			...repo,
 			repoIdentity: "local:broken",
 			repoName: "broken",
-			worktreeRoot: "/gone",
 		};
 		vi.mocked(collectSessionEvents).mockImplementation(async (opts) => {
 			if (opts.repoIdentity === "local:broken") throw new Error("worktree deleted");
 			return [sessionEvent];
 		});
-		const results = await backfillRepos([broken, repo], { dbPath });
+		const results = await dbBackfillRepos([broken, repo], { dbPath });
 		expect(results).toHaveLength(2);
 		// `repoName` and `error` ride on every result now: a repo that failed to
 		// import used to reach the log and nothing else, so the caller had no way to
@@ -485,9 +493,45 @@ describe("backfillRepos", () => {
 		});
 		expect(results[1].mode).toBe("bootstrapped");
 	});
+
+	it("reports a repo whose every recorded checkout is gone, without sweeping it", async () => {
+		// The registry is append-only in practice, so a repo whose directory was
+		// deleted stays in it forever. Sweeping it runs git against a path that does
+		// not exist — three warnings per pass, on every `jolli dashboard` launch —
+		// and it is not a failure the caller should print as "migration failed".
+		//
+		// Reported all the same, under its own mode: the identical evidence describes
+		// an unmounted share, where the user is still expecting these memories, and
+		// the log line the sweep-suppression left behind is at `debug` — which CLI
+		// mode keeps off the terminal entirely. `unavailable` is what lets the caller
+		// say it once without calling it a failure.
+		const gone: RegisteredRepo = {
+			...repo,
+			repoIdentity: "local:gone",
+			repoName: "gone",
+			worktreeRoot: join(dir, "deleted"),
+			worktrees: [join(dir, "deleted"), join(dir, "also-deleted")],
+		};
+		const results = await dbBackfillRepos([gone, repo], { dbPath });
+		// Worked-on repos first; the untouched entries are appended.
+		expect(results.map((r) => r.repoName)).toEqual(["jolliai", "gone"]);
+		expect(results[1]).toEqual({ mode: "unavailable", eventsApplied: 0, repoName: "gone" });
+		// Not swept at all: no collector ever saw it.
+		expect(vi.mocked(collectSessionEvents).mock.calls.every((c) => c[0].repoIdentity !== "local:gone")).toBe(true);
+	});
+
+	it("counts only the surviving repos when stamping each one's place in the run", async () => {
+		// `repoTotal` follows the list that is actually swept, so a dead entry does
+		// not make the progress line count to a total it will never reach.
+		const gone: RegisteredRepo = { ...repo, repoIdentity: "local:gone2", worktreeRoot: join(dir, "deleted") };
+		const seen: number[] = [];
+		await dbBackfillRepos([gone, repo], { dbPath, onProgress: (p) => seen.push(p.repoTotal) });
+		expect(seen.length).toBeGreaterThan(0);
+		expect(seen.every((total) => total === 1)).toBe(true);
+	});
 });
 
-describe("backfillRepo — SOT import wiring (v7)", () => {
+describe("dbBackfillRepo — SOT import wiring (v7)", () => {
 	it("runs the importer for the repo and reports its row counts", async () => {
 		vi.mocked(importRepoMemory).mockResolvedValue({
 			nodes: 3,
@@ -503,7 +547,7 @@ describe("backfillRepo — SOT import wiring (v7)", () => {
 			pruned: 2,
 		});
 
-		const result = await backfillRepo({ repo, dbPath, now: () => 4242 });
+		const result = await dbBackfillRepo({ repo, dbPath, now: () => 4242 });
 
 		expect(result.sotImport).toMatchObject({ nodes: 3, docs: 4, planProgress: 1, pruned: 2 });
 		expect(importRepoMemory).toHaveBeenCalledWith(
@@ -517,12 +561,12 @@ describe("backfillRepo — SOT import wiring (v7)", () => {
 		// before it picks a mode, so a provider stub without it never reaches the
 		// importer at all.
 		const storage = { kind: "orphan-branch" as const, listFiles: async () => [] } as never;
-		await backfillRepo({ repo, dbPath, storage });
+		await dbBackfillRepo({ repo, dbPath, storage });
 		expect(importRepoMemory).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ storage }));
 	});
 
 	it("imports in seed mode while the repo has never been fenced for cutover", async () => {
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		expect(importRepoMemory).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ mode: "seed" }));
 	});
 
@@ -536,7 +580,7 @@ describe("backfillRepo — SOT import wiring (v7)", () => {
 		const a = mkdtempSync(join(tmpdir(), "jolli-wt-a-"));
 		const b = mkdtempSync(join(tmpdir(), "jolli-wt-b-"));
 		try {
-			await backfillRepo({ repo: { ...repo, worktrees: [a, b] }, dbPath });
+			await dbBackfillRepo({ repo: { ...repo, worktrees: [a, b] }, dbPath });
 			expect(importRepoMemory).toHaveBeenCalledWith(
 				expect.anything(),
 				expect.objectContaining({ mode: "catch-up" }),
@@ -552,7 +596,7 @@ describe("backfillRepo — SOT import wiring (v7)", () => {
 		// reconciliation reading the now-frozen orphan branch would treat every
 		// one of them as "removed from the branch" and prune them right back out.
 		vi.mocked(readCutoverFence).mockResolvedValue({ reason: "cutover", at: "2026-08-06T00:00:00.000Z" });
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		expect(importRepoMemory).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ mode: "catch-up" }));
 	});
 
@@ -562,10 +606,10 @@ describe("backfillRepo — SOT import wiring (v7)", () => {
 		// seconds of every `jolli dashboard`, on a source that has not changed a
 		// byte. The tip is a hash of that whole source, so "unchanged tip" is an
 		// exact answer, not a heuristic.
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		vi.mocked(importRepoMemory).mockClear();
 
-		const result = await backfillRepo({ repo, dbPath });
+		const result = await dbBackfillRepo({ repo, dbPath });
 
 		expect(importRepoMemory).not.toHaveBeenCalled();
 		// The count still has to be right: the caller prints it, and a zero here
@@ -574,7 +618,7 @@ describe("backfillRepo — SOT import wiring (v7)", () => {
 	});
 
 	it("re-imports once the orphan tip moves", async () => {
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		vi.mocked(importRepoMemory).mockClear();
 		vi.mocked(execGit).mockImplementation(async (args) =>
 			args[0] === "rev-parse" && args[1] === "--verify"
@@ -582,7 +626,7 @@ describe("backfillRepo — SOT import wiring (v7)", () => {
 				: { stdout: "", stderr: "", exitCode: 0 },
 		);
 
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 
 		expect(importRepoMemory).toHaveBeenCalledTimes(1);
 	});
@@ -592,11 +636,11 @@ describe("backfillRepo — SOT import wiring (v7)", () => {
 		// without the branch moving, and the two modes do not write the same rows —
 		// seed reconciles, catch-up never deletes. A tip-only cursor would skip the
 		// one pass where the difference matters.
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		vi.mocked(importRepoMemory).mockClear();
 		vi.mocked(readCutoverFence).mockResolvedValue({ reason: "cutover", at: "2026-08-06T00:00:00.000Z" });
 
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 
 		expect(importRepoMemory).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ mode: "catch-up" }));
 	});
@@ -606,7 +650,7 @@ describe("backfillRepo — SOT import wiring (v7)", () => {
 		// or half-built; a repo still marked pending has not proven its rows are
 		// there, and a wrong skip costs the repo's memories while a wrong import
 		// costs one pass.
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		await withDashboardDb(
 			(db) => {
 				db.prepare("UPDATE repos SET bootstrap_state = 'pending'").run();
@@ -615,7 +659,7 @@ describe("backfillRepo — SOT import wiring (v7)", () => {
 		);
 		vi.mocked(importRepoMemory).mockClear();
 
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 
 		expect(importRepoMemory).toHaveBeenCalledTimes(1);
 	});
@@ -639,7 +683,7 @@ describe("backfillRepo — SOT import wiring (v7)", () => {
 			};
 		});
 
-		const results = await backfillRepos([repo, other], { dbPath });
+		const results = await dbBackfillRepos([repo, other], { dbPath });
 
 		expect(results[0]).toEqual({
 			mode: "skipped",
@@ -652,7 +696,7 @@ describe("backfillRepo — SOT import wiring (v7)", () => {
 	});
 });
 
-describe("backfillRepo — summaries sweep (memory tier)", () => {
+describe("dbBackfillRepo — summaries sweep (memory tier)", () => {
 	const summaryEvent = {
 		type: "commit.summary" as const,
 		repoIdentity: repo.repoIdentity,
@@ -671,7 +715,7 @@ describe("backfillRepo — summaries sweep (memory tier)", () => {
 		vi.mocked(getIndex).mockResolvedValue({ version: 3, entries: [] });
 		vi.mocked(collectSummaryEvents).mockResolvedValue({ events: [summaryEvent], complete: true });
 
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 
 		// The enrichment copies are gone (A3b): the sweep's job is the commits
 		// row; turns/ticket/insights live on the memory tables, which the
@@ -684,11 +728,11 @@ describe("backfillRepo — summaries sweep (memory tier)", () => {
 		vi.mocked(getIndex).mockResolvedValue({ version: 3, entries: [] });
 		vi.mocked(collectSummaryEvents).mockResolvedValue({ events: [summaryEvent], complete: true });
 
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		expect(collectSummaryEvents).toHaveBeenCalledTimes(1);
 
 		// Same index content → recovery skips the expensive summary read.
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		expect(collectSummaryEvents).toHaveBeenCalledTimes(1);
 
 		// Index changed (new summary stored) → sweep again.
@@ -705,12 +749,12 @@ describe("backfillRepo — summaries sweep (memory tier)", () => {
 				},
 			],
 		});
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		expect(collectSummaryEvents).toHaveBeenCalledTimes(2);
 	});
 
 	it("skips the sweep entirely when there is no summary index", async () => {
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		expect(collectSummaryEvents).not.toHaveBeenCalled();
 	});
 
@@ -721,19 +765,19 @@ describe("backfillRepo — summaries sweep (memory tier)", () => {
 		vi.mocked(getIndex).mockResolvedValue({ version: 3, entries: [] });
 		vi.mocked(collectSummaryEvents).mockResolvedValue({ events: [summaryEvent], complete: false });
 
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		expect(collectSummaryEvents).toHaveBeenCalledTimes(1);
 
 		// Same index content, but the cursor never moved — so the next pass
 		// re-reads instead of trusting an incomplete result.
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		expect(collectSummaryEvents).toHaveBeenCalledTimes(2);
 
 		// A clean sweep finally parks it.
 		vi.mocked(collectSummaryEvents).mockResolvedValue({ events: [summaryEvent], complete: true });
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		expect(collectSummaryEvents).toHaveBeenCalledTimes(3);
-		await backfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
 		expect(collectSummaryEvents).toHaveBeenCalledTimes(3);
 	});
 
@@ -745,7 +789,7 @@ describe("backfillRepo — summaries sweep (memory tier)", () => {
 		vi.mocked(collectSummaryEvents).mockResolvedValue({ events: [summaryEvent], complete: true });
 		const kinds = async (): Promise<string[]> => {
 			const seen: string[] = [];
-			await backfillRepo({
+			await dbBackfillRepo({
 				repo,
 				dbPath,
 				onProgress: (p) => {
@@ -778,7 +822,7 @@ describe("multiple checkouts of one project (§10.2)", () => {
 				},
 			]);
 
-			await backfillRepo({ repo: { ...repo, worktrees: [a, b] }, dbPath });
+			await dbBackfillRepo({ repo: { ...repo, worktrees: [a, b] }, dbPath });
 
 			const hashes = await withDashboardDb(
 				(db) =>
@@ -814,7 +858,7 @@ describe("multiple checkouts of one project (§10.2)", () => {
 				},
 			]);
 
-			await backfillRepo({ repo: { ...repo, worktrees: [a, b] }, dbPath });
+			await dbBackfillRepo({ repo: { ...repo, worktrees: [a, b] }, dbPath });
 
 			const branches = await withDashboardDb(
 				(db) =>
@@ -855,7 +899,7 @@ describe("multiple checkouts of one project (§10.2)", () => {
 				},
 			]);
 
-			await backfillRepo({ repo: { ...repo, worktrees: [a2, b2] }, dbPath });
+			await dbBackfillRepo({ repo: { ...repo, worktrees: [a2, b2] }, dbPath });
 
 			const branches = await withDashboardDb(
 				(db) =>
@@ -894,7 +938,7 @@ describe("multiple checkouts of one project (§10.2)", () => {
 					branches: ["main"],
 				},
 			]);
-			await backfillRepo({ repo: { ...repo, worktrees: [a3, b3] }, dbPath });
+			await dbBackfillRepo({ repo: { ...repo, worktrees: [a3, b3] }, dbPath });
 
 			// Pass 2: neither checkout's branch scan completed.
 			vi.mocked(collectCommitEvents).mockImplementation(async () => [
@@ -906,7 +950,7 @@ describe("multiple checkouts of one project (§10.2)", () => {
 					message: "touched, so the row is re-projected",
 				},
 			]);
-			await backfillRepo({ repo: { ...repo, worktrees: [a3, b3] }, dbPath });
+			await dbBackfillRepo({ repo: { ...repo, worktrees: [a3, b3] }, dbPath });
 
 			const branches = await withDashboardDb(
 				(db) =>
@@ -935,7 +979,7 @@ describe("multiple checkouts of one project (§10.2)", () => {
 			// keeps this assertion about the per-checkout composition, not hashing.
 			vi.mocked(execGit).mockResolvedValue({ stdout: "", stderr: "", exitCode: 1 });
 
-			await backfillRepo({ repo: { ...repo, worktrees: [a, b] }, dbPath });
+			await dbBackfillRepo({ repo: { ...repo, worktrees: [a, b] }, dbPath });
 
 			const cursor = await withDashboardDb(
 				(db) =>
@@ -962,7 +1006,7 @@ describe("multiple checkouts of one project (§10.2)", () => {
  * before it runs, because a phase that reports only on completion cannot break
  * the silence during it.
  */
-describe("backfillRepo — progress", () => {
+describe("dbBackfillRepo — progress", () => {
 	it("announces every phase before it runs, and forwards the importer's counter", async () => {
 		vi.mocked(importRepoMemory).mockImplementation(async (_db, opts) => {
 			opts.onProgress?.({ done: 1, total: 2 });
@@ -982,7 +1026,7 @@ describe("backfillRepo — progress", () => {
 			};
 		});
 		const seen: Array<{ kind: string; done: number; total?: number; detail?: string }> = [];
-		await backfillRepo({
+		await dbBackfillRepo({
 			repo,
 			dbPath,
 			onProgress: (p) =>
@@ -1017,7 +1061,7 @@ describe("backfillRepo — progress", () => {
 		const b = mkdtempSync(join(tmpdir(), "jolli-wt-b-"));
 		try {
 			const seen: string[] = [];
-			await backfillRepo({
+			await dbBackfillRepo({
 				repo: { ...repo, worktrees: [a, b] },
 				dbPath,
 				onProgress: (p) => {
@@ -1033,7 +1077,7 @@ describe("backfillRepo — progress", () => {
 
 	it("omits the checkout qualifier when there is only one", async () => {
 		const seen: Array<string | undefined> = [];
-		await backfillRepo({
+		await dbBackfillRepo({
 			repo,
 			dbPath,
 			onProgress: (p) => {
@@ -1043,10 +1087,10 @@ describe("backfillRepo — progress", () => {
 		expect(seen).toEqual([undefined]);
 	});
 
-	it("backfillRepos stamps each repo's place in the run", async () => {
+	it("dbBackfillRepos stamps each repo's place in the run", async () => {
 		const other: RegisteredRepo = { ...repo, repoIdentity: "https://example.com/other.git", repoName: "other" };
 		const seen: Array<{ repoName: string; repoIndex: number; repoTotal: number }> = [];
-		await backfillRepos([repo, other], {
+		await dbBackfillRepos([repo, other], {
 			dbPath,
 			onProgress: (p) => seen.push({ repoName: p.repoName, repoIndex: p.repoIndex, repoTotal: p.repoTotal }),
 		});
@@ -1055,7 +1099,7 @@ describe("backfillRepo — progress", () => {
 	});
 
 	it("runs unchanged when no callback is supplied", async () => {
-		const result = await backfillRepo({ repo, dbPath });
+		const result = await dbBackfillRepo({ repo, dbPath });
 		expect(result.mode).toBe("bootstrapped");
 	});
 });

--- a/cli/src/dashboard/DbBackfill.ts
+++ b/cli/src/dashboard/DbBackfill.ts
@@ -1,10 +1,17 @@
 /**
- * Backfill — one-time bootstrap and post-restart gap recovery for the
+ * DbBackfill — one-time bootstrap and post-restart gap recovery for the
  * dashboard database.
  *
  * Both run in a command process (`jolli dashboard`, `jolli enable`) — never in
  * the read-only HTTP service — and both feed the same `StatsWriter`, so an
  * imported fact and a live-written fact are indistinguishable in the DB.
+ *
+ * The `db` prefix on every export is load-bearing, not decoration: `src/backfill/`
+ * is an unrelated feature with the same name — the `jolli backfill` command, which
+ * spends LLM budget generating summaries for historical commits. Nothing here
+ * calls a model. The two used to collide outright (both declared a
+ * `BackfillOptions`), and the ambiguity reached users: `jolli cutover` and
+ * `jolli dashboard` print progress from THIS module, which reads as the LLM one.
  *
  * ## Correctness model (why cursors are not the mechanism)
  *
@@ -40,7 +47,7 @@ import {
 import type { DashboardDbHandle } from "./DashboardDb.js";
 import { inTransaction, withDashboardDb } from "./DashboardDb.js";
 import type { CommitCreatedEvent, ProducerKind, StatsEvent, StatsEventEnvelope } from "./DashboardModel.js";
-import { existingWorktrees, type RegisteredRepo, readRepoCutoverFence } from "./RepoRegistry.js";
+import { existingWorktrees, hasLiveWorktree, type RegisteredRepo, readRepoCutoverFence } from "./RepoRegistry.js";
 import {
 	countMemoriesAbsentFromListing,
 	EMPTY_IMPORT_RESULT,
@@ -51,7 +58,7 @@ import {
 } from "./SotImport.js";
 import { applyToDb, pruneProjectedEvents } from "./StatsWriter.js"; // recordRepoGraph parked — see SotSchema
 
-const log = createLogger("Backfill");
+const log = createLogger("DbBackfill");
 
 /**
  * Events per write transaction. Small on purpose: every batch takes SQLite's
@@ -132,7 +139,7 @@ async function checkoutFingerprint(path: string): Promise<string | null> {
 	return `${head}+${createHash("sha256").update(tips).digest("hex")}`;
 }
 
-export interface BackfillOptions {
+export interface DbBackfillOptions {
 	readonly repo: RegisteredRepo;
 	/** Test seam: path override for the dashboard DB. */
 	readonly dbPath?: string;
@@ -152,7 +159,7 @@ export interface BackfillOptions {
 }
 
 /**
- * What a backfill is working through right now, for one repo.
+ * What a DB backfill is working through right now, for one repo.
  *
  * `done: 0` is a **phase-start marker**, emitted BEFORE the work begins. That
  * is the only kind of event the slow phases can offer: measured on a two-repo
@@ -185,15 +192,24 @@ export interface RepoProgress {
 }
 
 /** {@link RepoProgress} plus the repo's place in a multi-repo run. */
-export interface BackfillProgress extends RepoProgress {
+export interface DbBackfillProgress extends RepoProgress {
 	/** 1-based. */
 	readonly repoIndex: number;
 	readonly repoTotal: number;
 }
 
-export interface BackfillResult {
-	/** 'bootstrapped' = full import ran; 'recovered' = incremental pass; 'skipped' = the repo errored out. */
-	readonly mode: "bootstrapped" | "recovered" | "skipped";
+export interface DbBackfillResult {
+	/**
+	 * 'bootstrapped' = full import ran; 'recovered' = incremental pass;
+	 * 'skipped' = the repo errored out; 'unavailable' = no registered checkout
+	 * exists on disk, so nothing was attempted (see {@link dbBackfillRepos}).
+	 *
+	 * The last two are deliberately different words for different facts: a
+	 * 'skipped' repo is a failure to report against the repo, an 'unavailable'
+	 * one is a repo that is not here right now. A caller that prints them the
+	 * same way turns an unmounted network share into "migration failed".
+	 */
+	readonly mode: "bootstrapped" | "recovered" | "skipped" | "unavailable";
 	readonly eventsApplied: number;
 	/** Row counts from the v7 SOT import; absent when the repo was skipped. */
 	readonly sotImport?: SotImportResult;
@@ -439,12 +455,12 @@ function repoEnabledEvent(repo: RegisteredRepo): StatsEvent {
  * exist has no memories, no KPIs and no page (every gated route redirects), and
  * a disabled repo whose `disabled_at` is still NULL keeps counting in every KPI
  * and picker. `jolli enable` gets the projection for free from the full
- * backfill it runs; a long-lived server mutating the registry over HTTP does
+ * DB backfill it runs; a long-lived server mutating the registry over HTTP does
  * not, and that is exactly the caller this exists for.
  *
  * Cheap by construction — two rows, no git, no import — so it is safe to await
  * inside a request handler before answering. The heavier memory import stays
- * `backfillRepo`'s job.
+ * `dbBackfillRepo`'s job.
  */
 export function projectRepoRegistryState(
 	db: DashboardDbHandle,
@@ -463,7 +479,7 @@ export function projectRepoRegistryState(
  * — a crash mid-import leaves `bootstrap_state = 'in-progress'`, and the next
  * run simply collects and applies again (UPSERTs make the redo harmless).
  */
-export async function backfillRepo(opts: BackfillOptions): Promise<BackfillResult> {
+export async function dbBackfillRepo(opts: DbBackfillOptions): Promise<DbBackfillResult> {
 	const now = opts.now ?? Date.now;
 	const producerKind = opts.producerKind ?? "bootstrap";
 	const repo = opts.repo;
@@ -901,43 +917,76 @@ export async function backfillRepo(opts: BackfillOptions): Promise<BackfillResul
 
 			const mode = isBootstrap ? "bootstrapped" : "recovered";
 			log.info("%s %s: %d events applied", mode, repo.repoName, applied);
-			return { mode, eventsApplied: applied, sotImport, repoName: repo.repoName } as BackfillResult;
+			return { mode, eventsApplied: applied, sotImport, repoName: repo.repoName } as DbBackfillResult;
 		},
 		{ dbPath: opts.dbPath },
 	);
 }
 
 /**
- * Backfills every repo in the list, independently — one broken repo (deleted
+ * Backfills every repo into the dashboard database, independently — one broken repo (deleted
  * worktree, git failure) must not stop the others from importing.
  */
-export async function backfillRepos(
+export async function dbBackfillRepos(
 	repos: ReadonlyArray<RegisteredRepo>,
-	opts: Omit<BackfillOptions, "repo" | "onProgress"> & {
+	opts: Omit<DbBackfillOptions, "repo" | "onProgress"> & {
 		/** Same events as the per-repo callback, plus where this repo sits in the run. */
-		readonly onProgress?: (progress: BackfillProgress) => void;
+		readonly onProgress?: (progress: DbBackfillProgress) => void;
 	},
-): Promise<ReadonlyArray<BackfillResult>> {
+): Promise<ReadonlyArray<DbBackfillResult>> {
 	// Pulled out of the spread: the two callbacks have different shapes, and
-	// letting the wide one ride along on `...rest` would hand `backfillRepo` a
+	// letting the wide one ride along on `...rest` would hand `dbBackfillRepo` a
 	// function expecting fields it never supplies.
 	const { onProgress: forward, ...rest } = opts;
-	const results: BackfillResult[] = [];
-	for (const [i, repo] of repos.entries()) {
-		// The index is injected here rather than passed down, so `backfillRepo`
+	// A repo whose every recorded checkout is gone is dropped BEFORE the sweep,
+	// not swept and warned about. `existingWorktrees` deliberately falls back to
+	// the recorded path rather than returning nothing, so sweeping such an entry
+	// runs `git` against a directory that does not exist: three warnings per repo
+	// per pass (HEAD unreadable → collection failed → prune skipped), on every
+	// `jolli dashboard` launch, forever — nothing prunes the registry, and
+	// `deregisterRepo` cannot reach a deleted directory. It is also not a failure
+	// worth a `mode: "skipped"` result, which the caller prints as "migration
+	// failed": there is no repo left to migrate.
+	//
+	// Deliberately NOT deregistration: the same predicate answers "temporarily
+	// unmounted" (network share, external drive, a worktree being recreated), and
+	// forgetting a repo on that evidence would throw away its registration for a
+	// directory that comes back. Skipping costs one converged pass; the entry is
+	// picked up again the moment a path exists.
+	//
+	// It IS reported, as `mode: "unavailable"`, and that is the half the log line
+	// alone cannot do. `log.debug` (and `log.info`) are suppressed from the
+	// terminal in CLI mode by design, so a repo that quietly stopped being
+	// imported — the unmounted-share case, where the user still expects their
+	// memories to keep arriving — had no signal anywhere the user looks. A result
+	// row lets the caller say it once per run, in the terminal it owns, without
+	// resurrecting the three warnings per repo per pass this replaced.
+	const unavailable: DbBackfillResult[] = [];
+	const live = repos.filter((repo) => {
+		if (hasLiveWorktree(repo)) return true;
+		log.debug("skipping %s -- no registered worktree exists on disk (%s)", repo.repoName, repo.worktreeRoot);
+		unavailable.push({ mode: "unavailable", eventsApplied: 0, repoName: repo.repoName });
+		return false;
+	});
+	const results: DbBackfillResult[] = [];
+	for (const [i, repo] of live.entries()) {
+		// The index is injected here rather than passed down, so `dbBackfillRepo`
 		// stays ignorant of the list it happens to be in.
 		const perRepo = forward
-			? { onProgress: (p: RepoProgress) => forward({ ...p, repoIndex: i + 1, repoTotal: repos.length }) }
+			? { onProgress: (p: RepoProgress) => forward({ ...p, repoIndex: i + 1, repoTotal: live.length }) }
 			: {};
 		try {
-			results.push(await backfillRepo({ ...rest, ...perRepo, repo }));
+			results.push(await dbBackfillRepo({ ...rest, ...perRepo, repo }));
 		} catch (err) {
-			log.error("backfill failed for %s: %s", repo.repoName, errMsg(err));
+			log.error("db backfill failed for %s: %s", repo.repoName, errMsg(err));
 			// Carried on the result, not just logged: the caller is the only thing
 			// with a terminal, and a repo that failed to import must not look
 			// identical to one that had nothing to do.
 			results.push({ mode: "skipped", eventsApplied: 0, repoName: repo.repoName, error: errMsg(err) });
 		}
 	}
-	return results;
+	// Appended, not prepended: a caller reading the list in order should see the
+	// repos that were worked on first, and these carry no per-repo detail to
+	// interleave with them.
+	return [...results, ...unavailable];
 }

--- a/cli/src/dashboard/FormatAsset.test.ts
+++ b/cli/src/dashboard/FormatAsset.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Unit test for `assets/js/format.js`'s `JD.safeHrefAttr` — the scheme allowlist
+ * standing between an archived third party's url and an `href` on a page that
+ * holds the dashboard token.
+ *
+ * Same rationale as `MemoriesAsset.test.ts` / `FeedCardAsset.test.ts`, and it
+ * applies harder to a security decision than to a renderer: the asset scripts
+ * are plain JS bundled verbatim into the served page, so tsc never checks them
+ * and the coverage floor cannot see them either (`vite.config.ts` excludes
+ * `src/dashboard/assets/**`). An allowlist that stops holding — a scheme
+ * quietly added, a probe that stops matching the browser — has no other signal.
+ */
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Control characters by code point, not as escapes: what is under test IS the
+ * handling of these bytes, so the literals must not be able to arrive as the
+ * two-character sequences an unescaping source transform would leave behind.
+ */
+const ch = (code: number) => String.fromCharCode(code);
+const TAB = ch(9);
+const LF = ch(10);
+const CR = ch(13);
+/** A C0 control that is NOT JS whitespace, so `String.trim()` does not remove it. */
+const SOH = ch(1);
+
+function loadSafeHrefAttr(): (url: unknown) => string | null {
+	const win = { JD: {} } as Record<string, unknown>;
+	const src = readFileSync(new URL("./assets/js/format.js", import.meta.url), "utf8");
+	// format.js touches nothing but `window` at load time.
+	new Function("window", src)(win);
+	return (win.JD as { safeHrefAttr: (url: unknown) => string | null }).safeHrefAttr;
+}
+
+const safeHrefAttr = loadSafeHrefAttr();
+
+describe("format.js — JD.safeHrefAttr", () => {
+	it("passes an allowlisted scheme through", () => {
+		expect(safeHrefAttr("https://linear.app/x/issue/ABC-1")).toBe("https://linear.app/x/issue/ABC-1");
+		expect(safeHrefAttr("http://localhost:3000/x")).toBe("http://localhost:3000/x");
+		expect(safeHrefAttr("mailto:someone@example.com")).toBe("mailto:someone@example.com");
+	});
+
+	it("suppresses a javascript: url", () => {
+		expect(safeHrefAttr("javascript:alert(1)")).toBeNull();
+		expect(safeHrefAttr("JavaScript:alert(1)")).toBeNull();
+		expect(safeHrefAttr("  javascript:alert(1)")).toBeNull();
+	});
+
+	it("suppresses the control-character spellings a browser would still navigate", () => {
+		// A browser removes tab/LF/CR from anywhere in a url before it reads the
+		// scheme, so each of these IS `javascript:` as far as navigation goes.
+		expect(safeHrefAttr(`java${LF}script:alert(1)`)).toBeNull();
+		expect(safeHrefAttr(`java${TAB}script:alert(1)`)).toBeNull();
+		expect(safeHrefAttr(`java${CR}script:alert(1)`)).toBeNull();
+		expect(safeHrefAttr(`${SOH}javascript:alert(1)`)).toBeNull();
+	});
+
+	it("suppresses anything outside the allowlist rather than filtering known-bad", () => {
+		// The point of an allowlist is that this list does not have to be complete.
+		expect(safeHrefAttr("data:text/html,<script>alert(1)</script>")).toBeNull();
+		expect(safeHrefAttr("vbscript:msgbox(1)")).toBeNull();
+		expect(safeHrefAttr("zoommtg://zoom.us/join?confno=1")).toBeNull();
+		expect(safeHrefAttr("//evil.example/x")).toBeNull();
+	});
+
+	it("returns an attribute-escaped value, because the caller interpolates it raw", () => {
+		const out = safeHrefAttr('https://x.example/?q="><img src=y onerror=alert(1)>');
+		expect(out).toBe("https://x.example/?q=&quot;&gt;&lt;img src=y onerror=alert(1)&gt;");
+	});
+
+	it("suppresses a missing url", () => {
+		expect(safeHrefAttr(undefined)).toBeNull();
+		expect(safeHrefAttr(null)).toBeNull();
+		expect(safeHrefAttr("")).toBeNull();
+		expect(safeHrefAttr("   ")).toBeNull();
+	});
+
+	it("mirrors the browser's own stripping rather than a superset of it", () => {
+		// Removed anywhere, so this one IS https to a browser and is allowed…
+		expect(safeHrefAttr(`ht${TAB}tps://x.example/a`)).toBe(`ht${TAB}tps://x.example/a`);
+		// …trimmed only at the front, so this one is too.
+		expect(safeHrefAttr(`${SOH}https://x.example/a`)).toBe(`${SOH}https://x.example/a`);
+		// But a C0 control INSIDE the scheme is not removed by any browser: this
+		// is not a url anything reads as https, so nothing should call it one.
+		// (The earlier spelling of the probe dropped every C0-or-space and let it
+		// through — harmless, since the raw form renders as a dead relative link,
+		// but not what the check claims to answer.)
+		expect(safeHrefAttr(`h${SOH}ttps://x.example/a`)).toBeNull();
+	});
+});

--- a/cli/src/dashboard/MemoriesAsset.test.ts
+++ b/cli/src/dashboard/MemoriesAsset.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Runtime smoke test for `assets/js/memories.js`'s context-row wiring.
+ *
+ * Same rationale as `FeedCardAsset.test.ts`: the asset scripts are plain JS
+ * bundled verbatim into the served page, so tsc never sees them and a keyboard
+ * handler that stops firing does so silently. This evaluates the real IIFEs
+ * against a stub document and drives the handlers the wiring installs.
+ */
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+interface FakeRow {
+	getAttribute: (name: string) => string | null;
+	onclick?: (event: unknown) => void;
+	onkeydown?: (event: unknown) => void;
+}
+
+interface FakeElement {
+	innerHTML: string;
+	style: Record<string, string>;
+	classList: { add: () => void; remove: () => void; contains: () => boolean };
+	querySelectorAll: () => ReadonlyArray<never>;
+	querySelector: () => null;
+	addEventListener: () => void;
+	setAttribute: () => void;
+	getAttribute: () => null;
+}
+
+/** The context row every case starts from: openable, no upstream url. */
+const PLAN_ROW = { kind: "plan", key: "plan-key", contextKey: "plan-key", title: "A plan" };
+
+/**
+ * Renders one memory detail and hands back both the markup it wrote into `#app`
+ * and the context rows with the handlers `wireContextRows` installed on them.
+ *
+ * The rows are stubs rather than parsed markup: what the keyboard cases test is
+ * which events reach `openContextDialog`, and the row element only has to answer
+ * `getAttribute` and accept the two handler assignments. The markup is read back
+ * separately, from the one element the full-page branch writes.
+ */
+function render(
+	context: ReadonlyArray<Record<string, unknown>>,
+	conversations: ReadonlyArray<Record<string, unknown>> = [],
+): { rows: FakeRow[]; html: string } {
+	const rows: FakeRow[] = [
+		{
+			getAttribute: (name: string) => (name === "data-context-kind" ? "plan" : "plan-key"),
+		},
+	];
+	const elements = new Map<string, FakeElement>();
+	const element = (): FakeElement => ({
+		innerHTML: "",
+		style: {} as Record<string, string>,
+		classList: { add: () => undefined, remove: () => undefined, contains: () => false },
+		querySelectorAll: () => [] as ReadonlyArray<never>,
+		querySelector: () => null,
+		addEventListener: () => undefined,
+		setAttribute: () => undefined,
+		getAttribute: () => null,
+	});
+	const doc = {
+		// `memTree` / `memSearch` answering null is what sends `renderMemories`
+		// down the full-page branch, the one that writes `#app`. Every other id is
+		// memoised so that write can be read back after the render.
+		getElementById: (id: string) => {
+			if (id === "memTree" || id === "memSearch") return null;
+			const hit = elements.get(id) ?? element();
+			elements.set(id, hit);
+			return hit;
+		},
+		// The only selector `wireContextRows` uses. Everything else in the module
+		// asks for elements by id, which the stub above always answers.
+		querySelectorAll: (selector: string) => (selector === "[data-context-key]" ? rows : []),
+		addEventListener: () => undefined,
+		createElement: element,
+		body: element(),
+	};
+	const win = { JD: {}, document: doc, addEventListener: () => undefined } as Record<string, unknown>;
+	for (const file of ["format.js", "shell.js", "charts.js", "memories.js"]) {
+		const src = readFileSync(new URL(`./assets/js/${file}`, import.meta.url), "utf8");
+		new Function("window", "document", src)(win, doc);
+	}
+	const JD = win.JD as { renderMemories: (model: unknown) => void };
+	// What the tests assert is `preventDefault`, not the dialog itself.
+	// `openContextDialog` is module-private and leaves nothing observable here: it
+	// writes into overlay elements that `getElementById` hands back as throwaway
+	// objects, and then fetches. But the handler calls `preventDefault()` on
+	// exactly the paths that go on to open it and on no others, so the event is
+	// the seam — prevented means "the row claimed this key", not prevented means
+	// "left to the link, or to the browser".
+	const model = {
+		memories: {
+			selected: {
+				title: "m",
+				conversations,
+				context,
+				excluded: [],
+				activity: [],
+				activityUncoveredSources: [],
+				topics: [],
+				files: [],
+				e2e: [],
+			},
+			tree: [],
+		},
+		scope: { kind: "all" },
+	};
+	JD.renderMemories(model);
+	return { rows, html: elements.get("app")?.innerHTML ?? "" };
+}
+
+/** The keyboard cases only ever look at the wired rows. */
+const wireRows = (): FakeRow[] => render([PLAN_ROW]).rows;
+
+const keyEvent = (key: string, insideLink: boolean) => {
+	let defaultPrevented = false;
+	return {
+		key,
+		target: { closest: (sel: string) => (insideLink && sel === ".mem-ctx-link" ? {} : null) },
+		preventDefault: () => {
+			defaultPrevented = true;
+		},
+		wasPrevented: () => defaultPrevented,
+	};
+};
+
+describe("memories.js — context row keyboard wiring", () => {
+	it("opens the dialog on Space even when the upstream-link glyph has focus", () => {
+		// Space is NOT a link activation key — the browser scrolls instead — so
+		// exempting it from the row handler traded a working affordance for
+		// nothing: with the glyph focused, Space opened the dialog before the
+		// link exemption landed and did neither afterwards.
+		const rows = wireRows();
+		const event = keyEvent(" ", true);
+		rows[0]?.onkeydown?.(event);
+		expect(event.wasPrevented()).toBe(true);
+	});
+
+	it("leaves Enter to the link when the glyph has focus", () => {
+		// Enter IS the anchor's own activation; the row's preventDefault would
+		// cancel the navigation and show the dialog instead.
+		const rows = wireRows();
+		const event = keyEvent("Enter", true);
+		rows[0]?.onkeydown?.(event);
+		expect(event.wasPrevented()).toBe(false);
+	});
+
+	it("still opens the dialog on Enter and Space from the row itself", () => {
+		const rows = wireRows();
+		for (const key of ["Enter", " "]) {
+			const event = keyEvent(key, false);
+			rows[0]?.onkeydown?.(event);
+			expect(event.wasPrevented()).toBe(true);
+		}
+	});
+});
+
+/**
+ * The other half of the same wiring: `JD.safeHrefAttr`'s own cases live in
+ * `FormatAsset.test.ts`, and these pin that this renderer routes the url through
+ * it and omits the whole anchor when it answers null — the row still renders,
+ * rather than carrying a glyph that navigates nowhere.
+ */
+describe("memories.js — context row upstream link", () => {
+	it("emits the link for an allowlisted url", () => {
+		const url = "https://linear.app/acme/issue/ABC-1";
+		const { html } = render([{ ...PLAN_ROW, url }]);
+		expect(html).toContain(`<a class="mem-ctx-link" href="${url}"`);
+		expect(html).toContain('rel="noreferrer noopener"');
+	});
+
+	it("emits no anchor at all when the scheme is not allowlisted, keeping the row", () => {
+		const { html } = render([{ ...PLAN_ROW, url: "javascript:alert(1)" }]);
+		expect(html).toContain("A plan");
+		expect(html).not.toContain("mem-ctx-link");
+		expect(html).not.toContain("javascript:");
+	});
+
+	it("emits no anchor for a row with no url", () => {
+		expect(render([PLAN_ROW]).html).not.toContain("mem-ctx-link");
+	});
+});
+
+/**
+ * `MemoryConversationRow.sessionId` is served on the strength of being rendered
+ * (see the rule on that type: nothing lands in it which the client does not
+ * use). These pin the render, so the field cannot quietly go back to being
+ * payload nothing reads — which is invisible to tsc and to the coverage floor,
+ * since neither sees this file.
+ */
+describe("memories.js — conversation rows", () => {
+	const conversation = (over: Record<string, unknown> = {}) => ({
+		title: "Add the rate limiter",
+		source: "claude",
+		messageCount: 12,
+		sessionId: "sess-abc",
+		...over,
+	});
+
+	it("renders the session id as the row's tooltip", () => {
+		const { html } = render([], [conversation()]);
+		expect(html).toContain('<div class="gd-row" title="Session sess-abc">');
+		expect(html).toContain("Add the rate limiter");
+	});
+
+	it("distinguishes two conversations from the same source", () => {
+		// The reason the field is there at all: same glyph, same `claude` meta, and
+		// titles that a first-user-message fallback can make near-identical.
+		const { html } = render([], [conversation({ sessionId: "sess-a" }), conversation({ sessionId: "sess-b" })]);
+		expect(html).toContain('title="Session sess-a"');
+		expect(html).toContain('title="Session sess-b"');
+	});
+
+	it("escapes the id, which reaches an attribute", () => {
+		const { html } = render([], [conversation({ sessionId: '"><img src=y onerror=alert(1)>' })]);
+		expect(html).toContain('title="Session &quot;&gt;&lt;img src=y onerror=alert(1)&gt;"');
+		expect(html).not.toContain("<img src=y");
+	});
+
+	it("omits the tooltip entirely when the archive carries no id", () => {
+		// Not `Session unknown`: an absent tooltip says nothing, where a placeholder
+		// says something false about the session.
+		const { html } = render([], [conversation({ sessionId: undefined })]);
+		expect(html).toContain('<div class="gd-row">');
+		expect(html).not.toContain('title="Session');
+	});
+});

--- a/cli/src/dashboard/MemoriesQuery.test.ts
+++ b/cli/src/dashboard/MemoriesQuery.test.ts
@@ -68,6 +68,8 @@ interface SeedMemoryOptions {
 		steps: ReadonlyArray<string>;
 		expectedResults: ReadonlyArray<string>;
 	}>;
+	/** v5 `summary.transcripts` — the id ORDER the conversation list is built in. */
+	readonly transcripts?: ReadonlyArray<string>;
 }
 
 /** Seeds one `memories` row (+ its `memory_topics`) with a hand-built summary payload. */
@@ -103,6 +105,7 @@ async function seedMemory(
 				...(opts.excludedContext ? { excludedContext: opts.excludedContext } : {}),
 				...(opts.e2eTestGuide ? { e2eTestGuide: opts.e2eTestGuide } : {}),
 				...(opts.jolliDocId != null ? { jolliDocId: opts.jolliDocId } : {}),
+				...(opts.transcripts ? { transcripts: opts.transcripts } : {}),
 				diffStats: { filesChanged: 2, insertions: 10, deletions: 3 },
 			};
 			db.prepare(
@@ -163,6 +166,8 @@ async function seedLinkedSession(
 		readonly source: string;
 		readonly sessionId: string;
 		readonly title: string;
+		/** `StoredSession.title` — the title the ARCHIVE recorded, absent on older memories. */
+		readonly archivedTitle?: string;
 		readonly messageCount: number;
 		readonly tools?: ReadonlyArray<{
 			toolName: string;
@@ -214,6 +219,7 @@ async function seedLinkedSession(
 								{
 									sessionId: opts.sessionId,
 									source: opts.source,
+									...(opts.archivedTitle ? { title: opts.archivedTitle } : {}),
 									entries: sliceHash === hash ? entries : [],
 								},
 							],
@@ -572,8 +578,16 @@ describe("MemoriesQuery", () => {
 			});
 
 			const detail = await withDashboardDb((db) => buildMemoryDetail(db, ALL, hash), { dbPath });
+			// Exactly four fields: this row is serialized into the page, so anything
+			// server-side on it would be in the payload. `toEqual` (not
+			// `objectContaining`) is what pins that.
 			expect(detail?.conversations).toEqual([
-				{ source: "claude", title: "Building the rate limiter", messageCount: 12 },
+				{
+					source: "claude",
+					title: "Building the rate limiter",
+					messageCount: 12,
+					sessionId: "s1",
+				},
 			]);
 			expect(detail?.activity).toEqual(
 				expect.arrayContaining([
@@ -582,6 +596,100 @@ describe("MemoriesQuery", () => {
 				]),
 			);
 			expect(detail?.activityUncoveredSources).toEqual([]);
+		});
+
+		it("orders conversations by the summary's transcripts[], not by query order", async () => {
+			// The editor builds its list from `summary.transcripts`, so the two surfaces
+			// disagreed on ORDER whenever SQLite handed the blobs back differently.
+			// Seeded s1 first, then s2, and named in the opposite order.
+			await seedRepo(dbPath, "repo-1", "acme-api");
+			const hash = "a".repeat(40);
+			await seedMemory(dbPath, "repo-1", hash, "feat: x", {
+				transcripts: [`${hash}-s2`, `${hash}-s1`],
+			});
+			await seedLinkedSession(dbPath, "repo-1", hash, {
+				source: "claude",
+				sessionId: "s1",
+				title: "first seeded",
+				messageCount: 1,
+			});
+			await seedLinkedSession(dbPath, "repo-1", hash, {
+				source: "claude",
+				sessionId: "s2",
+				title: "second seeded",
+				messageCount: 1,
+			});
+
+			const detail = await withDashboardDb((db) => buildMemoryDetail(db, ALL, hash), { dbPath });
+			expect(detail?.conversations.map((c) => c.sessionId)).toEqual(["s2", "s1"]);
+		});
+
+		it("keeps an unnamed transcript behind the named ones, in query order", async () => {
+			// An id the summary does not name scores `rank.size`, and the sort is stable
+			// — so it lands after everything named without disturbing its neighbours.
+			// This is the pre-v5 / partially-listed case, not a corrupt one.
+			await seedRepo(dbPath, "repo-1", "acme-api");
+			const hash = "b".repeat(40);
+			await seedMemory(dbPath, "repo-1", hash, "feat: y", { transcripts: [`${hash}-s3`] });
+			for (const id of ["s1", "s2", "s3"]) {
+				await seedLinkedSession(dbPath, "repo-1", hash, {
+					source: "claude",
+					sessionId: id,
+					title: id,
+					messageCount: 1,
+				});
+			}
+
+			const detail = await withDashboardDb((db) => buildMemoryDetail(db, ALL, hash), { dbPath });
+			expect(detail?.conversations.map((c) => c.sessionId)).toEqual(["s3", "s1", "s2"]);
+		});
+
+		it("prefers the title the ARCHIVE recorded over the live sessions row", async () => {
+			// The archived string is the full title ladder's answer as of this commit,
+			// resolved while the transcript was still readable. The `sessions` row is a
+			// different moment (whenever that session was last collected) and, for an
+			// old memory or one that arrived on another machine, does not exist at all.
+			await seedRepo(dbPath, "repo-1", "acme-api");
+			const hash = "a".repeat(40);
+			await seedMemory(dbPath, "repo-1", hash, "feat: x");
+			await seedLinkedSession(dbPath, "repo-1", hash, {
+				source: "claude",
+				sessionId: "s1",
+				title: "collected later, after the session moved on",
+				archivedTitle: "Add the rate limiter",
+				messageCount: 3,
+			});
+
+			const detail = await withDashboardDb((db) => buildMemoryDetail(db, ALL, hash), { dbPath });
+			expect(detail?.conversations[0]?.title).toBe("Add the rate limiter");
+		});
+
+		it("falls back to the live row, then the archived first message, for a memory with no archived title", async () => {
+			// Forward-only: every memory written before the field existed lands here,
+			// and must read exactly as it did before.
+			await seedRepo(dbPath, "repo-1", "acme-api");
+			const withRow = "a".repeat(40);
+			const withoutRow = "b".repeat(40);
+			await seedMemory(dbPath, "repo-1", withRow, "feat: x");
+			await seedMemory(dbPath, "repo-1", withoutRow, "feat: y");
+			await seedLinkedSession(dbPath, "repo-1", withRow, {
+				source: "claude",
+				sessionId: "s1",
+				title: "from the sessions row",
+				messageCount: 2,
+			});
+			await seedLinkedSession(dbPath, "repo-1", withoutRow, {
+				source: "claude",
+				sessionId: "s2",
+				title: "",
+				messageCount: 1,
+				entries: [{ role: "human", content: "restart the web backend" }],
+			});
+
+			const a = await withDashboardDb((db) => buildMemoryDetail(db, ALL, withRow), { dbPath });
+			const b = await withDashboardDb((db) => buildMemoryDetail(db, ALL, withoutRow), { dbPath });
+			expect(a?.conversations[0]?.title).toBe("from the sessions row");
+			expect(b?.conversations[0]?.title).toBe("restart the web backend");
 		});
 
 		it("reports an uncovered source honestly instead of a fabricated zero-activity claim", async () => {
@@ -709,7 +817,7 @@ describe("MemoriesQuery", () => {
 			// `resolveSessionTitle`'s step 3, which is what the editor lands on for an
 			// archived session (no stored title, no live transcript to read).
 			expect(detail?.conversations).toEqual([
-				{ source: "claude", title: "why is the proxy 504ing", messageCount: 2 },
+				{ source: "claude", title: "why is the proxy 504ing", messageCount: 2, sessionId: "s1" },
 			]);
 		});
 
@@ -728,7 +836,9 @@ describe("MemoriesQuery", () => {
 			});
 
 			const detail = await withDashboardDb((db) => buildMemoryDetail(db, ALL, hash), { dbPath });
-			expect(detail?.conversations).toEqual([{ source: "claude", title: "One conversation", messageCount: 3 }]);
+			expect(detail?.conversations).toEqual([
+				{ source: "claude", title: "One conversation", messageCount: 3, sessionId: "s1" },
+			]);
 		});
 
 		it("drops a usage-only carrier session, the way the editor's conversation list does", async () => {
@@ -769,7 +879,9 @@ describe("MemoriesQuery", () => {
 			);
 
 			const detail = await withDashboardDb((db) => buildMemoryDetail(db, ALL, hash), { dbPath });
-			expect(detail?.conversations).toEqual([{ source: "claude", title: "(untitled session)", messageCount: 0 }]);
+			expect(detail?.conversations).toEqual([
+				{ source: "claude", title: "(untitled session)", messageCount: 0, sessionId: "legacy" },
+			]);
 		});
 	});
 

--- a/cli/src/dashboard/MemoriesQuery.ts
+++ b/cli/src/dashboard/MemoriesQuery.ts
@@ -41,6 +41,7 @@ import {
 	aggregateConversationTokenBreakdown,
 	aggregateConversationTokens,
 	collectDisplayTopics,
+	getTranscriptIds,
 } from "../core/SummaryTree.js";
 import { estimateSummaryCostUsd } from "../core/TokenCost.js";
 import { TOOL_RECORDING_SOURCES } from "../core/TranscriptParser.js";
@@ -278,6 +279,7 @@ interface MemoryDetailRow {
 	readonly branch: string | null;
 	readonly commit_message: string | null;
 	readonly commit_author: string | null;
+	/** The COALESCEd committer date — see {@link buildMemoryDetail}, not the raw `memories.commit_date_ms`. */
 	readonly commit_date_ms: number;
 	readonly ticket_id: string | null;
 	readonly summary_json: string;
@@ -344,16 +346,40 @@ function linkedSessionCoverage(
  *     keeps growing after the commit. The count a memory should show is the
  *     number of turns archived INTO it.
  *
- * The live `sessions` row is still consulted, but only as the title of first
- * resort — it carries the discoverer's native title (opencode/cursor/copilot),
- * which is `resolveSessionTitle`'s own step 1. Its steps 2-3 need either the
- * live transcript file or the merged entries; only the latter is reachable from
- * a database transaction, and for an archived session it is what the editor
- * ends up using anyway (the stored session carries no `title`, and its
- * `transcriptPath` is usually gone), so `firstUserMessageTitleFromEntries` is
- * the same answer rather than an approximation of it.
+ * Titles come from the ARCHIVE first (`StoredSession.title`, resolved by
+ * `resolveArchivedTitle` when the memory was written), then from the live
+ * `sessions` row, then from the archived first user message. That order is the
+ * point: the archived string is the full ladder's answer as of this commit,
+ * taken while the transcript was still readable, and it is the only one of the
+ * three that survives session pruning or arriving on another machine.
+ *
+ * This whole function is synchronous, and that is now a property rather than a
+ * limitation. It used to hand each row a `transcriptPath` so a later async pass
+ * could re-read the live file for Claude's `ai-title` — which put an absolute
+ * path under the user's home into a payload nothing rendered, and (measured)
+ * could only fire where it was least likely to succeed: a row with a stored
+ * title skipped the read, and a row without one had no readable file to read.
+ *
+ * **The row ORDER comes from `summary.transcripts`, not from the link table.**
+ * `groupArchivedSessions` emits conversations in first-seen order over the
+ * transcripts it is handed, so the order this function feeds it IS the displayed
+ * order — and `memory_transcripts` cannot supply it. That table is a SET (its PK
+ * stores no array index, by the comment on it in `SotSchema.ts`), and the query
+ * below is served by the PK's covering index, so rows arrive sorted by
+ * `transcript_id` — a UUID, i.e. arbitrary (measured: `aaa`, `mmm`, `zzz` for
+ * insertions in the reverse order). The editor reads the summary's own
+ * `transcripts` array via `getTranscriptIds`, so the same memory listed its
+ * conversations in a different order on the two surfaces. Ordering by the array
+ * here is what makes them agree; a linked id the array does not name keeps its
+ * query position after the named ones rather than being dropped, since a row the
+ * link table has is still a real conversation.
  */
-function buildConversations(db: DashboardDbHandle, repoId: number, hash: string): ReadonlyArray<MemoryConversationRow> {
+function buildConversations(
+	db: DashboardDbHandle,
+	repoId: number,
+	hash: string,
+	summary: CommitSummary,
+): ReadonlyArray<MemoryConversationRow> {
 	const blobs = db
 		.prepare(
 			`SELECT mt.transcript_id, t.sessions_blob
@@ -363,8 +389,22 @@ function buildConversations(db: DashboardDbHandle, repoId: number, hash: string)
 		)
 		.all(repoId, hash) as ReadonlyArray<{ transcript_id: string; sessions_blob: Uint8Array }>;
 
+	// First occurrence wins: `transcripts[]` carries no uniqueness guarantee (a
+	// squash that concatenated two arrays repeats the shared ids), and the editor
+	// reaches such an id at its first position too.
+	const rank = new Map<string, number>();
+	for (const [i, id] of getTranscriptIds(summary).entries()) {
+		if (!rank.has(id)) rank.set(id, i);
+	}
+	// Unnamed ids all score `rank.size`, so the sort's stability keeps them in
+	// query order behind the named ones instead of shuffling them.
+	const unnamed = rank.size;
+	const ordered = [...blobs].sort(
+		(a, b) => (rank.get(a.transcript_id) ?? unnamed) - (rank.get(b.transcript_id) ?? unnamed),
+	);
+
 	const transcripts: Array<readonly [string, StoredTranscript]> = [];
-	for (const b of blobs) {
+	for (const b of ordered) {
 		try {
 			transcripts.push([b.transcript_id, JSON.parse(inflateSync(Buffer.from(b.sessions_blob)).toString("utf8"))]);
 		} catch (err) {
@@ -397,10 +437,16 @@ function buildConversations(db: DashboardDbHandle, repoId: number, hash: string)
 	const { order, grouped } = groupArchivedSessions(transcripts);
 	return order.map((key) => {
 		const g = grouped.get(key) as NonNullable<ReturnType<typeof grouped.get>>;
+		const source = g.session.source ?? "claude";
 		return {
-			source: g.session.source ?? "claude",
-			title: nativeTitles.get(key) ?? firstUserMessageTitleFromEntries(g.entries),
+			source,
+			// Archive first: see the note above for why it outranks a live row that
+			// may not exist. `?? ` and not `||` would be wrong the other way round —
+			// an archived empty string is not a title, and the writer stores the
+			// field only when it resolved one, so absence is the only empty case.
+			title: g.session.title ?? nativeTitles.get(key) ?? firstUserMessageTitleFromEntries(g.entries),
 			messageCount: g.entries.length,
+			sessionId: g.session.sessionId,
 		};
 	});
 }
@@ -547,11 +593,16 @@ export function buildMemoryDetail(
 	const filter = scopeFilter(resolved, "m.repo_id");
 	const row = db
 		.prepare(
-			`SELECT m.commit_hash, m.branch, m.commit_message, m.commit_author, m.commit_date_ms, m.ticket_id,
+			`SELECT m.commit_hash, m.branch, m.commit_message, m.commit_author, m.ticket_id,
+			        -- Same COALESCE as reachableMemoryRows and buildMemoryCards, for the
+			        -- same reason: raw m.commit_date_ms is the AUTHOR date, so a rebased
+			        -- memory would render one instant in the tree row and another here.
+			        COALESCE(cm.committed_at_ms, m.commit_date_ms) AS commit_date_ms,
 			        m.summary_json, m.files_changed, m.insertions, m.deletions, m.jolli_doc_id,
 			        m.repo_id, r.repo_identity, r.repo_name
 			   FROM memories m
 			   JOIN repos r ON r.id = m.repo_id
+			   LEFT JOIN commits cm ON cm.repo_id = m.repo_id AND cm.hash = m.commit_hash
 			  WHERE m.commit_hash = ?${filter.sql}
 			  -- Deterministic pick. Without a scope filter (the all-repos view) one
 			  -- hash can match rows in two repos — two clones of a project, or the
@@ -693,7 +744,7 @@ export function buildMemoryDetail(
 		...(tokens ? { tokens } : {}),
 		...(summarizedBy ? { summarizedBy } : {}),
 		...(summary.recap ? { recap: summary.recap } : {}),
-		conversations: buildConversations(db, row.repo_id, hash),
+		conversations: buildConversations(db, row.repo_id, hash, summary),
 		context,
 		excluded,
 		activity,

--- a/cli/src/dashboard/ProducerHooks.ts
+++ b/cli/src/dashboard/ProducerHooks.ts
@@ -299,6 +299,13 @@ export async function recordCommitsFromWorker(
 						committedAtMs,
 						message: info.message.split("\n")[0],
 						authorName: info.author,
+						// Both identity fields, not just the name: the standup board's
+						// "mine only" filter matches on EITHER, and a machine with
+						// `user.name` unset (git still commits under the OS ident) would
+						// otherwise have every commit made since the last backfill sweep
+						// silently dropped from the board — with the chip still claiming
+						// the rows are filtered to the user.
+						...(info.authorEmail ? { authorEmail: info.authorEmail } : {}),
 						...(onBranch ? { branch: onBranch, branches: [onBranch] } : {}),
 						// Absent (not empty) when the numstat pass failed, so a
 						// transient git error cannot delete rows an earlier pass

--- a/cli/src/dashboard/Recovery.test.ts
+++ b/cli/src/dashboard/Recovery.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { JolliMemoryConfig } from "../Types.js";
+import { setIsolatedHome } from "../testUtils/isolatedHome.js";
 import { formatUtcStamp, maybeSnapshot } from "./Backup.js";
 import { withDashboardDb } from "./DashboardDb.js";
 import { fillMemoriesFromMirrors, restoreFromSnapshot, surveyRecovery } from "./Recovery.js";
@@ -76,8 +77,7 @@ describe("surveyRecovery", () => {
 		// not whatever the real machine has stamped.
 		const fakeHome = join(dir, "home");
 		mkdirSync(fakeHome, { recursive: true });
-		const realHome = process.env.HOME;
-		process.env.HOME = fakeHome;
+		const restoreHome = setIsolatedHome(fakeHome);
 		let survey: Awaited<ReturnType<typeof surveyRecovery>>;
 		try {
 			// No configured backupFolder first: the default under HOME is scanned.
@@ -85,7 +85,7 @@ describe("surveyRecovery", () => {
 			expect(bare.candidates).toEqual([]);
 			survey = await surveyRecovery({ dbPath, config: cfg() });
 		} finally {
-			process.env.HOME = realHome;
+			restoreHome();
 		}
 		expect(survey.fileState).toBe("absent");
 		// No registry/mirror stamps in this fixture: a fresh install.
@@ -120,8 +120,7 @@ describe("fillMemoriesFromMirrors", () => {
 				"\t",
 			),
 		);
-		const realHome = process.env.HOME;
-		process.env.HOME = home;
+		const restoreHome = setIsolatedHome(home);
 		try {
 			const { mkdir, writeFile } = await import("node:fs/promises");
 			await mkdir(join(home, ".jolli", "jollimemory"), { recursive: true });
@@ -161,7 +160,7 @@ describe("fillMemoriesFromMirrors", () => {
 			);
 			expect(repos).toBe(2);
 		} finally {
-			process.env.HOME = realHome;
+			restoreHome();
 		}
 	});
 });
@@ -202,8 +201,7 @@ describe("fillMemoriesFromFrozenOrphans", () => {
 			],
 			"add",
 		);
-		const realHome = process.env.HOME;
-		process.env.HOME = home;
+		const restoreHome = setIsolatedHome(home);
 		try {
 			const { registerRepo } = await import("./RepoRegistry.js");
 			await registerRepo({ cwd: repoDir, now: () => new Date(0) });
@@ -228,7 +226,7 @@ describe("fillMemoriesFromFrozenOrphans", () => {
 			);
 			expect(rows).toEqual([{ commit_message: "frozen memory" }]);
 		} finally {
-			process.env.HOME = realHome;
+			restoreHome();
 		}
 	});
 
@@ -246,8 +244,7 @@ describe("fillMemoriesFromFrozenOrphans", () => {
 		execSync("git commit -q --allow-empty -m init", { cwd: repoDir });
 		const { OrphanBranchStorage } = await import("../core/OrphanBranchStorage.js");
 		await new OrphanBranchStorage(repoDir).ensure();
-		const realHome = process.env.HOME;
-		process.env.HOME = home;
+		const restoreHome = setIsolatedHome(home);
 		try {
 			const { registerRepo } = await import("./RepoRegistry.js");
 			await registerRepo({ cwd: repoDir, now: () => new Date(0) });
@@ -264,7 +261,7 @@ describe("fillMemoriesFromFrozenOrphans", () => {
 		} finally {
 			vi.doUnmock("./SotImport.js");
 			vi.resetModules();
-			process.env.HOME = realHome;
+			restoreHome();
 		}
 	});
 });

--- a/cli/src/dashboard/RepoRegistry.test.ts
+++ b/cli/src/dashboard/RepoRegistry.test.ts
@@ -25,6 +25,7 @@ import {
 	ensureWorktreeListed,
 	existingWorktrees,
 	getRepoRegistryPath,
+	hasLiveWorktree,
 	listActiveRepos,
 	readRegistryInstanceId,
 	readRepoRegistry,
@@ -190,6 +191,37 @@ describe("multiple checkouts of one project (§10.2)", () => {
 				enabledAt: "t",
 			};
 			expect(existingWorktrees(repo)).toEqual([real]);
+		} finally {
+			rmSync(real, { recursive: true, force: true });
+		}
+	});
+
+	it("hasLiveWorktree separates a gone repo from one the fallback makes look alive", () => {
+		const real = mkdtempSync(join(tmpdir(), "jolli-wt-"));
+		try {
+			const alive = {
+				repoIdentity: "id",
+				repoName: "r",
+				worktreeRoot: "/gone",
+				worktrees: ["/gone", real],
+				enabledAt: "t",
+			};
+			const gone = {
+				repoIdentity: "id",
+				repoName: "r",
+				worktreeRoot: "/gone",
+				worktrees: ["/gone", "/also-gone"],
+				enabledAt: "t",
+			};
+			expect(hasLiveWorktree(alive)).toBe(true);
+			expect(hasLiveWorktree(gone)).toBe(false);
+			// The distinction `existingWorktrees` cannot make: its non-empty fallback
+			// answers the same shape for both.
+			expect(existingWorktrees(gone)).toEqual(["/gone"]);
+			// Legacy entry with no `worktrees` list falls back to the root, here too.
+			expect(hasLiveWorktree({ repoIdentity: "id", repoName: "r", worktreeRoot: real, enabledAt: "t" })).toBe(
+				true,
+			);
 		} finally {
 			rmSync(real, { recursive: true, force: true });
 		}

--- a/cli/src/dashboard/RepoRegistry.ts
+++ b/cli/src/dashboard/RepoRegistry.ts
@@ -81,6 +81,24 @@ export function existingWorktrees(repo: RegisteredRepo): ReadonlyArray<string> {
 }
 
 /**
+ * Whether ANY checkout of this repo still exists on disk.
+ *
+ * The companion to {@link existingWorktrees}' deliberate non-empty fallback: a
+ * caller that only wants to know "is this entry still backed by anything?"
+ * cannot read that off the returned list, because the fallback makes a repo
+ * whose every path is gone look identical to one with a single live checkout.
+ *
+ * The registry is append-only in practice — nothing prunes it, and
+ * `deregisterRepo` has to run from inside the repo it removes, which a deleted
+ * directory makes impossible — so dead entries accumulate and every sweep pays
+ * for them again. Asking this first is how a sweep tells "gone" from "broken".
+ */
+export function hasLiveWorktree(repo: RegisteredRepo): boolean {
+	const known = repo.worktrees && repo.worktrees.length > 0 ? repo.worktrees : [repo.worktreeRoot];
+	return known.some((path) => existsSync(path));
+}
+
+/**
  * The repo's cutover fence, found by asking EVERY surviving checkout — plus the
  * root it was found in, which is the only one whose orphan branch is the frozen
  * one.

--- a/cli/src/dashboard/SotImport.ts
+++ b/cli/src/dashboard/SotImport.ts
@@ -24,7 +24,7 @@
  *
  * Failure semantics: this runs in the bootstrap path (`jolli dashboard` →
  * backfill), NOT in a hook — errors propagate to the per-repo handler in
- * `backfillRepos`. Individually malformed artifacts are skipped and counted,
+ * `dbBackfillRepos`. Individually malformed artifacts are skipped and counted,
  * never silently dropped.
  */
 
@@ -150,7 +150,7 @@ export const EMPTY_IMPORT_RESULT: SotImportResult = {
  * Losing the fence re-legalizes `seed`, whose reconciliation would then delete
  * every fence-era SQLite-only memory permanently — the branch it reconciles
  * against is frozen and will never list them again. Both callers that can pick
- * `seed` (the cutover CAS's pre-fence import and `Backfill`'s per-repo sweep)
+ * `seed` (the cutover CAS's pre-fence import and `DbBackfill`'s per-repo sweep)
  * must consult this; the sweep runs on every `jolli dashboard`, so it is the
  * one that matters most.
  *
@@ -634,7 +634,7 @@ const keyOf = (...parts: ReadonlyArray<string>): string => parts.join(KEY_SEP);
  * Deletes every row of `table` for this repo whose business key is absent from
  * `live`, returning how many rows it removed directly (FK cascades ride along
  * uncounted). This is the delete half of set reconciliation — the same model
- * `Backfill.pruneUnreachableCommits` applies to the derived commit tier.
+ * `DbBackfill.pruneUnreachableCommits` applies to the derived commit tier.
  *
  * `live` must be built from what the branch *lists*, never from what parsed
  * successfully: a present-but-malformed artifact is skipped by the import, and
@@ -727,7 +727,7 @@ export async function importRepoMemory(db: DashboardDbHandle, opts: SotImportOpt
 	try {
 		return await runRepoImport(db, opts);
 	} catch (err) {
-		// Recorded HERE and not in `backfillRepos`' per-repo catch: by the time the
+		// Recorded HERE and not in `dbBackfillRepos`' per-repo catch: by the time the
 		// error reaches that handler `withDashboardDb` has closed the connection,
 		// so the only place a failure can still be written down is inside the
 		// import. Rethrown unchanged — this marks, it does not swallow.
@@ -876,7 +876,7 @@ async function runRepoImport(db: DashboardDbHandle, opts: SotImportOptions): Pro
 	 * fence time and every import stamp from ONE `nowMs`, so a retry found every
 	 * attempt-0 row at exactly `protect`, `>=` held, catch-up updated nothing,
 	 * and the containment compare that the retry exists to satisfy could never
-	 * pass — the repo stayed `legacy-fenced` forever. Backfill and recovery hit
+	 * pass — the repo stayed `legacy-fenced` forever. DbBackfill and recovery hit
 	 * the same wall one pass later, with the wall clock landing past a fence
 	 * parsed off disk.
 	 *

--- a/cli/src/dashboard/SotSchema.ts
+++ b/cli/src/dashboard/SotSchema.ts
@@ -337,9 +337,9 @@ CREATE TABLE ingest_cursors (
 
 -- ── Code graph ──────────────────────────────────────────────────────────────
 -- PARKED, not deleted. The graph page was removed (no view token, no route, no
--- reader), which left this table written by Backfill and read by nothing — a few
+-- reader), which left this table written by DbBackfill and read by nothing — a few
 -- hundred KB of JSON per repo per import, for no query. The writer is commented
--- out in lockstep (StatsWriter.recordRepoGraph, Backfill's call site); uncomment
+-- out in lockstep (StatsWriter.recordRepoGraph, DbBackfill's call site); uncomment
 -- all three together if the page returns. Kept as commented DDL rather than
 -- dropped from history because this is the exact shape it would come back to.
 --
@@ -485,6 +485,34 @@ ALTER TABLE events_raw ADD COLUMN failed_kind TEXT;
 export const TOOL_CALL_TIME_DDL = `
 ALTER TABLE session_tool_use ADD COLUMN last_call_at_ms INTEGER;
 `;
+
+/*
+ * A stored `0` in this column is handled at the READ site, and deliberately not
+ * by a migration — do not add one back.
+ *
+ * 0 is the one value that breaks the fallback above: 0 is not NULL, so such a
+ * row resolves to epoch 0 and silently drops out of every window instead of
+ * keeping its session's placement. Both writers already wrap their
+ * `MAX(COALESCE(…,0), COALESCE(…,0))` in `NULLIF`, so nothing produces one; the
+ * remaining question is only what to do about a row that already holds one.
+ *
+ * A sweep entry was written for that and then removed, for two reasons that are
+ * worth keeping written down:
+ *
+ *  - **It cannot do the job it was added for.** Its stated purpose was that "a
+ *    third writer added later will not come with this reasoning attached" — but
+ *    a migration entry runs ONCE, on the step that crosses its version, so it is
+ *    long finished by the time that writer stores its first 0. Only the read can
+ *    be permanent, which is why `TOOL_CALL_TIME_SQL` wraps the column in
+ *    `NULLIF` rather than trusting what is on disk.
+ *  - **It cost a cross-surface version bump for a provably empty set.** Every
+ *    surface refuses a database stamped ahead of its own build, so a bump locks
+ *    older CLI / VS Code / IntelliJ builds out of the machine-global file. What
+ *    the sweep would have cleaned is 0 rows, and not merely by measurement:
+ *    both write paths DELETE the session's rows before inserting, so `ON
+ *    CONFLICT` can only fire on a duplicate `(tool_name, kind)` within one
+ *    event, which `ToolUseTally` cannot emit — that pair is its bucket key.
+ */
 
 /**
  * The memory tables, `context`, plan progress and the topic KB.

--- a/cli/src/dashboard/StatsWriter.test.ts
+++ b/cli/src/dashboard/StatsWriter.test.ts
@@ -346,7 +346,7 @@ describe("write-ahead log", () => {
 	});
 
 	it("reports the rows the claim LIMIT never reached as pending", async () => {
-		// `Backfill.applyBatches` refuses to advance the summaries cursor while
+		// `DbBackfill.applyBatches` refuses to advance the summaries cursor while
 		// anything is unprojected, so `pending` has to mean exactly that. The
 		// tally it replaces counted only future-schema rows plus this pass's own
 		// failures — so a first tick with more sessions than one batch reported a
@@ -373,7 +373,7 @@ describe("write-ahead log", () => {
 
 	it("scopes pending to the repos the caller is reporting on", async () => {
 		// `events_raw` is machine-global but the caller's gate is per-repo:
-		// `Backfill` asks "may I advance repo-1's summaries cursor?". Counting
+		// `DbBackfill` asks "may I advance repo-1's summaries cursor?". Counting
 		// another repo's in-flight rows answers a question nobody asked and holds
 		// repo-1 back for a reason repo-1 cannot act on. Unlike the future-schema
 		// case this one is self-healing, so it is scoped rather than an error.
@@ -589,7 +589,7 @@ describe("write-ahead log", () => {
 		const result = await withDashboardDb((db) => drainPending(db), { dbPath });
 		expect(result.projected).toBe(1);
 		// Reported as a CLEAR backlog even though 600 rows are still pending in the
-		// table. `pending` gates `Backfill`'s summaries cursor, and a future-schema
+		// table. `pending` gates `DbBackfill`'s summaries cursor, and a future-schema
 		// row can never be claimed by this build — `attempts` stays 0, so it never
 		// ages out either. Counting it stalls that cursor permanently, for every
 		// repo, and each pass then re-collects the whole index. The rows staying

--- a/cli/src/dashboard/StatsWriter.ts
+++ b/cli/src/dashboard/StatsWriter.ts
@@ -282,7 +282,7 @@ export function drainPending(
 		}
 	}
 	// Counted from the table, never accumulated. `pending` is what
-	// `Backfill.applyBatches` consults before advancing the summaries cursor, so
+	// `DbBackfill.applyBatches` consults before advancing the summaries cursor, so
 	// it has to mean "events still unprojected" — the tally it replaces counted
 	// only future-schema rows plus this pass's own failures, and said 0 while
 	// everything the `LIMIT` did not reach was still waiting. One first tick on a
@@ -611,8 +611,13 @@ function projectSession(db: DashboardDbHandle, event: SessionUpsertedEvent): voi
 			     -- instant a better read already recorded, and NULL is the one value this
 			     -- column cannot recover from: the transcript slice it came from is
 			     -- behind a cursor by then.
-			     last_call_at_ms = MAX(COALESCE(excluded.last_call_at_ms, 0),
-			                           COALESCE(session_tool_use.last_call_at_ms, 0))`,
+			     --
+			     -- NULLIF around the MAX keeps "neither side has a time" as NULL: the
+			     -- COALESCEs turn both-NULL into 0, and a stored 0 reads back as a real
+			     -- epoch-0 instant, so the display's fallback to the session's own
+			     -- timestamp would never fire.
+			     last_call_at_ms = NULLIF(MAX(COALESCE(excluded.last_call_at_ms, 0),
+			                                  COALESCE(session_tool_use.last_call_at_ms, 0)), 0)`,
 		);
 		for (const tool of event.tools) {
 			insertTool.run(eventId, tool.name, tool.kind, tool.server ?? null, tool.calls, tool.lastCallAtMs ?? null);
@@ -653,7 +658,7 @@ function projectRecallObserved(db: DashboardDbHandle, event: RecallObservedEvent
 
 // PARKED with the `repo_graphs` table (see SotSchema): the graph page was
 // removed, so nothing reads the artifact. Uncomment this, the table DDL and
-// Backfill's call site together if the page returns.
+// DbBackfill's call site together if the page returns.
 // /**
 //  * Records a repo's knowledge-graph artifact.
 //  *
@@ -811,8 +816,10 @@ function projectCommitSummary(db: DashboardDbHandle, event: CommitSummaryEvent):
 			`INSERT INTO session_tool_use (session_event_id, tool_name, kind, server, calls, last_call_at_ms)
 			 VALUES (?, ?, ?, ?, ?, ?)
 			 ON CONFLICT(session_event_id, tool_name, kind) DO UPDATE SET calls = excluded.calls,
-			     last_call_at_ms = MAX(COALESCE(excluded.last_call_at_ms, 0),
-			                           COALESCE(session_tool_use.last_call_at_ms, 0))`,
+			     -- NULLIF for the same reason as the live path above: both-NULL must stay
+			     -- NULL, or the row claims epoch 0 as a real last-call instant.
+			     last_call_at_ms = NULLIF(MAX(COALESCE(excluded.last_call_at_ms, 0),
+			                                  COALESCE(session_tool_use.last_call_at_ms, 0)), 0)`,
 		);
 		for (const link of event.sessionLinks) {
 			const sessionEventId = `session:${event.repoIdentity}:${link.source}:${link.sessionId}`;

--- a/cli/src/dashboard/assets/index.html
+++ b/cli/src/dashboard/assets/index.html
@@ -13,8 +13,8 @@
   repo pill and time-range control, and one `.wrap` per view.
 
   `data-tier` on `.jd` is load-bearing, not decorative — the stylesheet keys the
-  local/synced chips and the locked-preview treatments off it, so the shell
-  reflects the adoption tier without any JS branching in the page modules.
+  synced chip and the locked-preview treatments off it, so the shell reflects the
+  adoption tier without any JS branching in the page modules.
 -->
 <div class="jd" data-tier="0" id="jdRoot">
 	<aside class="sidebar" aria-label="Jolli local web server">
@@ -47,7 +47,6 @@
 					<div><button type="button" class="cta ghost sm" id="rangeCancel">Cancel</button><button type="submit" class="cta sm">Apply</button></div>
 				</div>
 			</form>
-			<span class="local-chip" id="localChip">Runs locally. Nothing leaves this machine.</span>
 			<span class="machines-chip" id="machinesChip">⟳ synced</span>
 			<div class="spacer"></div>
 		</header>

--- a/cli/src/dashboard/assets/js/format.js
+++ b/cli/src/dashboard/assets/js/format.js
@@ -13,6 +13,53 @@ window.JD = window.JD || {};
 			// authenticated call against the mutating /api routes.
 			.replace(/'/g, "&#39;");
 
+	/**
+	 * An ATTRIBUTE-READY href for an EXTERNAL url, or null when the url is not one
+	 * this page will navigate to.
+	 *
+	 * The `Attr` is in the name because the return value is already escaped, which
+	 * a caller cannot see from the argument: it goes straight between the quotes
+	 * of `href="…"` and must NOT be passed through `JD.esc` again (double-escaped)
+	 * or used in a context that escapes differently.
+	 *
+	 * Escaping alone is not enough for an `href`: `javascript:…` survives every
+	 * replacement above intact, and this page holds the dashboard token, so a
+	 * hostile url reaching a link would run authenticated against the mutating
+	 * /api routes. The url comes from an archived MCP reference — a third party's
+	 * string — so the scheme is allowlisted rather than filtered.
+	 *
+	 * The allowlist is narrower than the web but not narrower than the DATA: every
+	 * builtin reference source (Linear, Jira, Confluence, Slack, Notion, Zoom,
+	 * Asana, monday, context7) stores an https url, including the ones whose apps
+	 * also have a private scheme — so nothing is being swallowed today. Adding a
+	 * `zoommtg:`-style scheme here later is a decision about what this page will
+	 * hand to the OS, and should come with the row still rendering (unlinked) when
+	 * the answer is no.
+	 *
+	 * The check runs on a PROBE rather than on the url itself, because a browser
+	 * does not read a scheme byte-for-byte: it removes tab/LF/CR from anywhere in
+	 * a url and trims leading C0-or-space before it looks, so `java\nscript:`
+	 * navigates. The probe mirrors exactly those two rules and nothing else, while
+	 * the ESCAPED ORIGINAL is what gets rendered — so a url is emitted only when
+	 * the browser would read an allowed scheme out of that same original.
+	 *
+	 * Dropping every C0-or-space (the first spelling of this) was not a hole, and
+	 * why it wasn't is worth keeping: the probe only ever decides, it never becomes
+	 * the href, and a raw url the browser cannot read a scheme from is a RELATIVE
+	 * one — it resolves against this origin, so `http s://x` renders as a dead
+	 * same-origin link rather than escalating into a new scheme. What the superset
+	 * did cost is accuracy: it admitted spellings no browser reads as https, which
+	 * can only ever be that dead link.
+	 */
+	JD.safeHrefAttr = (url) => {
+		var raw = String(url == null ? "" : url).trim();
+		var probe = raw
+			.replace(/[\t\n\r]/g, "")
+			.replace(/^[\u0000-\u0020]+/, "")
+			.toLowerCase();
+		return /^(https?:|mailto:)/.test(probe) ? JD.esc(raw) : null;
+	};
+
 	/* Markdown rendering for LLM-written prose (topic trigger/decisions/
 	   response/todo, recap). Ported from the VS Code webview's
 	   `renderCalloutText` / `inlineBold` (vscode/src/views/SummaryUtils.ts) so

--- a/cli/src/dashboard/assets/js/memories.js
+++ b/cli/src/dashboard/assets/js/memories.js
@@ -370,7 +370,19 @@ window.JD = window.JD || {};
 		var body = rows(
 			detail.conversations,
 			(c) =>
-				'<div class="gd-row"><span class="mem-row-icon">' +
+				/* The session id is this row's tooltip, and that is what it is in the
+				   payload FOR — see MemoryConversationRow. Two conversations from the
+				   same source render identically otherwise (same glyph, same `claude`
+				   meta, and titles that a first-user-message fallback can make near
+				   duplicates), so a memory fed by three Claude sessions gave the user no
+				   way to tell which row is which, nor to match one against
+				   `sessions.json` or a log line. The whole attribute is omitted rather
+				   than filled with a placeholder when the archive carries no id: an
+				   absent tooltip says nothing, where `Session unknown` says something
+				   false about the session. */
+				'<div class="gd-row"' +
+				(c.sessionId ? ' title="Session ' + esc(c.sessionId) + '"' : "") +
+				'><span class="mem-row-icon">' +
 				memoryIcon("message") +
 				'</span><span class="mem-row-title">' +
 				esc(c.title || "(untitled)") +
@@ -425,6 +437,11 @@ window.JD = window.JD || {};
 		var rows = detail.context.map((c) => {
 			var meta = contextKindMeta(c.kind);
 			var openable = !!c.contextKey;
+			/* Scheme-checked, not just escaped: the url is a third party's string
+			   carried in from an archived MCP reference, and an unnavigable one
+			   renders as no link at all rather than as a dead glyph. Already
+			   escaped for an attribute — interpolated raw below, never via `esc`. */
+			var href = JD.safeHrefAttr(c.url);
 			return (
 				'<div class="gd-row' +
 				(openable ? " gd-row-open" : "") +
@@ -444,9 +461,9 @@ window.JD = window.JD || {};
 				esc(c.title) +
 				"</span>" +
 				(c.meta ? '<span class="mem-row-meta mem-ctx-sub">' + esc(c.meta) + "</span>" : "") +
-				(c.url
+				(href
 					? '<a class="mem-ctx-link" href="' +
-						esc(c.url) +
+						href +
 						'" target="_blank" rel="noreferrer noopener" title="Open upstream">' +
 						memoryIcon("link") +
 						"</a>"
@@ -721,14 +738,24 @@ window.JD = window.JD || {};
 		document.querySelectorAll("[data-context-key]").forEach((row) => {
 			var open = () =>
 				openContextDialog(detail, row.getAttribute("data-context-kind"), row.getAttribute("data-context-key"));
+			/* The upstream-link glyph is a real navigation nested inside a row that
+			   is itself a button; without this, activating it would ALSO open the
+			   archived snapshot behind the new tab. Both handlers need the exemption,
+			   but the keyboard one only for ENTER: that is an <a>'s own activation
+			   key, and this row's `preventDefault()` would cancel the navigation and
+			   show the dialog instead — the keyboard path is the one that has no
+			   other way in.
+			   SPACE is deliberately NOT exempted. It does not activate a link at all
+			   (the browser scrolls the page), so exempting it traded a working
+			   affordance for nothing: with the glyph focused, Space opened the dialog
+			   before and would do neither afterwards. */
+			var fromLink = (e) => !!(e && e.target && e.target.closest && e.target.closest(".mem-ctx-link"));
 			row.onclick = (e) => {
-				/* The upstream-link glyph is a real navigation nested inside a row that
-				   is itself a button; without this, clicking it would ALSO open the
-				   archived snapshot behind the new tab. */
-				if (e && e.target && e.target.closest && e.target.closest(".mem-ctx-link")) return;
+				if (fromLink(e)) return;
 				open();
 			};
 			row.onkeydown = (e) => {
+				if (fromLink(e) && e.key === "Enter") return;
 				if (e.key === "Enter" || e.key === " ") {
 					e.preventDefault();
 					open();

--- a/cli/src/dashboard/assets/styles/main.css
+++ b/cli/src/dashboard/assets/styles/main.css
@@ -241,8 +241,6 @@ body {
 
   .machines-chip { display: none; font-size: 12px; color: var(--ink-2); border: 1px dashed var(--border); border-radius: 999px; padding: 4px 10px; }
   .jd[data-tier="2"] .machines-chip { display: inline-block; }
-  .local-chip { font-size: 12px; color: var(--ink-2); border: 1px solid var(--border); border-radius: 999px; padding: 4px 10px; }
-  .jd[data-tier="2"] .local-chip { display: none; }
 
   /* ---------- sidebar ---------- */
   .sidebar {

--- a/cli/src/hooks/PostCommitHook.helpers.test.ts
+++ b/cli/src/hooks/PostCommitHook.helpers.test.ts
@@ -1630,8 +1630,8 @@ describe("PostCommitHook helpers", () => {
 	});
 
 	describe("buildStoredTranscript", () => {
-		it("falls back to the session transcript path when the session metadata is missing", () => {
-			const stored = __test__.buildStoredTranscript([
+		it("falls back to the session transcript path when the session metadata is missing", async () => {
+			const stored = await __test__.buildStoredTranscript([
 				{
 					sessionId: "sess-1",
 					transcriptPath: "/tmp/from-transcript.jsonl",

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -173,6 +173,25 @@ vi.mock("node:fs", async (importOriginal) => {
 	};
 });
 
+// The archive writer resolves each session's title, which streams the live
+// transcript. This whole describe runs on `vi.useFakeTimers()`, and a readline
+// stream's callbacks never fire under a fake clock — the test hangs to its
+// timeout rather than failing. Only the title path is faked; what these tests
+// are about is what gets persisted, and `resolveArchivedTitle`'s own behaviour
+// is covered against a real filesystem in QueueWorker.test.ts.
+vi.mock("../core/SessionTitleResolver.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../core/SessionTitleResolver.js")>();
+	return {
+		...actual,
+		// Mirrors the real answer for an absent transcript: the archived slice's
+		// first human turn, or undefined when it has none.
+		resolveArchivedTitle: vi.fn(async (session: { entries: ReadonlyArray<{ role: string; content: string }> }) => {
+			const first = session.entries.find((e) => e.role === "human" && e.content.trim().length > 0);
+			return first?.content;
+		}),
+	};
+});
+
 vi.mock("../core/CodexSessionDiscoverer.js", () => ({
 	discoverCodexSessions: vi.fn().mockResolvedValue([]),
 	isCodexInstalled: vi.fn().mockResolvedValue(true),

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -2735,7 +2735,7 @@ describe("QueueWorker", () => {
 			// Regression: the previous Map<sessionId,…> lookup would collapse these
 			// two into a single entry because UUID collisions across integrations
 			// can't be ruled out and the transcriptPath on collision differs per source.
-			const stored = __test__.buildStoredTranscript([
+			const stored = await __test__.buildStoredTranscript([
 				{
 					sessionId: "shared-uuid",
 					transcriptPath: "/claude/sessions/shared-uuid.jsonl",
@@ -2759,8 +2759,37 @@ describe("QueueWorker", () => {
 			expect(opencodeSession.transcriptPath).toBe("/tmp/opencode.db#shared-uuid");
 		});
 
+		it("archives the session's title, so no reader has to re-derive it from a path", async () => {
+			// The archive is the only artifact that travels: the live .jsonl is pruned on
+			// the agent's own schedule and the `sessions` row with `sessions.json`, so a
+			// reader on another machine has neither. It used to carry only
+			// `transcriptPath` — an absolute path under THIS machine's home.
+			const stored = await __test__.buildStoredTranscript([
+				{
+					sessionId: "s1",
+					transcriptPath: "/gone/s1.jsonl",
+					source: "claude",
+					entries: [{ role: "human", content: "restart the web backend", timestamp: "2026-04-22T10:00:00Z" }],
+				},
+			]);
+
+			// The live file is absent, so the ladder lands on its step 3 — and takes it
+			// from the ARCHIVED entries, which is the slice this memory owns.
+			expect(stored.sessions[0].title).toBe("restart the web backend");
+		});
+
+		it("omits title rather than storing a sentinel when no title can be resolved", async () => {
+			// Absence is what lets a reader fall back; a stored "(untitled session)"
+			// would be indistinguishable from a real title and pin the wrong answer.
+			const stored = await __test__.buildStoredTranscript([
+				{ sessionId: "s1", transcriptPath: "/gone/s1.jsonl", source: "claude", entries: [] },
+			]);
+
+			expect(stored.sessions[0]).not.toHaveProperty("title");
+		});
+
 		it("preserves sessionTranscripts that arrive without a source (legacy claude rows)", async () => {
-			const stored = __test__.buildStoredTranscript([
+			const stored = await __test__.buildStoredTranscript([
 				{
 					sessionId: "legacy-session",
 					transcriptPath: "/claude/legacy.jsonl",
@@ -2778,7 +2807,7 @@ describe("QueueWorker", () => {
 			// The worker computes this split in memory while reading slices; before it was
 			// persisted, only the merged total reached disk and detaching one conversation
 			// from a committed memory had no subtrahend to correct the token bar with.
-			const stored = __test__.buildStoredTranscript([
+			const stored = await __test__.buildStoredTranscript([
 				{
 					sessionId: "s1",
 					transcriptPath: "/claude/s1.jsonl",
@@ -2801,7 +2830,7 @@ describe("QueueWorker", () => {
 			// A stored zero would read as "this session used nothing", which detach would
 			// treat as a valid no-op subtraction; absent means "cannot attribute" and
 			// leaves the memory's totals alone. Sources with no usage must land on absent.
-			const stored = __test__.buildStoredTranscript([
+			const stored = await __test__.buildStoredTranscript([
 				{
 					sessionId: "s1",
 					transcriptPath: "/gemini/s1.json",
@@ -2816,8 +2845,8 @@ describe("QueueWorker", () => {
 			expect(stored.sessions[0]).not.toHaveProperty("usageByModel");
 		});
 
-		it("persists tool calls so the dashboard can read them after the transcript is gone", () => {
-			const stored = __test__.buildStoredTranscript([
+		it("persists tool calls so the dashboard can read them after the transcript is gone", async () => {
+			const stored = await __test__.buildStoredTranscript([
 				{
 					sessionId: "s1",
 					transcriptPath: "/claude/s1.jsonl",
@@ -2838,19 +2867,19 @@ describe("QueueWorker", () => {
 			]);
 		});
 
-		it("keeps an empty toolUse, which claims 'called no tools' — unlike absent", () => {
+		it("keeps an empty toolUse, which claims 'called no tools' — unlike absent", async () => {
 			// The two are different facts and the dashboard branches on which it got:
 			// `[]` replaces stored rows, absent leaves them alone. Length-gating this
 			// the way `usageByModel` is gated would collapse them.
-			const stored = __test__.buildStoredTranscript([
+			const stored = await __test__.buildStoredTranscript([
 				{ sessionId: "s1", transcriptPath: "/claude/s1.jsonl", source: "claude", entries: [], toolUse: [] },
 			]);
 
 			expect(stored.sessions[0].toolUse).toEqual([]);
 		});
 
-		it("omits toolUse for a source whose parser cannot report tool calls", () => {
-			const stored = __test__.buildStoredTranscript([
+		it("omits toolUse for a source whose parser cannot report tool calls", async () => {
+			const stored = await __test__.buildStoredTranscript([
 				{ sessionId: "s1", transcriptPath: "/gemini/s1.json", source: "gemini", entries: [] },
 			]);
 
@@ -5306,7 +5335,7 @@ describe("QueueWorker", () => {
 				// …and the stored transcript now carries the matching per-session record,
 				// so `subtractDetachedUsage` has an exact subtrahend and the leaf/amend
 				// writers allocate a transcript id for it.
-				const stored = __test__.buildStoredTranscript(result.sessionTranscripts);
+				const stored = await __test__.buildStoredTranscript(result.sessionTranscripts);
 				expect(stored.sessions).toHaveLength(1);
 				expect(stored.sessions[0].sessionId).toBe("claude-usage-only");
 				expect(stored.sessions[0].entries).toHaveLength(0);

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -93,6 +93,7 @@ import {
 } from "../core/references/ReferenceStore.js";
 import { getRegistry } from "../core/references/SourceDefinitionRegistry.js";
 import { renderBlock } from "../core/references/SourceEngine.js";
+import { resolveArchivedTitle } from "../core/SessionTitleResolver.js";
 import {
 	associateNoteWithCommit,
 	associatePlanWithCommit,
@@ -2330,7 +2331,7 @@ async function executePipeline(cwd: string, op: CommitGitOperation, force = fals
 	// transcript ID for it and stamp it onto the summary in one go. Overlays
 	// are already applied inside loadSessionTranscripts so the summary input,
 	// the empty-transcript guard, and the stored snapshot all see the same view.
-	const storedTranscript = buildStoredTranscript(sessionTranscripts);
+	const storedTranscript = await buildStoredTranscript(sessionTranscripts);
 	const hasTranscriptContent = storedTranscript.sessions.length > 0;
 	const transcriptId = hasTranscriptContent ? generateTranscriptId() : undefined;
 
@@ -3369,7 +3370,7 @@ async function handleAmendPipeline(
 	// Overlays are applied inside loadSessionTranscripts so this just packages
 	// them for storage. Allocate a v5 transcript ID for the delta upfront so
 	// every short-circuit can stamp it onto `summary.transcripts` consistently.
-	const amendStoredTranscript = buildStoredTranscript(sessionTranscripts);
+	const amendStoredTranscript = await buildStoredTranscript(sessionTranscripts);
 	const amendDeltaTranscriptId = amendStoredTranscript.sessions.length > 0 ? generateTranscriptId() : undefined;
 	const transcriptArtifact =
 		amendDeltaTranscriptId !== undefined ? { id: amendDeltaTranscriptId, data: amendStoredTranscript } : undefined;
@@ -4603,12 +4604,21 @@ function appendUsageOnlyCarriers(
  * integrations that happened to share an `sessionId`, silently rewriting
  * the later session's metadata onto the earlier one on serialize.
  */
-function buildStoredTranscript(sessionTranscripts: ReadonlyArray<SessionTranscript>): StoredTranscript {
+async function buildStoredTranscript(sessionTranscripts: ReadonlyArray<SessionTranscript>): Promise<StoredTranscript> {
+	// Titles are resolved HERE rather than attached upstream like `usage` and
+	// `toolUse`, even though that is the established pattern for this array: there
+	// are two call sites (commit and amend) plus the backfill's own writer, and an
+	// attach step is something a fourth writer can forget while still producing a
+	// well-formed archive. Serializing is the one thing no writer can skip. The
+	// cost is that this stops being a pure function — see `resolveArchivedTitle`
+	// for why commit time is the only moment the answer is available at all.
+	const titles = await Promise.all(sessionTranscripts.map((st) => resolveArchivedTitle(st)));
 	return {
-		sessions: sessionTranscripts.map((st) => ({
+		sessions: sessionTranscripts.map((st, i) => ({
 			sessionId: st.sessionId,
 			source: st.source,
 			transcriptPath: st.transcriptPath,
+			...(titles[i] ? { title: titles[i] } : {}),
 			entries: [...st.entries],
 			// Per-session usage is persisted only when non-zero: a stored `usage` of
 			// all zeros is indistinguishable from "this source reports no usage", and

--- a/cli/src/testUtils/isolatedHome.test.ts
+++ b/cli/src/testUtils/isolatedHome.test.ts
@@ -1,0 +1,67 @@
+import { homedir } from "node:os";
+import { describe, expect, it } from "vitest";
+import { setIsolatedHome, withIsolatedHome } from "./isolatedHome.js";
+
+describe("setIsolatedHome", () => {
+	it("redirects os.homedir() on this platform and restores the previous value", () => {
+		const before = homedir();
+		const restore = setIsolatedHome("/tmp/jolli-isolated-home");
+		try {
+			// The whole point: `HOME` alone is a no-op on Windows, so the assertion is
+			// on `os.homedir()` — what `getGlobalConfigDir()` actually calls — rather
+			// than on either environment variable.
+			expect(homedir()).toBe("/tmp/jolli-isolated-home");
+		} finally {
+			restore();
+		}
+		expect(homedir()).toBe(before);
+	});
+
+	it("sets both HOME and USERPROFILE, since which one is read depends on the platform", () => {
+		const restore = setIsolatedHome("/tmp/jolli-both");
+		try {
+			expect(process.env.HOME).toBe("/tmp/jolli-both");
+			expect(process.env.USERPROFILE).toBe("/tmp/jolli-both");
+		} finally {
+			restore();
+		}
+	});
+
+	it("deletes a variable that was absent rather than restoring the string 'undefined'", () => {
+		const previous = process.env.USERPROFILE;
+		delete process.env.USERPROFILE;
+		try {
+			setIsolatedHome("/tmp/jolli-absent")();
+			expect("USERPROFILE" in process.env).toBe(false);
+		} finally {
+			if (previous !== undefined) process.env.USERPROFILE = previous;
+		}
+	});
+
+	it("restores twice without reviving the isolated value", () => {
+		const before = homedir();
+		const restore = setIsolatedHome("/tmp/jolli-twice");
+		restore();
+		restore();
+		expect(homedir()).toBe(before);
+	});
+});
+
+describe("withIsolatedHome", () => {
+	it("restores after the block resolves", async () => {
+		const before = homedir();
+		const seen = await withIsolatedHome("/tmp/jolli-scoped", () => homedir());
+		expect(seen).toBe("/tmp/jolli-scoped");
+		expect(homedir()).toBe(before);
+	});
+
+	it("restores after the block throws", async () => {
+		const before = homedir();
+		await expect(
+			withIsolatedHome("/tmp/jolli-throws", async () => {
+				throw new Error("boom");
+			}),
+		).rejects.toThrow("boom");
+		expect(homedir()).toBe(before);
+	});
+});

--- a/cli/src/testUtils/isolatedHome.ts
+++ b/cli/src/testUtils/isolatedHome.ts
@@ -1,0 +1,59 @@
+/**
+ * Point every home-directory lookup at a scratch directory for the duration of
+ * a test, and restore the previous environment exactly.
+ *
+ * `process.env.HOME = …` on its own is NOT isolation — it is isolation on POSIX
+ * and a no-op on Windows. Machine-global paths resolve through `os.homedir()`
+ * (`getGlobalConfigDir()` in `core/SessionTracker.ts`), and libuv's
+ * `uv_os_homedir` reads `HOME` only on POSIX; on win32 it reads `USERPROFILE`
+ * and falls back to the Win32 profile API. So a test that sets `HOME` alone
+ * writes into the DEVELOPER'S REAL `~/.jolli/jollimemory/` when the suite runs
+ * on Windows.
+ *
+ * That is not hypothetical damage. `dashboard-repos.json` is append-only by
+ * design (no TTL, no cap, and `deregisterRepo` must run from inside the repo it
+ * removes — impossible once the temp directory is gone), and a remote-less repo
+ * gets a `local:<path hash>` identity, so every `mkdtemp` run is a brand-new
+ * entry that can never merge with an old one. One `npm run test` on Windows
+ * therefore added one permanent, dead registry row per test case that registers
+ * a repo, and every later `jolli dashboard` re-swept them and logged three
+ * warnings apiece.
+ *
+ * `HOMEDRIVE`/`HOMEPATH` are deliberately NOT touched: libuv ignores them, and
+ * clearing them would diverge from what the process would see for real.
+ */
+
+/** Restores the environment captured by {@link setIsolatedHome}. Idempotent. */
+export type RestoreHome = () => void;
+
+const HOME_VARS = ["HOME", "USERPROFILE"] as const;
+
+/**
+ * Redirects home-directory resolution to `home` and returns the restore
+ * function. A variable that was absent before is deleted again rather than set
+ * to `"undefined"` — assigning `undefined` to a `process.env` slot stringifies
+ * it, which would make `os.homedir()` resolve to a literal `undefined` path.
+ */
+export function setIsolatedHome(home: string): RestoreHome {
+	const previous = HOME_VARS.map((name) => [name, process.env[name]] as const);
+	for (const name of HOME_VARS) process.env[name] = home;
+	return () => {
+		for (const [name, value] of previous) {
+			if (value === undefined) delete process.env[name];
+			else process.env[name] = value;
+		}
+	};
+}
+
+/**
+ * Scoped form of {@link setIsolatedHome} for a single block. Supports sync and
+ * async `fn`; the environment is restored even when `fn` throws or rejects.
+ */
+export async function withIsolatedHome<T>(home: string, fn: () => T | Promise<T>): Promise<T> {
+	const restore = setIsolatedHome(home);
+	try {
+		return await fn();
+	} finally {
+		restore();
+	}
+}

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -4492,6 +4492,60 @@ describe("SidebarWebviewProvider", () => {
 			]);
 		});
 
+		it("shows the title the ARCHIVE recorded, without re-deriving it from the live transcript", async () => {
+			// `StoredSession.title` is resolved once, at commit time, and travels with
+			// the memory — so this panel and the dashboard show one string instead of
+			// two independently re-derived ones. It is fed in as the resolver's own
+			// step 1, which is why no branch here has to know about it. The path below
+			// does not exist: an archived title must not depend on the live file, which
+			// is exactly the case that used to fall back to "(untitled session)".
+			const view = makeMockView();
+			const getSummaryByHash = vi.fn().mockResolvedValue({
+				version: 5,
+				commitHash: "abc1234",
+				commitMessage: "feat: add widget",
+				commitAuthor: "Dev",
+				commitDate: "2024-01-01T00:00:00Z",
+				branch: "main",
+				generatedAt: "2024-01-01T00:01:00Z",
+				transcripts: ["tid-1"],
+			});
+			const readTranscriptById = vi.fn().mockResolvedValue({
+				sessions: [
+					{
+						sessionId: "sess-abc",
+						source: "claude" as const,
+						transcriptPath: "/gone/claude.jsonl",
+						title: "Add the rate limiter",
+						entries: [{ role: "human", content: "restart the web backend" }],
+					},
+				],
+			});
+			const provider = new SidebarWebviewProvider({
+				executeCommand: vi.fn(),
+				getInitialState: () => ({
+					enabled: true,
+					authenticated: false,
+					activeTab: "kb",
+					kbMode: "memories",
+					branchName: "main",
+					detached: false,
+					currentRepoName: "myrepo",
+				}),
+				extensionUri: mockExtensionUri as unknown as never,
+				getSummaryByHash,
+				readTranscriptById,
+			});
+			provider.resolveWebviewView(view as unknown as never);
+			view.webview.postMessage.mockClear();
+			view.webview.triggerMessage({ type: "kb:expandMemory", commitHash: "abc1234" });
+			const sent = await flushUntilMessage(view, "kb:memoryEvidence");
+			const evidenceMsg = sent.find((m) => m.type === "kb:memoryEvidence");
+			// Not the archived first human turn, which is what the ladder would have
+			// produced on its own for a session whose live file is gone.
+			expect(evidenceMsg.evidence.conversations[0].title).toBe("Add the rate limiter");
+		});
+
 		it("posts kb:memoryEvidence with projected conversations/context/files from the summary", async () => {
 			const view = makeMockView();
 			const fakeSummary = {

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -1685,6 +1685,15 @@ export class SidebarWebviewProvider
 							transcriptPath: session.transcriptPath ?? "",
 							updatedAt: "",
 							source: session.source,
+							// The title the archive recorded at commit time, fed in as the
+							// resolver's own step 1 rather than as a new branch here. When
+							// present it wins, which is what makes this panel and the
+							// dashboard show one string instead of two independently
+							// re-derived ones — and it is the only answer that survives the
+							// live transcript being pruned, or this memory arriving on a
+							// machine that never had the session. Absent on memories written
+							// before the field existed, where the ladder runs exactly as before.
+							...(session.title ? { title: session.title } : {}),
 						},
 						// readArchivedSessions always returns sessions with `entries` set
 						// to an array (`{ ...base, entries: sorted.flat() }`), so the `?? []`


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Context

- Skills used — 1 skill · 251.7k tokens

## Quick recap

Several bugs that caused the dashboard to silently show wrong or missing information were fixed across this batch of work. The memory detail page now displays the agent-assigned conversation title from the transcript file on disk when one is present, matching what the editor has always shown. A separate date discrepancy — where a rebased commit showed one timestamp in the memory list and a different one in the detail pane — was also corrected. Absolute file-system paths that the server needed to look up those titles are now consumed and discarded before the page data reaches the browser, so the client payload no longer contains any file-system layout information.

A security gap in reference link rendering was closed. Links from archived external sources are now checked against an allowlist of permitted URL schemes before being rendered, and control characters that browsers silently ignore inside scheme names are stripped before the check runs. Links with unrecognized schemes are suppressed entirely rather than rendered with a broken or dangerous href.

The standup board's "show only my commits" filter now correctly includes recent commits on machines where a git username is not configured. Live commit events carry the author's email address alongside the name, and the filter matches on whichever is available, closing a gap where commits made since the last background sync were quietly excluded while the "mine only" label remained visible.

The dashboard no longer logs repeated warnings on every startup for repositories whose directories have been deleted. The startup sweep now detects entries with no surviving directory and skips them at a lower log level, and the progress counter reflects only repositories that were actually processed. The internal module responsible for this sweep was also renamed to distinguish it clearly from the AI-powered summary generation feature that previously shared the same name in logs and progress output — the two features are now unambiguous in dashboard output and search results.

Keyboard navigation on the memories panel was restored. Pressing Space on a context row now opens the context dialog regardless of which element inside the row has focus, and pressing Enter on the upstream-link glyph correctly activates the link. A database migration that was supposed to clean up a class of malformed timestamp values was also fixed: the cleanup now runs as a separate migration step and reaches the databases that actually contain the affected rows, accompanied by a test that verifies the fix against a database constructed in exactly the affected state.

Running the test suite on Windows was permanently writing entries into the developer's real dashboard registry file. A new test isolation helper now correctly overrides the home directory on all platforms, and five test files were updated to use it, stopping the accumulation of dead registry entries on Windows developer machines.

---

## Topics (13)
<details>
<summary><strong>01 · Rename dashboard history import module to eliminate naming collision with AI backfill</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Two unrelated features shared the name "Backfill" in logs, IDE search results, and user-facing progress output. One generates AI summaries for historical commits and spends model budget; the other imports existing data into the dashboard database with no AI involvement. Developers and users could not tell from progress lines whether the AI feature was running during routine dashboard startup.

**💡 Decisions Behind the Code**

- **Rename with history preservation over in-place edit**: Using `git mv` keeps the full commit history attached to the new filename, which matters for a file with a long and meaningful history. A plain delete-and-create would have severed that history entirely.
- **Prefix all exports, not just the file**: Renaming the file alone would still leave `BackfillOptions` colliding with the identically named type in the AI backfill module. Prefixing every export makes the disambiguation visible at every call site and in IDE autocomplete, not just at the import declaration.
- **Leave plain-English "backfill" verb comments alone**: Comments in other modules that use "backfill" as a verb describing an action are not references to this module and were intentionally left unchanged to avoid misleading edits.

**✅ What Was Implemented**

- Renamed `Backfill.ts` and `Backfill.test.ts` to `DbBackfill.ts` and `DbBackfill.test.ts` via `git mv` to preserve file history. All exported symbols were prefixed with `db`: `backfillRepo` → `dbBackfillRepo`, `backfillRepos` → `dbBackfillRepos`, `BackfillOptions` → `DbBackfillOptions`, `BackfillProgress` → `DbBackfillProgress`, `BackfillResult` → `DbBackfillResult`. The logger tag changed from `[Backfill]` to `[DbBackfill]`.
- Updated all import sites across `DashboardCommand.ts`, `DashboardServer.ts`, `GuidedFrontDoor.ts`, `OrphanSotGuard.test.ts`, and `DashboardCommand.test.ts`. Comments in related modules that referred to the old module name were updated; comments using "backfill" as a plain English verb were left unchanged.

**📁 FILES**
- `cli/src/dashboard/DbBackfill.ts`
- `cli/src/commands/DashboardCommand.ts`
- `cli/src/dashboard/DashboardServer.ts`
- `cli/src/commands/GuidedFrontDoor.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Skip deleted repository directories in dashboard startup sweep to stop repeated warnings</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Every time the dashboard launched, it printed three warning lines about repositories whose folders had been deleted from disk. The warnings repeated on every run with no way to clear them, because the cleanup command required the folder to exist.

**💡 Decisions Behind the Code**

- **Filter before sweep, not inside it**: Dropping dead repos at the list-filtering stage rather than catching errors mid-sweep means the git layer never runs against a nonexistent path. This avoids the conservative "skip cursor advance" fallback that was the direct cause of the repeating warnings, and keeps the error surface clean — a missing directory is a registry hygiene issue, not a git failure.
- **Skip rather than deregister**: The same "no checkout exists" signal also describes a temporarily unmounted network share or external drive. Deregistering on that evidence would permanently forget a repo whose directory comes back, losing its registration for a transient absence. Skipping costs one missed sweep pass; the entry is picked up again the moment a path reappears.
- **Debug log, not warning**: The warnings were noise precisely because they fired on every launch for entries that would never recover. Downgrading to debug keeps the warning channel meaningful — a warning should indicate something actionable, and a deleted temporary directory is not.
- **Named predicate over inlined check**: Exposing this as a named function rather than inlining the check makes the distinction between "gone" and "broken" explicit at the call site, and lets the existing worktree fallback behavior remain unchanged for all other callers that depend on it.

**✅ What Was Implemented**

- Added a `hasLiveWorktree` predicate to the repo registry module that checks whether any recorded checkout path for a repo actually exists on disk, distinguishing a fully-gone repo from one with a single live checkout.
- Modified the backfill sweep (`DbBackfill.ts`) to filter out repos where no checkout exists before attempting any git operations, logging at debug level instead of warning. The progress counter now reflects only surviving repos so the progress line never counts toward a total it cannot reach.
- Updated the test fixture's worktree root from a made-up path to the system temp directory so the new dead-worktree skip does not silently exclude it from sweep tests. Added test cases covering the skip behavior, the progress count, and the distinction from the "sweep threw" error case.

**📁 FILES**
- `cli/src/dashboard/DbBackfill.ts`
- `cli/src/dashboard/RepoRegistry.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Neutralise a stored epoch-zero tool-call time at the read, not with a schema migration</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Every reader resolves a tool-call bucket's time as `COALESCE(last_call_at_ms, sessions.updated_at_ms)`, so the column's NULL means "this parser could not stamp a time, fall back to the session". A stored `0` means the same thing but is not NULL, so such a row resolved to epoch 0 and left every time window instead of keeping its session's placement.

**💡 Decisions Behind the Code**

- **At the read, not in a migration**: A migration entry runs ONCE, on the step that crosses its version, so it is long finished by the time a writer added later stores its first zero — which was the whole stated reason for adding one. Only the read is permanent. A `NULLIF` inside the shared time fragment covers rows that already exist and rows not yet written, for the same cost.
- **Not worth a schema version bump**: The version number is a cross-surface contract — every surface refuses a database stamped ahead of its own build, so the first surface to migrate locks the others out of the machine-global file until they are upgraded too. A sweep entry was written first and then removed: what it would have cleaned is provably an empty set, because both writers DELETE a session's rows before inserting, so `ON CONFLICT` can only fire on a duplicate `(tool_name, kind)` within one event, which the tally cannot emit — that pair is its bucket key.
- **Belt and braces, kept in both places**: the writers still refuse to store a zero (their `MAX(COALESCE(…,0), COALESCE(…,0))` is wrapped in `NULLIF`); the read no longer depends on them having done so.

**✅ What Was Implemented**

- Wrapped the column in `NULLIF` inside `TOOL_CALL_TIME_SQL` (`DashboardQuery.ts`), the single place every windowed tool-usage query reads it from, so a stored zero falls back to the session's own time exactly as NULL does.
- Left `DASHBOARD_SCHEMA_VERSION` at 5 and `MIGRATIONS` at five entries, with a note at the removed entry's old site in `SotSchema.ts` recording why there is no sweep and why a future one should not be added.
- Added a test that writes a zero by hand (neither writer can produce one) and asserts the row still lands in the window its session belongs to.

**📁 FILES**
- `cli/src/dashboard/DashboardQuery.ts`
- `cli/src/dashboard/SotSchema.ts`
- `cli/src/dashboard/DashboardDb.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Add author email to live commit events so the standup filter works without a git username</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The dashboard's "show only my commits" filter could silently drop commits made since the last background sync. On machines where a git username was not configured, the filter fell back to email-only matching — but live commit events never included the author's email address, so those commits were quietly excluded while the "mine only" label remained visible.

**💡 Decisions Behind the Code**

Email is appended as the last field rather than inserted in the middle of the existing format string. This preserves the positional contract for any caller or test that still produces a four-field line — those callers simply report no email and continue working, rather than misreading the date field as an email address.

**✅ What Was Implemented**

- Extended the git log format string in the commit info reader to append the author email as a fifth field, placed last so existing four-field callers remain valid. Added `authorEmail?: string` to the `CommitInfo` interface in `Types.ts`.
- Updated the live commit event emitter in `ProducerHooks.ts` to include `authorEmail` when present, so the standup board's author filter can match on either name or email for real-time commits.
- Added test cases covering the with-email and without-email branches.

**📁 FILES**
- `cli/src/core/GitOps.ts`
- `cli/src/Types.ts`
- `cli/src/dashboard/ProducerHooks.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Archive each session's title with the memory, so every surface reads one string</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The memory detail page showed different conversation titles than the editor for the same archived sessions — the dashboard fell back to the first line of a user message while the editor showed the agent-assigned title. The cause was that no artifact recorded the title: the archive stored a `transcriptPath` and the entries, so every reader re-derived the title from that pointer, and each derived it differently (the editor ran the full ladder against the live file, the dashboard joined its `sessions` table, the collector wrote a third answer into that table). Those agree only while someone keeps them agreeing.

**💡 Decisions Behind the Code**

- **Resolve once, at commit time, into the archive**: this is the only moment where the answer is both cheap and available — the live transcript was just read, so the agent-assigned step has the file it needs and the fallback step needs no second pass — and the only one that produces something durable. The transcript is pruned on the agent's own schedule, the `sessions` row is pruned with `sessions.json`, and on a machine that did not write the memory neither ever existed. The archive is the only artifact that travels, and it was carrying a path into the writing machine's home directory where it should have carried the string.
- **Feed it to the editor as the resolver's existing first step, not as a new branch**: the shared title resolver already prefers a session's own recorded title, so passing the archived string in makes both surfaces show it with no new logic and no second code path to keep in step.
- **Forward-only, absent rather than sentinel**: memories written before the field fall back exactly as they did before, and a session whose title could not be resolved stores nothing rather than a placeholder — absence is what lets a reader fall back, where a stored "(untitled)" would pin the wrong answer.
- **No server-side fields on the row that the page renders**: with the title archived there is nothing private left to carry, so the conversation row is exactly the four fields the client uses. The earlier approach carried a transcript path and a resolution flag and stripped them again at the last server-side step — a convention nothing could enforce, on a model that is serialized whole into the page. It also could only help where it was least able to: a row with a recorded title skipped the re-read, and a row without one had no readable file left to read.

**✅ What Was Implemented**

- Added `StoredSession.title` and `resolveArchivedTitle`, and resolved the title in both archive writers (the live commit/amend path and the historical backfill) so it is written with the memory rather than recomputed by readers.
- Simplified the dashboard's conversation query to prefer the archived title, then the live session row, then the archived first user message — and deleted the asynchronous file-read pass, its per-file cache, and the two server-only fields it needed.
- Fed the archived title into the editor's evidence list through the shared resolver's existing first step.
- Fixed the memory detail timestamp to join the commits table and use the committer date (with author-date fallback), eliminating a date discrepancy between the tree row and the detail pane for rebased commits.

**📁 FILES**
- `cli/src/Types.ts`
- `cli/src/core/SessionTitleResolver.ts`
- `cli/src/hooks/QueueWorker.ts`
- `cli/src/backfill/BackfillEngine.ts`
- `cli/src/dashboard/MemoriesQuery.ts`
- `cli/src/dashboard/DashboardServer.ts`
- `cli/src/dashboard/DashboardModel.ts`
- `vscode/src/views/SidebarWebviewProvider.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Allowlist the scheme of an external url before it reaches an href</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Reference links from archived external sources were rendered with HTML escaping only. Escaping does not constrain the scheme of an `href`, so a url that was never meant to be navigated to could still be emitted as a link. Scheme allowlisting is the check that belongs there, and the url is a third party's string carried in from an archived MCP reference rather than anything this page authored.

**💡 Decisions Behind the Code**

- **Strip control characters before the scheme check, not after**: Browsers ignore certain characters inside a scheme name, so a scheme can be spelled in a form a naive comparison does not recognise. The check runs on the stripped form while the rendered output uses the escaped original, so a url is only ever emitted after its own scheme has passed.
- **Suppress the link entirely on failure**: Returning null and omitting the anchor element is safer than falling back to a broken href. A row that renders without its link glyph is visually obvious and cannot be activated, and it leaves nothing for a browser's own edge-case handling to interpret.

**✅ What Was Implemented**

- Added a `safeHrefAttr` helper in the dashboard's front-end formatting module that strips the characters browsers ignore inside a scheme name, checks the cleaned result against an allowlist of `http:`, `https:` and `mailto:`, and returns the HTML-escaped original url only when the scheme passes — returning null otherwise to suppress the link entirely. The name carries `Attr` because the return value is already escaped for an attribute, which the argument cannot show.
- Updated the reference link rendering in the memories front-end module to route all link output through this helper.

**📁 FILES**
- `cli/src/dashboard/assets/js/format.js`
- `cli/src/dashboard/assets/js/memories.js`

</blockquote>
</details>
<details>
<summary><strong>07 · Fix keyboard Space and Enter handling on memory context rows with upstream links</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Pressing Enter on a context row that contained an upstream link would cancel the link navigation and open the archived snapshot dialog instead. A subsequent fix that exempted the upstream-link glyph from the row's keyboard handler was too broad: it also swallowed the Space key, which has no native meaning on a link, so pressing Space while the glyph was focused scrolled the page rather than opening the context dialog.

**💡 Decisions Behind the Code**

- **Narrow the exemption to Enter only**: Enter is the one key that natively activates an anchor element, so exempting it prevents the row handler from cancelling a real navigation. Space has no such native meaning on a link — the browser scrolls instead — so the original broad exemption removed a working affordance with no benefit. Tightening the guard to Enter-only restores Space without touching the Enter fix.
- **Add a runtime asset test**: The asset scripts are plain JavaScript that the TypeScript compiler never sees, so a broken keyboard handler fails silently. A test that evaluates the real script against a stub DOM and drives the installed handlers catches this class of regression at CI time rather than in a browser.

**✅ What Was Implemented**

- Extracted a shared link-detection helper in the memories front-end module and applied it to both the click and keydown handlers on context rows, so the exemption logic is not duplicated.
- Narrowed the keyboard exemption from "any key while inside a link" to "Enter while inside a link," restoring Space as a way to open the context dialog regardless of which element has focus.
- Added a new automated test file (`MemoriesAsset.test.ts`) that evaluates the real asset script against a stub browser environment, covering three cases: Space opens the dialog even when the glyph has focus, Enter is left to the link when the glyph has focus, and both Enter and Space open the dialog from the row itself.

**📁 FILES**
- `cli/src/dashboard/assets/js/memories.js`
- `cli/src/dashboard/MemoriesAsset.test.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Fix test environment isolation on Windows to stop polluting real user registry</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Running the test suite on Windows was permanently writing dead entries into the developer's real dashboard registry file. Each test run added dozens of entries for temporary repositories that were deleted after the test, and those entries accumulated with no cleanup path.

**💡 Decisions Behind the Code**

- **Set both HOME and USERPROFILE**: Node's home directory resolution on Windows reads `USERPROFILE` via libuv, completely ignoring `HOME`. Setting only `HOME` — the previous approach — was a no-op on Windows, which is why real files were being written. Setting both covers all platforms with one helper.
- **Restore by exact snapshot, not by re-deletion**: A variable that was absent before isolation must be deleted again on restore, not set to `"undefined"`. Assigning `undefined` to an environment slot stringifies it, which would leave a literal `"undefined"` path as the home directory for subsequent tests in the same process.

**✅ What Was Implemented**

- Created `cli/src/testUtils/isolatedHome.ts` with `setIsolatedHome` and `withIsolatedHome` helpers that set both `HOME` and `USERPROFILE` and restore the exact previous state — including deleting variables that were absent rather than setting them to the string `"undefined"`.
- Replaced five test files' inline home-directory override patterns with calls to the new helpers: `CutoverEngine.test.ts`, `AutoCutover.test.ts`, `Recovery.test.ts`, `Backup.test.ts`, and `DoctorCommand.test.ts`.

**📁 FILES**
- `cli/src/testUtils/isolatedHome.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · Cache git identity reads to avoid repeated subprocess spawning on dashboard polls</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The dashboard was spawning two git subprocesses per registered repository on every model request, and the page re-polls every 30 seconds while open. A user with several repositories was paying for a growing number of subprocesses continuously, to re-learn values that almost never change.

**💡 Decisions Behind the Code**

- **Instance-scoped cache, not module-global**: A module-global cache would persist across tests in the same process, causing one test's git call observations to depend on what an earlier test cached. Attaching the cache to the server instance matches the semantic scope of a git configuration and keeps tests independent.
- **Five-minute TTL rather than permanent memoization**: A permanent cache would require a server restart to pick up a manual edit to a repository's git configuration. Five minutes is short enough that a reconfiguration takes effect quickly, while long enough to eliminate the per-poll subprocess cost for normal usage.

**✅ What Was Implemented**

Added a per-worktree identity cache with a five-minute TTL inside the dashboard server instance. Both successful and empty results are cached. The identity reader now checks the cache before spawning subprocesses.

**📁 FILES**
- `cli/src/dashboard/DashboardServer.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · Align Skills panel date windowing with the Recall card to eliminate cross-panel contradictions</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Skills panel and the Recall card were reading the same database rows but grouping them by different dates. A tool call that fell inside the selected time window for one panel could appear outside it for the other, making the two panels contradict each other with no way for the user to reconcile the difference.

**💡 Decisions Behind the Code**

The coverage denominator query is kept on session time even though the two aggregation queries moved to call time. A session that made no tool calls at all has no call timestamp, so windowing it by call time would silently drop it from the count of total sessions in the period — quietly shrinking the base the coverage metric is built on. The two queries answer different questions (calls vs. sessions) and legitimately use different time anchors.

**✅ What Was Implemented**

- Updated the tool usage aggregation query to window both the per-tool and per-server aggregations by the call's own recorded timestamp (with a fallback to the session's update time), matching the logic already used by the Recall card.
- Left the coverage query — which counts sessions rather than calls — on session time, with an explanatory comment, because a session with no tool calls has no call timestamp to window by.
- Added a test case asserting that a session whose update time is outside the window but whose call time is inside appears in both panels simultaneously.

**📁 FILES**
- `cli/src/dashboard/DashboardQuery.ts`

</blockquote>
</details>
<details>
<summary><strong>12 · Fix epoch-zero timestamps being stored when tool-call records have no timestamp on either side</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a tool-call record had no recorded timestamp on either the incoming or existing side, the database was storing zero (the Unix epoch, 1 January 1970) instead of leaving the field empty. Downstream queries treated that zero as a real timestamp, causing those records to fall outside every time window and disappear from all panels.

**💡 Decisions Behind the Code**

`NULLIF` is applied around the outer `MAX` rather than restructuring the query. The `COALESCE(…,0)` pattern is necessary to make `MAX` compare two potentially-null values without SQL's null-propagation rules discarding one side. The fix is a minimal wrapper that corrects only the output of the already-correct comparison, leaving the comparison logic itself unchanged.

**✅ What Was Implemented**

Wrapped both `MAX(COALESCE(…,0), COALESCE(…,0))` expressions in the stats writer — one on the live-event path and one on the commit-summary path — with `NULLIF(…, 0)`. When both sides are null the `COALESCE` calls produce zero, and `NULLIF` converts that back to null, preserving the fallback behavior downstream.

**📁 FILES**
- `cli/src/dashboard/StatsWriter.ts`

</blockquote>
</details>
<details>
<summary><strong>13 · Remove &quot;Runs locally&quot; privacy chip from dashboard top bar</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The "Runs locally. Nothing leaves this machine." label in the dashboard's top bar was no longer wanted and needed to be removed cleanly.

**💡 Decisions Behind the Code**

- **Remove the element rather than empty it**: Clearing the text while leaving the container in place would have rendered a visible empty rounded-border pill in the top bar. Deleting the element entirely was the cleaner outcome.
- **Delete the companion CSS**: The chip's style rules became dead code the moment the element was removed. Leaving dead CSS increases maintenance surface and can cause confusion if a future developer searches for the class.

**✅ What Was Implemented**

- Removed the privacy chip element entirely from the dashboard HTML rather than just clearing its text content, avoiding a visible empty pill shape in the top bar.
- Deleted the two now-dead CSS rules for the chip and its tier-2 hide override, and updated the HTML comment describing the data-tier attribute to no longer reference the chip.

**📁 FILES**
- `cli/src/dashboard/assets/index.html`
- `cli/src/dashboard/assets/styles/main.css`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 11, 2026 at 11:00 AM · via Anthropic*
<!-- jollimemory-summary-end -->

