### PR TITLE
Use repoName instead of kb dir for wiki detailRepo scope token

### DIFF
--- a/cli/src/core/WikiMarkdownBuilder.ts
+++ b/cli/src/core/WikiMarkdownBuilder.ts
@@ -24,7 +24,8 @@ export interface WikiRenderContext {
 	 * Lookup helper from short commit hash (8-char hex prefix) to the
 	 * visible-md path **relative to `<kbRoot>/_wiki/`**. Returns null when
 	 * no visible summary exists (orphan-only mode / hash unknown).
-	 * Expected return shape: `../<branchFolder>/summary--<slug>-<hash8>.md`.
+	 * Expected return shape: `../<branchFolder>/<slug>-<hash8>.md` (the visible file
+	 * `FolderStorage` writes; there is no `summary--` prefix).
 	 */
 	readonly resolveCommitVisiblePath: (commitHash8: string) => string | null;
 	/**

--- a/cli/src/dashboard/DashboardModel.ts
+++ b/cli/src/dashboard/DashboardModel.ts
@@ -362,6 +362,17 @@ export interface KnowledgeRepo {
 	 */
 	readonly kb: string;
 	readonly repoName: string;
+	/**
+	 * The scope token a source-commit wiki jump sends as `/memories?detailRepo=`,
+	 * chosen like `JD.repoToken`: the readable display name when it is unique (so the
+	 * URL reads `?detailRepo=jolliai`, like every other dashboard link), and only the
+	 * dashboard `repoIdentity` (derived from the remote URL) when two repos share a
+	 * name and the ambiguous name must be disambiguated. Falls back to the name (then
+	 * page scope) when no usable identity exists. NOT shown in the UI — `repoName` is
+	 * the visible label; this is only the memory-jump scope token. See
+	 * `detailRepoToken` in `KnowledgeQuery.ts`.
+	 */
+	readonly detailRepo: string;
 	/** Whether `<kbRoot>/.jolli/graph/graph.json` exists — gates the row's Graph link. */
 	readonly graphAvailable: boolean;
 	readonly files: ReadonlyArray<KnowledgeFile>;

--- a/cli/src/dashboard/DashboardQuery.test.ts
+++ b/cli/src/dashboard/DashboardQuery.test.ts
@@ -2716,7 +2716,9 @@ describe("knowledge & graph payloads", () => {
 					scope: { kind: "all" },
 					timeZone: "UTC",
 					nowMs: 0,
-					knowledgeModel: { repos: [{ kb: "r", repoName: "r", graphAvailable: true, files: [] }] },
+					knowledgeModel: {
+						repos: [{ kb: "r", repoName: "r", detailRepo: "r", graphAvailable: true, files: [] }],
+					},
 				}),
 			{ dbPath },
 		);

