### PR TITLE
docs: carry the plugin README fixes back into the monorepo source

### DIFF
--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -19,6 +19,9 @@ Claude Code.
   configured yet, and injects a branch briefing. Those git hooks are what generate
   the memory everything else surfaces.
 - **A self-contained runtime** — no global `jolli` CLI installation required.
+  Jolli's CLI is still reachable at `~/.jolli/jollimemory/run-cli` (a bash script —
+  on Windows run it from Git Bash), which takes the same arguments as `jolli`
+  itself, for the few things below that are not a `/jolli:*` entry point.
 
 ## Install
 
@@ -77,7 +80,8 @@ expired" can be true here while the app looks fine.
 > **Prefer your own model API key?** Setting `ANTHROPIC_API_KEY` alone is not enough
 > once `local-agent` has been seeded, because the provider choice is resolved before
 > any key is consulted. Switch deliberately instead:
-> `jolli configure --set aiProvider=anthropic --set apiKey=sk-ant-...`. You need
+> `"$HOME/.jolli/jollimemory/run-cli" configure --set aiProvider=anthropic --set apiKey=sk-ant-...`
+> (plain `jolli configure …` if you also have the CLI installed globally). You need
 > neither this nor a Jolli login for generation to work.
 
 ## Sign in (optional, for sharing to a Jolli Space)
@@ -119,8 +123,11 @@ on its own whenever setup is incomplete.
 
 Jolli Memory collects anonymous, content-free usage data — never your code, your
 paths, or the contents of your memories — and it is **on by default**. Turn it off
