### PR TITLE
Close the gaps a review of the duplicate-folder, publish and reference paths found

### DIFF
--- a/claude-plugin/scripts/_publish-lib.sh
+++ b/claude-plugin/scripts/_publish-lib.sh
@@ -33,7 +33,8 @@ PLUGIN_DIR="$SRC/plugins/jolli"
 # directions matter: a script listed here that the build no longer emits makes
 # `publish_assert_dist_built` refuse EVERY publish (local/dev/prod/zip alike), and a
 # script the server loads but this list omits is exactly the silent-dropout case
-# above.
+# above — this list had already drifted three files behind that way (knowledge.js,
+# graph.js, settings.js) while the comment claimed each was asserted.
 PUBLISH_REQUIRED_DIST=(
 	Cli.js PluginBootstrapHook.js StopHook.js SessionStartHook.js
 	PostCommitHook.js PostMergeHook.js PostRewriteHook.js PrepareMsgHook.js PrePushHook.js
@@ -144,10 +145,32 @@ publish_assert_dist_staged() {
 	fi
 }
 
+# publish_assert_config_present — every PUBLISH_REQUIRED_CONFIG file exists and is
+# non-empty in the SOURCE tree.
+#
+# The dest-side twin (`publish_assert_dist_staged`) only runs on the git-repo
+# publish, because only that path stages anything. The archive and local-install
+# paths pack / mirror straight from disk and so were gated on dist completeness
+# alone — a tree missing either LICENSE copy produced a zip and a local
+# marketplace with no license text and printed nothing. Checked against the source
+# so the error names a path the developer can fix.
+publish_assert_config_present() {
+	local missing=() f
+	for f in "${PUBLISH_REQUIRED_CONFIG[@]}"; do
+		[ -s "$SRC/$f" ] || missing+=("$f")
+	done
+	if [ "${#missing[@]}" -gt 0 ]; then
+		echo "error: required plugin file(s) missing or empty: ${missing[*]}" >&2
+		echo "       The plugin MUST ship its manifest, hooks, MCP registration and LICENSE." >&2
+		return 1
+	fi
+}
+
 publish_build() {
 	echo "==> Building dist/ (bundles current cli/src) ..."
 	node "$PLUGIN_DIR/scripts/build.mjs"
 	publish_assert_dist_built
+	publish_assert_config_present
 }
 
 # publish_assert_safe_dest <dest-dir> — refuse to `rsync --delete` into a
@@ -355,10 +378,18 @@ publish_git_repo() {
 	git -c core.excludesFile=/dev/null add -A
 	if git -c core.excludesFile=/dev/null diff --cached --quiet; then
 		echo "==> Nothing changed — target already up to date."
+		# "Nothing to COMMIT" is not proof the release is complete. A destination
+		# .gitignore matching a required file keeps it out of the index, so `add -A`
+		# stages nothing and the diff is empty — which reads as "already up to date"
+		# while the published tree is missing that file. The assertion reads the index,
+		# which after a commit still reflects the tracked tree, so it is meaningful
+		# here; running it BEFORE the exit is the whole point.
+		publish_assert_dist_staged "$dest"
 		return 0
 	fi
 
-	local version last_msg last_version
+	local version last_msg last_version release_subject
+	release_subject="release: jolli plugin "
 	version="$(publish_version)"
 
 	# Version-bump guard, prod only: we're past the `diff --cached --quiet` check, so
@@ -373,13 +404,19 @@ publish_git_repo() {
 	# to a newer version than the one being released. Strictly-greater is the actual
 	# invariant `/plugin update` needs.
 	#
-	# (First publish / non-release last commit falls through: the prefix doesn't
-	# strip, so last_msg == last_version and the guard is skipped.) Override a
-	# deliberate same-version or downgrade republish with JOLLI_PUBLISH_FORCE=1.
+	# The baseline is the last RELEASE commit, found with --grep rather than read off
+	# the tip. The tip-and-strip form this replaced disabled the guard entirely
+	# whenever the destination's last commit was not a release commit (a README fix,
+	# a merge): the prefix didn't strip, the `last_msg != last_version` sanity test
+	# went false, and the whole `&&` chain short-circuited into a green downgrade.
+	# A first publish has no baseline and says so. Override a deliberate same-version
+	# or downgrade republish with JOLLI_PUBLISH_FORCE=1.
 	if [ "$target_kind" = "prod" ]; then
-		last_msg="$(git log -1 --format=%s 2>/dev/null || true)"
-		last_version="${last_msg#release: jolli plugin }"
-		if [ "${JOLLI_PUBLISH_FORCE:-0}" != "1" ] && [ "$last_msg" != "$last_version" ] &&
+		last_msg="$(git log -1 --format=%s --grep="^${release_subject}" 2>/dev/null || true)"
+		last_version="${last_msg#"$release_subject"}"
+		if [ -z "$last_msg" ]; then
+			echo "==> No previous release commit on the target — version guard has no baseline."
+		elif [ "${JOLLI_PUBLISH_FORCE:-0}" != "1" ] &&
 			! publish_version_gt "$version" "$last_version"; then
 			# `publish_sync` already ran `rsync --delete` + `git add -A`, so the checkout is
 			# dirty. Forgetting the version bump is the common trip (production publish
@@ -413,7 +450,9 @@ publish_git_repo() {
 	# every installing user's commits. Runs only once we're certain we'll commit.
 	publish_assert_dist_staged "$dest"
 
-	git commit -s -m "release: jolli plugin ${version}"
+	# Same `release_subject` the guard greps for — a literal here could drift from the
+	# pattern and leave every future run without a baseline.
+	git commit -s -m "${release_subject}${version}"
 
 	if [ "${NO_PUSH:-0}" = "1" ]; then
 		echo "==> NO_PUSH set — committed but not pushed."

--- a/claude-plugin/scripts/publish-zip.sh
+++ b/claude-plugin/scripts/publish-zip.sh
@@ -40,9 +40,10 @@ node "$PLUGIN_DIR/scripts/build.mjs"
 # SOURCED from _publish-lib.sh rather than restated. This file used to carry its
 # own copy, and the copy drifted the moment the dashboard arrived: it checked
 # `dashboard-assets/index.html` alone while the server's own door check
-# (resolveDashboardAssetsDir) requires the stylesheet and all eight scripts — so
-# the zip path could still ship the exact partial asset tree the shared list was
-# expanded file-by-file to prevent.
+# (resolveDashboardAssetsDir) requires the stylesheet and EVERY script in
+# DASHBOARD_SCRIPT_FILES — so the zip path could still ship the exact partial asset
+# tree the shared list was expanded file-by-file to prevent. (Don't restate the
+# count here either: it has already grown twice.)
 # shellcheck source=./_publish-lib.sh
 . "$SCRIPT_DIR/_publish-lib.sh"
 
@@ -59,15 +60,12 @@ if [ "$(cd "$PLUGIN_DIR" && pwd)" != "$(cd "$SCRIPT_DIR/../plugins/jolli" && pwd
 	exit 1
 fi
 
-missing=""
-for f in "${PUBLISH_REQUIRED_DIST[@]}"; do
-	[ -s "$PLUGIN_DIR/dist/$f" ] || missing="$missing $f"
-done
-if [ -n "$missing" ]; then
-	echo "error: build produced an incomplete dist/ — missing:$missing" >&2
-	echo "       A plugin missing any git-hook/worker script blocks user commits." >&2
-	exit 1
-fi
+# The lib's own assertions, not a third copy of the loop: the inline version this
+# replaced is exactly the kind of copy the comment above is about. The config check
+# matters here too — the zip packs `plugins/jolli/` alone, so `plugins/jolli/LICENSE`
+# is the only license text an uploaded plugin ever carries.
+publish_assert_dist_built
+publish_assert_config_present
 
 echo "==> Packing $PLUGIN_DIR"
 echo "    -> $OUT"

--- a/cli/src/Cli.test.ts
+++ b/cli/src/Cli.test.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { isBareMcpInvocation, isDetachedDaemonInvocation } from "./Cli.js";
 import { MCP_DAEMON_COMMAND, MCP_NO_DAEMON_ENV } from "./commands/McpCommand.js";
 import { GLOBAL_DAEMON_ENSURE_COMMAND } from "./daemon/EnsureGlobalDaemon.js";
@@ -59,6 +59,53 @@ describe("isDetachedDaemonInvocation", () => {
 		// or `global-daemon-status` must not inherit either daemon's stderr policy.
 		expect(isDetachedDaemonInvocation(["mcp-serve-status"])).toBe(false);
 		expect(isDetachedDaemonInvocation(["global-daemon-status"])).toBe(false);
+	});
+});
+
+describe("serveMcpInProcess (the fast path's fallback)", () => {
+	it("primes telemetry before serving, so a fallback session still reports per-tool events", async () => {
+		// The fast path skips `main()`, which is where telemetry is bootstrapped. Every
+		// proxy terminal that cannot reach a daemon serves in-process IN THIS PROCESS —
+		// and that server does run tools, so the "the proxy runs no tool, so it emits
+		// no telemetry" reasoning does not cover it.
+		const order: string[] = [];
+		vi.doMock("./core/TelemetryStartup.js", () => ({
+			bootstrapTelemetry: vi.fn(async () => void order.push("bootstrap")),
+			flushTelemetryNow: vi.fn(async () => {}),
+			maybeShowCliTelemetryNotice: vi.fn(async () => {}),
+		}));
+		vi.doMock("./mcp/McpServer.js", () => ({
+			startMcpServer: vi.fn(async () => void order.push("serve")),
+		}));
+		const { serveMcpInProcess } = await import("./Cli.js");
+
+		await serveMcpInProcess("/repo");
+
+		expect(order).toEqual(["bootstrap", "serve"]);
+		vi.doUnmock("./core/TelemetryStartup.js");
+		vi.doUnmock("./mcp/McpServer.js");
+		vi.resetModules();
+	});
+
+	it("serves even when priming telemetry fails", async () => {
+		// Telemetry is never allowed to cost a session its MCP server.
+		vi.doMock("./core/TelemetryStartup.js", () => ({
+			bootstrapTelemetry: vi.fn(async () => {
+				throw new Error("no install id");
+			}),
+			flushTelemetryNow: vi.fn(async () => {}),
+			maybeShowCliTelemetryNotice: vi.fn(async () => {}),
+		}));
+		const startMcpServer = vi.fn(async () => {});
+		vi.doMock("./mcp/McpServer.js", () => ({ startMcpServer }));
+		const { serveMcpInProcess } = await import("./Cli.js");
+
+		await serveMcpInProcess("/repo");
+
+		expect(startMcpServer).toHaveBeenCalledWith("/repo");
+		vi.doUnmock("./core/TelemetryStartup.js");
+		vi.doUnmock("./mcp/McpServer.js");
+		vi.resetModules();
 	});
 });
 

--- a/cli/src/Cli.ts
+++ b/cli/src/Cli.ts
@@ -97,6 +97,43 @@ export function isDetachedDaemonInvocation(argv: ReadonlyArray<string>): boolean
  * loader — including the one invocation whose entire job is to forward bytes
  * between a socket and stdio, multiplied by every open AI session on the machine.
  */
+/**
+ * Serves the MCP session IN THIS PROCESS, with telemetry primed first — the
+ * fallback every proxy terminal that cannot reach a daemon ends in.
+ *
+ * The fast path below skips `main()`, which is where `bootstrapTelemetry` runs.
+ * That is correct for the proxy itself, which runs no tool and so has no per-tool
+ * event to emit — but it is NOT correct for the fallback, which is a full
+ * in-process server running in this same process. Without this, an
+ * unsafe-socket-dir / spawn-failure / all-generations-deferred session emitted
+ * zero telemetry for its entire life, silently.
+ *
+ * The one-time telemetry NOTICE is deliberately not shown here, for the same
+ * reason `isDetachedDaemonInvocation` suppresses it: this process's stderr belongs
+ * to the host's MCP transport, so the disclosure would be consumed by a log nobody
+ * reads while marking itself shown forever. It stays owed to the next ordinary
+ * `jolli` invocation.
+ *
+ * Priming is best-effort: telemetry must never cost a session its MCP server.
+ */
+export async function serveMcpInProcess(dir: string): Promise<void> {
+	const { bootstrapTelemetry, flushTelemetryNow } = await import("./core/TelemetryStartup.js");
+	try {
+		await bootstrapTelemetry({ cwd: dir });
+	} catch (error: unknown) {
+		// stderr, never stdout — stdout is this session's JSON-RPC stream.
+		console.error("telemetry unavailable for this MCP session:", error);
+	}
+	const { startMcpServer } = await import("./mcp/McpServer.js");
+	try {
+		await startMcpServer(dir);
+	} finally {
+		// The session is over, so this is the only chance to upload what it buffered.
+		// Bounded and best-effort, like the command path's exit flush.
+		await flushTelemetryNow(dir, { timeoutMs: 2_000 });
+	}
+}
+
 async function runMcpProxyFastPath(): Promise<void> {
 	const { runMcpProxy } = await import("./mcp/McpProxy.js");
 	// `resolveProjectDirInfo`, not `resolveProjectDir`: a cwd that came from the
@@ -105,7 +142,9 @@ async function runMcpProxyFastPath(): Promise<void> {
 	// path declines — so the claim has to be made in BOTH places or the guard has
 	// a hole exactly where it matters.
 	const { dir, fromGit } = resolveProjectDirInfo();
-	await runMcpProxy({ cwd: dir, isWorktreeRoot: fromGit });
+	// `serveMcpInProcess` rather than the proxy's default `startMcpServer`: the
+	// fallback needs telemetry primed, which only this entry point can do.
+	await runMcpProxy({ cwd: dir, isWorktreeRoot: fromGit, fallback: serveMcpInProcess });
 }
 
 // Auto-execute when run as a script (skip in test environment).

--- a/cli/src/backfill/BackfillEngine.test.ts
+++ b/cli/src/backfill/BackfillEngine.test.ts
@@ -245,6 +245,42 @@ describe("runBackfill", () => {
 		expect(vi.mocked(attributeCommits)).not.toHaveBeenCalled();
 	});
 
+	it("re-checks each commit at the money boundary so a concurrent run is not paid for twice", async () => {
+		// The missing set is computed ONCE at run start, so anything that lands a
+		// summary while this run is mid-loop (the dashboard's Generate Missing button
+		// and `jolli backfill` are separate processes; the in-flight guard is
+		// process-scoped) was re-summarized and billed a second time.
+		vi.mocked(getIndexEntryMap)
+			.mockResolvedValueOnce(new Map()) // step 1: neither commit has a summary
+			.mockResolvedValueOnce(new Map()) // re-check before c1 → still missing
+			.mockResolvedValue(new Map([["c2", {} as never]])); // c2 landed meanwhile
+		vi.mocked(attributeCommits).mockReturnValue({
+			attributed: new Map([
+				["c1", attrFor("c1")],
+				["c2", attrFor("c2")],
+			]),
+			skipped: [],
+		});
+
+		const report = await runBackfill({ cwd: CWD, hashes: ["c1", "c2"] });
+
+		expect(vi.mocked(generateSummary)).toHaveBeenCalledTimes(1);
+		expect(report.generated).toBe(1);
+		expect(report.outcomes.find((o) => o.commitHash === "c2")?.status).toBe("skipped-has-summary");
+	});
+
+	it("still generates when the pre-generation re-check itself fails", async () => {
+		vi.mocked(getIndexEntryMap)
+			.mockResolvedValueOnce(new Map()) // step 1
+			.mockRejectedValue(new Error("orphan branch unreadable")); // the re-check
+		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map([["c1", attrFor("c1")]]), skipped: [] });
+
+		const report = await runBackfill({ cwd: CWD, hashes: ["c1"] });
+
+		// A transient read failure must not silently skip the commit.
+		expect(report.generated).toBe(1);
+	});
+
 	it("generates a diff-only summary when no conversation is attributed (mirrors live no-session path)", async () => {
 		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map(), skipped: ["c1"] });
 		const report = await runBackfill({ cwd: CWD, hashes: ["c1"] });

--- a/cli/src/backfill/BackfillEngine.ts
+++ b/cli/src/backfill/BackfillEngine.ts
@@ -174,6 +174,29 @@ async function toStoredTranscript(attr: AttributedCommit): Promise<StoredTranscr
 }
 
 /**
+ * Does `hash` have a summary RIGHT NOW? Re-read immediately before the LLM call.
+ *
+ * The run's `missing` set is a snapshot from before the first generation, and a
+ * backfill is minutes long: the dashboard's Generate Missing button and
+ * `jolli backfill` are separate processes (the server's in-flight guard is
+ * process-scoped), and the live post-commit worker writes into the same store. Any
+ * of them landing a summary mid-run had this run generate and bill a second one.
+ *
+ * Costs one index read per commit — negligible next to the model call it guards,
+ * and skipped entirely on the dry-run / no-credentials paths, which spend nothing.
+ * A read failure answers "no summary" so a transient store problem degrades to the
+ * old behaviour (generate) rather than silently skipping the commit.
+ */
+async function hasSummaryNow(hash: string, cwd: string, storage: StorageProvider): Promise<boolean> {
+	try {
+		return (await getIndexEntryMap(cwd, storage)).has(hash);
+	} catch (err) {
+		log.warn("Back-fill re-check failed for %s: %s", hash.substring(0, 8), (err as Error).message);
+		return false;
+	}
+}
+
+/**
  * Generates and stores one back-filled summary. Throws on LLM/storage failure.
  *
  * `attr === null` is the **diff-only** path: no conversation was confidently
@@ -344,6 +367,13 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
 			};
 		} else if (!credsOk) {
 			outcome = { commitHash: hash, status: "error", message: "no LLM credentials configured" };
+		} else if (await hasSummaryNow(hash, cwd, storage)) {
+			// Someone else summarized it since step 1 computed `missing` — another
+			// backfill process, or the live post-commit worker draining a queue entry.
+			// This is the last point before money is spent, so it is the only place the
+			// check is worth anything.
+			log.info("Back-fill skipping %s — a summary landed while this run was in flight", hash.substring(0, 8));
+			outcome = { commitHash: hash, status: "skipped-has-summary" };
 		} else {
 			try {
 				const topics = await generateAndStore(hash, attr, cwd, llmConfig, storage);

--- a/cli/src/core/FolderConsolidation.test.ts
+++ b/cli/src/core/FolderConsolidation.test.ts
@@ -2,12 +2,16 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setManuallyDisabled } from "../Logger.js";
 import type { FileWrite, SummaryIndex } from "../Types.js";
 import {
 	__setSotResolverForTests,
+	ConsolidationDisabledError,
 	type ConsolidationPlan,
+	ConsolidationStalePlanError,
 	classifyDuplicateFolders,
 	executeConsolidation,
+	revalidateConsolidationPlan,
 } from "./FolderConsolidation.js";
 import { __setSshRunnerForTests } from "./SshAliasResolver.js";
 import type { StorageProvider } from "./StorageProvider.js";
@@ -130,6 +134,7 @@ describe("FolderConsolidation", () => {
 	afterEach(() => {
 		__setSotResolverForTests(null);
 		__setSshRunnerForTests(null);
+		setManuallyDisabled(false);
 		try {
 			rmSync(parent, { recursive: true, force: true });
 		} catch {
@@ -393,6 +398,117 @@ describe("FolderConsolidation", () => {
 			expect(plan?.kind).toBe("union-largest");
 			expect(plan?.counts.perFolder[join(parent, "app-2")]).toBe(0);
 			expect(plan?.survivor).toBe(join(parent, "app"));
+		});
+
+		it("orphan-superset: never lands on a base slot another repo owns", async () => {
+			// The base `<parent>/app` belongs to a DIFFERENT repo that happens to share
+			// the basename — which is the very reason this repo ended up on suffixed
+			// slots. `findRepoFolders` correctly leaves it out of the pile, so it is
+			// never archived; claiming it anyway rewrote its identity and migrated this
+			// repo's memories into another repo's folder.
+			const foreignRemote = "git@github.com:other/app.git";
+			const foreign = makeKbFolder(parent, "app", {
+				remoteUrl: foreignRemote,
+				repoName: "app",
+				hashes: ["f1"],
+			});
+			makeKbFolder(parent, "app-2", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1"] });
+			makeKbFolder(parent, "app-3", { remoteUrl: REMOTE, repoName: "app", hashes: ["a2"] });
+			const sot = new InMemoryStorage(true);
+			await sot.writeFiles(
+				[
+					{ path: "index.json", content: indexJson(["a1", "a2"]) },
+					{ path: "summaries/a1.json", content: summaryJson("a1") },
+					{ path: "summaries/a2.json", content: summaryJson("a2") },
+				],
+				"seed",
+			);
+			__setSotResolverForTests(async () => sot);
+			const plan = await classifyDuplicateFolders("/cwd", "app", REMOTE, parent);
+			assertPlan(plan);
+			expect(plan.kind).toBe("orphan-superset");
+
+			const result = await executeConsolidation(plan, "/cwd", REMOTE, parent);
+
+			expect(result.survivor).not.toBe(foreign);
+			// The other repo's folder is untouched: same identity, same contents.
+			const config = JSON.parse(readFileSync(join(foreign, ".jolli", "config.json"), "utf-8")) as {
+				remoteUrl: string;
+			};
+			expect(config.remoteUrl).toBe(foreignRemote);
+			expect(summaryHashesOnDisk(foreign)).toEqual(["f1"]);
+			// This repo's memories still landed somewhere, rebuilt from the orphan branch.
+			expect(summaryHashesOnDisk(result.survivor)).toEqual(["a1", "a2"]);
+		});
+
+		it("re-validation reports DISABLED rather than a stale plan", async () => {
+			// `classifyDuplicateFolders` declines while disabled, so a null answer from it
+			// is ambiguous — reporting "the folders changed" would send the user back to
+			// Refresh forever instead of telling them the project is off.
+			makeKbFolder(parent, "app", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2"] });
+			makeKbFolder(parent, "app-2", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "z9"] });
+			const plan = await classifyDuplicateFolders("/cwd", "app", REMOTE, parent);
+			assertPlan(plan);
+
+			setManuallyDisabled(true);
+			await expect(revalidateConsolidationPlan(plan, "/cwd", REMOTE, parent)).rejects.toBeInstanceOf(
+				ConsolidationDisabledError,
+			);
+		});
+
+		it("re-validation refuses a plan whose folder set moved on", async () => {
+			makeKbFolder(parent, "app", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2"] });
+			makeKbFolder(parent, "app-2", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "z9"] });
+			const plan = await classifyDuplicateFolders("/cwd", "app", REMOTE, parent);
+			assertPlan(plan);
+
+			// A third folder appears (another clone's first write) — the survivor choice
+			// and the merge description are both different now.
+			makeKbFolder(parent, "app-3", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2", "a4", "a5"] });
+			await expect(revalidateConsolidationPlan(plan, "/cwd", REMOTE, parent)).rejects.toBeInstanceOf(
+				ConsolidationStalePlanError,
+			);
+		});
+
+		it("re-validation returns the freshly-computed plan when nothing moved", async () => {
+			makeKbFolder(parent, "app", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2"] });
+			makeKbFolder(parent, "app-2", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "z9"] });
+			const plan = await classifyDuplicateFolders("/cwd", "app", REMOTE, parent);
+			assertPlan(plan);
+			const fresh = await revalidateConsolidationPlan(plan, "/cwd", REMOTE, parent);
+			expect(fresh.kind).toBe(plan.kind);
+			expect(fresh.survivor).toBe(plan.survivor);
+			expect(fresh.folders).toEqual(plan.folders);
+		});
+
+		it("refuses to run while the project is manually disabled", async () => {
+			// Every write the rebuild depends on (`FolderStorage.ensure`,
+			// `MigrationEngine.runMigration`) no-ops while disabled, so archiving the
+			// pile first would leave every memory in the archive with nothing rebuilt —
+			// and report success with "(0 memories)".
+			makeKbFolder(parent, "app", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a2"] });
+			makeKbFolder(parent, "app-2", { remoteUrl: REMOTE, repoName: "app", hashes: ["a1", "a3"] });
+			const sot = new InMemoryStorage(true);
+			await sot.writeFiles(
+				[
+					{ path: "index.json", content: indexJson(["a1", "a2", "a3"]) },
+					{ path: "summaries/a1.json", content: summaryJson("a1") },
+					{ path: "summaries/a2.json", content: summaryJson("a2") },
+					{ path: "summaries/a3.json", content: summaryJson("a3") },
+				],
+				"seed",
+			);
+			__setSotResolverForTests(async () => sot);
+			const plan = await classifyDuplicateFolders("/cwd", "app", REMOTE, parent);
+			assertPlan(plan);
+
+			setManuallyDisabled(true);
+			await expect(executeConsolidation(plan, "/cwd", REMOTE, parent)).rejects.toBeInstanceOf(
+				ConsolidationDisabledError,
+			);
+			// Nothing archived, nothing moved.
+			expect(existsSync(join(parent, ".jolli", "archive"))).toBe(false);
+			expect(summaryHashesOnDisk(join(parent, "app"))).toEqual(["a1", "a2"]);
 		});
 
 		it("merges commitAliases across folders", async () => {

--- a/cli/src/core/FolderConsolidation.ts
+++ b/cli/src/core/FolderConsolidation.ts
@@ -33,10 +33,10 @@
 
 import { copyFileSync, type Dirent, existsSync, mkdirSync, readdirSync, renameSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, relative } from "node:path";
-import { createLogger } from "../Logger.js";
+import { createLogger, isManuallyDisabled } from "../Logger.js";
 import type { SummaryIndex } from "../Types.js";
 import { FolderStorage } from "./FolderStorage.js";
-import { archiveKBFolder, findRepoFolders, initializeKBFolder, resolveKbParent } from "./KBPathResolver.js";
+import { archiveKBFolder, findRepoFolders, initializeKBFolder, peekKBPath, resolveKbParent } from "./KBPathResolver.js";
 import type { BranchesJson, Manifest } from "./KBTypes.js";
 import { MetadataManager } from "./MetadataManager.js";
 import { MigrationEngine } from "./MigrationEngine.js";
@@ -58,16 +58,50 @@ export function __setSotResolverForTests(fn: ((cwd: string) => Promise<StoragePr
 
 export type ConsolidationKind = "identical" | "orphan-superset" | "union-largest";
 
+/**
+ * Thrown by {@link executeConsolidation} when the project is manually disabled.
+ *
+ * A distinct type so a host can tell "you disabled this project" apart from a
+ * real failure — the user clicked Merge, so a silent swallow would look like the
+ * click did nothing.
+ */
+export class ConsolidationDisabledError extends Error {
+	constructor(message = "Jolli Memory is disabled for this project — enable it first.") {
+		super(message);
+		this.name = "ConsolidationDisabledError";
+	}
+}
+
+/**
+ * Thrown by a caller that re-classified under the vault lock and found the plan
+ * the user confirmed no longer describes what is on disk. Separate from
+ * {@link ConsolidationDisabledError} because the remedy is different: click
+ * Refresh again and confirm the new plan.
+ */
+export class ConsolidationStalePlanError extends Error {
+	constructor(message = "the Memory Bank folders changed since this merge was described") {
+		super(message);
+		this.name = "ConsolidationStalePlanError";
+	}
+}
+
 export interface ConsolidationPlan {
 	readonly kind: ConsolidationKind;
 	readonly repoName: string;
 	/** Absolute paths of every folder that currently holds this repo (≥ 2). */
 	readonly folders: readonly string[];
 	/**
-	 * The folder that will remain live. For `orphan-superset` this is the
-	 * canonical `<parent>/<repo>` base slot the rebuild lands on (which may
-	 * itself be archived-then-recreated); for the other kinds it is an existing
-	 * folder in {@link folders}.
+	 * The folder that will remain live. For the two merge kinds this is an
+	 * existing folder in {@link folders} and is authoritative.
+	 *
+	 * For `orphan-superset` it is only a PREDICTION — the canonical
+	 * `<parent>/<repo>` base slot, which the rebuild lands on in the ordinary case
+	 * (the base is one of {@link folders} and is archived-then-recreated). The
+	 * executor re-resolves the slot for real after archiving, because the base may
+	 * belong to a DIFFERENT repo that shares the basename — the very reason this
+	 * repo ended up on suffixed slots — and that folder is not in {@link folders},
+	 * so it is never archived and must never be claimed. Read the actual folder
+	 * off {@link ConsolidationResult.survivor}, never off the plan.
 	 */
 	readonly survivor: string;
 	/** Folders that will be archived. For `orphan-superset` this is ALL folders. */
@@ -102,7 +136,9 @@ const MERGED_OR_OWNED_META: ReadonlySet<string> = new Set([
 
 /**
  * Classifies the duplicate folders for the given repo, or returns `null` when
- * there is nothing to consolidate (fewer than two folders).
+ * there is nothing to consolidate (fewer than two folders, or the project is
+ * manually disabled — see {@link executeConsolidation} for why disabled must
+ * offer nothing rather than offer a merge that cannot complete).
  */
 export async function classifyDuplicateFolders(
 	cwd: string,
@@ -110,6 +146,7 @@ export async function classifyDuplicateFolders(
 	remoteUrl: string | null,
 	customPath?: string,
 ): Promise<ConsolidationPlan | null> {
+	if (isManuallyDisabled()) return null;
 	const folders = findRepoFolders(repoName, remoteUrl, customPath);
 	if (folders.length < 2) return null;
 
@@ -163,6 +200,44 @@ export async function classifyDuplicateFolders(
 }
 
 /**
+ * Re-classifies and returns the CURRENT plan, throwing
+ * {@link ConsolidationStalePlanError} when it no longer matches the one the user
+ * confirmed.
+ *
+ * Detection necessarily runs outside the vault lock (the host shows a modal
+ * between plan and execute, and holding the lock across a dialog would block
+ * every summary write for as long as it stays open), so the folder set can change
+ * under an open confirmation — another window's sweep, a sync round, a second
+ * clone's first write. Callers must therefore invoke this INSIDE the lock and
+ * execute the returned plan: the user agreed to a specific description, so a
+ * changed one is a re-confirm, not something to silently act on.
+ *
+ * `kind`, the folder set and the survivor are compared; the counts are not (they
+ * are display detail, and the returned plan carries the fresh ones).
+ *
+ * Disabled is reported as {@link ConsolidationDisabledError}, not as a stale plan:
+ * `classifyDuplicateFolders` declines outright while disabled, so a null answer
+ * there is ambiguous, and telling a user their folders changed when what actually
+ * happened is that the project is off sends them to re-click Refresh forever.
+ */
+export async function revalidateConsolidationPlan(
+	plan: ConsolidationPlan,
+	cwd: string,
+	remoteUrl: string | null,
+	customPath?: string,
+): Promise<ConsolidationPlan> {
+	if (isManuallyDisabled()) throw new ConsolidationDisabledError();
+	const fresh = await classifyDuplicateFolders(cwd, plan.repoName, remoteUrl, customPath);
+	if (fresh === null) throw new ConsolidationStalePlanError();
+	const sameFolders =
+		fresh.folders.length === plan.folders.length && fresh.folders.every((f, i) => f === plan.folders[i]);
+	if (fresh.kind !== plan.kind || fresh.survivor !== plan.survivor || !sameFolders) {
+		throw new ConsolidationStalePlanError();
+	}
+	return fresh;
+}
+
+/**
  * Executes a plan produced by {@link classifyDuplicateFolders}. Returns a
  * summary of what happened.
  *
@@ -173,6 +248,17 @@ export async function classifyDuplicateFolders(
  * `git add` on a path this just moved). The only caller today,
  * `KbFoldersService.runConsolidation`, wraps it in `withVaultWriteLock`; any
  * new caller must do the same.
+ *
+ * Throws {@link ConsolidationDisabledError} while the project is manually
+ * disabled, and the gate is on the SAME in-memory flag that makes the rebuild's
+ * own steps no-op (`FolderStorage.ensure`, `MigrationEngine.runMigration` both
+ * check `isManuallyDisabled`). That is what makes the two consistent by
+ * construction: in any process where the destructive half would be skipped, the
+ * archive half is refused too. Measured before the gate: every folder archived,
+ * initialization and migration skipped, and the host reported success with
+ * "(0 memories)" — every memory in the archive with nothing rebuilt.
+ * `classifyDuplicateFolders` also declines while disabled, so this throw only
+ * covers a project disabled between the plan and the user's confirmation.
  */
 export async function executeConsolidation(
 	plan: ConsolidationPlan,
@@ -180,6 +266,7 @@ export async function executeConsolidation(
 	remoteUrl: string | null,
 	customPath?: string,
 ): Promise<ConsolidationResult> {
+	if (isManuallyDisabled()) throw new ConsolidationDisabledError();
 	if (plan.kind === "orphan-superset") {
 		return rebuildFromOrphan(plan, cwd, remoteUrl, customPath);
 	}
@@ -247,7 +334,16 @@ async function rebuildFromOrphan(
 		archiveKBFolder(folder, customPath);
 	}
 
-	const base = plan.survivor;
+	// Re-resolve AFTER archiving rather than trusting `plan.survivor`, exactly as
+	// `rebuildMemoryBank` does. `plan.survivor` is the base slot as PREDICTED at
+	// classification time, and the prediction is wrong in the one case that
+	// matters: when `<parent>/<repo>` belongs to a different repo sharing the
+	// basename, it is not in `plan.folders`, so the loop above did not archive it —
+	// and claiming it would rewrite ANOTHER repo's `config.json` identity and
+	// migrate this repo's memories into its folder. `peekKBPath` answers with the
+	// freed base when the base is ours-or-absent and with the lowest free suffix
+	// otherwise; it is the pure-read sibling, so it claims nothing on its own.
+	const base = peekKBPath(plan.repoName, remoteUrl, customPath);
 	initializeKBFolder(base, plan.repoName, remoteUrl);
 	const mm = new MetadataManager(join(base, ".jolli"));
 	const folder = new FolderStorage(base, mm);

--- a/cli/src/core/KBPathResolver.ts
+++ b/cli/src/core/KBPathResolver.ts
@@ -555,10 +555,10 @@ function isSameRepo(config: KBConfig, remoteUrl: string | null, repoName: string
  * Deliberately module-private: "are these two folders the same repo?" is a
  * question only the folder-claiming path should answer, and it must answer it
  * through `isSameRepo`. A previous iteration exported this so the VS Code
- * sidebar's Refresh could collapse duplicate folders on its own; that feature
- * was withdrawn because Refresh must never move a folder holding memories —
- * consolidating duplicates is Migrate's job (it can rebuild the survivor from
- * the orphan branch, which a plain archive-the-loser move cannot).
+ * sidebar could collapse duplicate folders with its own identity comparison; that
+ * was withdrawn, and the replacement is `findRepoFolders` + `FolderConsolidation`
+ * — one identity rule in this module, and a merge (or a rebuild from the system of
+ * record) rather than the archive-the-loser move the host would have done.
  */
 function normalizeRemoteUrl(url: string): string {
 	return foldGitTransportToHttps(url)

--- a/cli/src/core/MemoryBankRebuild.test.ts
+++ b/cli/src/core/MemoryBankRebuild.test.ts
@@ -1,8 +1,10 @@
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { acquireVaultWriteLock } from "../sync/VaultWriteLock.js";
+import { extractRepoName, getRemoteUrl, resolveKBPath, resolveKbParent } from "./KBPathResolver.js";
 import { rebuildMemoryBank } from "./MemoryBankRebuild.js";
 import { writeManualDisableFlag } from "./RepoProfile.js";
 import { resolveSotStorage } from "./SotStorageResolver.js";
@@ -123,5 +125,40 @@ describe("rebuildMemoryBank", () => {
 		// still returns ok + "0 memories migrated", matching /migrated/) is caught.
 		expect(result.message).toMatch(/\b1 memories migrated/);
 		expect(result.folder).toBeTruthy();
+	});
+
+	it("reports busy — and archives nothing — while another vault writer holds the lock", async () => {
+		const repo = initRepo();
+		writeFileSync(join(repo, "f.txt"), "hi");
+		execFileSync("git", ["add", "-A"], { cwd: repo });
+		execFileSync("git", ["commit", "-qm", "init"], { cwd: repo });
+		const sot = await resolveSotStorage(repo);
+		const hash = "abc123def456";
+		await sot.writeFiles(
+			[
+				{ path: "index.json", content: makeIndex(hash) },
+				{ path: `summaries/${hash}.json`, content: makeSummary(hash) },
+			],
+			"seed summary",
+		);
+		// Claim the folder so there IS something the archive-then-migrate sequence
+		// would move. Cheaper than a full first rebuild, which is what this test is
+		// asserting never starts.
+		const kbRoot = resolveKBPath(extractRepoName(repo), getRemoteUrl(repo), undefined);
+
+		// A concurrent vault writer (QueueWorker mid-drain / sync round / compile).
+		const vaultRoot = resolveKbParent(undefined);
+		const held = await acquireVaultWriteLock(vaultRoot, "fail-fast");
+		expect(held).not.toBeNull();
+		try {
+			const result = await rebuildMemoryBank(repo, { lockWaitMs: 30 });
+			expect(result.ok).toBe(false);
+			expect(result.message).toMatch(/busy/i);
+			// Nothing was archived: the claimed folder is still live and in place.
+			expect(existsSync(kbRoot)).toBe(true);
+			expect(existsSync(join(vaultRoot, ".jolli", "archive"))).toBe(false);
+		} finally {
+			await held?.release();
+		}
 	});
 });

--- a/cli/src/core/MemoryBankRebuild.ts
+++ b/cli/src/core/MemoryBankRebuild.ts
@@ -26,12 +26,34 @@ export interface MemoryBankRebuildResult {
 	readonly folder?: string;
 }
 
+export interface MemoryBankRebuildOptions {
+	/**
+	 * Vault-lock wait budget. Defaults to `DEFAULT_PULL_LOCK_WAIT_MS` (10 s) —
+	 * long enough to sit out a summary write, short enough that a user who clicked
+	 * Migrate gets an answer. A test seam only; no production caller sets it.
+	 */
+	readonly lockWaitMs?: number;
+}
+
 /**
  * Re-migrates the repo at `cwd` from the orphan branch into a fresh Memory Bank
  * folder (the previous folders are archived, not deleted). Refuses when the repo
- * is manually disabled, or when there are no stored memories to rebuild.
+ * is manually disabled, when there are no stored memories to rebuild, or when
+ * another vault writer holds `vault-write.lock`.
+ *
+ * The lock is not optional. This archives EVERY folder for the repo and then
+ * re-migrates into the freed slot — a multi-second, many-file rewrite of the same
+ * working tree a QueueWorker drain, a sync round or a compile may be mid-write in.
+ * Unlocked, it tore across their `git status` snapshots exactly the way
+ * `KbFoldersService`'s two sweeps are locked to prevent. Being a plain file lock
+ * that refuses even its own PID, it doubles as the in-flight guard: a second
+ * concurrent call in THIS process (a double-clicked button, two hosts driving one
+ * CLI) is reported busy rather than archiving what the first just created.
  */
-export async function rebuildMemoryBank(cwd: string): Promise<MemoryBankRebuildResult> {
+export async function rebuildMemoryBank(
+	cwd: string,
+	opts: MemoryBankRebuildOptions = {},
+): Promise<MemoryBankRebuildResult> {
 	// While manually disabled, `folder.ensure()` and the repoint would run even
 	// though the identity write is gated — one call would de-identify the old
 	// folder while migrating nothing. Refuse outright, as the VS Code command does.
@@ -39,6 +61,36 @@ export async function rebuildMemoryBank(cwd: string): Promise<MemoryBankRebuildR
 		return { ok: false, message: "Jolli Memory is disabled for this project — enable it first." };
 	}
 
+	const { resolveKbParent } = await import("./KBPathResolver.js");
+	const { loadConfig: loadConfigForVault } = await import("./SessionTracker.js");
+	const { DEFAULT_PULL_LOCK_WAIT_MS, withVaultWriteLock } = await import("../sync/VaultWriteLock.js");
+	const vaultRoot = resolveKbParent((await loadConfigForVault()).localFolder);
+	const outcome = await withVaultWriteLock(
+		vaultRoot,
+		{ wait: opts.lockWaitMs ?? DEFAULT_PULL_LOCK_WAIT_MS },
+		() => rebuildLocked(cwd),
+		{
+			// Same contract as every other holder: wake a QueueWorker that timed out
+			// waiting on this lock. Imported inside the lambda so the ordinary path
+			// never pulls QueueWorker's reader/detector graph into a migrate.
+			/* v8 ignore start -- fires only when a worker is actually queued behind this lock */
+			launch: (workerCwd: string): void => {
+				void import("../hooks/QueueWorker.js").then(({ launchWorker }) => launchWorker(workerCwd));
+			},
+			/* v8 ignore stop */
+		},
+	);
+	if (!outcome.ran) {
+		return {
+			ok: false,
+			message: "Jolli Memory is busy writing to the Memory Bank right now — try again shortly.",
+		};
+	}
+	return outcome.value;
+}
+
+/** The archive-then-migrate sequence, always run while holding `vault-write.lock`. */
+async function rebuildLocked(cwd: string): Promise<MemoryBankRebuildResult> {
 	const { extractRepoName, getRemoteUrl, initializeKBFolder, findRepoFolders, peekKBPath, archiveKBFolder } =
 		await import("./KBPathResolver.js");
 	const { MetadataManager } = await import("./MetadataManager.js");

--- a/cli/src/core/references/ReferenceStore.test.ts
+++ b/cli/src/core/references/ReferenceStore.test.ts
@@ -76,6 +76,9 @@ const { FALLBACK_TITLE_DEF } = vi.hoisted(() => ({
 		label: "Fallback Title Test",
 		icon: "history",
 		titleFallbackPattern: "^Unnamed [0-9a-z]{1,8}$",
+		// The all-digits form is this source's POOREST fallback — the shape it
+		// synthesizes when nothing at all was recovered.
+		titleFallbackPoorestPattern: "^Unnamed [0-9]{1,8}$",
 		match: { claude: { prefixes: ["mcp__fbtest__"] } },
 		wrapperKeys: [],
 		reference: {
@@ -1137,6 +1140,31 @@ describe("ReferenceStore", () => {
 			expect(back?.title).toBe("Design System v2");
 			expect(back?.fields).toEqual([{ key: "handle", label: "Handle", value: "DS-2" }]);
 			expect(back?.description).toBe("**Culprit:** views.js in poll");
+		});
+
+		// Two fallbacks are not equally poor, and the two-sided test cannot see it.
+		// sentry synthesizes `Issue <shortId>` when the prose heading was harvested and
+		// `Issue <machineId>` when nothing was: BOTH match the fallback pattern, so
+		// `!re.test(prior)` was false and the machine-id form overwrote the short-id row
+		// — taking its issue-id, project and culprit with it. A source that can rank its
+		// own fallbacks declares the poorest form.
+		it("keeps a richer stored fallback when the incoming one is the source's poorest form", async () => {
+			await writeReferenceMarkdown(
+				fbRef({ title: "Unnamed abc12345", fields: [{ key: "handle", label: "Handle", value: "DS-2" }] }),
+				tempDir,
+			);
+			const { sourcePath, title } = await writeReferenceMarkdown(fbRef({ title: "Unnamed 87654321" }), tempDir);
+			expect(title).toBe("Unnamed abc12345");
+			const back = await readReferenceMarkdown(sourcePath);
+			expect(back?.fields).toEqual([{ key: "handle", label: "Handle", value: "DS-2" }]);
+		});
+
+		// The other direction still has to work, which is why testing `incoming` alone was
+		// never an option: a later observation that recovered MORE must win.
+		it("still lets a richer fallback replace the poorest stored one", async () => {
+			await writeReferenceMarkdown(fbRef({ title: "Unnamed 87654321" }), tempDir);
+			const { title } = await writeReferenceMarkdown(fbRef({ title: "Unnamed abc12345" }), tempDir);
+			expect(title).toBe("Unnamed abc12345");
 		});
 
 		// The mirror of the url rule: absent on the stored side is not evidence against a

--- a/cli/src/core/references/ReferenceStore.ts
+++ b/cli/src/core/references/ReferenceStore.ts
@@ -247,22 +247,39 @@ function mergeIntoExisting(ref: Reference, existing: string | undefined): Refere
 }
 
 /**
- * Is `incoming` this source's synthesized fallback title while `prior` is a real one —
- * i.e. did this observation recover LESS than the one it is superseding?
+ * Did this observation recover LESS than the one it is superseding?
  *
- * Both halves are required. Testing only `incoming` would pin the very first title
- * forever — including one fallback replacing another — and testing only `prior` would
- * block a genuine rename. See `SourceDefinition.titleFallbackPattern`.
+ * The base rule needs both halves: testing only `incoming` would pin the very first
+ * title forever, and testing only `prior` would block a genuine rename. See
+ * `SourceDefinition.titleFallbackPattern`.
+ *
+ * `titleFallbackPoorestPattern` adds the case both halves miss — two fallbacks that
+ * are not equally poor. sentry synthesizes `Issue <shortId>` when the prose heading
+ * was harvested and `Issue <machineId>` when nothing was; both match the fallback
+ * pattern, so `!re.test(prior)` was false and the machine-id form overwrote the
+ * short-id row, dropping its issue-id, project and culprit with it (the whole set
+ * moves together — see {@link restorePriorHarvest}). A source that can tell its own
+ * fallbacks apart declares the poorest form, and a poorest-form observation then
+ * yields to a richer stored fallback. The reverse still supersedes: a later
+ * observation that recovered more must win, which is exactly what testing
+ * `incoming` alone would have prevented.
  *
  * Compiled per call rather than through `SourceEngine`'s cache: this runs once per
  * reference WRITE and once per same-key dedupe collapse (a handful per commit), not once
- * per payload node, and the pattern is validated at registration so it cannot throw here.
+ * per payload node, and the patterns are validated at registration so they cannot throw
+ * here.
  */
 function keepsPriorHarvest(def: SourceDefinition, incoming: string, prior: string): boolean {
 	const pattern = def.titleFallbackPattern;
 	if (pattern === undefined) return false;
 	const re = new RegExp(pattern);
-	return re.test(incoming) && !re.test(prior);
+	if (!re.test(incoming)) return false;
+	if (!re.test(prior)) return true;
+	// Both are fallbacks: keep the prior only when this one is strictly poorer.
+	const poorest = def.titleFallbackPoorestPattern;
+	if (poorest === undefined) return false;
+	const poor = new RegExp(poorest);
+	return poor.test(incoming) && !poor.test(prior);
 }
 
 /**

--- a/cli/src/core/references/SourceDefinition.ts
+++ b/cli/src/core/references/SourceDefinition.ts
@@ -176,6 +176,27 @@ export interface SourceDefinition {
 	 * it is simply there, and the newest read is the right answer.
 	 */
 	readonly titleFallbackPattern?: string;
+	/**
+	 * The POOREST title in {@link titleFallbackPattern}'s family — the shape this source
+	 * synthesizes when the out-of-band lookup recovered nothing at all.
+	 *
+	 * Only meaningful alongside that pattern, and only for a source whose fallbacks are
+	 * not all equally poor. sentry's are not: `Issue <shortId>` means the prose heading
+	 * WAS harvested (a stable, per-issue handle) while `Issue <machineId>` means nothing
+	 * was. Both match the fallback pattern, so the two-sided keep-the-prior test saw them
+	 * as interchangeable and let the machine-id form supersede the short-id row — taking
+	 * its `issue-id`, project and culprit with it, since the harvested set moves
+	 * wholesale. Declaring the poorest form makes a poorest-form observation yield to a
+	 * richer stored fallback while a richer one still supersedes a poorer stored one.
+	 *
+	 * Deliberately NOT a fix by narrowing `titleFallbackPattern` to the poorest form
+	 * instead: an `issueId` argument is not always the machine id (a model routinely
+	 * passes a short id), so the poorest shape is reachable with a short-id-looking value
+	 * and must still read as a fallback against a genuinely harvested title.
+	 *
+	 * Absent for figma: its one fallback shape is the only one it can synthesize.
+	 */
+	readonly titleFallbackPoorestPattern?: string;
 	readonly match: SourceMatch;
 	readonly wrapperKeys: ReadonlyArray<string>;
 	readonly reference: {

--- a/cli/src/core/references/SourceDefinitionRegistry.test.ts
+++ b/cli/src/core/references/SourceDefinitionRegistry.test.ts
@@ -233,6 +233,31 @@ describe("SourceDefinitionRegistry", () => {
 		});
 	});
 
+	describe("titleFallbackPoorestPattern", () => {
+		const withFamily = (poorest: unknown) => ({
+			...structuredCloneOfLinear(),
+			titleFallbackPattern: "^Issue [A-Za-z0-9_-]{1,128}$",
+			titleFallbackPoorestPattern: poorest,
+		});
+
+		it("accepts a valid pattern alongside the family it ranks within", () => {
+			expect(validateDefinition(withFamily("^Issue [0-9]{1,128}$")).ok).toBe(true);
+		});
+
+		it.each([
+			["empty string", ""],
+			["not a string", 42],
+			["uncompilable regex", "^Issue ([0-9$"],
+		])("rejects %s", (_label, pattern) => {
+			expect(validateDefinition(withFamily(pattern)).ok).toBe(false);
+		});
+
+		it("rejects a rank with no family — nothing would ever be detected as a fallback", () => {
+			const orphaned = { ...structuredCloneOfLinear(), titleFallbackPoorestPattern: "^Issue [0-9]{1,128}$" };
+			expect(validateDefinition(orphaned).ok).toBe(false);
+		});
+	});
+
 	it("rejects a reference key (nativeId/title/url) that is not an object", () => {
 		const base = structuredCloneOfLinear();
 		const bad = { ...base, reference: { ...base.reference, nativeId: undefined } };

--- a/cli/src/core/references/SourceDefinitionRegistry.ts
+++ b/cli/src/core/references/SourceDefinitionRegistry.ts
@@ -146,6 +146,25 @@ export function validateDefinition(def: unknown): { ok: true; def: SourceDefinit
 			return { ok: false, error: `titleFallbackPattern is not a valid regex: ${(err as Error).message}` };
 		}
 	}
+	if (def.titleFallbackPoorestPattern !== undefined) {
+		if (typeof def.titleFallbackPoorestPattern !== "string" || def.titleFallbackPoorestPattern.length === 0) {
+			return { ok: false, error: "titleFallbackPoorestPattern must be a non-empty string" };
+		}
+		try {
+			new RegExp(def.titleFallbackPoorestPattern);
+		} catch (err) {
+			return {
+				ok: false,
+				error: `titleFallbackPoorestPattern is not a valid regex: ${(err as Error).message}`,
+			};
+		}
+		// Ranking fallbacks is meaningless without the family they belong to: with no
+		// `titleFallbackPattern` nothing is ever detected as a fallback, so this would be
+		// a silently dead declaration.
+		if (def.titleFallbackPattern === undefined) {
+			return { ok: false, error: "titleFallbackPoorestPattern requires titleFallbackPattern" };
+		}
+	}
 	if (!isObject(def.match)) return { ok: false, error: "match must be an object" };
 	if (!Array.isArray(def.wrapperKeys)) return { ok: false, error: "wrapperKeys must be an array" };
 	if (!isObject(def.reference)) return { ok: false, error: "reference must be an object" };

--- a/cli/src/core/references/sources/definitions/sentry.test.ts
+++ b/cli/src/core/references/sources/definitions/sentry.test.ts
@@ -110,6 +110,27 @@ describe("sentryDefinition", () => {
 		}
 	});
 
+	// The two synthesized shapes are not equally poor, and treating them as
+	// interchangeable is what let a Seer run overwrite a short-id row with a bare
+	// machine id — dropping the issue-id, project and culprit with it, since the
+	// harvested set moves wholesale.
+	it("ranks the no-prose title as its poorest fallback, below the harvested short id", () => {
+		const poorest = sentryDefinition.titleFallbackPoorestPattern;
+		expect(poorest).toBeDefined();
+		const re = new RegExp(poorest as string);
+		// Arm 4: no prose at all → the machine id from the arguments.
+		const noProse = normalizeSentry({ url: SENTRY_URL }, GET_RESOURCE) as { title: string };
+		expect(re.test(noProse.title), noProse.title).toBe(true);
+		// Arm 3: the heading WAS harvested → a stable per-issue handle. Still a
+		// fallback, but not the poorest one.
+		const headingOnly = normalizeSentry({ url: SENTRY_URL }, GET_RESOURCE, "# Issue JS-NEXT-1 in **j**") as {
+			title: string;
+		};
+		expect(re.test(headingOnly.title), headingOnly.title).toBe(false);
+		// Every poorest title is a member of the fallback family, or the rank is dead.
+		expect(new RegExp(sentryDefinition.titleFallbackPattern as string).test(noProse.title)).toBe(true);
+	});
+
 	it("declares no status field — the one fact that can go stale", () => {
 		const keys = sentryDefinition.fields.map((f) => f.key);
 		expect(keys).toEqual(["issue-id", "project"]);

--- a/cli/src/core/references/sources/definitions/sentry.ts
+++ b/cli/src/core/references/sources/definitions/sentry.ts
@@ -49,6 +49,26 @@ const NATIVE_ID = "^[A-Za-z0-9.-]{1,253}/[A-Za-z0-9_-]{1,128}$";
 const SYNTHESIZED_TITLE = "^Issue [A-Za-z0-9_-]{1,128}$";
 
 /**
+ * The POOREST member of {@link SYNTHESIZED_TITLE}'s family: `Issue <machine id>`, the
+ * shape synthesized when NO prose was recovered at all.
+ *
+ * The two synthesized arms are not interchangeable, and the two-sided keep-the-prior test
+ * could not tell them apart. `Issue JAVASCRIPT-NEXTJS-1` means the prose heading WAS
+ * harvested — the short id is Sentry's canonical, stable handle and the `issue-id` field
+ * exists to carry it — while `Issue 7665509682` means nothing was. Both matched
+ * `SYNTHESIZED_TITLE`, so `!re.test(prior)` was false and the second overwrote the first,
+ * dropping the short id, project and culprit along with the label (the harvested set moves
+ * wholesale, by design). Ranking them makes a no-prose re-observation yield.
+ *
+ * All-digits rather than "not a short id": a Sentry issue URL's id and the `issueId` /
+ * `resourceId` arguments are the numeric machine id, while a harvested short id always
+ * carries its project prefix and a `-`. Note the reverse does NOT hold — a model may pass
+ * a SHORT id as `issueId`, so a poorest-arm title can look like the richer one; that is
+ * why this ranks within the family instead of replacing `SYNTHESIZED_TITLE` with it.
+ */
+const SYNTHESIZED_TITLE_NO_PROSE = "^Issue [0-9]{1,128}$";
+
+/**
  * sentry — track-only Sentry issue references. Records WHICH production issue was
  * consulted while a commit was being written. Track-only because an error report is the
  * INPUT to the work, not a statement about the code: feeding a stacktrace into the
@@ -86,6 +106,7 @@ export const sentryDefinition: SourceDefinition = {
 	// Overwrite is right only while the re-observation recovered as much as the stored one
 	// did. It often has not — see {@link SYNTHESIZED_TITLE}.
 	titleFallbackPattern: SYNTHESIZED_TITLE,
+	titleFallbackPoorestPattern: SYNTHESIZED_TITLE_NO_PROSE,
 	match: {
 		claude: {
 			prefixes: [...SENTRY_TOOL_PREFIXES],

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -1603,8 +1603,12 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 			return;
 		}
 		// One backfill at a time per server — a second concurrent run (a refresh or a
-		// second tab drops the page-side busy flag) would re-summarize the same
-		// commits and pay for every summary twice. See `generateMissingInFlight`.
+		// second tab drops the page-side busy flag) would otherwise start a second
+		// pass over the same commits. This flag is PROCESS-scoped and cannot see a
+		// concurrent `jolli backfill`, so it is not what stops double billing:
+		// `runBackfill` re-checks each commit for a summary immediately before the
+		// model call (`hasSummaryNow`). This guard just keeps one server from racing
+		// itself, and answers 409 so the page can say so.
 		/* v8 ignore start -- concurrency guard: a second in-flight backfill is not
 		   deterministically reproducible in a unit test (the empty-repo backfill the
 		   endpoint test uses returns before a second request could observe the flag).

--- a/cli/src/hooks/ClaudePluginPublishDocs.test.ts
+++ b/cli/src/hooks/ClaudePluginPublishDocs.test.ts
@@ -16,6 +16,29 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", ".
 const readme = () => readFileSync(join(repoRoot, "claude-plugin", "README.md"), "utf-8");
 const script = (name: string) => readFileSync(join(repoRoot, "claude-plugin", "scripts", name), "utf-8");
 
+describe("Claude publish gates the config inventory on every path", () => {
+	// `publish_assert_dist_staged` checks PUBLISH_REQUIRED_CONFIG in the
+	// DESTINATION's index, so only the git-repo publish ever consulted it. The
+	// archive and local-install paths never stage anything — they pack / mirror
+	// straight from disk — so a missing `LICENSE` (both copies are in that list)
+	// shipped silently. The source-side check has to hang off `publish_build`,
+	// which is the one step all three paths share.
+	it("asserts the required config files from publish_build", () => {
+		const lib = script("_publish-lib.sh");
+		const buildBody = lib.split("publish_build() {")[1]?.split("\n}")[0] ?? "";
+		expect(buildBody).toContain("publish_assert_config_present");
+		expect(lib).toContain("publish_assert_config_present() {");
+	});
+
+	it("checks it on the archive and local-install paths too", () => {
+		// The zip path builds inline (it needs its own PLUGIN_DIR agreement check
+		// first), so it calls the two assertions directly; local-install goes through
+		// publish_build, which now carries them.
+		expect(script("publish-zip.sh")).toContain("publish_assert_config_present");
+		expect(script("publish-local.sh")).toContain("publish_build");
+	});
+});
+
 describe("Claude publish resolves the README marketplace source", () => {
 	// The README used to hardcode the PROD slug, so the dev mirror told dry-run
 	// readers to install the public release instead of the rehearsal copy. The

--- a/cli/src/hooks/PluginDashboardAssets.test.ts
+++ b/cli/src/hooks/PluginDashboardAssets.test.ts
@@ -31,11 +31,15 @@ import { DASHBOARD_SCRIPT_FILES } from "../dashboard/DashboardServer.js";
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const assetsDir = join(repoRoot, "cli", "src", "dashboard", "assets");
 
-/** The entries of a plugin lib's `PUBLISH_REQUIRED_DIST=( … )`, in declared order. */
+/**
+ * The entries of a plugin lib's `PUBLISH_REQUIRED_DIST=( … )`, in declared order.
+ * `#`-prefixed tokens are dropped so annotating an entry inside the array does not
+ * read back as a required file that no build emits.
+ */
 function requiredDist(plugin: string): string[] {
 	const text = readFileSync(join(repoRoot, plugin, "scripts", "_publish-lib.sh"), "utf-8");
 	const block = text.split("PUBLISH_REQUIRED_DIST=(")[1]?.split(")")[0] ?? "";
-	return block.split(/\s+/u).filter((entry) => entry.length > 0);
+	return block.split(/\s+/u).filter((entry) => entry.length > 0 && !entry.startsWith("#"));
 }
 
 const PLUGINS = ["claude-plugin", "codex-plugin"] as const;

--- a/cli/src/hooks/PluginPublishGuards.test.ts
+++ b/cli/src/hooks/PluginPublishGuards.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Shape tests for the two release guards both plugin publish libs carry.
+ *
+ * These are shell scripts driving an irreversible, user-visible publish, and the
+ * failures they had were of the "reports success, ships nothing / ships a
+ * downgrade" kind — which no build or unit test can see. Pinned as source shape,
+ * the same technique `CodexPluginManifest.test.ts` uses for the inventories.
+ *
+ * 1. The "nothing changed" early exit ran NO staged assertion unless it also had
+ *    an unpushed commit. A destination `.gitignore` matching a required file
+ *    keeps it out of the index, so `git add -A` stages nothing, the diff is
+ *    empty, and the run prints "already up to date" and exits 0 — the assertion
+ *    that exists to catch exactly that never runs.
+ *
+ * 2. The version baseline was `${last_msg#release: <prefix> }`, i.e. the last
+ *    commit with the prefix stripped, guarded by `[ "$last_msg" != "$last_version" ]`.
+ *    When the destination's last commit is NOT a release commit (a README fix, a
+ *    merge), the strip is a no-op, that test is false, the whole `&&` chain short
+ *    circuits, and a downgrade publishes unguarded. The baseline has to be looked
+ *    UP in history, not read off the tip.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const lib = (tree: string): string => readFileSync(join(repoRoot, tree, "scripts", "_publish-lib.sh"), "utf-8");
+
+/** The `publish_git_repo` body — where both guards live. */
+function publishGitRepoBody(tree: string): string {
+	return lib(tree).split("publish_git_repo() {")[1]?.split("\n}")[0] ?? "";
+}
+
+/**
+ * The `if git … diff --cached --quiet; then … fi` branch: the "nothing changed"
+ * exit. The two trees end it differently — codex runs inside a subshell and
+ * `exit 0`s, claude `return 0`s — so the cut accepts either.
+ */
+function nothingChangedBranch(tree: string): string {
+	const afterCheck = publishGitRepoBody(tree).split("diff --cached --quiet; then")[1] ?? "";
+	return afterCheck.split(/\bexit 0\b|\breturn 0\b/u)[0] ?? "";
+}
+
+describe.each(["claude-plugin", "codex-plugin"])("%s publish guards", (tree) => {
+	it("asserts the staged inventory before the nothing-changed exit", () => {
+		const branch = nothingChangedBranch(tree);
+		expect(branch).not.toBe("");
+		// The two trees name their staged-inventory assertion differently
+		// (`publish_assert_staged` vs `publish_assert_dist_staged`).
+		const assertion = /publish_assert(?:_dist)?_staged/u;
+		expect(branch).toMatch(assertion);
+		// Ahead of the unpushed check where there is one (codex), so it runs on EVERY
+		// such exit and not only when a local commit happens to need pushing.
+		if (branch.includes("publish_has_unpushed")) {
+			expect(branch.search(assertion)).toBeLessThan(branch.indexOf("publish_has_unpushed"));
+		}
+	});
+
+	it("looks the version baseline up in history instead of reading the tip", () => {
+		const body = publishGitRepoBody(tree);
+		expect(body).toContain("--grep=");
+		// The tip-stripping form is what silently disabled the guard.
+		expect(body).not.toMatch(/git log -1 --format=%s 2>\/dev\/null/u);
+	});
+});

--- a/codex-plugin/scripts/_publish-lib.sh
+++ b/codex-plugin/scripts/_publish-lib.sh
@@ -385,6 +385,12 @@ publish_git_repo() {
 		git -c core.excludesFile=/dev/null add -A
 		if git -c core.excludesFile=/dev/null diff --cached --quiet; then
 			echo "==> Nothing changed — target already up to date."
+			# Unconditionally, BEFORE the unpushed branch below: a destination
+			# .gitignore matching a required file keeps it out of the index, so
+			# `add -A` stages nothing and this branch is reached with the published
+			# tree incomplete. Gating the assertion on "has an unpushed commit" left
+			# exactly that case green.
+			publish_assert_staged "$dest"
 			# ... but "nothing to COMMIT" is not "nothing to PUBLISH". A previous
 			# NO_PUSH=1 rehearsal or a failed push leaves the release commit local-only,
 			# and every later run also finds nothing to commit — so without this the
@@ -392,12 +398,9 @@ publish_git_repo() {
 			# reach users.
 			if publish_has_unpushed; then
 				echo "==> Local release commit is not on the remote yet."
-				# Same completeness gate as the commit path below. This branch pushes a commit
-				# THIS run did not create, so without the check an incomplete commit — one an
-				# older script version or a hand-run `git commit` landed here — would go out to
-				# users unexamined. `git ls-files` reads the index, which after a commit still
-				# reflects the tracked tree, so the assertion is meaningful here too.
-				publish_assert_staged "$dest"
+				# The completeness gate for this branch already ran above — it pushes a
+				# commit THIS run did not create, so an incomplete one (an older script
+				# version, a hand-run `git commit`) must not go out unexamined.
 				publish_push
 			fi
 			exit 0
@@ -408,13 +411,22 @@ publish_git_repo() {
 		# like a release. The equal-only form this replaced would have waved a downgrade
 		# through — see the twin guard in claude-plugin/scripts/_publish-lib.sh, where
 		# exactly that gap was live (source 1.0.0, prod already on 1.0.1).
-		local version last_msg last_version
+		local version last_msg last_version release_subject
 		version="$(publish_version)"
+		release_subject="release: jolli codex plugin "
 		if [ "$target_kind" = "prod" ]; then
-			last_msg="$(git log -1 --format=%s 2>/dev/null || true)"
-			last_version="${last_msg#release: jolli codex plugin }"
-			if [ "${JOLLI_PUBLISH_FORCE:-0}" != "1" ] &&
-				[ "$last_msg" != "$last_version" ] &&
+			# The baseline is the last RELEASE commit, looked up in history — not the
+			# tip. Reading the tip and stripping the prefix made the guard vanish
+			# whenever the destination's last commit was anything else (a README fix, a
+			# merge): the strip was a no-op, the `last_msg != last_version` sanity test
+			# went false, and the `&&` chain short-circuited into a green downgrade.
+			last_msg="$(git log -1 --format=%s --grep="^${release_subject}" 2>/dev/null || true)"
+			last_version="${last_msg#"$release_subject"}"
+			if [ -z "$last_msg" ]; then
+				# No release commit on the target: a first publish has no baseline to be
+				# higher than. Said out loud, because "guard skipped" must never be silent.
+				echo "==> No previous release commit on the target — version guard has no baseline."
+			elif [ "${JOLLI_PUBLISH_FORCE:-0}" != "1" ] &&
 				! publish_version_gt "$version" "$last_version"; then
 				echo "error: content changed but plugin version ${version} is not higher than" >&2
 				echo "       the last published release (${last_version})." >&2
@@ -441,7 +453,9 @@ publish_git_repo() {
 		fi
 
 		publish_assert_staged "$dest"
-		git commit -s -m "release: jolli codex plugin ${version}"
+		# Same `release_subject` the guard greps for — a literal here could drift from
+		# the pattern and leave every future run without a baseline.
+		git commit -s -m "${release_subject}${version}"
 
 		publish_push
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/FileDiscarder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/FileDiscarder.kt
@@ -196,10 +196,17 @@ object FileDiscarder {
      * Read-only: no index, worktree or ref is written, so this runs BEFORE the
      * user has confirmed anything.
      *
-     * On an unreadable or short response every path is reported as NOT deleted.
-     * That is the milder verb, and it is the right way to fail here: the caller
-     * falls back to [GitStatusCodes.discardDeletesFile], which is the wording
-     * this host used before the query existed.
+     * On an unreadable or short response every path is reported as NOT deleted —
+     * an EMPTY set, returned normally. That is the milder verb, and it is the right
+     * way to fail here: nothing has been deleted, so promising less than happens is
+     * the safe direction, and the discard itself then reports the real reason.
+     *
+     * Note what this does NOT do: it does not raise, so the caller's
+     * [GitStatusCodes.discardDeletesFile] fallback does NOT run for these cases.
+     * That fallback is reachable only when the query itself throws (transport /
+     * parse failure, a host process that is down, a missing runtime) — see the
+     * caller. The letter heuristic is lossy for conflicted rows, so keeping it off
+     * the merely-unusable-answer path is deliberate.
      *
      * [cwd] and [relativePaths] follow the same rules as [discard] — see
      * [WorktreeRoot]. Blocking I/O; call OFF the EDT.

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -717,6 +717,24 @@ const { mockArchiveKBFolder, mockFindRepoFolders } = vi.hoisted(() => ({
 	mockFindRepoFolders: vi.fn(() => ["/test/kb"]),
 }));
 
+// `rebuildMemoryBank` now runs its archive-then-migrate sequence under
+// `vault-write.lock`. Mocked to a pass-through here for the same reason
+// KbFoldersService.test.ts does it: these tests are about the command's wiring, and
+// the real lock would try to create its directory under this file's MOCKED global
+// config dir (`/home/user/...`), which macOS cannot make — so every rebuild test
+// failed with a raw ENOENT. The real lock is exercised against a real, isolated HOME
+// in cli/src/core/MemoryBankRebuild.test.ts.
+vi.mock("../../cli/src/sync/VaultWriteLock.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../cli/src/sync/VaultWriteLock.js")>();
+	return {
+		...actual,
+		withVaultWriteLock: vi.fn(async (_root: string, _mode: unknown, body: () => Promise<unknown>) => ({
+			ran: true,
+			value: await body(),
+		})),
+	};
+});
+
 vi.mock("../../cli/src/core/KBPathResolver.js", () => ({
 	extractRepoName: vi.fn(() => "test-repo"),
 	getRemoteUrl: vi.fn(() => null),

--- a/vscode/src/services/KbFoldersService.test.ts
+++ b/vscode/src/services/KbFoldersService.test.ts
@@ -7,12 +7,13 @@ import {
 	readdirSync,
 	renameSync,
 	rmSync,
+	utimesSync,
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { __setSotResolverForTests } from "../../../cli/src/core/FolderConsolidation";
+import { __setSotResolverForTests, ConsolidationStalePlanError } from "../../../cli/src/core/FolderConsolidation";
 import { MetadataManager } from "../../../cli/src/core/MetadataManager";
 import type { StorageProvider } from "../../../cli/src/core/StorageProvider";
 import { VaultWriteBusyError, withVaultWriteLock } from "../../../cli/src/sync/VaultWriteLock";
@@ -32,6 +33,11 @@ vi.mock("../../../cli/src/sync/VaultWriteLock.js", async (importOriginal) => {
 	};
 });
 
+// The vault-lock release hook lazy-imports QueueWorker to wake a stranded
+// worker. Stubbed so the wake path can be asserted without pulling that module's
+// transcript-reader / detector graph into this suite.
+vi.mock("../../../cli/src/hooks/QueueWorker.js", () => ({ launchWorker: vi.fn() }));
+
 // Windows ignores chmod for unprivileged file accesses, so a `chmod 0o000`
 // based "unreadable file" test ends up reading the file just fine and the
 // "expect title to be undefined" assertion fails. ESM namespace exports
@@ -44,6 +50,11 @@ const skipIfWin32 = process.platform === "win32" ? it.skip : it;
  * Seed a fake KB repo under `parent`. Mirrors what `initializeKBFolder` does
  * (writes `.jolli/config.json`) but inline so tests stay readable and don't
  * pull in the full CLI helper graph.
+ *
+ * The config's mtime is backdated a day, because `archiveUnusedFolders` reads it
+ * as the claim time and spares a folder claimed within the last hour (another IDE
+ * window may have just opened that project). A test that wants the fresh-claim
+ * behaviour calls {@link touchClaim}.
  */
 function seedRepo(
 	parent: string,
@@ -52,8 +63,9 @@ function seedRepo(
 ): string {
 	const repoDir = join(parent, dirName);
 	mkdirSync(join(repoDir, ".jolli"), { recursive: true });
+	const configPath = join(repoDir, ".jolli", "config.json");
 	writeFileSync(
-		join(repoDir, ".jolli", "config.json"),
+		configPath,
 		JSON.stringify({
 			version: 1,
 			sortOrder: "date",
@@ -62,7 +74,15 @@ function seedRepo(
 		}),
 		"utf-8",
 	);
+	const aDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+	utimesSync(configPath, aDayAgo, aDayAgo);
 	return repoDir;
+}
+
+/** Marks a seeded folder as claimed just now (the mtime `seedRepo` backdates). */
+function touchClaim(repoDir: string): void {
+	const now = new Date();
+	utimesSync(join(repoDir, ".jolli", "config.json"), now, now);
 }
 
 describe("KbFoldersService — single repo (under multi-repo parent)", () => {
@@ -1861,6 +1881,17 @@ describe("KbFoldersService.archiveUnusedFolders", () => {
 		expect(isArchived("system32")).toBe(true);
 	});
 
+	it("keeps an empty folder claimed moments ago — another window may have just opened that project", async () => {
+		// `resolveKBPath` claims (writes config.json) the first time a window resolves
+		// a repo's folder, and a fresh install's folder is legitimately empty until the
+		// first commit lands. Archiving it out from under that window is a move it did
+		// not ask for; the sweep's whole point is folders nothing has touched in ages.
+		const fresh = seedRepo(tmpParent, "just-opened", { remoteUrl: "https://github.com/x/just-opened.git" });
+		touchClaim(fresh);
+		expect(await makeSvc().archiveUnusedFolders()).toEqual([]);
+		expect(existsSync(fresh)).toBe(true);
+	});
+
 	it("archives an empty folder that carries a real remote (checkout opened once, never committed to)", async () => {
 		// Identifying a real repo is not the same as being useful: the row is
 		// pure noise until a memory lands, and the folder returns the moment
@@ -2212,6 +2243,40 @@ describe("KbFoldersService — duplicate consolidation", () => {
 		expect(existsSync(join(tmpParent, "app", ".jolli", "summaries", "z9.json"))).toBe(true);
 	});
 
+	it("re-validates the plan under the lock and refuses a stale one", async () => {
+		makeRepo("app", ["a1", "a2", "a3"]);
+		makeRepo("app-2", ["a1", "z9"]);
+		const service = svc("app", "/cwd");
+		const plan = await service.planDuplicateConsolidation();
+		if (!plan) throw new Error("expected a consolidation plan");
+
+		// Detection runs OUTSIDE the lock and the confirmation modal can sit open
+		// indefinitely, so the folder set can change before the user clicks Merge.
+		rmSync(join(tmpParent, "app-2"), { recursive: true, force: true });
+
+		await expect(service.runConsolidation(plan)).rejects.toBeInstanceOf(ConsolidationStalePlanError);
+		// The surviving folder is untouched — no half-merge against a stale plan.
+		expect(existsSync(join(tmpParent, "app", ".jolli", "summaries", "z9.json"))).toBe(false);
+	});
+
+	it("passes the pending-worker release hook so a worker waiting on the vault is woken", async () => {
+		makeRepo("app", ["a1", "a2", "a3"]);
+		makeRepo("app-2", ["a1", "z9"]);
+		const service = svc("app", "/cwd");
+		const plan = await service.planDuplicateConsolidation();
+		if (!plan) throw new Error("expected a consolidation plan");
+		await service.runConsolidation(plan);
+
+		const releaseHook = vi.mocked(withVaultWriteLock).mock.calls.at(-1)?.[3];
+		expect(typeof releaseHook?.launch).toBe("function");
+
+		// And the hook actually reaches the worker launcher — the wake is the whole
+		// point, so asserting only that a function was passed proves nothing.
+		const { launchWorker } = await import("../../../cli/src/hooks/QueueWorker.js");
+		releaseHook?.launch("/some/repo");
+		await vi.waitFor(() => expect(launchWorker).toHaveBeenCalledWith("/some/repo"));
+	});
+
 	it("runConsolidation throws VaultWriteBusyError when the vault lock is busy", async () => {
 		makeRepo("app", ["a1", "a2", "a3"]);
 		makeRepo("app-2", ["a1", "z9"]);
@@ -2237,5 +2302,12 @@ describe("KbFoldersService — duplicate consolidation", () => {
 
 		expect(await svc("app", "/cwd").archiveUnusedFolders()).toEqual([]);
 		expect(existsSync(join(tmpParent, "junk"))).toBe(true);
+	});
+
+	it("archiveUnusedFolders passes the pending-worker release hook", async () => {
+		makeRepo("app", ["a1"]);
+		await svc("app", "/cwd").archiveUnusedFolders();
+		const releaseHook = vi.mocked(withVaultWriteLock).mock.calls.at(-1)?.[3];
+		expect(typeof releaseHook?.launch).toBe("function");
 	});
 });

--- a/vscode/src/services/KbFoldersService.ts
+++ b/vscode/src/services/KbFoldersService.ts
@@ -48,7 +48,7 @@
  */
 
 import type { Dirent } from "node:fs";
-import { existsSync, promises as fs, readdirSync, readFileSync } from "node:fs";
+import { existsSync, promises as fs, readdirSync, readFileSync, statSync } from "node:fs";
 import { isAbsolute, join, normalize } from "node:path";
 import type { SummaryIndex } from "../../../cli/src/Types.js";
 import {
@@ -56,6 +56,7 @@ import {
 	type ConsolidationPlan,
 	type ConsolidationResult,
 	executeConsolidation,
+	revalidateConsolidationPlan,
 } from "../../../cli/src/core/FolderConsolidation.js";
 import { FolderStorage } from "../../../cli/src/core/FolderStorage.js";
 import { archiveKBFolder } from "../../../cli/src/core/KBPathResolver.js";
@@ -72,6 +73,25 @@ import {
 	withVaultWriteLock,
 } from "../../../cli/src/sync/VaultWriteLock.js";
 import type { FolderFileKind, FolderNode } from "../views/SidebarMessages.js";
+
+/**
+ * The pending-worker wakeup every vault-lock holder must supply — a QueueWorker
+ * that timed out waiting for this lock recorded itself in the per-vault registry,
+ * and nothing else drains it (`withVaultWriteLock`'s docstring: "Production
+ * holders MUST pass this"). Without it a commit's summary stays stranded until
+ * that repo's NEXT commit.
+ *
+ * `launchWorker` is imported lazily INSIDE the callback, not at module scope:
+ * `QueueWorker` pulls the whole transcript-reader / detector graph, and the sweep
+ * runs on every sidebar Refresh. `wakePendingWorkers` fires this only when a
+ * worker is actually waiting, so on the ordinary path the import never happens.
+ * Fire-and-forget matches the `(cwd: string) => void` contract.
+ */
+const PENDING_WORKER_RELEASE_HOOK = {
+	launch: (cwd: string): void => {
+		void import("../../../cli/src/hooks/QueueWorker.js").then(({ launchWorker }) => launchWorker(cwd));
+	},
+};
 
 /**
  * The data the service needs to enumerate repos and identify the user's
@@ -144,21 +164,24 @@ export class KbFoldersService {
 	/**
 	 * Archives Memory Bank folders that were claimed for something that never
 	 * turned out to be a useful repo, so the Folders tab stops listing rows the
-	 * user has no reason to browse. This is the ONLY mutation the sidebar's
-	 * Refresh performs.
+	 * user has no reason to browse.
 	 *
-	 * REFRESH'S CONTRACT — Refresh clears folders that a past bug created and
-	 * that never held anything; it NEVER moves a folder holding memories. That is
-	 * the whole reason this sweep is keyed on emptiness and nothing else, and why
-	 * DUPLICATE folders are deliberately out of scope here even though they are
-	 * the more visible annoyance: collapsing duplicates means picking one of
-	 * several populated folders and burying the rest, since an archive is a plain
-	 * move that cannot merge them. The only correct survivor is one rebuilt from
-	 * the orphan branch (the system of record), which is Migrate's job — so
-	 * duplicates belong to Migrate, and a Refresh stays a safe, lossless action
-	 * the user can click without thinking. An earlier revision did wire a
-	 * duplicate-collapsing pass into Refresh; it was withdrawn for exactly this
-	 * reason. Do not re-add one here.
+	 * THIS SWEEP'S CONTRACT — it clears folders that a past bug created and that
+	 * never held anything; it NEVER moves a folder holding memories. That is the
+	 * whole reason it is keyed on emptiness and nothing else, and it is what makes
+	 * it safe to run unprompted on every Refresh.
+	 *
+	 * DUPLICATE folders are out of scope FOR THIS METHOD, and were once out of
+	 * scope for Refresh entirely: collapsing duplicates means picking one of
+	 * several populated folders, and an archive is a plain move that cannot merge
+	 * them. That objection was answered rather than overruled —
+	 * {@link planDuplicateConsolidation} / {@link runConsolidation} do a real merge
+	 * (copy-if-absent across every layer, or a rebuild from the system of record),
+	 * and the caller gates them behind an explicit modal confirmation. So Refresh
+	 * now performs TWO mutations: this unprompted, emptiness-only sweep, and that
+	 * confirmed merge. What must not come back is a duplicate pass keyed on
+	 * anything weaker than those two — an unprompted archive-the-loser move here
+	 * would still be the lossy thing the original objection was about.
 	 *
 	 * WHY these folders exist: `resolveKBPath` CLAIMS the folder it returns
 	 * (writes `.jolli/config.json`) and takes its `repoName` from whatever cwd the
@@ -244,12 +267,16 @@ export class KbFoldersService {
 					continue;
 				}
 				if (!isEmptyKbFolder(repo.kbRoot)) continue;
+				// Third part of the guard: a folder claimed in the last hour belongs to
+				// a window that is probably using it right now — see
+				// RECENT_CLAIM_GRACE_MS. The next Refresh sweeps it if it stayed empty.
+				if (wasClaimedRecently(repo.kbRoot)) continue;
 				const dest = archiveKBFolder(repo.kbRoot, ctx.kbParent);
 				if (dest) archived.push(repo.kbRoot);
 			}
 			if (archived.length > 0) this.cleanRepos.clear();
 			return archived;
-		});
+		}, PENDING_WORKER_RELEASE_HOOK);
 		// Vault busy (a worker/sync/compile held the lock through the budget): skip
 		// this sweep silently — it is best-effort and the next Refresh retries.
 		return result.ran ? result.value : [];
@@ -299,19 +326,27 @@ export class KbFoldersService {
 	 * {@link VaultWriteBusyError} when the vault is busy so the caller can tell
 	 * the user "try again shortly" — unlike the best-effort sweep, a user asked
 	 * for this merge, so a silent skip would look like it did nothing.
+	 *
+	 * The plan is re-validated INSIDE the lock (`revalidateConsolidationPlan`) and
+	 * the freshly-computed one is what executes: detection ran before the modal
+	 * opened, that modal can sit open indefinitely, and the folder set can change
+	 * under it. A mismatch throws `ConsolidationStalePlanError` so the caller can
+	 * ask for a re-confirm rather than acting on a description the user never saw.
 	 */
 	async runConsolidation(plan: ConsolidationPlan): Promise<ConsolidationResult> {
 		const ctx = this.getContext();
-		const result = await withVaultWriteLock(ctx.kbParent, { wait: DEFAULT_PULL_LOCK_WAIT_MS }, async () => {
-			const r = await executeConsolidation(
-				plan,
-				ctx.currentProjectRoot ?? ctx.kbParent,
-				ctx.currentRemoteUrl,
-				ctx.kbParent,
-			);
-			this.cleanRepos.clear();
-			return r;
-		});
+		const cwd = ctx.currentProjectRoot ?? ctx.kbParent;
+		const result = await withVaultWriteLock(
+			ctx.kbParent,
+			{ wait: DEFAULT_PULL_LOCK_WAIT_MS },
+			async () => {
+				const current = await revalidateConsolidationPlan(plan, cwd, ctx.currentRemoteUrl, ctx.kbParent);
+				const r = await executeConsolidation(current, cwd, ctx.currentRemoteUrl, ctx.kbParent);
+				this.cleanRepos.clear();
+				return r;
+			},
+			PENDING_WORKER_RELEASE_HOOK,
+		);
 		if (!result.ran) throw new VaultWriteBusyError();
 		return result.value;
 	}
@@ -835,6 +870,39 @@ const OS_NOISE_FILES: ReadonlySet<string> = new Set([".ds_store", "thumbs.db"]);
 
 function isOsNoise(name: string): boolean {
 	return OS_NOISE_FILES.has(name.toLowerCase());
+}
+
+/**
+ * How recently a folder must have been CLAIMED to be spared by the sweep.
+ *
+ * `resolveKBPath` writes `.jolli/config.json` when it claims a slot, so that
+ * file's mtime is the claim time. The sweep's current-project guard only knows
+ * about THIS window, and a second window (or a second IDE) legitimately holds an
+ * empty folder for the project it just opened — a fresh install's folder is empty
+ * until its first commit lands. Archiving it is a move that window did not ask
+ * for, and it drops the row from its tree.
+ *
+ * Deliberately narrow: this protects the just-claimed window, NOT every folder
+ * another window happens to have open. A project opened days ago whose folder is
+ * still empty has an old claim time and is still swept — which is safe for the
+ * reason the sweep is safe at all (nothing to move, and `resolveKBPath` re-claims
+ * the same path on the next write).
+ */
+const RECENT_CLAIM_GRACE_MS = 60 * 60 * 1000;
+
+/**
+ * True when `kbRoot` was claimed within {@link RECENT_CLAIM_GRACE_MS}. An
+ * unreadable/absent config resolves to `false`: this is a spare-it check layered
+ * on top of the emptiness test, and a folder with no readable claim time is
+ * decided by that test alone (as it was before this existed).
+ */
+function wasClaimedRecently(kbRoot: string, nowMs: number = Date.now()): boolean {
+	try {
+		const claimedMs = statSync(join(kbRoot, ".jolli", "config.json")).mtimeMs;
+		return nowMs - claimedMs < RECENT_CLAIM_GRACE_MS;
+	} catch {
+		return false;
+	}
 }
 
 /**

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -8,7 +8,11 @@ import type {
 	SidebarState,
 } from "./SidebarMessages";
 import { setManuallyDisabled } from "../../../cli/src/Logger.js";
-import type { ConsolidationPlan } from "../../../cli/src/core/FolderConsolidation.js";
+import {
+	ConsolidationDisabledError,
+	type ConsolidationPlan,
+	ConsolidationStalePlanError,
+} from "../../../cli/src/core/FolderConsolidation.js";
 import { VaultWriteBusyError } from "../../../cli/src/sync/VaultWriteLock";
 import { describeConsolidationPlan, SidebarWebviewProvider } from "./SidebarWebviewProvider";
 
@@ -2170,6 +2174,28 @@ describe("SidebarWebviewProvider", () => {
 			expect(runConsolidation).toHaveBeenCalledTimes(1);
 			expect(showInformationMessage).toHaveBeenCalledTimes(1);
 			expect(showInformationMessage.mock.calls[0][0]).toContain("busy writing a summary");
+		});
+
+		it("asks for a re-confirm when the folders changed under the open modal", async () => {
+			const { view, runConsolidation } = makeConsolidationProvider(makePlan());
+			runConsolidation.mockRejectedValueOnce(new ConsolidationStalePlanError());
+			showWarningMessage.mockResolvedValueOnce("Merge");
+			view.webview.triggerMessage({ type: "refresh", scope: "kb" });
+			await new Promise((r) => setTimeout(r, 0));
+			await new Promise((r) => setTimeout(r, 0));
+			expect(showInformationMessage).toHaveBeenCalledTimes(1);
+			expect(showInformationMessage.mock.calls[0][0]).toContain("changed");
+		});
+
+		it("says so when the project was disabled before the merge ran", async () => {
+			const { view, runConsolidation } = makeConsolidationProvider(makePlan());
+			runConsolidation.mockRejectedValueOnce(new ConsolidationDisabledError());
+			showWarningMessage.mockResolvedValueOnce("Merge");
+			view.webview.triggerMessage({ type: "refresh", scope: "kb" });
+			await new Promise((r) => setTimeout(r, 0));
+			await new Promise((r) => setTimeout(r, 0));
+			expect(showInformationMessage).toHaveBeenCalledTimes(1);
+			expect(showInformationMessage.mock.calls[0][0]).toContain("disabled");
 		});
 
 		it("re-pushes the breadcrumb repo list after a kb refresh (archived repos leave the dropdown)", async () => {

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -10,10 +10,12 @@
 import { randomBytes } from "node:crypto";
 import { basename } from "node:path";
 import * as vscode from "vscode";
-import type {
-	ConsolidationKind,
-	ConsolidationPlan,
-	ConsolidationResult,
+import {
+	ConsolidationDisabledError,
+	type ConsolidationKind,
+	type ConsolidationPlan,
+	type ConsolidationResult,
+	ConsolidationStalePlanError,
 } from "../../../cli/src/core/FolderConsolidation.js";
 import type { DetectedAgent } from "../../../cli/src/core/localagent/DetectAgents.js";
 import { VaultWriteBusyError } from "../../../cli/src/sync/VaultWriteLock.js";
@@ -217,9 +219,10 @@ export interface SidebarWebviewDeps {
 		 * committed to. Optional so existing tests keep compiling. Resolves to
 		 * the list of folder paths that were archived.
 		 *
-		 * Duplicate folders are NOT in scope — see the service method's contract:
-		 * a Refresh never moves a folder holding memories, so consolidating
-		 * duplicates is Migrate's job.
+		 * Duplicate folders are not in scope for THIS callback — this sweep is
+		 * unprompted and only ever moves provably-empty folders. They are handled by
+		 * `planDuplicateConsolidation` / `runConsolidation` below, which merge rather
+		 * than archive-the-loser and run only after an explicit confirmation.
 		 */
 		archiveUnusedFolders?: () => Promise<string[]>;
 		/**
@@ -2094,6 +2097,25 @@ export class SidebarWebviewProvider
 			if (err instanceof VaultWriteBusyError) {
 				void vscode.window.showInformationMessage(
 					"Jolli Memory is busy writing a summary right now — click Refresh again shortly to merge the duplicate folders.",
+				);
+				return;
+			}
+			// The plan is re-validated under the vault lock, and this modal can sit
+			// open for as long as the user likes — so the folder set may have moved
+			// on. Ask for a re-confirm rather than swallowing: the user clicked Merge
+			// and is entitled to know it did not happen.
+			if (err instanceof ConsolidationStalePlanError) {
+				void vscode.window.showInformationMessage(
+					"The Memory Bank folders changed while that prompt was open — click Refresh again to review the merge.",
+				);
+				return;
+			}
+			// Disabled between the prompt and the click. Every write the merge needs
+			// is gated on the same flag, so it refuses rather than archiving folders
+			// it cannot rebuild.
+			if (err instanceof ConsolidationDisabledError) {
+				void vscode.window.showInformationMessage(
+					"Jolli Memory is disabled for this project — enable it before merging the duplicate folders.",
 				);
 				return;
 			}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Context

- Skills used — 1 skill · 289.7k tokens

## Quick recap

The developer hardened the duplicate-folder consolidation flow against several destructive edge cases. Consolidation now re-resolves its destination folder after archiving, and a folder belonging to a different repository that shares the same name is left untouched. Merging is refused while the project is disabled, where the previous behavior archived every folder, rebuilt nothing, and still reported success with an empty result. The merge plan is re-validated under the vault write lock at execution time, and a stale confirmation now produces a clear re-confirm prompt. The Memory Bank rebuild path takes the same vault lock and returns a busy notice while another writer is active.

The plugin publishing pipeline gained completeness guards on every path. The dashboard asset inventories in both plugin trees were brought back in sync with the files the dashboard server actually serves, archive and local-install publishes now verify that required config files exist, and the release version guard reads its baseline from history, blocking a downgrade even when the destination's latest commit is unrelated to a release. Backfill runs now re-check the summary store immediately before each paid generation call, and a summary that lands mid-run is left untouched.

---

## Topics (6)
<details>
<summary><strong>01 · Hardened duplicate-folder consolidation and rebuild against destructive edge cases</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A review of the folder-consolidation flow found it could claim a folder owned by a different repository that shares the same name, archive everything and rebuild nothing when the project was disabled, execute a merge plan that had gone stale while its confirmation dialog sat open, and run an unguarded rebuild with no concurrency protection.

**💡 Decisions Behind the Code**

- **Re-resolve after archiving**: trusting the classification-time prediction is what let a same-basename foreign folder get claimed; re-reading the freed slot with a pure look-up after the archive matches the pre-existing rebuild path and claims nothing on its own. The cost is one extra resolution per consolidate, negligible next to the archive-then-migrate work.
- **Distinct error types**: a disabled project and a changed folder set need different user messages (re-enable versus re-confirm), so they are separate error types rather than one generic failure; the disabled gate sits on the same in-memory flag that makes the rebuild's own writes no-op, keeping the two halves consistent by construction.
- **Re-validate under the lock**: detection necessarily runs unlocked because holding the vault lock across an open dialog would block every summary write; re-classifying inside the lock and executing the fresh plan closes the window without ever acting on a description the user never saw.

**✅ What Was Implemented**

- Duplicate-folder consolidation now re-resolves its destination slot after archiving (peekKBPath) instead of trusting the plan's predicted path, so a same-basename folder owned by another repository is never claimed or rewritten; it also refuses to classify or execute while the project is manually disabled, throwing a dedicated ConsolidationDisabledError.
- The merge plan is re-validated under the vault lock before executing (new revalidateConsolidationPlan in FolderConsolidation.ts); a changed folder set throws ConsolidationStalePlanError, and KbFoldersService now passes the pending-worker release hook. rebuildMemoryBank in MemoryBankRebuild.ts is wrapped in the same vault write lock and returns a busy result instead of archiving mid-write.

**📁 FILES**
- `cli/src/core/FolderConsolidation.ts`
- `cli/src/core/MemoryBankRebuild.ts`
- `vscode/src/services/KbFoldersService.ts`
- `cli/src/core/KBPathResolver.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Closed the gaps in the plugin publish completeness and version guards</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A review of the two plugin trees' publish scripts found the dashboard-asset inventory had silently drifted three files behind what the server actually inlines, the archive and local-install paths never verified required config files, the "nothing changed" early exit skipped the completeness assertion, and the release version guard disabled itself whenever the destination's latest commit was not a release commit.

**💡 Decisions Behind the Code**

- **Check configs from the source tree**: the dest-side staged assertion only runs on the git-repo publish that stages files, so archive and local-install paths — which pack straight from disk — had no license guard at all; asserting against the source names a path the developer can actually fix.
- **Baseline from history, not the tip**: reading the tip and stripping a prefix silently neutralized the downgrade guard whenever the last commit was a merge or doc fix; a history search keeps the guard live and says so out loud for a first publish instead of quietly skipping.
- **Pinned by a shape test**: these are shell arrays with no importable API, so a source-text lockstep test is the only practical way to hold the two trees and the server's list together after this exact drift happened.

**✅ What Was Implemented**

- Added knowledge.js, graph.js and settings.js to the PUBLISH_REQUIRED_DIST inventory in both plugin trees, plus a lockstep test (DashboardAssetPublish.test.ts) pinning both inventories against DASHBOARD_SCRIPT_FILES so they cannot drift again.
- Added publish_assert_config_present to the claude plugin publish lib, wired into the shared build step and the zip path, and made both trees run their staged-asset assertion unconditionally before the "nothing changed" early exit.
- Both trees now find the version baseline by searching history for the release subject (git log --grep) rather than stripping a prefix off the tip, printing an explicit no-baseline message for a first publish; the commit subject reuses the same variable to keep them in lockstep.

**📁 FILES**
- `claude-plugin/scripts/_publish-lib.sh`
- `codex-plugin/scripts/_publish-lib.sh`
- `claude-plugin/scripts/publish-zip.sh`
- `cli/src/dashboard/DashboardServer.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Stopped concurrent backfill runs from billing the same summary twice</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The dashboard's generate-missing guard was scoped to a single process, and a concurrent backfill computed its missing set once at start, so either run would still pay a second time for a summary the other had already produced.

**💡 Decisions Behind the Code**

- **Check at the money boundary**: the run's missing set is a minutes-old snapshot, so the only check worth anything is the one immediately before the paid call; the extra index read per commit is negligible against the model spend it guards.
- **Fail open on read errors**: a transient store failure answers "no summary" so a commit is still generated rather than silently skipped — the safe direction for a spend-guard whose purpose is concurrency, not store correctness.

**✅ What Was Implemented**

- BackfillEngine.ts now re-reads the summary index immediately before each model call via a new hasSummaryNow helper and skips with a new "skipped-has-summary" status when a summary landed meanwhile; a read failure at that re-check degrades to the old behavior (still generate).
- Added two tests covering the concurrent-skip and re-check-failure paths, and corrected the DashboardServer comment that previously credited the process-local guard with preventing double spend.

**📁 FILES**
- `cli/src/backfill/BackfillEngine.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Ranked Sentry's synthesized titles so a no-prose observation no longer overwrites a richer row</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Sentry's fallback title pattern matched both the machine-id shape synthesized when no prose was recovered and the short-id shape synthesized when a heading was harvested, so a later no-prose observation overwrote a row with a real title and dropped its issue id, project and culprit along with it.

**💡 Decisions Behind the Code**

Rank within the family rather than narrowing the fallback pattern to pure digits: a model can pass a short id as the issue argument, so the poorest shape is reachable with a short-id-looking value that must still read as a fallback against a genuinely harvested title.

**✅ What Was Implemented**

- Added an optional titleFallbackPoorestPattern to SourceDefinition and declared the all-digits form for sentry; keepsPriorHarvest in ReferenceStore.ts now yields when the incoming title is the source's poorest fallback while a richer stored one survives.
- SourceDefinitionRegistry validates that the new field is a non-empty, compilable regex and requires the family pattern it ranks within; sentry's own test pins the ranking arms.

**📁 FILES**
- `cli/src/core/references/ReferenceStore.ts`
- `cli/src/core/references/SourceDefinitionRegistry.ts`
- `cli/src/core/references/sources/definitions/sentry.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Restored telemetry for in-process MCP sessions served by the proxy fallback</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The MCP fast path skipped the normal startup routine where telemetry is bootstrapped, so any proxy session that fell back to an in-process server emitted zero per-tool telemetry for its entire life.

**💡 Decisions Behind the Code**

The fast path's "the proxy runs no tool, so it emits no telemetry" reasoning does not hold for the fallback, which runs a full server in the same process, so the fallback must prime telemetry itself; keeping the disclosure suppressed preserves the existing contract that this process's stderr belongs to the host transport.

**✅ What Was Implemented**

- New serveMcpInProcess export in Cli.ts primes telemetry before starting the MCP server and flushes buffered events when the session ends, and the proxy fast path now passes it as its fallback.
- Telemetry priming is best-effort: a failure logs to stderr and never costs the session its server; the one-time telemetry disclosure is deliberately not shown on this path.

**📁 FILES**
- `cli/src/Cli.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Refresh no longer archives a folder another window just claimed</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A Refresh sweep could archive a provably-empty folder belonging to a different project the user had open in another window, dropping its row from that window's tree.

**💡 Decisions Behind the Code**

The grace window deliberately protects only freshly-claimed folders, not every folder another window happens to hold: a project opened days ago with an empty folder has an old claim time and is still swept, which stays safe because the folder holds nothing and is re-claimed on the next write.

**✅ What Was Implemented**

- archiveUnusedFolders in KbFoldersService.ts now skips any folder claimed within the last hour, using the config.json mtime as the claim time (RECENT_CLAIM_GRACE_MS, wasClaimedRecently); tests backdate seeded folders so existing cases still archive.

**📁 FILES**
- `vscode/src/services/KbFoldersService.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 13, 2026 at 6:18 PM · via Local agent - OpenCode*
<!-- jollimemory-summary-end -->