--- a/cli/src/dashboard/DashboardServer.test.ts
+++ b/cli/src/dashboard/DashboardServer.test.ts
@@ -494,6 +494,12 @@ describe("routes", () => {
 			expect(body).toContain("window.marked.parse(");
 			// The document must NOT carry the dashboard mutation token.
 			expect(body).not.toContain("__JOLLI_DASHBOARD_TOKEN__");
+			// It carries the link-rewrite script: source-commit links postMessage the
+			// hash up to the parent, and other relative links are de-linked. (The
+			// script's actual classification behavior is covered end-to-end in
+			// WikiViewerScript.test.ts against real href shapes.)
+			expect(body).toContain('window.parent.postMessage({type:"jolli-wiki-nav",hash:hash}');
+			expect(body).toContain("a.parentNode.replaceChild(s,a)");
 		});
 
 		it("neutralizes a </script> breakout payload in the wiki body", async () => {

--- a/cli/src/dashboard/DashboardServer.test.ts
+++ b/cli/src/dashboard/DashboardServer.test.ts
@@ -112,15 +112,29 @@ function writeTestAssets(base: string): string {
  */
 function writeMemoryBank(
 	base: string,
-	repos: ReadonlyArray<{ dir: string; wiki?: Record<string, string>; graph?: string }>,
+	repos: ReadonlyArray<{
+		dir: string;
+		repoName?: string;
+		remoteUrl?: string;
+		wiki?: Record<string, string>;
+		graph?: string;
+	}>,
 ): string {
 	const mb = join(base, "mb");
 	for (const r of repos) {
 		const kbRoot = join(mb, r.dir);
 		mkdirSync(join(kbRoot, ".jolli"), { recursive: true });
+		// `repoName` defaults to the dir name; `remoteUrl` is optional. A test sets them
+		// so it can prove which token a route serves (dir name vs display name vs the
+		// repoIdentity derived from the remote).
 		writeFileSync(
 			join(kbRoot, ".jolli", "config.json"),
-			JSON.stringify({ version: 1, sortOrder: "date", repoName: r.dir }),
+			JSON.stringify({
+				version: 1,
+				sortOrder: "date",
+				repoName: r.repoName ?? r.dir,
+				...(r.remoteUrl ? { remoteUrl: r.remoteUrl } : {}),
+			}),
 		);
 		if (r.wiki) {
 			mkdirSync(join(kbRoot, "_wiki"), { recursive: true });
@@ -480,7 +494,19 @@ describe("routes", () => {
 
 	describe("wiki-viewer & graph-viewer iframes", () => {
 		it("renders a wiki page via marked, sandbox-isolated (frame-ancestors self, no-store)", async () => {
-			const configDir = writeMemoryBank(dir, [{ dir: "repoA", wiki: { "topic--a.md": "# Hello\n\nbody" } }]);
+			// TWO repos SHARE the display name ("Repo Alpha"), so the served repo's token
+			// must be its repoIdentity (to disambiguate) — differing from BOTH the kb dir
+			// name ("repoA") and the shared display name. This proves the route injects
+			// the derived identity via detailRepoToken, not either name.
+			const configDir = writeMemoryBank(dir, [
+				{
+					dir: "repoA",
+					repoName: "Repo Alpha",
+					remoteUrl: "git@github.com:acme/repo-alpha.git",
+					wiki: { "topic--a.md": "# Hello\n\nbody" },
+				},
+				{ dir: "repoB", repoName: "Repo Alpha", remoteUrl: "git@github.com:other/repo-alpha.git" },
+			]);
 			const port = await listen(testServer({ configDir }));
 			const res = await get(port, "/wiki-viewer?kb=repoA&file=topic--a.md");
 			expect(res.status).toBe(200);
@@ -500,6 +526,14 @@ describe("routes", () => {
 			// WikiViewerScript.test.ts against real href shapes.)
 			expect(body).toContain('window.parent.postMessage({type:"jolli-wiki-nav",hash:hash}');
 			expect(body).toContain("a.parentNode.replaceChild(s,a)");
+			// The owning repo's repoIdentity (derived from its remote URL) is injected as
+			// the detailRepo scope token — NOT the kb dir name ("repoA") nor the display
+			// name ("Repo Alpha"). End-to-end proof that resolveKbRepo → buildWikiViewerHtml
+			// serves the identity (what resolveScope matches, unique across same-named
+			// repos), not either name; all three values differ so it can't pass by accident.
+			expect(body).toContain('window.__JOLLI_WIKI_DETAIL_REPO__ = "https://github.com/acme/repo-alpha";');
+			expect(body).not.toContain('window.__JOLLI_WIKI_DETAIL_REPO__ = "repoA"');
+			expect(body).not.toContain('window.__JOLLI_WIKI_DETAIL_REPO__ = "Repo Alpha"');
 		});
 
 		it("neutralizes a </script> breakout payload in the wiki body", async () => {

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -126,6 +126,7 @@ import {
 	buildKnowledgeModel,
 	readGraphJson,
 	readWikiBody,
+	resolveKbRepo,
 	resolveKbRoot,
 	WIKI_FILE_PATTERN,
 } from "./KnowledgeQuery.js";
@@ -334,16 +335,22 @@ body { margin: 0; padding: 24px 40px; font: 14px/1.6 -apple-system, BlinkMacSyst
  *   - **Source-commit** links — `../<branch>/<slug>-<hash8>.md` (NO `summary--`
  *     prefix: the visible file `FolderStorage` writes is `<slug>-<hash8>.md`, and
  *     the link's visible label is that 8-char hash) — get their `href` REWRITTEN
- *     to the real target `/memories?hash=…&detailRepo=<kb>` (so the browser status
- *     bar previews where a click goes) but still `preventDefault` + `postMessage`
- *     the hash up to the Knowledge page, which performs the actual navigation.
- *     This frame is sandboxed (opaque origin) — a bare `<a>` click would navigate
- *     the FRAME, not the top page — so the anchor cannot be left to do the jump.
- *     `kb` for the href is read from this frame's own `?kb=` (its URL already
- *     names the repo); the parent navigates to the SAME `detailRepo=<kb>`, so the
- *     previewed URL and the real one match exactly. Classified as a relative `.md`
- *     whose trailing `-<hex>.md` (or link text) is a commit hash; the hash is
- *     read from that trailing group, falling back to the link text.
+ *     to the real target `/memories?hash=…&detailRepo=<token>` (so the browser
+ *     status bar previews where a click goes) but still `preventDefault` +
+ *     `postMessage` the hash up to the Knowledge page, which performs the actual
+ *     navigation. This frame is sandboxed (opaque origin) — a bare `<a>` click
+ *     would navigate the FRAME, not the top page — so the anchor cannot be left to
+ *     do the jump. `detailRepo` is the repo's SCOPE TOKEN (see `detailRepoToken`:
+ *     the dashboard repoIdentity from the remote URL when one exists, else the
+ *     display name — NOT the frame's own `?kb=`, a Memory Bank DIRECTORY name that
+ *     `resolveScope` cannot scope by), injected by `buildWikiViewerHtml` as
+ *     `window.__JOLLI_WIKI_DETAIL_REPO__`. The parent navigates to the SAME
+ *     `detailRepo` — both values come from `discoverRepos` for the same `dirName`,
+ *     so they normally match exactly (the injected one is read at request time, the
+ *     parent's from the page's model, so a mid-session folder rename could
+ *     momentarily diverge them — a status-bar-preview cosmetic, not a wrong jump).
+ *     Classified as a relative `.md` whose trailing `-<hex>.md` (or link text) is a
+ *     commit hash; the hash is read from that trailing group, falling back to text.
  *   - **Related-branch** links — `../<folder>/` — plus the index page's bare
  *     `topic--<slug>.md` links and any other leftover relative link keep their
  *     text but drop the anchor (local dashboard has no branch page, and every
@@ -354,7 +361,10 @@ body { margin: 0; padding: 24px 40px; font: 14px/1.6 -apple-system, BlinkMacSyst
  */
 export const WIKI_LINK_REWRITE_SCRIPT =
 	'(function(){var md=document.getElementById("md");if(!md)return;' +
-	'var kb=(new URLSearchParams(window.location.search)).get("kb")||"";' +
+	// The owning repo's scope token (repoIdentity, or display name when it has no
+	// remote), injected by buildWikiViewerHtml — for /memories?detailRepo=. A Memory
+	// Bank dir name would not resolve.
+	'var repo=window.__JOLLI_WIKI_DETAIL_REPO__||"";' +
 	'Array.prototype.forEach.call(md.querySelectorAll("a[href]"),function(a){' +
 	'var href=a.getAttribute("href")||"";' +
 	"var rel=/^\\.{1,2}\\//.test(href);" +
@@ -363,10 +373,10 @@ export const WIKI_LINK_REWRITE_SCRIPT =
 	// Source-commit link: a relative .md whose trailing -<hex>.md (or visible label)
 	// is a commit hash. There is NO "summary--" prefix — the file is <slug>-<hash8>.md.
 	"if(rel&&/\\.md$/i.test(href)&&/^[0-9a-f]{7,40}$/i.test(hash)){" +
-	// Show the real destination in the status bar (kb from this frame's own URL);
-	// the click still goes through the parent, since a sandboxed <a> would only
-	// navigate the frame. The parent navigates to this SAME detailRepo=<kb>.
-	'a.setAttribute("href","/memories?hash="+encodeURIComponent(hash)+(kb?"&detailRepo="+encodeURIComponent(kb):""));' +
+	// Show the real destination in the status bar; the click still goes through the
+	// parent, since a sandboxed <a> would only navigate the frame. The parent
+	// navigates to this SAME detailRepo=<token>.
+	'a.setAttribute("href","/memories?hash="+encodeURIComponent(hash)+(repo?"&detailRepo="+encodeURIComponent(repo):""));' +
 	'a.addEventListener("click",function(e){e.preventDefault();' +
 	'window.parent.postMessage({type:"jolli-wiki-nav",hash:hash},"*");});' +
 	"return;}" +
@@ -376,14 +386,18 @@ export const WIKI_LINK_REWRITE_SCRIPT =
 	"s.textContent=a.textContent;if(a.parentNode)a.parentNode.replaceChild(s,a);}" +
 	"});})();";
 
-function buildWikiViewerHtml(graphAssetsDir: string, bodyMd: string): string {
+function buildWikiViewerHtml(graphAssetsDir: string, bodyMd: string, detailRepo: string): string {
 	const marked = readFileSync(join(graphAssetsDir, "vendor", "marked.min.js"), "utf8");
 	const safe = escapeForInlineScript(JSON.stringify(bodyMd));
+	// The scope token the rewrite script writes into each source-commit link's
+	// `detailRepo`. Escaped like `bodyMd` (not developer-controlled — a repo URL).
+	const safeRepo = escapeForInlineScript(JSON.stringify(detailRepo));
 	return (
 		`<!doctype html><html lang="en"><head><meta charset="utf-8" />` +
 		`<meta name="viewport" content="width=device-width, initial-scale=1" />` +
 		`<style>${WIKI_VIEWER_CSS}</style></head><body><article id="md" class="md"></article>` +
 		`<script>\n${marked}\n</script>` +
+		`<script>window.__JOLLI_WIKI_DETAIL_REPO__ = ${safeRepo};</script>` +
 		`<script>document.getElementById("md").innerHTML = window.marked.parse(${safe});</script>` +
 		`<script>${WIKI_LINK_REWRITE_SCRIPT}</script>` +
 		`</body></html>`
@@ -1220,16 +1234,20 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 				sendText(res, 400, "invalid wiki file");
 				return;
 			}
-			const kbRoot = await resolveKbRoot(configDir, kb);
-			const body = kbRoot ? readWikiBody(kbRoot, file) : undefined;
-			if (body === undefined) {
+			const repo = await resolveKbRepo(configDir, kb);
+			const body = repo ? readWikiBody(repo.kbRoot, file) : undefined;
+			if (!repo || body === undefined) {
 				sendViewerHtml(res, 404, viewerMessageHtml("This wiki page could not be found."));
 				return;
 			}
 			// A partially-shipped viz asset tree would throw here; the outer request
 			// catch turns that into a 500 (never a crash), same as any page route.
 			graphAssetsDir ??= resolveGraphAssetsDir();
-			sendViewerHtml(res, 200, buildWikiViewerHtml(graphAssetsDir, body));
+			// The rewritten source-commit links carry `repo.detailRepo` (the dashboard
+			// repoIdentity when a remote exists, else the display name — NOT the `kb`
+			// dir name) so the memory jump scopes to the owning repo even when two
+			// repos share a display name. See the script's docstring and `resolveKbRepo`.
+			sendViewerHtml(res, 200, buildWikiViewerHtml(graphAssetsDir, body, repo.detailRepo));
 			return;
 		}
 

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -325,7 +325,7 @@ body { margin: 0; padding: 24px 40px; font: 14px/1.6 -apple-system, BlinkMacSyst
  * parent page — the CSP `frame-ancestors 'self'` only controls who may embed it.
  * `bodyMd` is inlined as `escapeForInlineScript(JSON.stringify(bodyMd))`: it must
  * become a JS string literal first (marked.parse takes a string), then have
- * `</script>` / ` ` neutralised.
+ * `</script>` and the U+2028 / U+2029 line separators neutralised.
  */
 /**
  * Runs after `marked` renders `#md`. The wiki's links are all repo-relative
@@ -847,6 +847,15 @@ async function readJsonBody(req: IncomingMessage): Promise<unknown> {
 
 /** How long a Settings sign-in may wait for the browser callback before failing. */
 const SIGNIN_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * The one sign-in error text that is safe to return to the client: a developer
+ * authored constant, carrying no internal detail. A CAUGHT error's own message
+ * can leak implementation specifics (CWE-209), so `handleSignIn` returns this or
+ * a generic fallback — never `errMsg(err)` — while still logging the real error
+ * server-side. Shared with the `withTimeout` call so the two cannot drift.
+ */
+const SIGNIN_TIMEOUT_MESSAGE = "sign-in timed out — please try again";
 
 /**
  * Rejects with `message` if `promise` has not settled within `ms`. Used to cap
@@ -1548,11 +1557,20 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 	   underlying browserLogin is covered by cli/src/auth/Login.test.ts. */
 	async function handleSignIn(res: ServerResponse): Promise<void> {
 		try {
-			await withTimeout(browserLogin(getJolliUrl()), SIGNIN_TIMEOUT_MS, "sign-in timed out — please try again");
+			await withTimeout(browserLogin(getJolliUrl()), SIGNIN_TIMEOUT_MS, SIGNIN_TIMEOUT_MESSAGE);
 			sendJson(res, 200, { ok: true });
 		} catch (err) {
+			// Log the real error server-side, but return only a CONSTANT to the
+			// client: a caught error's message can carry internal detail (CWE-209),
+			// so nothing derived from `err` reaches the response. The timeout text is
+			// a safe developer-authored constant worth preserving; anything else is a
+			// generic message and the detail stays in the log above.
 			log.warn("sign-in failed: %s", errMsg(err));
-			sendJson(res, 400, { error: errMsg(err) });
+			const clientError =
+				errMsg(err) === SIGNIN_TIMEOUT_MESSAGE
+					? SIGNIN_TIMEOUT_MESSAGE
+					: "Sign-in failed — see the server log for details.";
+			sendJson(res, 400, { error: clientError });
 		}
 	}
 	/* v8 ignore stop */

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -327,6 +327,55 @@ body { margin: 0; padding: 24px 40px; font: 14px/1.6 -apple-system, BlinkMacSyst
  * become a JS string literal first (marked.parse takes a string), then have
  * `</script>` / ` ` neutralised.
  */
+/**
+ * Runs after `marked` renders `#md`. The wiki's links are all repo-relative
+ * (`../<branch>/…`) and dead inside this framed viewer, so:
+ *
+ *   - **Source-commit** links — `../<branch>/<slug>-<hash8>.md` (NO `summary--`
+ *     prefix: the visible file `FolderStorage` writes is `<slug>-<hash8>.md`, and
+ *     the link's visible label is that 8-char hash) — get their `href` REWRITTEN
+ *     to the real target `/memories?hash=…&detailRepo=<kb>` (so the browser status
+ *     bar previews where a click goes) but still `preventDefault` + `postMessage`
+ *     the hash up to the Knowledge page, which performs the actual navigation.
+ *     This frame is sandboxed (opaque origin) — a bare `<a>` click would navigate
+ *     the FRAME, not the top page — so the anchor cannot be left to do the jump.
+ *     `kb` for the href is read from this frame's own `?kb=` (its URL already
+ *     names the repo); the parent navigates to the SAME `detailRepo=<kb>`, so the
+ *     previewed URL and the real one match exactly. Classified as a relative `.md`
+ *     whose trailing `-<hex>.md` (or link text) is a commit hash; the hash is
+ *     read from that trailing group, falling back to the link text.
+ *   - **Related-branch** links — `../<folder>/` — plus the index page's bare
+ *     `topic--<slug>.md` links and any other leftover relative link keep their
+ *     text but drop the anchor (local dashboard has no branch page, and every
+ *     other relative target is a 404 here).
+ *   - Absolute / external links are left untouched.
+ *
+ * Self-contained, no user data — inlined verbatim (unlike `bodyMd`).
+ */
+export const WIKI_LINK_REWRITE_SCRIPT =
+	'(function(){var md=document.getElementById("md");if(!md)return;' +
+	'var kb=(new URLSearchParams(window.location.search)).get("kb")||"";' +
+	'Array.prototype.forEach.call(md.querySelectorAll("a[href]"),function(a){' +
+	'var href=a.getAttribute("href")||"";' +
+	"var rel=/^\\.{1,2}\\//.test(href);" +
+	"var m=href.match(/-([0-9a-f]{7,40})\\.md$/i);" +
+	'var hash=m?m[1]:(a.textContent||"").trim();' +
+	// Source-commit link: a relative .md whose trailing -<hex>.md (or visible label)
+	// is a commit hash. There is NO "summary--" prefix — the file is <slug>-<hash8>.md.
+	"if(rel&&/\\.md$/i.test(href)&&/^[0-9a-f]{7,40}$/i.test(hash)){" +
+	// Show the real destination in the status bar (kb from this frame's own URL);
+	// the click still goes through the parent, since a sandboxed <a> would only
+	// navigate the frame. The parent navigates to this SAME detailRepo=<kb>.
+	'a.setAttribute("href","/memories?hash="+encodeURIComponent(hash)+(kb?"&detailRepo="+encodeURIComponent(kb):""));' +
+	'a.addEventListener("click",function(e){e.preventDefault();' +
+	'window.parent.postMessage({type:"jolli-wiki-nav",hash:hash},"*");});' +
+	"return;}" +
+	// Branch dir (../x/), the index page's bare topic--<slug>.md, or any other
+	// relative dead link → keep the text, drop the anchor.
+	'if(rel||/^[^/:]+\\.md$/i.test(href)){var s=document.createElement("span");' +
+	"s.textContent=a.textContent;if(a.parentNode)a.parentNode.replaceChild(s,a);}" +
+	"});})();";
+
 function buildWikiViewerHtml(graphAssetsDir: string, bodyMd: string): string {
 	const marked = readFileSync(join(graphAssetsDir, "vendor", "marked.min.js"), "utf8");
 	const safe = escapeForInlineScript(JSON.stringify(bodyMd));
@@ -336,6 +385,7 @@ function buildWikiViewerHtml(graphAssetsDir: string, bodyMd: string): string {
 		`<style>${WIKI_VIEWER_CSS}</style></head><body><article id="md" class="md"></article>` +
 		`<script>\n${marked}\n</script>` +
 		`<script>document.getElementById("md").innerHTML = window.marked.parse(${safe});</script>` +
+		`<script>${WIKI_LINK_REWRITE_SCRIPT}</script>` +
 		`</body></html>`
 	);
 }

--- a/cli/src/dashboard/KnowledgeAsset.test.ts
+++ b/cli/src/dashboard/KnowledgeAsset.test.ts
@@ -74,6 +74,9 @@ function setup() {
 				{
 					kb: "jolliai",
 					repoName: "Jolli AI",
+					// The scope token — distinct from BOTH kb and repoName so the assertion
+					// proves the nav uses detailRepo (the repoIdentity), not either name.
+					detailRepo: "https://github.com/acme/jolliai",
 					graphAvailable: true,
 					files: [{ file: "topic--x.md", title: "X" }],
 				},
@@ -90,13 +93,14 @@ function setup() {
 }
 
 describe("knowledge.js — wiki source-commit navigation", () => {
-	it("navigates to /memories with the hash and the open page's kb as detailRepo", () => {
+	it("navigates to /memories with the hash and the owning repo's detailRepo scope token", () => {
 		const h = setup();
 		h.openWikiRow(); // sets state.selected → kb "jolliai"
 		h.fireMessage({ type: "jolli-wiki-nav", hash: "a742fa47" });
-		// detailRepo is the kb — the SAME value the iframe wrote into the link's
-		// visible href, so the status-bar preview and the real destination match.
-		expect(h.href()).toBe("/memories?hash=a742fa47&detailRepo=jolliai");
+		// detailRepo is the repo's scope token (its repoIdentity here), URL-encoded —
+		// NOT the kb dir name and NOT the display name. resolveScope matches identity
+		// exactly and it disambiguates repos that share a display name.
+		expect(h.href()).toBe("/memories?hash=a742fa47&detailRepo=https%3A%2F%2Fgithub.com%2Facme%2Fjolliai");
 	});
 
 	it("ignores a message whose hash is not a valid hex commit id", () => {

--- a/cli/src/dashboard/KnowledgeAsset.test.ts
+++ b/cli/src/dashboard/KnowledgeAsset.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Runtime smoke test for `assets/js/knowledge.js`'s wiki-navigation wiring.
+ *
+ * Same rationale as `MemoriesAsset.test.ts`: the asset scripts are plain JS
+ * bundled verbatim into the served page — tsc never sees them and the coverage
+ * floor excludes `assets/**`, so a listener that stops firing does so silently.
+ * This evaluates the real IIFE against a stub document and drives the `message`
+ * handler `wireWikiNav` installs, which turns a source-commit link click inside
+ * the sandboxed wiki iframe into a `/memories?hash=…&detailRepo=…` navigation.
+ */
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+type MessageHandler = (event: { data: unknown }) => void;
+
+interface FakeRow {
+	getAttribute: (name: string) => string | null;
+	onclick?: () => void;
+}
+
+/**
+ * Loads `format.js` + `knowledge.js` into a stub window/document, renders one
+ * repo's wiki list, and returns the seams the tests drive: the captured `message`
+ * handler, a click on the (single) wiki row to set `state.selected`, and the
+ * `location` object whose `href` the navigation writes.
+ */
+function setup() {
+	let messageHandler: MessageHandler | undefined;
+	const location = { href: "" };
+
+	// One wiki row; its click sets the module's `state.selected = {kb, file}`.
+	const row: FakeRow = {
+		getAttribute: (name: string) => (name === "data-kb" ? "jolliai" : "topic--x.md"),
+	};
+
+	const makeEl = () => ({
+		innerHTML: "",
+		value: "",
+		oninput: undefined as undefined | (() => void),
+		style: {} as Record<string, string>,
+	});
+	const byId = new Map<string, ReturnType<typeof makeEl>>();
+
+	const doc = {
+		getElementById: (id: string) => {
+			const hit = byId.get(id) ?? makeEl();
+			byId.set(id, hit);
+			return hit;
+		},
+		querySelectorAll: (selector: string) => (selector === "#knList .kn-row" ? [row] : []),
+		createElement: () => makeEl(),
+	};
+
+	const win = {
+		JD: {},
+		document: doc,
+		location,
+		addEventListener: (type: string, fn: MessageHandler) => {
+			if (type === "message") messageHandler = fn;
+		},
+		removeEventListener: () => undefined,
+	} as Record<string, unknown>;
+
+	for (const file of ["format.js", "knowledge.js"]) {
+		const src = readFileSync(new URL(`./assets/js/${file}`, import.meta.url), "utf8");
+		new Function("window", "document", src)(win, doc);
+	}
+
+	const JD = win.JD as { renderKnowledge: (model: unknown) => void };
+	const model = {
+		knowledge: {
+			repos: [
+				{
+					kb: "jolliai",
+					repoName: "Jolli AI",
+					graphAvailable: true,
+					files: [{ file: "topic--x.md", title: "X" }],
+				},
+			],
+		},
+	};
+	JD.renderKnowledge(model);
+
+	return {
+		openWikiRow: () => row.onclick?.(),
+		fireMessage: (data: unknown) => messageHandler?.({ data }),
+		href: () => location.href,
+	};
+}
+
+describe("knowledge.js — wiki source-commit navigation", () => {
+	it("navigates to /memories with the hash and the open page's kb as detailRepo", () => {
+		const h = setup();
+		h.openWikiRow(); // sets state.selected → kb "jolliai"
+		h.fireMessage({ type: "jolli-wiki-nav", hash: "a742fa47" });
+		// detailRepo is the kb — the SAME value the iframe wrote into the link's
+		// visible href, so the status-bar preview and the real destination match.
+		expect(h.href()).toBe("/memories?hash=a742fa47&detailRepo=jolliai");
+	});
+
+	it("ignores a message whose hash is not a valid hex commit id", () => {
+		const h = setup();
+		h.openWikiRow();
+		h.fireMessage({ type: "jolli-wiki-nav", hash: "../../etc/passwd" });
+		expect(h.href()).toBe("");
+	});
+
+	it("ignores a message of the wrong type", () => {
+		const h = setup();
+		h.openWikiRow();
+		h.fireMessage({ type: "something-else", hash: "a742fa47" });
+		expect(h.href()).toBe("");
+	});
+
+	it("navigates without detailRepo when no wiki page is open yet", () => {
+		const h = setup();
+		// No openWikiRow(): state.selected is null, so there is no owning repo.
+		h.fireMessage({ type: "jolli-wiki-nav", hash: "a742fa47" });
+		expect(h.href()).toBe("/memories?hash=a742fa47");
+	});
+});

--- a/cli/src/dashboard/KnowledgeQuery.test.ts
+++ b/cli/src/dashboard/KnowledgeQuery.test.ts
@@ -27,6 +27,7 @@ afterEach(() => {
 interface RepoSpec {
 	readonly dir: string;
 	readonly repoName?: string;
+	readonly remoteUrl?: string; // written into config.json; drives detailRepo (identity)
 	readonly wiki?: Record<string, string>; // file name -> body
 	readonly manifestTitles?: Record<string, string>; // wiki path -> title
 	readonly graph?: string; // graph.json contents; omit for no graph
@@ -40,7 +41,12 @@ function scaffold(repos: RepoSpec[]): { configDir: string } {
 		mkdirSync(join(kbRoot, ".jolli"), { recursive: true });
 		writeFileSync(
 			join(kbRoot, ".jolli", "config.json"),
-			JSON.stringify({ version: 1, sortOrder: "date", ...(spec.repoName ? { repoName: spec.repoName } : {}) }),
+			JSON.stringify({
+				version: 1,
+				sortOrder: "date",
+				...(spec.repoName ? { repoName: spec.repoName } : {}),
+				...(spec.remoteUrl ? { remoteUrl: spec.remoteUrl } : {}),
+			}),
 		);
 		if (spec.wiki) {
 			mkdirSync(join(kbRoot, "_wiki"), { recursive: true });
@@ -79,6 +85,31 @@ describe("WIKI_FILE_PATTERN", () => {
 });
 
 describe("buildKnowledgeModel", () => {
+	it("uses the display name when unique, the repoIdentity to disambiguate a shared name", async () => {
+		const { configDir } = scaffold([
+			// UNIQUE name → the readable name itself (even though it has a remote), so the
+			// URL stays short and matches the rest of the dashboard.
+			{ dir: "solo", repoName: "Solo", remoteUrl: "git@github.com:acme/solo.git" },
+			// Two repos SHARE the name "Dup" → each gets its identity to disambiguate.
+			{ dir: "dupA", repoName: "Dup", remoteUrl: "git@github.com:teamA/dup.git" },
+			{ dir: "dupB", repoName: "Dup", remoteUrl: "git@github.com:teamB/dup.git" },
+			// SHARED name but no usable (non-file:) identity → the ambiguous name
+			// (best-effort; the jump then degrades to the page scope, never a file:// token).
+			{ dir: "localA", repoName: "LocalDup", remoteUrl: "/home/user/a.git" },
+			{ dir: "localB", repoName: "LocalDup" },
+		]);
+		const model = await buildKnowledgeModel(configDir);
+		const byKb = new Map(model.repos.map((r) => [r.kb, r]));
+		// Unique name → the name (short, dashboard-consistent), NOT its identity.
+		expect(byKb.get("solo")?.detailRepo).toBe("Solo");
+		// Shared name → the identity (github path lower-cased by normalizeRemoteUrl).
+		expect(byKb.get("dupA")?.detailRepo).toBe("https://github.com/teama/dup");
+		expect(byKb.get("dupB")?.detailRepo).toBe("https://github.com/teamb/dup");
+		// Shared name, no usable identity → the ambiguous name, never a file:// token.
+		expect(byKb.get("localA")?.detailRepo).toBe("LocalDup");
+		expect(byKb.get("localB")?.detailRepo).toBe("LocalDup");
+	});
+
 	it("lists a repo's wiki TOPICS by title, excluding the _index and non-wiki files", async () => {
 		const { configDir } = scaffold([
 			{

--- a/cli/src/dashboard/KnowledgeQuery.ts
+++ b/cli/src/dashboard/KnowledgeQuery.ts
@@ -12,10 +12,11 @@
  *
  *   - **`kb` is `DiscoveredRepo.dirName`, not a dashboard `repoIdentity`.** The
  *     Knowledge/Graph pages browse the Memory Bank *folder*, a different identity
- *     space from `dashboard-repos.json`. The `/wiki-viewer` and `/graph-viewer`
- *     routes resolve a `kb` back to a `kbRoot` through {@link resolveKbRoot} —
- *     which matches against `discoverRepos` output and NEVER joins caller input
- *     into a path, so a `../` `kb` cannot escape the Memory Bank root.
+ *     space from `dashboard-repos.json`. Both viewer routes resolve a `kb` back to
+ *     a `kbRoot` — `/graph-viewer` through {@link resolveKbRoot}, `/wiki-viewer`
+ *     through {@link resolveKbRepo} (which also returns `repoName` for the memory
+ *     jump's scope token) — matching against `discoverRepos` output and NEVER
+ *     joining caller input into a path, so a `../` `kb` cannot escape the root.
  *
  *   - **Every disk read is independently guarded.** `_wiki` is wiped and
  *     rewritten wholesale on each `jolli compile` (see `FolderStorage`), so an
@@ -25,7 +26,8 @@
 
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { discoverRepos } from "../core/KBRepoDiscoverer.js";
+import { normalizeRemoteUrl } from "../core/GitRemoteUtils.js";
+import { type DiscoveredRepo, discoverRepos } from "../core/KBRepoDiscoverer.js";
 import type { Manifest } from "../core/KBTypes.js";
 import { getGlobalConfigDir, loadConfigFromDir } from "../core/SessionTracker.js";
 import type { GraphModel, GraphRepo, KnowledgeFile, KnowledgeModel, KnowledgeRepo } from "./DashboardModel.js";
@@ -110,13 +112,49 @@ function listWikiFiles(kbRoot: string): KnowledgeFile[] {
 	return files;
 }
 
+/**
+ * The `/memories?detailRepo=` scope token for a source-commit wiki jump, chosen the
+ * same way `JD.repoToken` chooses one for the memories tree, so the URL reads the
+ * same across the dashboard:
+ *
+ *   - **Unique display name → the display name.** When no other repo shares it,
+ *     `resolveScope` resolves the name to exactly one repo, so the readable
+ *     `?detailRepo=jolliai` is enough — and matches every other dashboard link.
+ *   - **Shared display name → the `repoIdentity`.** Only when two repos share a
+ *     name does `resolveScope` refuse the ambiguous name; then we need the identity,
+ *     which `normalizeRemoteUrl` derives from the remote URL by the SAME transform
+ *     the collector runs, so it equals `repos.repo_identity` and is unique.
+ *
+ * The identity is used only when it is a usable, non-`file:` one — mirroring the
+ * collector's classification ({@link resolveRepoIdentity}): a `file:` result (a
+ * local-path / unparseable remote) is stored there as `local:<hash of the WORKTREE
+ * root>`, which this side (rooted at `kbRoot`) cannot reconstruct. So a shared name
+ * with no usable identity falls back to the (ambiguous) name — best-effort, and the
+ * jump then degrades to the page scope + hash rather than sending an unmatchable
+ * `file://<kbRoot>`.
+ *
+ * Uniqueness is judged over the Memory Bank folders (`repos`), which normally equals
+ * the dashboard's repo set; a rare divergence (a repo enabled but not yet compiled)
+ * only costs a page-scope fallback, never a wrong jump.
+ */
+function detailRepoToken(repo: DiscoveredRepo, repos: ReadonlyArray<DiscoveredRepo>): string {
+	if (repos.filter((r) => r.repoName === repo.repoName).length === 1) return repo.repoName;
+	if (repo.remoteUrl) {
+		const identity = normalizeRemoteUrl(repo.remoteUrl, repo.kbRoot);
+		if (!identity.startsWith("file:")) return identity;
+	}
+	return repo.repoName;
+}
+
 /** Knowledge page: every Memory Bank repo's `_wiki` file list. */
 export async function buildKnowledgeModel(configDir?: string): Promise<KnowledgeModel> {
 	const localFolder = await readLocalFolder(configDir);
-	const repos = discoverRepos(null, null, localFolder).map(
+	const discovered = discoverRepos(null, null, localFolder);
+	const repos = discovered.map(
 		(r): KnowledgeRepo => ({
 			kb: r.dirName,
 			repoName: r.repoName,
+			detailRepo: detailRepoToken(r, discovered),
 			graphAvailable: hasGraph(r.kbRoot),
 			files: listWikiFiles(r.kbRoot),
 		}),
@@ -141,6 +179,24 @@ export async function buildGraphModel(configDir?: string): Promise<GraphModel> {
 export async function resolveKbRoot(configDir: string | undefined, kb: string): Promise<string | undefined> {
 	const localFolder = await readLocalFolder(configDir);
 	return discoverRepos(null, null, localFolder).find((r) => r.dirName === kb)?.kbRoot;
+}
+
+/**
+ * Like {@link resolveKbRoot}, but also returns the memory-jump SCOPE TOKEN — see
+ * {@link detailRepoToken}: the readable display name when it is unique, else the
+ * `repoIdentity` to disambiguate a shared name (else a page-scope fallback). This
+ * MUST use the same derivation over the same repo set that `buildKnowledgeModel`
+ * gives the client — hence it discovers ALL repos, not just the one — so the
+ * iframe-injected href and the parent's navigation carry the identical `detailRepo`.
+ */
+export async function resolveKbRepo(
+	configDir: string | undefined,
+	kb: string,
+): Promise<{ kbRoot: string; detailRepo: string } | undefined> {
+	const localFolder = await readLocalFolder(configDir);
+	const discovered = discoverRepos(null, null, localFolder);
+	const repo = discovered.find((r) => r.dirName === kb);
+	return repo ? { kbRoot: repo.kbRoot, detailRepo: detailRepoToken(repo, discovered) } : undefined;
 }
 
 /**

--- a/cli/src/dashboard/MemoriesQuery.test.ts
+++ b/cli/src/dashboard/MemoriesQuery.test.ts
@@ -480,19 +480,21 @@ describe("MemoriesQuery", () => {
 			expect(short?.conversations.length).toBe(full?.conversations.length);
 		});
 
-		it("resolves a short-hash prefix collision within ONE repo deterministically", async () => {
+		it("resolves a short-hash prefix collision within ONE repo by a deterministic RULE (lexicographic hash)", async () => {
 			await seedRepo(dbPath, "repo-1", "acme-api");
-			const h1 = `abcd1234${"1".repeat(32)}`;
+			// Seed the lexicographically-LARGER hash first, so a passing test proves the
+			// ORDER BY commit_hash rule — not merely insertion/rowid order (which is what
+			// `ORDER BY repo_id` alone left to the engine when repo_id ties within a repo).
+			const h1 = `abcd1234${"1".repeat(32)}`; // lexicographically first
 			const h2 = `abcd1234${"2".repeat(32)}`;
-			await seedMemory(dbPath, "repo-1", h1, "first", { commitDateMs: 1 });
 			await seedMemory(dbPath, "repo-1", h2, "second", { commitDateMs: 2 });
+			await seedMemory(dbPath, "repo-1", h1, "first", { commitDateMs: 1 });
 
-			// Both share prefix "abcd1234" in the SAME repo, so detailRepo cannot
-			// disambiguate; the pick must be stable across calls (not throw, not vary).
-			const a = await withDashboardDb((db) => buildMemoryDetail(db, ALL, "abcd1234"), { dbPath });
-			const b = await withDashboardDb((db) => buildMemoryDetail(db, ALL, "abcd1234"), { dbPath });
-			expect(a?.commitHash).toBe(b?.commitHash);
-			expect([h1, h2]).toContain(a?.commitHash);
+			// Both share prefix "abcd1234" in the SAME repo (same repo_id), so repo_id is
+			// a tie; the full-hash tie-breaker must pick h1 — the lexicographically first —
+			// regardless of insert order.
+			const detail = await withDashboardDb((db) => buildMemoryDetail(db, ALL, "abcd1234"), { dbPath });
+			expect(detail?.commitHash).toBe(h1);
 		});
 
 		it("splits a topic's decisions prose into bullets, and falls back to one bullet for a plain sentence", async () => {

--- a/cli/src/dashboard/MemoriesQuery.test.ts
+++ b/cli/src/dashboard/MemoriesQuery.test.ts
@@ -441,6 +441,60 @@ describe("MemoriesQuery", () => {
 			expect(detail).toBeUndefined();
 		});
 
+		it("resolves a SHORT hash prefix to the same memory as the full hash", async () => {
+			// The wiki's source-commit links carry an 8-char hash, so /memories?hash=a742fa47
+			// must open the same memory the full 40-char hash does.
+			await seedRepo(dbPath, "repo-1", "acme-api");
+			const hash = `a742fa47${"b".repeat(32)}`;
+			await seedMemory(dbPath, "repo-1", hash, "feat: something", { branch: "main" });
+
+			const short = await withDashboardDb((db) => buildMemoryDetail(db, ALL, "a742fa47"), { dbPath });
+			const full = await withDashboardDb((db) => buildMemoryDetail(db, ALL, hash), { dbPath });
+			expect(short?.commitHash).toBe(hash);
+			expect(full?.commitHash).toBe(hash);
+		});
+
+		it("a SHORT hash opens the SAME rich detail (files + conversations) as the full hash", async () => {
+			// Guards that the resolved row's FULL hash — not the short prefix — feeds
+			// the downstream exact-match lookups (commit_files, transcripts). With the
+			// short prefix, those miss and the detail silently degrades to a bare row:
+			// no per-file line counts, no conversations.
+			await seedRepo(dbPath, "repo-1", "acme-api");
+			const hash = `a742fa47${"b".repeat(32)}`;
+			await seedMemory(dbPath, "repo-1", hash, "feat: rich", { branch: "main" });
+			await seedCommitFiles(dbPath, "repo-1", hash, [{ path: "src/a.ts", insertions: 10, deletions: 2 }]);
+			await seedLinkedSession(dbPath, "repo-1", hash, {
+				source: "claude",
+				sessionId: "s1",
+				title: "Session",
+				messageCount: 4,
+			});
+
+			const short = await withDashboardDb((db) => buildMemoryDetail(db, ALL, "a742fa47"), { dbPath });
+			const full = await withDashboardDb((db) => buildMemoryDetail(db, ALL, hash), { dbPath });
+			// Per-file line counts come ONLY from the hash-matched commit_files query;
+			// a short-hash miss would fall back to (empty) topic filesAffected.
+			expect(short?.files).toEqual([{ path: "src/a.ts", insertions: 10, deletions: 2 }]);
+			expect(short?.files).toEqual(full?.files);
+			expect(short?.conversations.length).toBeGreaterThan(0);
+			expect(short?.conversations.length).toBe(full?.conversations.length);
+		});
+
+		it("resolves a short-hash prefix collision within ONE repo deterministically", async () => {
+			await seedRepo(dbPath, "repo-1", "acme-api");
+			const h1 = `abcd1234${"1".repeat(32)}`;
+			const h2 = `abcd1234${"2".repeat(32)}`;
+			await seedMemory(dbPath, "repo-1", h1, "first", { commitDateMs: 1 });
+			await seedMemory(dbPath, "repo-1", h2, "second", { commitDateMs: 2 });
+
+			// Both share prefix "abcd1234" in the SAME repo, so detailRepo cannot
+			// disambiguate; the pick must be stable across calls (not throw, not vary).
+			const a = await withDashboardDb((db) => buildMemoryDetail(db, ALL, "abcd1234"), { dbPath });
+			const b = await withDashboardDb((db) => buildMemoryDetail(db, ALL, "abcd1234"), { dbPath });
+			expect(a?.commitHash).toBe(b?.commitHash);
+			expect([h1, h2]).toContain(a?.commitHash);
+		});
+
 		it("splits a topic's decisions prose into bullets, and falls back to one bullet for a plain sentence", async () => {
 			await seedRepo(dbPath, "repo-1", "acme-api");
 			const hash = "a".repeat(40);
@@ -905,6 +959,26 @@ describe("MemoriesQuery", () => {
 			const withUnknownHash = await withDashboardDb((db) => buildMemories(db, ALL, "z".repeat(40)), { dbPath });
 			expect(withUnknownHash.selected).toBeUndefined();
 			expect(withUnknownHash.items).toHaveLength(1);
+		});
+
+		it("uses detailRepo (repo name) to disambiguate a short-hash prefix shared by two repos", async () => {
+			await seedRepo(dbPath, "repo-1", "acme-api");
+			await seedRepo(dbPath, "repo-2", "acme-web");
+			const h1 = `abcd1234${"1".repeat(32)}`;
+			const h2 = `abcd1234${"2".repeat(32)}`;
+			await seedMemory(dbPath, "repo-1", h1, "in api", { commitDateMs: 1 });
+			await seedMemory(dbPath, "repo-2", h2, "in web", { commitDateMs: 2 });
+
+			// The short prefix "abcd1234" matches BOTH repos; detailRepo picks one.
+			const toWeb = await withDashboardDb((db) => buildMemories(db, ALL, "abcd1234", undefined, "acme-web"), {
+				dbPath,
+			});
+			expect(toWeb.selected?.commitHash).toBe(h2);
+
+			// Without detailRepo the pick is deterministic (lowest repo_id), proving
+			// the disambiguation is what steered it to acme-web above.
+			const ambiguous = await withDashboardDb((db) => buildMemories(db, ALL, "abcd1234"), { dbPath });
+			expect(ambiguous.selected?.commitHash).toBe(h1);
 		});
 	});
 	describe("readContextDoc", () => {

--- a/cli/src/dashboard/MemoriesQuery.ts
+++ b/cli/src/dashboard/MemoriesQuery.ts
@@ -621,10 +621,19 @@ export function buildMemoryDetail(
 			  -- Deterministic pick. Without a scope filter (the all-repos view) one
 			  -- hash can match rows in two repos — two clones of a project, or the
 			  -- same commit cherry-picked into another — and an unordered LIMIT 1 let
-			  -- the engine hand back a different repo's memory between renders. A short
-			  -- hash can also prefix-collide within one repo; the same ORDER makes that
-			  -- pick deterministic, and detailRepo narrows the scope first.
-			  ORDER BY m.repo_id
+			  -- the engine hand back a different repo's memory between renders.
+			  -- m.commit_hash is the SECOND key, not decoration: a short hash can
+			  -- prefix-collide WITHIN one repo (same repo_id), where repo_id alone is a
+			  -- tie and LIMIT 1 would again be engine-defined. Ordering by the full
+			  -- hash breaks that tie by a stable rule (lexicographic first), so the pick
+			  -- is reproducible rather than whichever row the engine emits. It is a
+			  -- deterministic choice among ambiguous matches, not a claim about which
+			  -- commit the user meant — an 8-char prefix cannot say. detailRepo narrows
+			  -- the scope first; within one scope a FULL hash matches exactly one row.
+			  -- (In the all-repos view a full hash can still match two rows — the same
+			  -- commit cherry-picked into two repos — but there the repo_id key breaks
+			  -- the tie and the equal commit_hash makes the second key inert.)
+			  ORDER BY m.repo_id, m.commit_hash
 			  LIMIT 1`,
 		)
 		.get(hash, hash, ...filter.params) as MemoryDetailRow | undefined;

--- a/cli/src/dashboard/MemoriesQuery.ts
+++ b/cli/src/dashboard/MemoriesQuery.ts
@@ -589,6 +589,12 @@ export function buildMemoryDetail(
 	scope: DashboardScope,
 	hash: string,
 ): MemoryDetail | undefined {
+	// Guard the empty string explicitly: with the prefix predicate below,
+	// `length("")=0` makes `substr(commit_hash,1,0)=""` true for EVERY row (the
+	// old `commit_hash = ""` matched none), so an empty hash would resolve to an
+	// arbitrary memory. `buildMemories` already returns early on a falsy hash, but
+	// this is exported and must not depend on every caller repeating that guard.
+	if (!hash) return undefined;
 	const resolved = scopeToRepoId(db, scope);
 	const filter = scopeFilter(resolved, "m.repo_id");
 	const row = db
@@ -603,16 +609,35 @@ export function buildMemoryDetail(
 			   FROM memories m
 			   JOIN repos r ON r.id = m.repo_id
 			   LEFT JOIN commits cm ON cm.repo_id = m.repo_id AND cm.hash = m.commit_hash
-			  WHERE m.commit_hash = ?${filter.sql}
+			  -- Prefix match on the leading length(hash) chars, so a SHORT hash
+			  -- resolves too: the wiki's source-commit links carry an 8-char hash
+			  -- (commitHash.substring(0,8)), and /memories?hash=a742fa47 must open the
+			  -- same memory as the full 40-char form. A full hash makes this
+			  -- substr(commit_hash,1,40)=hash, i.e. exactly the old '=' — so every
+			  -- existing full-hash caller (stats/memories cards) is unchanged. substr
+			  -- rather than LIKE ...||'%' keeps it a plain equality with no wildcard or
+			  -- escape semantics (a hash is hex, but this stays true if that changes).
+			  WHERE substr(m.commit_hash, 1, length(?)) = ?${filter.sql}
 			  -- Deterministic pick. Without a scope filter (the all-repos view) one
 			  -- hash can match rows in two repos — two clones of a project, or the
 			  -- same commit cherry-picked into another — and an unordered LIMIT 1 let
-			  -- the engine hand back a different repo's memory between renders.
+			  -- the engine hand back a different repo's memory between renders. A short
+			  -- hash can also prefix-collide within one repo; the same ORDER makes that
+			  -- pick deterministic, and detailRepo narrows the scope first.
 			  ORDER BY m.repo_id
 			  LIMIT 1`,
 		)
-		.get(hash, ...filter.params) as MemoryDetailRow | undefined;
+		.get(hash, hash, ...filter.params) as MemoryDetailRow | undefined;
 	if (!row) return undefined;
+
+	// The `hash` argument may be a SHORT prefix (wiki source-commit links carry an
+	// 8-char hash). The WHERE above resolved it to a row, but every downstream
+	// lookup below matches `commit_hash = ?` EXACTLY — feeding the short prefix
+	// would miss, silently degrading the detail (bare row instead of the folded
+	// tree → tokens understated ~5x and topics lost; no commit_files → per-file
+	// line counts lost; empty activity; conversations vanish entirely). Use the
+	// full hash the row actually carries for all of them.
+	const fullHash = row.commit_hash;
 
 	// Not guarded: `memories` computes STORED generated columns with
 	// `json_extract`, so SQLite rejects a malformed payload at INSERT
@@ -624,7 +649,7 @@ export function buildMemoryDetail(
 	// on those folded children. Reading the row alone reported 639k tokens for a
 	// memory the editor shows as 3.45M. Falls back to the row if assembly finds
 	// nothing, so a detail page never fails on a tree query.
-	const summary = (assembleMemoryTree(db, row.repo_id, hash) ?? JSON.parse(row.summary_json)) as CommitSummary;
+	const summary = (assembleMemoryTree(db, row.repo_id, fullHash) ?? JSON.parse(row.summary_json)) as CommitSummary;
 
 	const categoryLabels = commitCategoryLabels(db, scope);
 	const category = categoryLabels.get(`${row.repo_identity}\0${row.commit_hash}`);
@@ -637,7 +662,11 @@ export function buildMemoryDetail(
 			  WHERE c.repo_id = ? AND c.hash = ?
 			  ORDER BY cf.path`,
 		)
-		.all(row.repo_id, hash) as ReadonlyArray<{ path: string; insertions: number | null; deletions: number | null }>;
+		.all(row.repo_id, fullHash) as ReadonlyArray<{
+		path: string;
+		insertions: number | null;
+		deletions: number | null;
+	}>;
 	const topicsRaw = collectDisplayTopics(summary);
 	// `commit_files` comes from the collector's `--numstat` pass over git, which
 	// only ever ran for commits it walked — a repo enrolled after the fact has
@@ -672,7 +701,7 @@ export function buildMemoryDetail(
 		reason: e.reason,
 	}));
 
-	const { activity, uncoveredSources } = buildActivity(db, row.repo_id, hash);
+	const { activity, uncoveredSources } = buildActivity(db, row.repo_id, fullHash);
 
 	// Aggregated over the tree, matching the editor's token meter
 	// (`SummaryHtmlBuilder.buildTokenMeter`): a squash/amend memory keeps its
@@ -744,7 +773,7 @@ export function buildMemoryDetail(
 		...(tokens ? { tokens } : {}),
 		...(summarizedBy ? { summarizedBy } : {}),
 		...(summary.recap ? { recap: summary.recap } : {}),
-		conversations: buildConversations(db, row.repo_id, hash, summary),
+		conversations: buildConversations(db, row.repo_id, fullHash, summary),
 		context,
 		excluded,
 		activity,

--- a/cli/src/dashboard/MemoriesScroll.test.ts
+++ b/cli/src/dashboard/MemoriesScroll.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Runtime test for `memories.js`'s "scroll the selected memory into view" wiring.
+ *
+ * Landing on `/memories?hash=…` (e.g. a jump from the wiki viewer) should center
+ * the selected row in the tree — but the 30s refresh tick re-runs renderMemories,
+ * and scrolling on every tick would yank the view back while the user reads. So
+ * the scroll fires only when the selected hash CHANGES. This drives the real IIFE
+ * against a stub document whose `scrollIntoView` is a spy.
+ */
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function setup(commitHash: string | undefined) {
+	let scrolled = 0;
+	let opts: unknown = null;
+	const row = {
+		scrollIntoView: (o: unknown) => {
+			scrolled++;
+			opts = o;
+		},
+	};
+	const element = () => ({
+		innerHTML: "",
+		style: {} as Record<string, string>,
+		classList: { add: () => undefined, remove: () => undefined, contains: () => false },
+		querySelectorAll: () => [] as ReadonlyArray<never>,
+		querySelector: () => null,
+		addEventListener: () => undefined,
+		setAttribute: () => undefined,
+		getAttribute: () => null,
+	});
+	const elements = new Map<string, ReturnType<typeof element>>();
+	const doc = {
+		// memTree/memSearch null → the full first-render branch, which ends in the
+		// scroll call; every other id is memoised.
+		getElementById: (id: string) => {
+			if (id === "memTree" || id === "memSearch") return null;
+			const hit = elements.get(id) ?? element();
+			elements.set(id, hit);
+			return hit;
+		},
+		querySelectorAll: () => [] as ReadonlyArray<never>,
+		querySelector: (sel: string) => (sel === '#memTree [aria-current="true"]' ? row : null),
+		addEventListener: () => undefined,
+		createElement: element,
+		body: element(),
+	};
+	const win = { JD: {}, document: doc, addEventListener: () => undefined } as Record<string, unknown>;
+	for (const file of ["format.js", "shell.js", "charts.js", "memories.js"]) {
+		const src = readFileSync(new URL(`./assets/js/${file}`, import.meta.url), "utf8");
+		new Function("window", "document", src)(win, doc);
+	}
+	const JD = win.JD as { renderMemories: (model: unknown) => void };
+	const model = {
+		memories: {
+			selected: {
+				commitHash,
+				title: "m",
+				conversations: [],
+				context: [],
+				excluded: [],
+				activity: [],
+				activityUncoveredSources: [],
+				topics: [],
+				files: [],
+				e2e: [],
+			},
+			items: [],
+			tree: [],
+		},
+		scope: { kind: "all" },
+	};
+	return { render: () => JD.renderMemories(model), scrolled: () => scrolled, opts: () => opts };
+}
+
+describe("memories.js — scroll selected into view", () => {
+	it("centers the selected row on first render, and does NOT re-scroll on an unchanged re-render", () => {
+		const h = setup("abc1234def");
+		h.render();
+		expect(h.scrolled()).toBe(1);
+		expect(h.opts()).toEqual({ block: "center" });
+
+		// The 30s tick re-renders the same selection — must not fight the reader.
+		h.render();
+		expect(h.scrolled()).toBe(1);
+	});
+
+	it("does not scroll when no memory is selected", () => {
+		const h = setup(undefined);
+		h.render();
+		expect(h.scrolled()).toBe(0);
+	});
+});

--- a/cli/src/dashboard/MemoriesScroll.test.ts
+++ b/cli/src/dashboard/MemoriesScroll.test.ts
@@ -11,15 +11,22 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
-function setup(commitHash: string | undefined) {
-	let scrolled = 0;
-	let opts: unknown = null;
-	const row = {
-		scrollIntoView: (o: unknown) => {
-			scrolled++;
-			opts = o;
-		},
-	};
+/**
+ * @param commitHash   the selected memory's hash (undefined = nothing selected)
+ * @param opts.rows    the tree rows carrying `aria-current` (all share the hash);
+ *                     defaults to a single "repo-1" row
+ * @param opts.owner   which repoIdentity actually OWNS the selected detail
+ *                     (defaults to "repo-1"); the row we expect to be centered
+ */
+function setup(commitHash: string | undefined, opts?: { rows?: string[]; owner?: string }) {
+	const scrolls: Array<{ repoIdentity: string; opts: unknown }> = [];
+	const makeRow = (repoIdentity: string) => ({
+		getAttribute: (name: string) => (name === "data-repo" ? repoIdentity : null),
+		scrollIntoView: (o: unknown) => scrolls.push({ repoIdentity, opts: o }),
+	});
+	// Cross-repo hash reuse → the tree marks EVERY row with the hash aria-current.
+	const rows = (opts?.rows ?? ["repo-1"]).map(makeRow);
+	const owner = opts?.owner ?? "repo-1";
 	const element = () => ({
 		innerHTML: "",
 		style: {} as Record<string, string>,
@@ -40,8 +47,8 @@ function setup(commitHash: string | undefined) {
 			elements.set(id, hit);
 			return hit;
 		},
-		querySelectorAll: () => [] as ReadonlyArray<never>,
-		querySelector: (sel: string) => (sel === '#memTree [aria-current="true"]' ? row : null),
+		querySelectorAll: (sel: string) => (sel === '#memTree [aria-current="true"]' ? rows : []),
+		querySelector: () => null,
 		addEventListener: () => undefined,
 		createElement: element,
 		body: element(),
@@ -56,6 +63,7 @@ function setup(commitHash: string | undefined) {
 		memories: {
 			selected: {
 				commitHash,
+				repoIdentity: owner,
 				title: "m",
 				conversations: [],
 				context: [],
@@ -71,15 +79,18 @@ function setup(commitHash: string | undefined) {
 		},
 		scope: { kind: "all" },
 	};
-	return { render: () => JD.renderMemories(model), scrolled: () => scrolled, opts: () => opts };
+	return {
+		render: () => JD.renderMemories(model),
+		scrolls: () => scrolls,
+		scrolled: () => scrolls.length,
+	};
 }
 
 describe("memories.js — scroll selected into view", () => {
 	it("centers the selected row on first render, and does NOT re-scroll on an unchanged re-render", () => {
 		const h = setup("abc1234def");
 		h.render();
-		expect(h.scrolled()).toBe(1);
-		expect(h.opts()).toEqual({ block: "center" });
+		expect(h.scrolls()).toEqual([{ repoIdentity: "repo-1", opts: { block: "center" } }]);
 
 		// The 30s tick re-renders the same selection — must not fight the reader.
 		h.render();
@@ -90,5 +101,20 @@ describe("memories.js — scroll selected into view", () => {
 		const h = setup(undefined);
 		h.render();
 		expect(h.scrolled()).toBe(0);
+	});
+
+	it("centers the OWNER repo's row when the same hash exists in two repos", () => {
+		// A cherry-pick: repo-A and repo-B both have this hash, so BOTH rows are marked
+		// aria-current. The detail pane belongs to repo-B (detailRepo scoped the jump
+		// there), so the scroll must land on repo-B's row, not the first (repo-A).
+		const h = setup("abc1234def", { rows: ["repo-A", "repo-B"], owner: "repo-B" });
+		h.render();
+		expect(h.scrolls()).toEqual([{ repoIdentity: "repo-B", opts: { block: "center" } }]);
+	});
+
+	it("falls back to the first selected row when none matches the owner (should not happen)", () => {
+		const h = setup("abc1234def", { rows: ["repo-A", "repo-B"], owner: "repo-Z" });
+		h.render();
+		expect(h.scrolls()).toEqual([{ repoIdentity: "repo-A", opts: { block: "center" } }]);
 	});
 });

--- a/cli/src/dashboard/WikiViewerScript.test.ts
+++ b/cli/src/dashboard/WikiViewerScript.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Behavioral test for `WIKI_LINK_REWRITE_SCRIPT` — the script `buildWikiViewerHtml`
+ * injects into the sandboxed `/wiki-viewer` iframe. It is inlined JS (tsc never
+ * runs it, coverage excludes it once served), so an earlier version silently
+ * misclassified EVERY source-commit link: it required a `summary--` filename
+ * prefix that `FolderStorage` does not write (the real file is `<slug>-<hash8>.md`),
+ * so every commit link was de-linked and the whole jump feature was dead — while
+ * string-only assertions on the served HTML stayed green.
+ *
+ * This runs the actual script against stub anchors carrying the REAL href shapes
+ * (measured from a live Memory Bank `_wiki`) and checks what each becomes.
+ */
+
+import { describe, expect, it } from "vitest";
+import { WIKI_LINK_REWRITE_SCRIPT } from "./DashboardServer.js";
+
+interface StubAnchor {
+	getAttribute: (name: string) => string | null;
+	textContent: string;
+	hrefSet: string | null;
+	clickHandler: ((e: { preventDefault: () => void }) => void) | null;
+	replacedWithText: string | null;
+	setAttribute: (name: string, value: string) => void;
+	addEventListener: (type: string, fn: (e: { preventDefault: () => void }) => void) => void;
+	parentNode: { replaceChild: (newNode: { textContent: string }, old: unknown) => void };
+}
+
+function anchor(href: string, text: string): StubAnchor {
+	const a: StubAnchor = {
+		getAttribute: (name) => (name === "href" ? href : null),
+		textContent: text,
+		hrefSet: null,
+		clickHandler: null,
+		replacedWithText: null,
+		setAttribute: (name, value) => {
+			if (name === "href") a.hrefSet = value;
+		},
+		addEventListener: (type, fn) => {
+			if (type === "click") a.clickHandler = fn;
+		},
+		parentNode: {
+			replaceChild: (newNode) => {
+				a.replacedWithText = newNode.textContent;
+			},
+		},
+	};
+	return a;
+}
+
+/** Runs the rewrite script over `anchors`; returns the messages posted to the parent. */
+function run(anchors: StubAnchor[], search = "?kb=jolliai&file=topic--x.md"): Array<{ type: string; hash: string }> {
+	const posted: Array<{ type: string; hash: string }> = [];
+	const md = { querySelectorAll: (sel: string) => (sel === "a[href]" ? anchors : []) };
+	const doc = {
+		getElementById: (id: string) => (id === "md" ? md : null),
+		createElement: () => ({ textContent: "" }),
+	};
+	// The frame reads its own ?kb= to build the real /memories href (status-bar preview).
+	const win = {
+		parent: { postMessage: (msg: { type: string; hash: string }) => posted.push(msg) },
+		document: doc,
+		location: { search },
+	};
+	new Function("window", "document", WIKI_LINK_REWRITE_SCRIPT)(win, doc);
+	return posted;
+}
+
+describe("WIKI_LINK_REWRITE_SCRIPT", () => {
+	it("rewrites a real source-commit link (NO summary-- prefix) to the /memories href and postMessages on click", () => {
+		// Measured real href — <branch>/<slug>-<hash8>.md, label is the hash.
+		const a = anchor(
+			"../feature-context-relevance-filtering/add-ai-context-relevance-filtering-layer-to-commit-a2bc7940.md",
+			"a2bc7940",
+		);
+		const posted = run([a]);
+		// href becomes the REAL destination (kb from the frame's own URL) so the
+		// browser status bar previews where the click goes.
+		expect(a.hrefSet).toBe("/memories?hash=a2bc7940&detailRepo=jolliai");
+		expect(a.replacedWithText).toBeNull();
+		expect(posted).toEqual([]); // nothing posts until the click fires
+		a.clickHandler?.({ preventDefault: () => undefined });
+		expect(posted).toEqual([{ type: "jolli-wiki-nav", hash: "a2bc7940" }]);
+	});
+
+	it("omits detailRepo from the href when the frame's URL carries no kb", () => {
+		const a = anchor("../main/add-thing-a2bc7940.md", "a2bc7940");
+		run([a], "?file=topic--x.md");
+		expect(a.hrefSet).toBe("/memories?hash=a2bc7940");
+	});
+
+	it("extracts the TRAILING hash from the filename, not a hex-looking slug segment", () => {
+		// The slug embeds "deadbeef" (valid hex) and the label is deliberately that
+		// wrong value; only correct trailing-group extraction yields "12345678".
+		const a = anchor("../main/fix-deadbeef-in-parser-12345678.md", "deadbeef");
+		const posted = run([a]);
+		a.clickHandler?.({ preventDefault: () => undefined });
+		expect(posted).toEqual([{ type: "jolli-wiki-nav", hash: "12345678" }]);
+	});
+
+	it("de-links a related-branch link, keeping its text", () => {
+		const a = anchor("../main/", "main");
+		run([a]);
+		expect(a.replacedWithText).toBe("main");
+		expect(a.hrefSet).toBeNull();
+		expect(a.clickHandler).toBeNull();
+	});
+
+	it("de-links the index page's bare topic--<slug>.md link", () => {
+		const a = anchor("topic--knowledge-graph-feature.md", "Knowledge graph feature");
+		run([a]);
+		expect(a.replacedWithText).toBe("Knowledge graph feature");
+		expect(a.hrefSet).toBeNull();
+	});
+
+	it("leaves an absolute/external link untouched", () => {
+		const a = anchor("https://linear.app/acme/issue/ABC-1", "ABC-1");
+		const posted = run([a]);
+		expect(a.hrefSet).toBeNull();
+		expect(a.replacedWithText).toBeNull();
+		expect(a.clickHandler).toBeNull();
+		expect(posted).toEqual([]);
+	});
+});

--- a/cli/src/dashboard/WikiViewerScript.test.ts
+++ b/cli/src/dashboard/WikiViewerScript.test.ts
@@ -48,18 +48,19 @@ function anchor(href: string, text: string): StubAnchor {
 }
 
 /** Runs the rewrite script over `anchors`; returns the messages posted to the parent. */
-function run(anchors: StubAnchor[], search = "?kb=jolliai&file=topic--x.md"): Array<{ type: string; hash: string }> {
+function run(anchors: StubAnchor[], detailRepo = "Jolli AI"): Array<{ type: string; hash: string }> {
 	const posted: Array<{ type: string; hash: string }> = [];
 	const md = { querySelectorAll: (sel: string) => (sel === "a[href]" ? anchors : []) };
 	const doc = {
 		getElementById: (id: string) => (id === "md" ? md : null),
 		createElement: () => ({ textContent: "" }),
 	};
-	// The frame reads its own ?kb= to build the real /memories href (status-bar preview).
+	// buildWikiViewerHtml injects the owning repo's display name as this global; the
+	// script reads it to build the real /memories href (status-bar preview).
 	const win = {
 		parent: { postMessage: (msg: { type: string; hash: string }) => posted.push(msg) },
 		document: doc,
-		location: { search },
+		__JOLLI_WIKI_DETAIL_REPO__: detailRepo,
 	};
 	new Function("window", "document", WIKI_LINK_REWRITE_SCRIPT)(win, doc);
 	return posted;
@@ -73,18 +74,18 @@ describe("WIKI_LINK_REWRITE_SCRIPT", () => {
 			"a2bc7940",
 		);
 		const posted = run([a]);
-		// href becomes the REAL destination (kb from the frame's own URL) so the
-		// browser status bar previews where the click goes.
-		expect(a.hrefSet).toBe("/memories?hash=a2bc7940&detailRepo=jolliai");
+		// href becomes the REAL destination, using the injected repo DISPLAY NAME as
+		// detailRepo (URL-encoded), so the browser status bar previews the click.
+		expect(a.hrefSet).toBe("/memories?hash=a2bc7940&detailRepo=Jolli%20AI");
 		expect(a.replacedWithText).toBeNull();
 		expect(posted).toEqual([]); // nothing posts until the click fires
 		a.clickHandler?.({ preventDefault: () => undefined });
 		expect(posted).toEqual([{ type: "jolli-wiki-nav", hash: "a2bc7940" }]);
 	});
 
-	it("omits detailRepo from the href when the frame's URL carries no kb", () => {
+	it("omits detailRepo from the href when no owning repo is injected", () => {
 		const a = anchor("../main/add-thing-a2bc7940.md", "a2bc7940");
-		run([a], "?file=topic--x.md");
+		run([a], "");
 		expect(a.hrefSet).toBe("/memories?hash=a2bc7940");
 	});
 

--- a/cli/src/dashboard/assets/js/knowledge.js
+++ b/cli/src/dashboard/assets/js/knowledge.js
@@ -172,6 +172,27 @@ window.JD = window.JD || {};
 			redrawList(model);
 		};
 		wireList(model);
+		wireWikiNav();
+	}
+
+	// A source-commit link clicked inside the wiki iframe posts up its commit hash
+	// (the frame is sandboxed / opaque-origin, so it can't navigate us). We validate
+	// the hash shape — the frame is untrusted — and navigate to that memory, scoped
+	// by the currently-open page's `kb`. This is the SAME `detailRepo=<kb>` the frame
+	// wrote into the link's visible href, so the status-bar preview and the real
+	// destination match. Re-registered per render, previous handler removed first so
+	// repeated renders don't stack listeners (mirrors graph.js's syncUrlWithFrame).
+	function wireWikiNav() {
+		if (JD._wikiNavHandler) window.removeEventListener("message", JD._wikiNavHandler);
+		JD._wikiNavHandler = function (ev) {
+			var d = ev && ev.data;
+			if (!d || d.type !== "jolli-wiki-nav" || typeof d.hash !== "string") return;
+			if (!/^[0-9a-f]{7,40}$/i.test(d.hash)) return;
+			var kb = (state.selected && state.selected.kb) || "";
+			window.location.href =
+				"/memories?hash=" + encodeURIComponent(d.hash) + (kb ? "&detailRepo=" + encodeURIComponent(kb) : "");
+		};
+		window.addEventListener("message", JD._wikiNavHandler);
 	}
 
 	JD.renderKnowledge = (model) => render(model);

--- a/cli/src/dashboard/assets/js/knowledge.js
+++ b/cli/src/dashboard/assets/js/knowledge.js
@@ -172,25 +172,34 @@ window.JD = window.JD || {};
 			redrawList(model);
 		};
 		wireList(model);
-		wireWikiNav();
+		wireWikiNav(model);
 	}
 
 	// A source-commit link clicked inside the wiki iframe posts up its commit hash
 	// (the frame is sandboxed / opaque-origin, so it can't navigate us). We validate
 	// the hash shape — the frame is untrusted — and navigate to that memory, scoped
-	// by the currently-open page's `kb`. This is the SAME `detailRepo=<kb>` the frame
-	// wrote into the link's visible href, so the status-bar preview and the real
-	// destination match. Re-registered per render, previous handler removed first so
-	// repeated renders don't stack listeners (mirrors graph.js's syncUrlWithFrame).
-	function wireWikiNav() {
+	// by the owning repo's SCOPE TOKEN (`detailRepo`: the dashboard repoIdentity when
+	// the repo has a remote, else its display name). This is the SAME `detailRepo`
+	// the frame wrote into the link's visible href, so the status-bar preview and the
+	// real destination match. Re-registered per render, previous handler removed
+	// first so repeated renders don't stack listeners (mirrors graph.js).
+	function wireWikiNav(model) {
 		if (JD._wikiNavHandler) window.removeEventListener("message", JD._wikiNavHandler);
 		JD._wikiNavHandler = function (ev) {
 			var d = ev && ev.data;
 			if (!d || d.type !== "jolli-wiki-nav" || typeof d.hash !== "string") return;
 			if (!/^[0-9a-f]{7,40}$/i.test(d.hash)) return;
-			var kb = (state.selected && state.selected.kb) || "";
+			// detailRepo is the owning repo's scope token — repoIdentity (unique, and
+			// what resolveScope matches even when two repos share a display name) when a
+			// remote exists, else the name. `kb` (the Memory Bank dir name) is NOT a
+			// scope token, so a short hash could open the wrong repo's memory.
+			var kb = state.selected && state.selected.kb;
+			var repo = allRepos(model).filter((r) => r.kb === kb)[0];
+			var detailRepo = repo ? repo.detailRepo : "";
 			window.location.href =
-				"/memories?hash=" + encodeURIComponent(d.hash) + (kb ? "&detailRepo=" + encodeURIComponent(kb) : "");
+				"/memories?hash=" +
+				encodeURIComponent(d.hash) +
+				(detailRepo ? "&detailRepo=" + encodeURIComponent(detailRepo) : "");
 		};
 		window.addEventListener("message", JD._wikiNavHandler);
 	}

--- a/cli/src/dashboard/assets/js/memories.js
+++ b/cli/src/dashboard/assets/js/memories.js
@@ -20,6 +20,12 @@ window.JD = window.JD || {};
 	JD.memView = JD.memView || "branches";
 	JD.memCollapsed = JD.memCollapsed || {};
 	JD.memQuery = JD.memQuery || "";
+	/* The hash we last scrolled the tree to. Landing on /memories?hash=… should
+	   bring the selected row into view (centered), but the 30s tick re-renders the
+	   same page — scrolling every tick would yank the view back while the user
+	   reads. So we scroll only when the selected hash CHANGES. Reset to null on
+	   each page load (a fresh module), which is exactly when we DO want to scroll. */
+	JD.memLastScrolledHash = JD.memLastScrolledHash || null;
 
 	const MEMORY_ICONS = {
 		database: '<ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v14c0 1.7 3.6 3 8 3s8-1.3 8-3V5"/><path d="M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3"/>',
@@ -278,6 +284,20 @@ window.JD = window.JD || {};
 	function refreshTree(model) {
 		document.getElementById("memTree").innerHTML = renderTreeBody(model);
 		wireTree(model);
+	}
+
+	/* Center the selected memory's row in the tree when the selection changes —
+	   the landing case for /memories?hash=…&detailRepo=… (e.g. a click from the
+	   wiki viewer), where the row is often scrolled out of view. Guarded by
+	   memLastScrolledHash so the 30s tick does not fight the user's own scrolling.
+	   Only reached from renderMemories, never from refreshTree (collapse toggles /
+	   load-more must not reposition the tree). No-op when the row isn't loaded. */
+	function scrollSelectedIntoView(model) {
+		var sel = model.memories && model.memories.selected ? model.memories.selected.commitHash : null;
+		if (!sel || sel === JD.memLastScrolledHash) return;
+		JD.memLastScrolledHash = sel;
+		var row = document.querySelector('#memTree [aria-current="true"]');
+		if (row && row.scrollIntoView) row.scrollIntoView({ block: "center" });
 	}
 
 	function renderToolbar(model) {
@@ -904,6 +924,7 @@ window.JD = window.JD || {};
 			if (detail) detail.innerHTML = '<div class="mem-read-inner">' + renderDetail(model) + "</div>";
 			wireTree(model);
 			wireDetail(model);
+			scrollSelectedIntoView(model);
 			return;
 		}
 		document.getElementById("app").innerHTML =
@@ -917,5 +938,6 @@ window.JD = window.JD || {};
 		wireToolbar(model);
 		wireTree(model);
 		wireDetail(model);
+		scrollSelectedIntoView(model);
 	};
 })(window.JD);

--- a/cli/src/dashboard/assets/js/memories.js
+++ b/cli/src/dashboard/assets/js/memories.js
@@ -293,10 +293,25 @@ window.JD = window.JD || {};
 	   Only reached from renderMemories, never from refreshTree (collapse toggles /
 	   load-more must not reposition the tree). No-op when the row isn't loaded. */
 	function scrollSelectedIntoView(model) {
-		var sel = model.memories && model.memories.selected ? model.memories.selected.commitHash : null;
-		if (!sel || sel === JD.memLastScrolledHash) return;
-		JD.memLastScrolledHash = sel;
-		var row = document.querySelector('#memTree [aria-current="true"]');
+		var detail = model.memories && model.memories.selected;
+		var hash = detail ? detail.commitHash : null;
+		if (!hash || hash === JD.memLastScrolledHash) return;
+		JD.memLastScrolledHash = hash;
+		// The tree marks selection by commit hash ALONE, so when the same hash exists
+		// in two repos (a cherry-pick) BOTH rows carry aria-current. Center the row
+		// whose repo actually OWNS this detail (matched on repoIdentity), not just the
+		// first — otherwise the scroll can land on the other repo's row while the
+		// detail pane shows this one. Match by data-repo (each row carries it); fall
+		// back to the first selected row if none matches (should not happen).
+		var selected = document.querySelectorAll('#memTree [aria-current="true"]');
+		var row = null;
+		for (var i = 0; i < selected.length; i++) {
+			if (selected[i].getAttribute("data-repo") === detail.repoIdentity) {
+				row = selected[i];
+				break;
+			}
+		}
+		if (!row) row = selected[0];
 		if (row && row.scrollIntoView) row.scrollIntoView({ block: "center" });
 	}
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (3)

1. Add wiki link rewrite script and wire cross-frame commit navigation (`3ca78fb`) — [Memory](https://jolli.ai/very/o/default/articles/add-wiki-link-rewrite-script-and-wire-cross-frame-commit-navigation-11391)
2. Fix sign-in error exposure and scroll selected memory into view (`d28a0ba`)
3. Use repoName instead of kb dir for wiki detailRepo scope token (`0892449`)


## Quick recap (3)

### Commit 1 of 3: Add wiki link rewrite script and wire cross-frame commit navigation (`3ca78fb`)

Wiki source-commit links in the Knowledge page's document viewer are now fully functional. Clicking a commit reference opens the corresponding memory detail page, with the selected commit scrolled to the center of the tree so it is immediately visible without manual searching. The browser status bar previews the exact destination address before the user clicks, and the preview matches where the page actually navigates.

A subtle but significant data-correctness fix accompanied the navigation feature. When a short commit identifier was used to look up a memory, four separate downstream queries — covering per-file line counts, token totals, activity, and conversation history — were silently receiving the short identifier instead of the full one stored in the database. All four would return empty results, producing a detail page that appeared to load correctly but was missing most of its content. The fix resolves the full identifier from the matched row and passes that through to every downstream query, so short-hash and full-hash lookups now produce identical detail pages.

### Commit 2 of 3: Fix sign-in error exposure and scroll selected memory into view (`d28a0ba`)

Sign-in error handling in the dashboard server was tightened so that internal failure details no longer reach the browser. Previously, whatever message an exception carried was sent directly to the client; now only two controlled strings are ever returned: a specific timeout notice or a generic prompt to check the server log. The full error detail is still recorded server-side for debugging. A shared constant ties the timeout text used when starting the sign-in flow to the text checked in the error handler, keeping the two in sync automatically as the code evolves.

### Commit 3 of 3: Use repoName instead of kb dir for wiki detailRepo scope token (`0892449`)

Two bugs in the wiki-to-memory navigation feature were identified and fixed. The first affected how the dashboard scoped a memory search when a user clicked a source-commit link in the wiki viewer: the system was using the Memory Bank folder name as the lookup key, but the dashboard's repo-scoping system does not recognize folder names — it works with display names and unique identity strings. As a result, scoping silently failed and the search fell back to all repos, where a short hash could match the wrong memory. The fix threads the repo's display name through the server render and the parent page's click handler, with both sides drawing from the same underlying data so their values stay in sync.

The second bug affected what happened when two commits in the same repository shared the same eight-character hash prefix. The database query had no stable rule for choosing between them, leaving the result up to the database engine's internal ordering — which could vary across versions or after a database rebuild. Adding the full commit hash as a secondary sort key gives the query a deterministic, rule-governed tiebreaker: the lexicographically first full hash always wins. The accompanying test was also redesigned to actually prove this rule holds, by seeding the larger hash first and confirming the smaller one is returned regardless of insertion order.

## Topics (7)
<details>
<summary><strong>01 · [3ca78fb] Wiki commit links now navigate to the correct memory detail page</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Clicking a source-commit link inside the wiki viewer did nothing useful — the links were dead inside the sandboxed iframe, and even if they had worked, the destination URL only accepted a full 40-character commit identifier, while the wiki only embeds an 8-character short hash.

**💡 Decisions Behind the Code**

- **Real URL in the status bar vs. a placeholder hash**: The commit links' href attribute is set to the actual `/memories` destination rather than a no-op anchor. This required reading the repo identifier from the iframe's own URL at script execution time, so the previewed address and the address the parent actually navigates to are identical. The alternative — keeping `href="#"` — would have left users with no way to preview the destination before clicking.
- **Short hash via prefix comparison rather than exact match**: The wiki embeds only an 8-character hash in both the filename and the link label, so the memory lookup had to tolerate partial identifiers. A substring prefix comparison was chosen over a `LIKE` wildcard to avoid any wildcard-escape semantics. After the row is resolved, the full stored hash is used for all downstream queries, preventing silent data loss (missing conversations, understated token counts) that would occur if the short prefix were passed through unchanged.
- **Repo identity passed as the directory name, not the display name**: The iframe's own URL already carries the repo's directory name, and the parent navigation listener reads that same value from module state. This keeps the previewed href and the real navigation destination in exact agreement without requiring the iframe to know anything about the repo's display name or internal database identity.

**✅ What Was Implemented**

- Rewrote the link-rewriting script injected into the wiki viewer iframe (`WIKI_LINK_REWRITE_SCRIPT` in `DashboardServer.ts`). The script now classifies links by inspecting the trailing filename segment for a hex hash rather than requiring a `summary--` filename prefix that never existed in real files. Source-commit links get their href rewritten to the real `/memories?hash=…&detailRepo=…` destination (so the browser status bar previews the target), and a click handler posts the hash up to the parent page via `postMessage`. Branch directory links and any other relative dead links are converted to plain text, preserving their visible label.
- Extended the memory detail query in `MemoriesQuery.ts` to accept short hash prefixes. The SQL equality check was replaced with a prefix comparison, and after the matching row is found, all four downstream exact-match lookups (memory tree assembly, per-file line counts, activity, and conversations) now use the full hash from the matched row rather than the short prefix that was passed in. An empty-hash guard was also added to prevent the prefix logic from accidentally matching every row.
- Added the parent-side navigation listener in `knowledge.js`. When a `postMessage` arrives from the wiki iframe, the handler validates the hash shape, reads the currently-open page's repo identifier from module state, and performs a full-page navigation to `/memories` with both the hash and the repo as query parameters.

**📁 FILES**
- `cli/src/dashboard/DashboardServer.ts`
- `cli/src/dashboard/MemoriesQuery.ts`
- `cli/src/dashboard/assets/js/knowledge.js`
- `cli/src/core/WikiMarkdownBuilder.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [3ca78fb] Selected commit scrolls into view when landing from a wiki link</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Jumping from the wiki viewer to a specific commit on the memories page could leave the selected row scrolled out of sight, requiring the user to manually hunt for it in the tree.

**💡 Decisions Behind the Code**

The scroll is guarded by the previously-scrolled hash rather than running unconditionally on every render. The memories page refreshes itself periodically in the background, and scrolling on every refresh would repeatedly snap the view back to the selected row while the user scrolls elsewhere to read context. Firing only on a hash change means the initial landing scroll happens as expected, and subsequent background refreshes leave the user's scroll position alone.

**✅ What Was Implemented**

Added `scrollSelectedIntoView` in `memories.js`, called at the end of both full-render paths. After the tree renders, the function finds the currently-selected row and scrolls it to the center of the visible area. A guard variable tracks the last hash that triggered a scroll, so the automatic 30-second refresh tick does not reposition the view while the user is reading — the scroll fires only when the selected commit actually changes.

**📁 FILES**
- `cli/src/dashboard/assets/js/memories.js`

</blockquote>
</details>
<details>
<summary><strong>03 · [3ca78fb] Behavioral tests catch wiki link classification against real file shapes</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The original test suite checked only that certain string fragments appeared in the served HTML, which meant a fundamental misclassification bug — every commit link being treated as a dead branch link — passed all tests and went undetected until manual review.

**💡 Decisions Behind the Code**

- **Execute the script against real href shapes, not just assert its text**: The previous approach checked that certain substrings appeared in the HTML response, which gave no signal about whether the classification logic actually worked. The new tests instantiate the script in a controlled environment and feed it the exact href patterns that appear in real wiki files, making it impossible for a regex mistake to pass undetected.
- **Export the rewrite script constant for direct import in tests**: Making the constant importable lets tests run the exact same code that gets served to the browser, with no duplication or approximation. The alternative — parsing the served HTML to extract and eval the script — would have been fragile and harder to read.

**✅ What Was Implemented**

- Added `WikiViewerScript.test.ts`, which imports the rewrite script as a module and executes it against stub anchor elements carrying real href shapes measured from a live wiki directory. Tests cover source-commit links (with and without a repo identifier in the URL), the trailing-hash extraction when the filename slug also contains hex characters, branch directory links, bare topic links, and external links.
- Added `KnowledgeAsset.test.ts` and `MemoriesScroll.test.ts`, which load the respective JavaScript files into a stub browser environment and drive the message listener and scroll guard through their key scenarios, including the hash-change guard that prevents repeated scrolling on background refreshes.

**📁 FILES**
- `cli/src/dashboard/WikiViewerScript.test.ts`
- `cli/src/dashboard/KnowledgeAsset.test.ts`
- `cli/src/dashboard/MemoriesScroll.test.ts`
- `cli/src/dashboard/MemoriesQuery.test.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · [d28a0ba] Prevent internal error details from leaking to sign-in clients</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When sign-in failed, the raw error message was being sent directly back to the browser. This risked exposing internal implementation details to end users and potential attackers.

**💡 Decisions Behind the Code**

- **Constant over dynamic message**: The timeout message was extracted into a named constant rather than duplicated as a string literal in two places. This ensures the client-side check and the `withTimeout` call always refer to the same text, eliminating a class of silent drift bugs where one copy gets updated and the other does not.
- **Allowlist over blocklist for client errors**: Rather than trying to sanitize or redact the caught error message, the handler uses an explicit allowlist: only the known-safe timeout constant passes through; everything else collapses to a generic fallback. This is safer than attempting to strip sensitive content from arbitrary error strings, and it keeps the security boundary easy to audit.

**✅ What Was Implemented**

- Introduced a named constant `SIGNIN_TIMEOUT_MESSAGE` in `DashboardServer.ts` to hold the one developer-authored timeout string that is safe to surface to clients. This constant is shared between the `withTimeout` call and the error handler so the two cannot drift apart.
- Rewrote the `handleSignIn` catch block in `DashboardServer.ts` to log the real error server-side via `log.warn` while returning only a controlled string to the client: the timeout constant if the error matches it, or a generic "see the server log" message otherwise. The raw `errMsg(err)` value no longer reaches the HTTP response.
- Updated the inline comment block in `DashboardServer.ts` to clarify that U+2028 and U+2029 line separators (not just `</script>`) are neutralised in the inline-script escaping path.

**📁 FILES**
- `cli/src/dashboard/DashboardServer.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [0892449] Fix wiki-to-memory navigation using wrong repo identifier for scoping</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When clicking a source-commit link in the wiki viewer, the navigation used the Memory Bank folder name to scope the destination memory to a specific repo. This folder name is not a valid repo identifier in the dashboard's lookup system, so the scoping silently failed and fell back to searching all repos — meaning a short hash could open the wrong memory when multiple repos shared the same commit prefix.

**💡 Decisions Behind the Code**

- **Display name over folder name**: The dashboard's repo-scoping lookup accepts a repo's display name or its unique identity string, not its Memory Bank directory name. Using the display name aligns with how the existing memories tree already scopes navigation, and covers cases where the folder name carries a disambiguation suffix that the display name does not. The fallback when the name cannot be resolved is the same graceful degradation as before — searching all repos — so the worst case is no worse than the old behavior.
- **Injected global over URL parameter**: The iframe's own URL carries only the folder name, which is the wrong identifier. Injecting the display name as a server-side global at render time means the rewrite script never needs to re-derive or guess the correct token; it is handed the right value directly. This also keeps the iframe's public URL stable and avoids encoding repo identity information in a URL that users might copy or bookmark.
- **Consistent sourcing for iframe href and parent navigation**: Both the status-bar preview href (written into each link by the iframe script) and the actual navigation (triggered by the parent page on click) now come from the same `discoverRepos` output for the same directory. A mid-session folder rename could momentarily make them diverge, but this is a cosmetic status-bar inconsistency, not a wrong jump, and was judged an acceptable edge case.

**✅ What Was Implemented**

- Added `resolveKbRepo` in `KnowledgeQuery.ts`, a new function that resolves a Memory Bank directory name to both its file-system root and its display name (`repoName`). The wiki-viewer route in `DashboardServer.ts` was updated to call this instead of the old root-only resolver, and the display name is now injected into the iframe as a JavaScript global (`window.__JOLLI_WIKI_DETAIL_REPO__`) rather than read from the URL query string.
- Updated `WIKI_LINK_REWRITE_SCRIPT` in `DashboardServer.ts` to read the injected global instead of parsing the frame's own URL, and updated the parent-page navigation handler in `knowledge.js` to look up the open repo's display name from the page model and use that as the scope token when jumping to a memory.
- The two sources of the scope token — the iframe's link href (set at request time by the server) and the parent page's navigation (set at click time from the client model) — both derive from the same underlying `discoverRepos` call for the same directory name, guaranteeing they normally match.

**📁 FILES**
- `cli/src/dashboard/KnowledgeQuery.ts`
- `cli/src/dashboard/DashboardServer.ts`
- `cli/src/dashboard/assets/js/knowledge.js`

</blockquote>
</details>
<details>
<summary><strong>06 · [0892449] Make short commit hash lookup deterministic when prefixes collide within one repo</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When two commits in the same repository shared the same eight-character hash prefix, the database query used to find the matching memory had no stable rule for choosing between them. The database engine was free to return either row, meaning the same short hash could open different memories across renders or database versions.

**💡 Decisions Behind the Code**

- **Lexicographic order over recency**: Adding the full commit hash as a secondary sort key produces a deterministic, rule-governed choice that is stable across database rebuilds and SQLite versions. Sorting by most-recent commit instead would introduce a time-based semantic claim the system cannot actually honor (an eight-character prefix genuinely cannot identify which commit the user intended), and would be harder to test precisely. The chosen approach is honest: it picks consistently, not meaningfully.
- **Determinism over disambiguation**: When a short hash is genuinely ambiguous, the right answer is to pick one commit by a stable rule rather than to error or prompt the user. Hash prefix collisions within a single repo require tens of thousands of commits before the probability becomes non-negligible, so silent deterministic selection is the appropriate trade-off at this scale. A future improvement could detect collisions and surface a disambiguation prompt, but that is out of scope for this fix.

**✅ What Was Implemented**

- Extended the `ORDER BY` clause in `buildMemoryDetail` (`MemoriesQuery.ts`) from a single repo identifier key to a two-key sort: repo identifier first, then full commit hash. Within one repo the repo identifier is always tied for colliding prefixes, so the full hash becomes the effective tiebreaker, producing a stable lexicographic selection.
- Updated the collision test in `MemoriesQuery.test.ts` to seed the lexicographically larger hash first (giving it the lower row ID), then assert that the result is the lexicographically smaller hash — proving the `ORDER BY` rule governs the pick rather than insertion order or row ID.

**📁 FILES**
- `cli/src/dashboard/MemoriesQuery.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · [0892449] Strengthen route test to prove display name is injected, not folder name</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The existing server route test for the wiki viewer used a fixture where the repo's display name happened to equal its folder name, so the assertion that the correct value was injected into the page would pass equally whether the server was using the display name or the folder name. The test gave false confidence that the fix was working end-to-end.

**💡 Decisions Behind the Code**

The test fixture was deliberately constructed so that the correct and incorrect values are distinct strings. A test that passes for both the old and new implementation provides no real coverage of the behavioral change; making the two identifiers differ is the minimum requirement for the assertion to be meaningful. The negative assertion (confirming the folder name is absent) was added alongside the positive one to close the remaining gap.

**✅ What Was Implemented**

Extended `writeMemoryBank` in `DashboardServer.test.ts` to accept an optional `repoName` field separate from the directory name. The wiki-viewer route test now uses a fixture where these two values differ ("Repo Alpha" vs "repoA"), and asserts both that the injected global contains the display name and that it does not contain the folder name — making the test fail on the old behavior.

**📁 FILES**
- `cli/src/dashboard/DashboardServer.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 13, 2026 at 3:47 PM · via Anthropic*
<!-- jollimemory-summary-end -->