### PR TITLE
Exclude foreign-repo plans at discovery time, before plans.json

### DIFF
--- a/cli/src/core/plans/TranscriptPlanDiscovery.foreignPlans.test.ts
+++ b/cli/src/core/plans/TranscriptPlanDiscovery.foreignPlans.test.ts
@@ -1,0 +1,105 @@
+// Discovery-time containment gate for scanPlansFrom: an external `.md` that
+// belongs to ANOTHER git repository (a sibling checkout the agent incidentally
+// read/wrote) must never be registered into plans.json in the first place, while
+// an in-repo external `.md` is registered as before. This is the front-of-pipe
+// counterpart to the archive-time gate covered by QueueWorker.foreignPlans.test.ts.
+//
+// The real git-identity logic lives in PlanContainment and is exercised against a
+// real resolver in PlanContainment.test.ts / QueueWorker.foreignPlans.test.ts.
+// Here we stub GitOps.resolveContainingRepoCommonDir by directory so the test is
+// deterministic and fast, and asserts the ONE new thing: scanPlansFrom wires the
+// classifier and drops `foreign` external paths before upsert.
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Classify by directory: the current worktree (cwd) is one repo, anything under a
+// path segment named `foreign-repo` is a different repo, everything else is "not a
+// git repo" (null → classified `unknown` → kept). normalizePathForCompare lowercases
+// and forward-slashes both the argument and our return, so the string comparison in
+// defaultResolveRepoId is stable across platforms.
+let ownCwd = "";
+vi.mock("../GitOps.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../GitOps.js")>()),
+	resolveContainingRepoCommonDir: vi.fn(async (dir: string) => {
+		const norm = dir.replace(/\\/g, "/").toLowerCase();
+		if (norm.includes("/foreign-repo")) return "/foreign-repo/.git";
+		if (ownCwd && norm.startsWith(ownCwd.replace(/\\/g, "/").toLowerCase())) return "/own-repo/.git";
+		return null;
+	}),
+}));
+
+// Run the plans.json read-modify-write body inline — the lock contract itself is
+// covered in Locks.test.ts, and a real per-worktree lock would need extra setup.
+vi.mock("../Locks.js", () => ({
+	withPlansLock: (_cwd: string | undefined, fn: () => Promise<unknown>) => fn(),
+}));
+
+import { loadPlansRegistry } from "../SessionTracker.js";
+import { scanPlansFrom } from "./TranscriptPlanDiscovery.js";
+
+/** Builds a Claude-style JSONL transcript line for a Write of `absPath`. JSON
+ *  escaping (Windows `\`) is handled by JSON.stringify so the scanner decodes it
+ *  back to the original path. */
+function writeLine(absPath: string): string {
+	return JSON.stringify({ type: "tool_use", name: "Write", input: { file_path: absPath } });
+}
+
+describe("scanPlansFrom — discovery-time foreign-repo exclusion", () => {
+	const dirs: string[] = [];
+	let cwd = "";
+
+	const makeCwd = (): string => {
+		const dir = mkdtempSync(join(tmpdir(), "jm-tpd-"));
+		dirs.push(dir);
+		mkdirSync(join(dir, ".jolli", "jollimemory"), { recursive: true });
+		return dir;
+	};
+
+	beforeEach(() => {
+		cwd = makeCwd();
+		ownCwd = cwd;
+	});
+
+	afterAll(() => {
+		for (const d of dirs) rmSync(d, { recursive: true, force: true });
+	});
+
+	it("registers an in-repo external plan and drops a sibling-repo one", async () => {
+		// Local external plan: a real .md inside the worktree (isPathInside → local,
+		// no resolver call; existsSync must see it).
+		const localPlan = join(cwd, "docs", "local-plan.md");
+		mkdirSync(join(cwd, "docs"), { recursive: true });
+		writeFileSync(localPlan, "# Local Plan\nbody\n");
+
+		// Foreign external plan: a path in a sibling checkout, outside cwd and outside
+		// any temp root (so isExternalPlanCandidate does not pre-drop it as scratch).
+		// It need not exist on disk — the gate drops it before the existsSync check.
+		const foreignPlan = "/work/foreign-repo/design.md";
+
+		const transcript = join(cwd, "session.jsonl");
+		writeFileSync(transcript, `${writeLine(localPlan)}\n${writeLine(foreignPlan)}\n`);
+
+		await scanPlansFrom(transcript, 0, cwd, "claude");
+
+		const registry = await loadPlansRegistry(cwd);
+		const slugs = Object.keys(registry.plans);
+		expect(slugs).toContain("local-plan");
+		expect(slugs).not.toContain("design");
+		expect(registry.plans["local-plan"]?.sourcePath).toBe(localPlan);
+	});
+
+	it("writes nothing when every external plan is foreign", async () => {
+		const foreignA = "/work/foreign-repo/plan-a.md";
+		const foreignB = "/work/foreign-repo/nested/plan-b.md";
+		const transcript = join(cwd, "session.jsonl");
+		writeFileSync(transcript, `${writeLine(foreignA)}\n${writeLine(foreignB)}\n`);
+
+		await scanPlansFrom(transcript, 0, cwd, "claude");
+
+		const registry = await loadPlansRegistry(cwd);
+		expect(Object.keys(registry.plans)).toHaveLength(0);
+	});
+});