-with `jolli telemetry off`, or by setting `DO_NOT_TRACK` to any non-empty value
-other than `0`. Exactly what is collected is listed at
+by setting `DO_NOT_TRACK` to any non-empty value other than `0`, or by running
+`"$HOME/.jolli/jollimemory/run-cli" telemetry off` (plain `jolli telemetry off` if
+you also have the CLI installed globally). The `telemetry off` form is written to
+the machine-global config, so it applies to every Jolli integration on this
+machine. Exactly what is collected is listed at
 [jolli.ai/telemetry](https://www.jolli.ai/telemetry) and in
 [TELEMETRY.md](https://github.com/jolliai/jolliai/blob/main/TELEMETRY.md).
 

--- a/codex-plugin/README.md
+++ b/codex-plugin/README.md
@@ -6,9 +6,9 @@ Codex.
 
 ## What the plugin includes
 
-- **Skills** — eleven `$jolli:*` entry points covering setup, sign-in, status,
-  recall, search, decision timelines, Space publishing, and local/remote workflow
-  runs, plus a bare `$jolli` front door that ships in the bundle.
+- **Skills** — eleven in all: a bare `$jolli` front door that ships in the bundle,
+  plus ten `$jolli:*` entry points covering setup, sign-in, status, recall, search,
+  decision timelines, Space publishing, and local/remote workflow runs.
 - **MCP tools** — `recall`, `search`, `get_decision_timeline`, `list_branches`,
   `get_pr_description`, `queue_status`, `status`, plus the Jolli Space tools. The
   bootstrap registers them with Codex, so they load from your **second** session
@@ -18,6 +18,9 @@ Codex.
   local summarization agent when no provider is configured yet, and injects a branch
   briefing. Those git hooks are what generate the memory everything else surfaces.
 - **A self-contained runtime** — no global `jolli` CLI installation required.
+  Jolli's CLI is still reachable at `~/.jolli/jollimemory/run-cli` (a bash script —
+  on Windows run it from Git Bash), which takes the same arguments as `jolli`
+  itself, for the few things below that are not a `$jolli:*` entry point.
 
 ## Install
 
@@ -91,7 +94,8 @@ own, so "authentication expired" can be true here while the app looks fine.
 > **Prefer your own model API key?** Setting a provider key alone is not enough once
 > `local-agent` has been seeded, because the provider choice is resolved before any
 > key is consulted. Switch deliberately instead:
-> `jolli configure --set aiProvider=anthropic --set apiKey=sk-ant-...`. You need
+> `"$HOME/.jolli/jollimemory/run-cli" configure --set aiProvider=anthropic --set apiKey=sk-ant-...`
+> (plain `jolli configure …` if you also have the CLI installed globally). You need
 > neither this nor a Jolli login for generation to work.
 
 ## Sign in (optional, for sharing to a Jolli Space)
@@ -132,8 +136,11 @@ on its own whenever setup is incomplete.
 
 Jolli Memory collects anonymous, content-free usage data — never your code, your
 paths, or the contents of your memories — and it is **on by default**. Turn it off
-with `jolli telemetry off`, or by setting `DO_NOT_TRACK` to any non-empty value
-other than `0`. Exactly what is collected is listed at
+by setting `DO_NOT_TRACK` to any non-empty value other than `0`, or by running
+`"$HOME/.jolli/jollimemory/run-cli" telemetry off` (plain `jolli telemetry off` if
+you also have the CLI installed globally). The `telemetry off` form is written to
+the machine-global config, so it applies to every Jolli integration on this
+machine. Exactly what is collected is listed at
 [jolli.ai/telemetry](https://www.jolli.ai/telemetry) and in
 [TELEMETRY.md](https://github.com/jolliai/jolliai/blob/main/TELEMETRY.md).
 


### PR DESCRIPTION
Both marketplace repos took a README fix that the next publish would have reverted. `publish-prod.sh` mirrors the plugin tree over them with `rsync -a --delete`, so a correction that lands only downstream survives exactly until the next release. This brings those fixes into the source of truth, plus one gap review found in the fix itself.

Downstream PRs, both merged: [jolli-claude-plugin#1](https://github.com/jolliai/jolli-claude-plugin/pull/1), [jolli-chatgpt-plugin#2](https://github.com/jolliai/jolli-chatgpt-plugin/pull/2).

## 1. The page tells you to run a command it just said you don't have

Both READMEs promise:

> **A self-contained runtime** — no global `jolli` CLI installation required.

and then twice instruct a bare `jolli` — `jolli configure --set aiProvider=…` and `jolli telemetry off`. For exactly the audience that promise describes, both are `command not found`.

The telemetry one is the half that matters. A reader who wants to opt out runs the documented command, it fails, and nothing tells them the opt-out never happened. A privacy control that silently no-ops is worse than one that is undocumented.

Fixed by naming the `~/.jolli/jollimemory/run-cli` dispatcher once where the self-contained claim is made, routing both instructions through it, and leading the telemetry paragraph with `DO_NOT_TRACK`, which needs no CLI at all.

## 2. The Codex skills bullet double-counts the front door

It read "eleven `$jolli:*` entry points … **plus** a bare `$jolli` front door", which implies twelve. `plugins/jolli/skills/` holds eleven directories and one of them (`jolli/`) **is** the front door — so it is ten namespaced plus one bare, the shape the page's own "What you can invoke" list already showed. The file contradicted itself.

The Claude sibling's equivalent line is **correct** and is deliberately left alone: its eight really are all namespaced, and its bare `/jolli` genuinely is separate, written into `.claude/skills/` because a Claude plugin skill can only ever be invoked as `/jolli:<name>`.

## 3. Routing through `run-cli` reproduced a narrower version of defect 1

Found in review of the downstream fix, so it is not in either merged PR. That script is `#!/bin/bash` with no extension: from PowerShell or cmd it does not run, and `~` does not expand there either — a documented command that fails for part of the audience, with nothing on the page saying so.

This is a known hazard in this repo, not an edge case. `SHELL_PREREQUISITE_BLOCK` in `cli/src/install/SkillInstaller.ts` pins Git Bash for every shell-backed skill for exactly this script (it is written via Windows Node's `os.homedir()` to `%USERPROFILE%`, and only Git Bash's `$HOME` agrees), and `codex-plugin/DEVELOPMENT.md` states outright that on Windows the global entry cannot use the extensionless `run-cli`.

Severity differed between the two uses. Telemetry was already mitigated by leading with `DO_NOT_TRACK`, which works everywhere. `configure --set aiProvider=…` was not: that paragraph explicitly rules out the env-var route, so a Windows reader had no working documented path left. One clause on the bullet that introduces the dispatcher covers both consumers at once.

The two copy-paste commands also use the quoted `"$HOME/…"` form that every shipped skill and command recipe uses. In those bodies `~/…` appears only in prose ("if it does not exist"), never in a command; these two are commands.

## Verification

- Apart from defect 3's clause, the content matches the merged downstream READMEs modulo the `<marketplace-source>` placeholder that `publish_readme_source` resolves per target. That clause **re-diverges them on purpose** — publish is what carries it out to the marketplace repos, which is the same mechanism this PR exists to use.
- The two shape tests that read these files — `ClaudePluginPublishDocs.test.ts` and `CodexPluginManifest.test.ts` — still hold: one placeholder each, at most one per line, no hardcoded `jolliai/` or `jolli-plugin-dev/` slug, and the Claude front-door assertions (`Start with **/jolli**`, no "is the one-shot path", the `brand-new repo … /jolli:init` proximity match) are in untouched sections.
- No bare-`jolli` command instruction remains in either file.
- Docs-only; no code, no bundle input, nothing in `PUBLISH_REQUIRED_CONFIG` or `PUBLISH_REQUIRED_DIST`, and `codex-plugin/plugins/jolli/skills/` is untouched, so the "re-run `generate-skills.ts`" trap does not apply.

## Not taken from review

The suggestion to tighten "for the few things below" to "the few CLI-only settings covered later" — accurate, but the phrase reads fine and every extra edit widens the gap with the just-merged downstream copies for no reader benefit.