--- a/cli/src/core/plans/TranscriptPlanDiscovery.ts
+++ b/cli/src/core/plans/TranscriptPlanDiscovery.ts
@@ -19,6 +19,7 @@ import { withPlansLock } from "../Locks.js";
 import { normalizePathForCompare } from "../PathUtils.js";
 import { getClaudePlansDir } from "../PlanPaths.js";
 import { loadPlansRegistry, savePlansRegistry } from "../SessionTracker.js";
+import { createPlanSourceClassifier } from "./PlanContainment.js";
 import { getPlanScanner } from "./PlanTranscriptScanner.js";
 
 const log = createLogger("PlanDiscovery");
@@ -202,7 +203,32 @@ export async function scanPlansFrom(
 	// read — byte-equivalent to the pre-refactor Claude behaviour.
 	const filteredExternal = new Set([...externalPlans].filter((p) => isExternalPlanCandidate(p, cwd)));
 
-	if (slugs.size === 0 && filteredExternal.size === 0) {
+	// Discovery-time containment gate: an external `.md` that belongs to ANOTHER
+	// git repository (a sibling checkout the agent incidentally read/wrote) never
+	// enters plans.json in the first place — the same deterministic, no-LLM rule
+	// the archive path enforces (see PlanContainment), moved up to discovery so a
+	// foreign-repo file is never registered rather than being filtered out later.
+	// Only external paths can be foreign: the `slugs` set is always canonical
+	// ~/.claude/plans (whitelisted `local`), so it is not classified. `unknown`
+	// (a loose file in no git repo) is KEPT — "don't drop on uncertainty" matches
+	// the archive gate and leaves temp residue to the separate pruning concern.
+	// The classifier strips the hook-injected git location env vars before asking
+	// git, so this resolves by cwd even inside the detached post-commit worker.
+	let localExternal = filteredExternal;
+	if (filteredExternal.size > 0) {
+		const classify = createPlanSourceClassifier(cwd);
+		const kept = new Set<string>();
+		for (const absPath of filteredExternal) {
+			if ((await classify(absPath)) === "foreign") {
+				log.info("Plan discovery: %s belongs to another repository — not registering", absPath);
+				continue;
+			}
+			kept.add(absPath);
+		}
+		localExternal = kept;
+	}
+
+	if (slugs.size === 0 && localExternal.size === 0) {
 		return totalLines;
 	}
 
@@ -304,7 +330,7 @@ export async function scanPlansFrom(
 	//        editing even though that particular edit didn't land — accepted as a
 	//        benign true-ish positive, and identical to the long-standing Claude
 	//        behaviour (a failed Edit to an existing .md registers the same way).
-	for (const absPath of filteredExternal) {
+	for (const absPath of localExternal) {
 		if (!existsSync(absPath)) continue;
 		if (noteSourcePaths.has(normalizePathForCompare(absPath))) {
 			log.info("Plan discovery: %s already a note — skipping plan registration", absPath);
@@ -382,7 +408,7 @@ export async function scanPlansFrom(
 		log.info(
 			"Plan discovery: upserted %d slug(s) + %d external path(s) into plans.json",
 			slugs.size,
-			filteredExternal.size,
+			localExternal.size,
 		);
 	}
 

--- a/cli/src/hooks/StopHook.test.ts
+++ b/cli/src/hooks/StopHook.test.ts
@@ -49,6 +49,12 @@ vi.mock("../core/TelemetryStartup.js", () => ({
 vi.mock("../core/GitOps.js", async (importOriginal) => ({
 	...(await importOriginal<typeof import("../core/GitOps.js")>()),
 	resolveStateRoot: vi.fn((cwd: string) => cwd),
+	// The discovery-time foreign-repo gate (PlanContainment) resolves each
+	// out-of-worktree external plan's owning repo via this. These unit tests use
+	// synthetic paths (`/repo/docs/*.md` under a `/my/project` cwd) that no real
+	// git repo owns, so stub it to null → the plan classifies as `unknown` and is
+	// KEPT, preserving the pre-gate behaviour without spawning real git per test.
+	resolveContainingRepoCommonDir: vi.fn().mockResolvedValue(null),
 }));
 
 // Mock Locks — these unit tests run with synthetic cwds (e.g. "/project"), so


### PR DESCRIPTION
Extend the deterministic foreign-repo containment gate (PlanContainment, introduced for the archive path) to plan DISCOVERY: an external `.md` a session incidentally read/wrote in a sibling checkout of another git repository is now dropped inside scanPlansFrom and never registered into plans.json in the first place, rather than being filtered out later when a commit's summary/PR description is built.

scanPlansFrom is the single upsert chokepoint for every transcript-scanned source (Claude StopHook, Codex tick, the catch-up path for hookless sources), and its `filteredExternal` set is the only route by which an arbitrary out-of-repo sourcePath enters plans.json — canonical ~/.claude/plans slugs are always local and PlanService's registrations are canonical-dir only. Classifying just the external paths there therefore covers all agents with one change. `local`/`unknown` are kept (worktree siblings stay local; loose non-repo files are left to the separate pruning concern), matching the archive gate exactly. The archive-time gate remains as defence-in-depth.

The classifier strips the hook-injected git location env vars before asking git, so foreign detection resolves by cwd even inside the detached post-commit worker.

Tests: a fast, deterministic scanPlansFrom integration test that stubs the repo-id resolver by directory (real git-identity logic stays covered by PlanContainment / QueueWorker.foreignPlans suites); and a stub for resolveContainingRepoCommonDir in StopHook's GitOps mock so its synthetic out-of-cwd plan paths classify as unknown without spawning real git.
