### PR TITLE
Replace branch reachability scan with summary-recorded branch attribution

### DIFF
--- a/cli/src/core/JolliRefs.test.ts
+++ b/cli/src/core/JolliRefs.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { isJolliInternalRef, JOLLI_REFS_EXCLUDE_GLOB } from "./JolliRefs.js";
+
+describe("isJolliInternalRef", () => {
+	// The namespace-vs-prefix distinction used to be pinned through
+	// `DashboardCollector`'s branch-attribution scan, which is gone (attribution is
+	// now the summary's recorded branch, not a per-ref reachability union). The rule
+	// itself is still live in `DbBackfill.checkoutFingerprint`, where getting it
+	// wrong is a silent stall rather than a visible error: a user branch wrongly
+	// classified as internal is filtered out of the fingerprint, so commits landing
+	// on it never move the cursor and never trigger a sweep.
+	it("matches the reserved namespace in both the short and full ref forms", () => {
+		expect(isJolliInternalRef("jollimemory/summaries/v3")).toBe(true);
+		expect(isJolliInternalRef("refs/heads/jollimemory/summaries/v3")).toBe(true);
+		// A retired version inside the namespace goes with it.
+		expect(isJolliInternalRef("jollimemory/summaries/v2")).toBe(true);
+	});
+
+	it("leaves a user branch merely NAMED like the namespace alone", () => {
+		// Matched by namespace (`jollimemory/`), never by prefix — `jollimemory-notes`
+		// is ordinary work and must keep counting.
+		expect(isJolliInternalRef("jollimemory-notes")).toBe(false);
+		expect(isJolliInternalRef("refs/heads/jollimemory-notes")).toBe(false);
+		// The bare namespace with no separator is not the namespace either.
+		expect(isJolliInternalRef("jollimemory")).toBe(false);
+	});
+
+	it("leaves unrelated branches alone", () => {
+		expect(isJolliInternalRef("main")).toBe(false);
+		expect(isJolliInternalRef("feature/jollimemory/x")).toBe(false);
+	});
+});
+
+describe("JOLLI_REFS_EXCLUDE_GLOB", () => {
+	// Measured: the `refs/heads/`-prefixed form matches NOTHING under `--branches`
+	// and is silently ignored (2468 commits listed, exactly as if absent), while
+	// this form listed 668. Neither shape errors or warns, so the only thing
+	// standing between the two is this assertion.
+	it("is relative to the selector and keeps its mandatory trailing glob", () => {
+		expect(JOLLI_REFS_EXCLUDE_GLOB).toBe("--exclude=jollimemory/*");
+		expect(JOLLI_REFS_EXCLUDE_GLOB).not.toContain("refs/heads/");
+	});
+});

--- a/cli/src/dashboard/DashboardCollector.test.ts
+++ b/cli/src/dashboard/DashboardCollector.test.ts
@@ -192,7 +192,7 @@ describe("collectCommitEvents", () => {
 	const SEP = "\u001f";
 	const REC = "\u0001";
 
-	it("combines git log, branch reachability and summary-index enrichment", async () => {
+	it("combines git log with summary-index enrichment, attributing the recorded branch", async () => {
 		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
 			if (args[0] === "log") {
 				return git(
@@ -202,9 +202,6 @@ describe("collectCommitEvents", () => {
 					].join("\n"),
 				);
 			}
-			if (args[0] === "for-each-ref") return git("main\nfeature/x\n");
-			if (args[0] === "rev-list" && args[1] === "main") return git("aaa\nbbb\n");
-			if (args[0] === "rev-list" && args[1] === "feature/x") return git("aaa\n");
 			// The numstat pass is a separate `git log`, prefixed with -c.
 			if (args[0] === "-c") {
 				return git(
@@ -235,7 +232,9 @@ describe("collectCommitEvents", () => {
 			message: "feat: one",
 			authorName: "Foster",
 			branch: "feature/x", // recorded branch from the summary index
-			branches: ["main", "feature/x"],
+			// The SAME fact as `branch`, as a one-element list — not a reachability
+			// union. No `rev-list` is run at all any more.
+			branches: ["feature/x"],
 			filesChanged: 3,
 			insertions: 10,
 			deletions: 2,
@@ -245,9 +244,57 @@ describe("collectCommitEvents", () => {
 			// Binary: git prints "-", so neither count is recorded rather than 0.
 			{ path: "docs/logo.png" },
 		]);
-		expect(events[1]).toMatchObject({ hash: "bbb", branches: ["main"] });
+		// `bbb` has no summary entry, so nothing records a branch for it: `[]`, which
+		// CLEARS any stored attribution rather than leaving a stale one behind.
+		expect(events[1]).toMatchObject({ hash: "bbb", branches: [] });
 		expect(events[1]?.files).toEqual([{ path: "src/a.ts", insertions: 1, deletions: 0 }]);
 		expect(events[1]).not.toHaveProperty("filesChanged");
+	});
+
+	// The churn regression. `for-each-ref --sort=-committerdate` + `slice(0, 50)`
+	// was an UNSTABLE window on a repo past the cap: a commit on ANY branch
+	// reorders it. `unchangedCommitEvent` compares `branches` for exact set
+	// equality, so a window that swaps one member re-projected every commit the
+	// window reached — forever, never converging. Measured on a 350-branch repo:
+	// 11,953 commits re-enqueued per shift and 24.6 MB of duplicate `events_raw`
+	// rows, plus branch attribution that was a moving target because `branches` is
+	// replace-when-present. The fix makes the value depend only on the summary's
+	// recorded branch, which is a historical fact and cannot reshuffle.
+	const collectWithBranchWindow = async (branchList: ReadonlyArray<string>, recordedBranch = "feature/x") => {
+		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			if (args[0] === "log") return git(`aaa${SEP}2026-07-30T08:00:00+08:00${SEP}F${SEP}f@x${SEP}one`);
+			if (args[0] === "for-each-ref") return git(`${branchList.join("\n")}\n`);
+			// Every branch reaches the commit, which is the normal shape: old feature
+			// branches all contain main's history.
+			if (args[0] === "rev-list") return git("aaa\n");
+			return git("");
+		});
+		vi.mocked(getIndex).mockResolvedValue({
+			version: 3,
+			entries: [
+				{
+					commitHash: "aaa",
+					parentCommitHash: null,
+					commitMessage: "one",
+					commitDate: "2026-07-30",
+					branch: recordedBranch,
+					generatedAt: "t",
+				},
+			],
+		});
+		const events = await collectCommitEvents({ repoIdentity: "r", cwd: "/w" });
+		return events[0]?.branches;
+	};
+
+	it("emits a stable branches value when the branch window reshuffles", async () => {
+		const many = Array.from({ length: 60 }, (_, i) => `b${i}`);
+		const first = await collectWithBranchWindow(many);
+		// One branch enters the window and one falls out — exactly what a single
+		// commit on any branch does to a `-committerdate` sort.
+		const second = await collectWithBranchWindow(["newcomer", ...many.slice(0, 59)]);
+		expect(second).toEqual(first);
+		// And the value is the commit's recorded branch, not a reachability union.
+		expect(first).toEqual(["feature/x"]);
 	});
 
 	it("passes --since through to log and rev-list when given", async () => {
@@ -286,48 +333,49 @@ describe("collectCommitEvents", () => {
 		}
 	});
 
-	it("excludes Jolli's own storage refs from both log passes and from attribution", async () => {
+	it("excludes Jolli's own storage refs from both log passes", async () => {
 		// The orphan branch is a local branch like any other, so every ref-scoped
 		// call here picks it up unless told not to — and it holds one commit PER
 		// MEMORY. Measured on this repo before the exclusion: 1800 of 2468 stored
-		// commits were `Add summary for …`, and `jollimemory/summaries/v3` outranked
-		// `main` in the branch attribution.
+		// commits were `Add summary for …`.
+		//
+		// The attribution half of this test is gone with the reachability scan; the
+		// namespace-vs-prefix rule it also covered now has direct tests in
+		// `core/JolliRefs.test.ts`, next to the function that owns it.
 		const calls: string[][] = [];
 		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
 			calls.push([...args]);
 			if (args[0] === "log") return git(`aaa${SEP}2026-07-30T08:00:00+08:00${SEP}F${SEP}f@x.com${SEP}one`);
-			// Sorted by committerdate, so the orphan branch — written on every memory
-			// — is realistically the FIRST entry, not an afterthought at the end.
-			if (args[0] === "for-each-ref") return git("jollimemory/summaries/v3\nmain\n");
-			if (args[0] === "rev-list" && args[1] === "main") return git("aaa\n");
 			return git("");
 		});
 		vi.mocked(getIndex).mockResolvedValue(null);
-		const events = await collectCommitEvents({ repoIdentity: "r", cwd: "/w" });
+		await collectCommitEvents({ repoIdentity: "r", cwd: "/w" });
 		// Two ways to get this wrong silently, so both are pinned. `--exclude` is
 		// positional — it applies only to the selector that FOLLOWS it — and its
 		// pattern is relative to that selector, so the `refs/heads/`-prefixed form
 		// matches nothing under `--branches` and is ignored without a word.
-		for (const pass of calls.filter((c) => c[0] === "log" || c[0] === "-c")) {
+		const logPasses = calls.filter((c) => c[0] === "log" || c[0] === "-c");
+		expect(logPasses.length).toBeGreaterThan(0);
+		for (const pass of logPasses) {
 			expect(pass.indexOf("--exclude=jollimemory/*")).toBe(pass.indexOf("--branches") - 1);
 		}
-		// Never walked, so it can never be attributed either.
-		expect(calls.filter((c) => c[0] === "rev-list").map((c) => c[1])).toEqual(["main"]);
-		expect(events[0]?.branches).toEqual(["main"]);
 	});
 
-	it("keeps a branch merely NAMED like the internal namespace", async () => {
-		// Excluded by namespace (`jollimemory/`), not by prefix match — a user's
-		// own `jollimemory-notes` branch is ordinary work and must stay attributed.
+	it("runs no per-branch rev-list at all", async () => {
+		// The 350 subprocesses this replaced were both the cost and the churn: the
+		// window they were driven from reshuffled on every commit. Pinned as a call
+		// shape because a reintroduced `rev-list` would still produce correct-looking
+		// output — it is the instability, not the values, that was wrong.
+		const calls: string[][] = [];
 		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
+			calls.push([...args]);
 			if (args[0] === "log") return git(`aaa${SEP}2026-07-30T08:00:00+08:00${SEP}F${SEP}f@x.com${SEP}one`);
-			if (args[0] === "for-each-ref") return git("jollimemory-notes\n");
-			if (args[0] === "rev-list" && args[1] === "jollimemory-notes") return git("aaa\n");
 			return git("");
 		});
 		vi.mocked(getIndex).mockResolvedValue(null);
-		const events = await collectCommitEvents({ repoIdentity: "r", cwd: "/w" });
-		expect(events[0]?.branches).toEqual(["jollimemory-notes"]);
+		await collectCommitEvents({ repoIdentity: "r", cwd: "/w" });
+		expect(calls.filter((c) => c[0] === "rev-list")).toEqual([]);
+		expect(calls.filter((c) => c[0] === "for-each-ref")).toEqual([]);
 	});
 
 	it("scans --numstat only for commits the caller has not stored", async () => {
@@ -435,54 +483,6 @@ describe("collectCommitEvents", () => {
 		expect(numstat).toContain("--branches");
 	});
 
-	// The `MAX_BRANCHES` cap is a documented reachability gap, but it must not be
-	// expressed as the CLAIM `branches: []` — that array is replace-when-present,
-	// so a commit only the branches past the cap reach would have its correct
-	// stored attribution deleted on every pass.
-	it("omits branches for a commit no listed branch reaches when the ref list was truncated", async () => {
-		const listed = Array.from({ length: 51 }, (_, i) => `b${i}`);
-		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
-			if (args[0] === "log") {
-				return git(
-					[
-						`aaa${SEP}2026-07-30T08:00:00+08:00${SEP}F${SEP}f@x${SEP}one`,
-						`bbb${SEP}2026-07-29T08:00:00+08:00${SEP}F${SEP}f@x${SEP}two`,
-					].join("\n"),
-				);
-			}
-			// Listed in full and capped in JS — asking git for one past the cap would
-			// spend that slot on Jolli's own refs, which are filtered out here.
-			if (args[0] === "for-each-ref") {
-				expect(args).not.toContain("--count=51");
-				return git(`${listed.join("\n")}\n`);
-			}
-			if (args[0] === "rev-list" && args[1] === "b0") return git("aaa\n");
-			return git("");
-		});
-		vi.mocked(getIndex).mockResolvedValue(null);
-		const events = await collectCommitEvents({ repoIdentity: "r", cwd: "/w" });
-		// Reached by a listed branch → its (capped) attribution still refreshes.
-		expect(events[0]).toMatchObject({ hash: "aaa", branches: ["b0"] });
-		// Reached by nothing listed → could be on a branch past the cap, so the
-		// stored value is left alone rather than claimed empty.
-		expect(events[1]).not.toHaveProperty("branches");
-		// Only the branches WITHIN the cap are walked.
-		expect(vi.mocked(execGit).mock.calls.filter((c) => c[0][0] === "rev-list")).toHaveLength(50);
-	});
-
-	it("still emits an empty branches array when the ref list exactly fills the cap", async () => {
-		// 50 listed is not truncation — asking for 51 and getting 50 proves it.
-		const listed = Array.from({ length: 50 }, (_, i) => `b${i}`);
-		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
-			if (args[0] === "log") return git(`aaa${SEP}2026-07-30T08:00:00+08:00${SEP}F${SEP}f@x${SEP}one`);
-			if (args[0] === "for-each-ref") return git(`${listed.join("\n")}\n`);
-			return git("");
-		});
-		vi.mocked(getIndex).mockResolvedValue(null);
-		const events = await collectCommitEvents({ repoIdentity: "r", cwd: "/w" });
-		expect(events[0]?.branches).toEqual([]);
-	});
-
 	it("still emits commits when only the numstat pass fails, without a files field", async () => {
 		// The numstat pass is deliberately separate so its failure costs file
 		// detail and nothing else — this is the test that pins that down.
@@ -508,50 +508,78 @@ describe("collectCommitEvents", () => {
 		await expect(collectCommitEvents({ repoIdentity: "r", cwd: "/w" })).rejects.toThrow(/git log failed/);
 	});
 
-	// `branches` is REPLACE-when-present in the projection, so the distinction
-	// this asserts is the whole guard: `[]` claims no branch reaches the commit
-	// (and deletes its rows), `undefined` says "not observed" and leaves them.
-	it("omits branches entirely when a per-branch rev-list failed", async () => {
+	// `branches` is REPLACE-when-present in the projection, so ABSENT vs EMPTY is
+	// the whole guard, and the three next tests are the set that pins it:
+	//   `[]`        → "the index records no branch for this commit" → CLEARS its rows
+	//   `undefined` → "no index loaded, so could not tell"          → LEAVES them
+	// Collapsing them either way is a silent bug in one direction or the other.
+	const logOneCommit = () => {
 		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
 			if (args[0] === "log") return git(`aaa${SEP}2026-07-30T08:00:00+08:00${SEP}F${SEP}f@x${SEP}feat: one`);
-			if (args[0] === "for-each-ref") return git("main\n");
-			// The per-branch reachability pass fails; the commit survives, but its
-			// stored attribution must not be replaced by a partial union.
-			return gitFail("rev-list exploded");
+			return git("");
 		});
-		vi.mocked(getIndex).mockResolvedValue(null);
+	};
+
+	it("omits branches entirely when the summary index throws", async () => {
+		// "Could not tell", so the stored attribution has to survive it — one
+		// unreadable index must not wipe the repo's branch rows in a single pass.
+		logOneCommit();
+		vi.mocked(getIndex).mockRejectedValue(new Error("index unreadable"));
 		const events = await collectCommitEvents({ repoIdentity: "r", cwd: "/w" });
 		expect(events).toHaveLength(1);
 		expect(events[0]).not.toHaveProperty("branches");
 	});
 
-	// The worse half of the same bug: one failed ref listing used to emit `[]`
-	// for EVERY commit, wiping the repo's whole branch attribution in one pass.
-	it("omits branches entirely when the ref listing itself failed", async () => {
-		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
-			if (args[0] === "log") return git(`aaa${SEP}2026-07-30T08:00:00+08:00${SEP}F${SEP}f@x${SEP}feat: one`);
-			if (args[0] === "for-each-ref") return gitFail("boom");
-			return git("");
-		});
+	it("omits branches entirely when the summary index resolves null", async () => {
+		// THE REGRESSION THIS PINS. A resolved `null` used to be read as "readable,
+		// records nothing" and emitted `[]`, which CLEARS every commit_branches row.
+		// But `getIndex` resolves null for every genuine read failure too —
+		// `FolderStorage` classifies EACCES/EIO to a warn + null, `readFileFromBranch`
+		// does the same for a failed `git show`, and a malformed `index.json` is
+		// swallowed at the `JSON.parse` — so a throw is the rare shape and that guard
+		// protected almost nothing. One EACCES wiped the repo's whole attribution, and
+		// since the pass is otherwise complete the cursor advances and the next sweep
+		// skips collection, so the blank outlived the failure.
+		//
+		// Absent is the safe reading of BOTH cases: a repo that has no index yet keeps
+		// rows an older client stored, and those are invisible until an index exists
+		// (the only query reading them inner-joins `memories`), at which point a commit
+		// the index does not mention gets `[]` and clears them anyway.
+		logOneCommit();
 		vi.mocked(getIndex).mockResolvedValue(null);
 		const events = await collectCommitEvents({ repoIdentity: "r", cwd: "/w" });
-		expect(events).toHaveLength(1);
 		expect(events[0]).not.toHaveProperty("branches");
 	});
 
-	// And the case that must keep emitting `[]`: a clean scan where no branch
-	// reaches the commit is a real answer, and the only thing that can prune a
-	// branch the commit has genuinely left.
-	it("emits an empty branches array when the scan succeeded and found none", async () => {
-		vi.mocked(execGit).mockImplementation(async (args: ReadonlyArray<string>) => {
-			if (args[0] === "log") return git(`aaa${SEP}2026-07-30T08:00:00+08:00${SEP}F${SEP}f@x${SEP}feat: one`);
-			if (args[0] === "for-each-ref") return git("main\n");
-			if (args[0] === "rev-list") return git("zzz\n"); // reaches some other commit
-			return git("");
+	it("emits an empty branches array for an index entry carrying no branch name", async () => {
+		// The EMPTY half of the pair, and the one that keeps a mid-transition database
+		// converging: an index that loaded is a real answer, so a commit it records
+		// nothing for must clear its old reachability rows rather than keep them.
+		// (The other shape of this — a loaded index that has no entry for the commit
+		// at all — is `bbb` in the first test of this describe.)
+		//
+		// `SummaryIndexEntry.branch` is a required
+		// `string`, so the empty value is the type-legal shape of "recorded nothing";
+		// a legacy on-disk entry written before the field existed reaches the same
+		// falsy path (the type already documents that legacy entries omit fields —
+		// see `parentCommitHash`'s `undefined` case). Both must clear, not preserve.
+		logOneCommit();
+		vi.mocked(getIndex).mockResolvedValue({
+			version: 3,
+			entries: [
+				{
+					commitHash: "aaa",
+					parentCommitHash: null,
+					commitMessage: "feat: one",
+					commitDate: "2026-07-30",
+					branch: "",
+					generatedAt: "t",
+				},
+			],
 		});
-		vi.mocked(getIndex).mockResolvedValue(null);
 		const events = await collectCommitEvents({ repoIdentity: "r", cwd: "/w" });
-		expect(events[0].branches).toEqual([]);
+		expect(events[0]?.branches).toEqual([]);
+		expect(events[0]).not.toHaveProperty("branch");
 	});
 
 	it("skips malformed log lines and survives a missing summary index", async () => {

--- a/cli/src/dashboard/DashboardCollector.ts
+++ b/cli/src/dashboard/DashboardCollector.ts
@@ -15,7 +15,7 @@
 
 import { UNTITLED_SESSION } from "../core/FallbackTitle.js";
 import { execGit, getCurrentBranch } from "../core/GitOps.js";
-import { isJolliInternalRef, JOLLI_REFS_EXCLUDE_GLOB } from "../core/JolliRefs.js";
+import { JOLLI_REFS_EXCLUDE_GLOB } from "../core/JolliRefs.js";
 import { extractRepoName, getRemoteUrl, resolveKBPath } from "../core/KBPathResolver.js";
 import { estimateModelCostUsd, PRICES_AS_OF } from "../core/Pricing.js";
 import { resolveSessionTitle } from "../core/SessionTitleResolver.js";
@@ -81,14 +81,6 @@ function toStatsModelUsage(models: ReadonlyArray<ModelTokenUsage>): StatsModelUs
 			};
 		});
 }
-
-/**
- * Ceiling on per-ref `rev-list` fan-out. Reachability refresh unions rev-list
- * output per branch; a repo with hundreds of stale branches would turn that
- * into hundreds of subprocesses for data nobody scopes a dashboard to. The most
- * recently committed branches win.
- */
-const MAX_BRANCHES = 50;
 
 /**
  * Loads raw `SessionInfo`s from every source, without the sidebar's filters.
@@ -389,7 +381,7 @@ const NUMSTAT_ARGS = ["-c", "core.quotePath=false", "log", "--numstat", "--no-re
 
 /**
  * The history this machine owns: every local branch EXCEPT Jolli's own storage
- * refs (see {@link isJolliInternalRef}), plus HEAD so a detached checkout
+ * refs (see `isJolliInternalRef` in `core/JolliRefs`), plus HEAD so a detached checkout
  * (mid-rebase, bisect) is not invisible. Deliberately NOT `--all` — see
  * {@link collectCommitEvents} for why remote-tracking refs and tags are out of
  * scope. Shared by the commit pass and the file-stats pass so the two can never
@@ -525,23 +517,36 @@ export async function collectFilesForCommits(
 }
 
 /**
- * Collects one `commit.created` per commit reachable from any local branch,
- * with the branch-reachability set attached.
+ * Collects one `commit.created` per commit reachable from any local branch, with
+ * the branch it was COMMITTED ON attached.
  *
- * Reachability is computed by unioning per-ref `git rev-list` (bounded by
- * {@link MAX_BRANCHES}) — never `git branch --contains` per commit, which is
- * O(commits × branches) subprocess calls.
+ * **Attribution is a single recorded value, not a reachability set, and that is a
+ * deliberate reversal.** This used to union a per-ref `git rev-list` over the 50
+ * newest-committed branches. Two things were wrong with it. The window
+ * (`--sort=-committerdate` + a cap) reshuffles whenever any branch gains a
+ * commit, and `unchangedCommitEvent` compares `branches` for exact set equality —
+ * so on a repo past the cap every commit the window reached was re-projected on
+ * every pass and never converged (measured on a 350-branch repo: 11,953 commits
+ * re-enqueued per shift, 24.6 MB of duplicate `events_raw` rows). And because the
+ * field is replace-when-present, a branch falling out of the window DELETED its
+ * rows, making stored attribution a moving target — under the one query that
+ * reads it, per-branch token/cost. The recorded branch is a historical fact about
+ * one commit, so it cannot reshuffle, and it is also the better answer for that
+ * query: reachability counted every commit on `main` under every feature branch
+ * based off it, which is why the reader needed an apportioning division at all.
  *
- * Both passes are scoped to {@link LOCAL_HISTORY_ARGS}, the same ref set the
- * attribution loop below walks. `--all` was wrong on both ends of that: it adds
- * remote-tracking refs and tags, so a commit living only on a colleague's fetched
- * branch or an old tag was counted as this machine's work AND displayed with no
- * branch at all, because `refs/heads` could never explain where it came from.
- * Aligning them means "in the dashboard" and "attributable to a local branch"
- * are one statement. The one gap left is {@link MAX_BRANCHES}: a commit reachable
- * only from a branch past the cap is collected but unattributed — left absent, not
- * emitted as `branches: []`, so the replace-when-present projection keeps whatever
- * a fuller earlier pass stored instead of erasing it.
+ * The cost is that "which branches can see this commit NOW" is no longer
+ * answerable. That was checked against the question the dashboard actually asks
+ * (cost per PR, cost per commit) and is not needed for either. `commit_branches`
+ * and `branches` are retained, still written (one row per commit) and still read
+ * by released clients — see the note on those tables in `SotSchema`.
+ *
+ * Both `git log` passes are scoped to {@link LOCAL_HISTORY_ARGS}. `--all` was
+ * wrong here: it adds remote-tracking refs and tags, so a commit living only on a
+ * colleague's fetched branch or an old tag was counted as this machine's work AND
+ * displayed with no branch at all, because `refs/heads` could never explain where
+ * it came from. Scoping to local branches keeps "in the dashboard" and
+ * "attributable to a local branch" one statement.
  *
  * Summary-index metadata (recorded branch, diff stats) enriches commits the
  * memory pipeline saw; plain `git log` fields cover the rest.
@@ -557,9 +562,11 @@ export async function collectCommitEvents(opts: CollectCommitsOptions): Promise<
 	const sinceArgs = opts.sinceMs ? [`--since=${new Date(opts.sinceMs).toISOString()}`] : [];
 	const logResult = await execGit(
 		// `%cI`, not `%aI`. The field this feeds is `committedAtMs`, and every
-		// window this collector works in is a COMMITTER-date window: `--since`
-		// here and on the per-branch `rev-list` below both filter committer date,
-		// and the cursor is derived from the same. Reading the author date instead
+		// window this collector works in is a COMMITTER-date window: `--since` here
+		// filters committer date, and the cursor is derived from the same. (It also
+		// used to hold for the per-branch `rev-list` that computed reachability;
+		// that pass is gone, but the rule is unchanged for the two that remain.)
+		// Reading the author date instead
 		// put every rebased or cherry-picked commit in a day bucket the filter had
 		// already excluded — collected, then invisible in standup, and counted
 		// under whichever day it was originally written rather than the day the
@@ -581,67 +588,32 @@ export async function collectCommitEvents(opts: CollectCommitsOptions): Promise<
 		throw new CommitCollectionFailedError(opts.cwd, logResult.stderr.trim());
 	}
 
-	// Branch reachability: newest-committed branches first, capped.
-	const refsResult = await execGit(
-		// Listed in full and capped below in JS, rather than with git's `--count`.
-		// The cap exists to bound the per-branch `rev-list` fan-out, and Jolli's own
-		// refs are dropped from the list before it is applied — asking git for
-		// `MAX_BRANCHES + 1` and filtering afterwards would spend a slot on a branch
-		// that is never scanned, and the orphan branch is written on every memory so
-		// it sorts FIRST by committerdate essentially always. Listing every local
-		// branch name is one cheap ref walk (`DbBackfill`'s fingerprint already does
-		// exactly that); it is the rev-list per branch that is expensive.
-		["for-each-ref", "refs/heads", "--sort=-committerdate", "--format=%(refname:short)"],
-		opts.cwd,
-	);
-	// Tracked for the same reason `files` is (see below): `branches` is
-	// REPLACE-when-present in the projection, so emitting a partial union is a
-	// claim that the missing branches no longer reach the commit. A failed
-	// `for-each-ref` would have emitted `[]` for every commit and wiped the
-	// repo's whole branch attribution in one pass; a single branch that was
-	// deleted or repacked between the ref list and its own `rev-list` (an
-	// ordinary concurrent rebase) would silently have stripped just that one.
-	// Incomplete means: emit nothing, keep what is stored.
-	let branchScanComplete = refsResult.exitCode === 0;
-	const listed =
-		refsResult.exitCode === 0
-			? refsResult.stdout.split("\n").filter((name) => name && !isJolliInternalRef(name))
-			: [];
-	// A repo past {@link MAX_BRANCHES} is the documented reachability gap, but it
-	// must not be expressed as the CLAIM `branches: []`. The union is
-	// replace-when-present, so emitting an empty array for a commit that only the
-	// branches past the cap reach would delete a correct stored attribution on
-	// every pass. Truncated therefore behaves like a partially failed scan for the
-	// commits nothing listed reaches — see the emit below — while the commits the
-	// listed branches DO reach keep getting their (capped) attribution refreshed.
-	const branchesTruncated = listed.length > MAX_BRANCHES;
-	const branches = branchesTruncated ? listed.slice(0, MAX_BRANCHES) : listed;
-	const branchesByHash = new Map<string, string[]>();
-	for (const branch of branches) {
-		const revs = await execGit(["rev-list", branch, ...sinceArgs], opts.cwd);
-		if (revs.exitCode !== 0) {
-			branchScanComplete = false;
-			continue;
-		}
-		for (const hash of revs.stdout.split("\n")) {
-			if (!hash) continue;
-			const list = branchesByHash.get(hash);
-			if (list) list.push(branch);
-			else branchesByHash.set(hash, [branch]);
-		}
-	}
-
-	if (!branchScanComplete) {
-		log.warn("branch scan incomplete for %s -- leaving stored branch attribution untouched", opts.cwd);
-	} else if (branchesTruncated) {
-		log.warn(
-			"branch list truncated at %d for %s -- commits reached only by older branches keep their stored attribution",
-			MAX_BRANCHES,
-			opts.cwd,
-		);
-	}
-
-	// Summary-index enrichment, keyed by commit hash.
+	// Summary-index enrichment, keyed by commit hash. Also the source of branch
+	// attribution — see the emit below.
+	//
+	// The emit below keys ABSENT-vs-EMPTY on whether this LOADED — `index !== null`
+	// — and not on whether the call threw. A throw is the rare shape: `getIndex`
+	// resolves `null` for every genuine read failure it meets (`FolderStorage`
+	// classifies EACCES/EIO to a warn + `null`, `readFileFromBranch` does the same
+	// for a non-absence `git show` failure, and a malformed `index.json` is caught
+	// at the `JSON.parse`), which is why its own contract says callers must read
+	// null as "nothing to read", NOT as "nothing went wrong". Treating only the
+	// throw as "could not tell" therefore left the failures it names on the
+	// clear-the-rows path: one unreadable index emitted `branches: []` for every
+	// commit and DELETED the repo's whole attribution in a single pass — and
+	// because that pass is otherwise complete, the cursor advances and the next
+	// sweep skips collection, so the blank outlives the failure.
+	//
+	// Folding "absent index" in with "unreadable index" is the safe direction, and
+	// the reason is that the two cases the old comment separated are not
+	// symmetrical. A repo with no index yet keeps whatever an older client's
+	// reachability pass stored, which sounds like the stale-rows bug this change
+	// exists to escape — but the ONE query that reads `commit_branches` inner-joins
+	// `memories` (see `buildSeries`'s branch axis), so rows belonging to a repo with
+	// no summaries are invisible, and they are replaced the moment an index appears:
+	// a commit the index does not mention still gets `[]` below. Wiping live
+	// attribution is visible immediately; keeping unreadable rows is not visible at
+	// all.
 	const index = await getIndex(opts.cwd, opts.storage).catch(() => null);
 	const summaryByHash = new Map(index?.entries.map((e) => [e.commitHash, e]) ?? []);
 
@@ -651,10 +623,13 @@ export async function collectCommitEvents(opts: CollectCommitsOptions): Promise<
 	// `git log --numstat` over the whole history is where this collection's wall
 	// clock goes (6-12 s per checkout, measured), and it is pure waste for a commit
 	// whose file rows are already stored: a commit's diff is immutable, so a hash
-	// already in the database can never need a re-scan. Everything ELSE here stays
-	// whole-history on purpose — the commit list is what the prune is computed
-	// against, and branch reachability changes for OLD commits every time a branch
-	// moves, so neither can be narrowed to the new arrivals.
+	// already in the database can never need a re-scan. The commit LIST stays
+	// whole-history on purpose, and now for exactly one reason: it is what the prune
+	// is computed against, so narrowing it to the new arrivals would read as "every
+	// older commit is gone". (It used to have a second reason — branch reachability
+	// changed for OLD commits whenever any branch moved. Attribution is the
+	// summary's recorded branch now, which never changes for a given hash, so that
+	// half is void; the prune keeps the requirement alive by itself.)
 	//
 	// Omitting `files` for a known commit is not a downgrade: absent means "keep
 	// what is stored" in the projection (the same contract a failed numstat pass
@@ -708,15 +683,29 @@ export async function collectCommitEvents(opts: CollectCommitsOptions): Promise<
 			// The summary's recorded branch is where the commit was actually made;
 			// reachability can only say where it is visible NOW.
 			...(summary?.branch ? { branch: summary.branch } : {}),
-			// Absent (not empty) when the scan above was incomplete — an empty
-			// array here is the meaningful claim "no branch reaches this commit",
-			// and it is only true when every local branch was actually walked. Under
-			// truncation the same reasoning applies per commit: a hit is still a hit,
-			// but "nothing reached it" may just mean the branch that does sits past
-			// the cap, so that case falls back to leaving the stored value alone.
-			...(branchScanComplete && (!branchesTruncated || branchesByHash.has(hash))
-				? { branches: branchesByHash.get(hash) ?? [] }
-				: {}),
+			// `branches` carries the SAME single fact, as a one-element list — not a
+			// reachability union. It used to be the union of a per-branch `rev-list`
+			// over the 50 newest-committed branches, and that window was the bug: it
+			// reshuffles whenever any branch gains a commit, while
+			// `unchangedCommitEvent` compares this field for exact set equality, so
+			// every commit the window reached was re-projected on every pass, forever.
+			// Measured on a 350-branch repo: 11,953 commits re-enqueued per shift and
+			// 24.6 MB of duplicate `events_raw` rows, plus branch attribution that was
+			// a moving target because the field is replace-when-present. The recorded
+			// branch cannot reshuffle — it is a historical fact about one commit — so
+			// the comparison converges after one projection.
+			//
+			// ABSENT vs EMPTY is load-bearing, and `[]` is the common case:
+			//   - no index loaded   → absent → projection keeps whatever is stored
+			//     (the "could not tell" answer — unreadable and not-present alike;
+			//     see the `getIndex` call above for why those cannot be told apart)
+			//   - index loaded, no recorded branch → `[]` → CLEARS the stored rows
+			// Writing absent for the second would leave every such commit carrying its
+			// old N-row reachability set forever, permanently mixed in with the 1-row
+			// commits. Note `[]` is truthy, which is what makes `projectCommit`'s
+			// `if (event.branches)` run its DELETE — do not "simplify" that to a
+			// `.length` test, in either place.
+			...(index ? { branches: summary?.branch ? [summary.branch] : [] } : {}),
 			// Absent (not empty) when the numstat pass failed, so a transient git
 			// failure leaves previously collected file rows in place.
 			...(filesByHash.has(hash) ? { files: filesByHash.get(hash) } : {}),

--- a/cli/src/dashboard/DashboardModel.ts
+++ b/cli/src/dashboard/DashboardModel.ts
@@ -113,9 +113,26 @@ export interface CommitCreatedEvent {
 	readonly hash: string;
 	readonly branch?: string;
 	/**
-	 * Every branch this commit is currently reachable from. Replaces the whole
-	 * `commit_branches` set for the commit — an empty array is meaningful (the
-	 * commit is unreachable from any tracked ref) and prunes the old rows.
+	 * The branch this commit was COMMITTED ON, as a one-element list — the same
+	 * fact as `branch`, in the shape `commit_branches` stores.
+	 *
+	 * **Not a reachability set.** It was one (the union of a per-ref `git rev-list`
+	 * over the newest branches) and that was the churn bug: the window reshuffled on
+	 * every commit while `unchangedCommitEvent` compares this field for exact set
+	 * equality, so nothing ever converged. See `collectCommitEvents` and the
+	 * `commit_branches` note in `SotSchema` for the measurements and for why the two
+	 * tables are kept.
+	 *
+	 * Still REPLACES the whole stored set, so the absent/empty distinction is
+	 * load-bearing in both directions:
+	 * - `[]` — the summary index was read and records no branch for this commit;
+	 *   PRUNES its rows. The common case (a commit with no memory), and `[]` is
+	 *   truthy, which is what makes the projection's `if (event.branches)` run its
+	 *   DELETE.
+	 * - `undefined` — could not tell, because no summary index was loaded at all;
+	 *   LEAVES the stored rows alone. A read failure and a repo that has no index
+	 *   yet arrive as the same `null` from `getIndex` and are deliberately treated
+	 *   alike — see the collector for why that asymmetry is the safe one.
 	 */
 	readonly branches?: ReadonlyArray<string>;
 	readonly message?: string;

--- a/cli/src/dashboard/DashboardQuery.ts
+++ b/cli/src/dashboard/DashboardQuery.ts
@@ -675,14 +675,20 @@ function buildSeries(
 			.all(fromMs, toMs, ...filter.params) as UsageRow[];
 	} else if (effective === "branch") {
 		const filter = scopeFilter(scopeToRepoId(db, scope), "c.repo_id");
-		// A commit reachable from several branches contributes to each — the axis
-		// answers "where did the spend land", not "sum to the exact total". That
-		// licenses duplication ACROSS SERIES, never in the day totals, which is
-		// why the spend is apportioned exactly as the category axis apportions
-		// across topics. `commit_branches` is a per-branch `git rev-list` union,
-		// so every commit on `main` is also listed under every feature branch
-		// based off it: unapportioned, one 10k-token commit on a repo with five
-		// such branches added 60k tokens (and 6x the cost) to the day.
+		// `commit_branches` now holds ONE row per commit — the branch it was
+		// committed on — so this axis answers "what did the work on this branch
+		// cost", which is the per-PR question, and a commit counts once.
+		//
+		// **The apportioning division is kept deliberately even though the divisor
+		// is 1 for anything this build wrote.** It is the transition safeguard: a
+		// database written by an older client still holds that client's per-branch
+		// `git rev-list` UNION (every commit on `main` also listed under every
+		// feature branch based off it) until the first sweep re-projects each commit.
+		// Unapportioned against those rows, one 10k-token commit on a repo with five
+		// such branches would add 60k tokens — and 6x the cost — to the day. Dividing
+		// keeps the reading sane until the rows converge, then costs nothing.
+		// Removing it would make THIS build the one that reads a mid-transition
+		// database wrong while an older client read it correctly.
 		rows = db
 			.prepare(
 				`SELECT c.committed_at_ms AS at_ms, br.name AS key,

--- a/cli/src/dashboard/DbBackfill.test.ts
+++ b/cli/src/dashboard/DbBackfill.test.ts
@@ -28,6 +28,10 @@ vi.mock("../core/GitOps.js", () => ({
 }));
 vi.mock("../core/SummaryStore.js", () => ({
 	getIndex: vi.fn(),
+	// The commit tier's branch-attribution read is threaded from here now. Left
+	// unmocked it is `undefined` and every test in this file dies on the call, so
+	// the identity default doubles as the assertion target for the seam below.
+	resolveReadStorage: vi.fn(),
 }));
 vi.mock("../core/RepoProfile.js", () => ({
 	readCutoverFence: vi.fn(),
@@ -46,7 +50,7 @@ vi.mock("./SotImport.js", async (importOriginal) => ({
 
 import { execGit, getHeadHash, listFilesInBranch } from "../core/GitOps.js";
 import { readCutoverFence } from "../core/RepoProfile.js";
-import { getIndex } from "../core/SummaryStore.js";
+import { getIndex, resolveReadStorage } from "../core/SummaryStore.js";
 import {
 	collectCommitEvents,
 	collectRepoGraph,
@@ -137,6 +141,10 @@ beforeEach(() => {
 	});
 	// No summary store by default — the summaries sweep is opt-in per test.
 	vi.mocked(getIndex).mockResolvedValue(null);
+	// Identity: the real one answers `opts.storage` when given one, and the
+	// ambient system of record otherwise. `null` stands in for "no override" —
+	// what the collector then does with it is `collectCommitEvents`' own suite.
+	vi.mocked(resolveReadStorage).mockImplementation(async (storage) => storage as never);
 	// Not fenced for cutover by default — the orphan branch is still authoritative.
 	vi.mocked(readCutoverFence).mockResolvedValue(null);
 });
@@ -147,6 +155,18 @@ afterEach(() => {
 
 async function query<T>(sql: string, ...params: unknown[]): Promise<T[]> {
 	return withDashboardDb((db) => db.prepare(sql).all(...params) as T[], { dbPath });
+}
+
+/** The branch axis's own view of one commit: `commit_branches`, resolved to names. */
+async function branchesOf(hash: string): Promise<string[]> {
+	const rows = await query<{ name: string }>(
+		`SELECT b.name FROM commit_branches cb
+		   JOIN branches b ON b.id = cb.branch_id
+		   JOIN commits c  ON c.id = cb.commit_id
+		  WHERE c.hash = ? ORDER BY b.name`,
+		hash,
+	);
+	return rows.map((r) => r.name);
 }
 
 describe("dbBackfillRepo — bootstrap", () => {
@@ -351,10 +371,13 @@ describe("dbBackfillRepo — recovery", () => {
 		expect(hashes).toEqual(["aaa", "bbb", "ccc"]);
 	});
 
-	it("re-projects a commit whose branch reachability changed", async () => {
+	it("re-projects a commit whose branch attribution changed", async () => {
 		// `branches` is replace-when-present, so a stale set is a wrong answer to
 		// "group by branch" — this is the one field that legitimately changes for an
 		// OLD commit, and skipping it is what a naive "already stored" test would do.
+		// (It used to change because a reachability window reshuffled, which never
+		// converged; it now changes only when the recorded branch really does — a
+		// late-arriving memory or an amend. See `unchangedCommitEvent`.)
 		await dbBackfillRepo({ repo, dbPath });
 		vi.mocked(getHeadHash).mockResolvedValue("head-2");
 		vi.mocked(collectCommitEvents).mockResolvedValue([
@@ -371,6 +394,48 @@ describe("dbBackfillRepo — recovery", () => {
 			)
 		).map((r) => r.name);
 		expect(names).toEqual(["feature/x", "main"]);
+	});
+
+	it("fills branch attribution for a commit whose memory arrived after it", async () => {
+		// The gap the churn was accidentally papering over. A commit lands before its
+		// memory exists, so the first sweep records no branch for it; the summary
+		// arrives moments later. While the reachability window thrashed, EVERY pass
+		// re-emitted every commit and re-read the recorded branch, so this filled
+		// itself as a side effect of the bug. Now that a commit converges after one
+		// projection, the late fill is a distinct transition that has to work on its
+		// own — and three UI cards render `commits.branch`.
+		//
+		// `[]`, not absent: the commit genuinely has no recorded branch yet, and that
+		// answer must CLEAR rows rather than preserve them.
+		vi.mocked(collectCommitEvents).mockResolvedValue([{ ...commitEvent("aaa"), branch: undefined, branches: [] }]);
+		await dbBackfillRepo({ repo, dbPath });
+		expect(await query<{ branch: string | null }>("SELECT branch FROM commits WHERE hash = 'aaa'")).toEqual([
+			{ branch: null },
+		]);
+		expect(await query("SELECT 1 FROM commit_branches")).toEqual([]);
+
+		// The memory lands. One more emission, and it is a real change.
+		const beforeFill = await dbBackfillRepo({ repo, dbPath });
+		vi.mocked(getHeadHash).mockResolvedValue("head-2");
+		vi.mocked(collectCommitEvents).mockResolvedValue([
+			{ ...commitEvent("aaa"), branch: "feature/x", branches: ["feature/x"] },
+		]);
+		const filled = await dbBackfillRepo({ repo, dbPath });
+		expect(filled.eventsApplied).toBe(beforeFill.eventsApplied + 1);
+		expect(await query<{ branch: string | null }>("SELECT branch FROM commits WHERE hash = 'aaa'")).toEqual([
+			{ branch: "feature/x" },
+		]);
+		// Exactly one row — the whole point of the new shape.
+		expect(
+			await query<{ name: string }>(
+				`SELECT b.name FROM commit_branches cb JOIN branches b ON b.id = cb.branch_id`,
+			),
+		).toEqual([{ name: "feature/x" }]);
+
+		// And it converges: a further identical pass emits nothing new.
+		vi.mocked(getHeadHash).mockResolvedValue("head-3");
+		const settled = await dbBackfillRepo({ repo, dbPath });
+		expect(settled.eventsApplied).toBe(beforeFill.eventsApplied);
 	});
 
 	it("re-offers a commit whose file rows were never collected", async () => {
@@ -563,6 +628,30 @@ describe("dbBackfillRepo — SOT import wiring (v7)", () => {
 		const storage = { kind: "orphan-branch" as const, listFiles: async () => [] } as never;
 		await dbBackfillRepo({ repo, dbPath, storage });
 		expect(importRepoMemory).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ storage }));
+	});
+
+	it("gives the same injected provider to the COMMIT sweep, not just the importer", async () => {
+		// The commit tier reads `index.json` too — that is where branch attribution
+		// comes from — and it used to take whatever `getIndex`'s ambient fallback
+		// resolved instead. So the seam covered half the pass: a test could feed the
+		// importer one index while the attribution came from the real machine.
+		const storage = { kind: "orphan-branch" as const, listFiles: async () => [] } as never;
+		await dbBackfillRepo({ repo, dbPath, storage });
+		expect(vi.mocked(resolveReadStorage).mock.calls[0]?.[0]).toBe(storage);
+		expect(vi.mocked(collectCommitEvents).mock.calls[0]?.[0].storage).toBe(storage);
+	});
+
+	it("threads ONE routed provider into the commit sweep, resolved outside the db handle", async () => {
+		// Not `orphanStorage`: that one is pinned to the orphan tip, which a fenced
+		// repo has frozen — attribution for every post-fence commit would come back
+		// empty and DELETE its rows. The routed system of record is right in both
+		// states, so what the sweep must receive is this resolver's answer.
+		const routed = { kind: "sqlite" as const } as never;
+		vi.mocked(resolveReadStorage).mockResolvedValue(routed);
+		await dbBackfillRepo({ repo, dbPath });
+		// One resolution for the pass, not one per checkout.
+		expect(resolveReadStorage).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(collectCommitEvents).mock.calls[0]?.[0].storage).toBe(routed);
 	});
 
 	it("imports in seed mode while the repo has never been fenced for cutover", async () => {
@@ -781,6 +870,46 @@ describe("dbBackfillRepo — summaries sweep (memory tier)", () => {
 		expect(collectSummaryEvents).toHaveBeenCalledTimes(3);
 	});
 
+	it("lands branch attribution from a summary that arrived after the sweep", async () => {
+		// THE ordinary race, and the one the commit tier structurally cannot close:
+		// its cursor hashes HEAD plus `refs/heads` minus Jolli's own refs, so the
+		// orphan branch gaining the memory moves nothing it watches. Pass 2 skips
+		// `collectCommitEvents` entirely — if `commit.summary` only wrote the
+		// `commits.branch` column, the branch axis (which joins `commit_branches`)
+		// would keep reading nothing until an unrelated ref happened to move.
+		vi.mocked(collectCommitEvents).mockResolvedValue([{ ...commitEvent("aaa"), branches: [] }]);
+		await dbBackfillRepo({ repo, dbPath });
+		expect(await branchesOf("aaa")).toEqual([]);
+
+		vi.mocked(collectCommitEvents).mockClear();
+		vi.mocked(getIndex).mockResolvedValue({ version: 3, entries: [] });
+		vi.mocked(collectSummaryEvents).mockResolvedValue({
+			events: [{ ...summaryEvent, branch: "feature/x" }],
+			complete: true,
+		});
+
+		// Nothing in git moved — only the orphan branch did.
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(collectCommitEvents).not.toHaveBeenCalled();
+		expect(await branchesOf("aaa")).toEqual(["feature/x"]);
+	});
+
+	it("leaves stored attribution alone for a summary that records no branch", async () => {
+		// The absent half of the same replace-when-present contract. Only
+		// `commit.created` may claim "no branch", because only it can tell an
+		// unreadable index from one that does not list the hash; a summary without
+		// a branch knows nothing and must not clear what the sweep established.
+		await dbBackfillRepo({ repo, dbPath });
+		expect(await branchesOf("aaa")).toEqual(["main"]);
+
+		vi.mocked(getIndex).mockResolvedValue({ version: 3, entries: [] });
+		vi.mocked(collectSummaryEvents).mockResolvedValue({ events: [summaryEvent], complete: true });
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await branchesOf("aaa")).toEqual(["main"]);
+	});
+
 	it("announces the sweep only when it is going to run", async () => {
 		// The marker is the caller's evidence that something is worth narrating, so
 		// a skipped sweep has to be silent — announcing "Indexing stored memories…"
@@ -923,8 +1052,8 @@ describe("multiple checkouts of one project (§10.2)", () => {
 		// The regression: the merge wrote `branches` unconditionally, so two omissions
 		// unioned into `[]` — and `[]` is the meaningful claim "no branch reaches this
 		// commit", which deletes every commit_branches row. A repo with two checkouts
-		// and one failed `for-each-ref` (or a MAX_BRANCHES truncation) lost its whole
-		// branch attribution on the next sweep.
+		// where neither could load a summary index lost its whole branch attribution
+		// on the next sweep.
 		const a3 = mkdtempSync(join(tmpdir(), "jolli-wt-a-"));
 		const b3 = mkdtempSync(join(tmpdir(), "jolli-wt-b-"));
 		try {

--- a/cli/src/dashboard/DbBackfill.ts
+++ b/cli/src/dashboard/DbBackfill.ts
@@ -34,7 +34,7 @@ import { execGit, getHeadHash } from "../core/GitOps.js";
 import { GitRefStorage, resolveCommittish } from "../core/GitRefStorage.js";
 import { isJolliInternalRef } from "../core/JolliRefs.js";
 import type { StorageProvider } from "../core/StorageProvider.js";
-import { getIndex } from "../core/SummaryStore.js";
+import { getIndex, resolveReadStorage } from "../core/SummaryStore.js";
 import { createLogger, errMsg, ORPHAN_BRANCH } from "../Logger.js";
 import {
 	collectCommitEvents,
@@ -372,10 +372,25 @@ function storedCommitRows(
  *  - `committed_at_ms` is written unconditionally, so it is compared even when
  *    every other field matches.
  *  - `branches` is replace-when-present, so a present set must match exactly;
- *    absent (a failed branch scan) means "leave the rows alone".
+ *    absent (no summary index was loaded, whether unreadable or not yet written)
+ *    means "leave the rows alone".
  *  - `files` present is never skipped. It is replace-when-present too, and the
  *    stored file rows are not read here — a commit whose files this pass actually
  *    scanned is by construction a new one, so this costs nothing in practice.
+ *
+ * **Why this function converges, and why it did not used to.** Nothing here was
+ * changed to fix the churn — the fix was making its INPUT stable. Every field
+ * compared above is immutable for a given hash, and `branches` now carries only
+ * the commit's recorded branch, which is a historical fact and equally immutable.
+ * So a commit is projected once and then judged unchanged forever. Previously
+ * `branches` was a reachability union over the 50 newest-committed branches, and
+ * that window reshuffled whenever ANY branch gained a commit: exact set equality
+ * then failed on every pass, re-enqueueing every commit the window reached
+ * (measured: 11,953 per shift on a 350-branch repo). The lesson generalises — if
+ * a `slice(0, N)` result feeds an idempotency comparison, ask whether the window
+ * is stable. `files` was always the right shape here for the same reason: its skip
+ * is keyed on whether `commit_files` rows EXIST (monotonic state), not on
+ * comparing content.
  */
 function unchangedCommitEvent(
 	event: CommitCreatedEvent,
@@ -512,6 +527,35 @@ export async function dbBackfillRepo(opts: DbBackfillOptions): Promise<DbBackfil
 	const orphanTip = opts.storage ? null : await resolveCommittish(ORPHAN_BRANCH, cwd);
 	const orphanStorage = opts.storage ?? (orphanTip ? new GitRefStorage(orphanTip, cwd) : null);
 
+	// The commit tier's read side, threaded explicitly into `collectCommitEvents`
+	// — which reads `index.json` for branch attribution and, given nothing, falls
+	// back to the ambient system of record inside `getIndex`. That fallback
+	// re-resolved the backend once per CHECKOUT and silently ignored the
+	// `--storage` seam, so a test could feed the importer an index the commit tier
+	// never saw.
+	//
+	// One provider for every checkout, resolved at `cwd`, because the index is
+	// per-REPO: it is dual-written identically into each clone, which is the same
+	// reason the summaries cursor and `orphanStorage` are taken from `cwd` alone.
+	// That makes the `branches` union in the merge loop below degenerate — every
+	// checkout now reports the same recorded branch for a hash — without making it
+	// removable; see the ABSENT note there.
+	//
+	// **NOT `orphanStorage`, and that is why it is a second provider.** The pinned
+	// one is the ORPHAN TIP, which a fenced repo has frozen: every commit made
+	// after the fence is absent from that index, and an index that loads without
+	// the entry is the "no recorded branch" answer — `[]`, which the projection
+	// honours by DELETING the commit's rows. Pinning here would wipe attribution
+	// for exactly the commits a cut-over repo still creates. The routed system of
+	// record is right in both states: the orphan branch before cutover,
+	// `SqliteStorage` after (its `synthIndex` rebuilds `index.json` from the
+	// `memories` rows, `branch` included).
+	//
+	// Resolved out here for the same reason `readRepoCutoverFence` is: after
+	// cutover this opens the database, and that must not sit inside the writable
+	// handle's lifetime.
+	const indexStorage = await resolveReadStorage(opts.storage, cwd);
+
 	// Once this repo is fenced for cutover, new memories land in SQLite only —
 	// the orphan branch stops moving. Read before opening the DB, so the async
 	// call cannot sit inside the handle's lifetime.
@@ -598,6 +642,9 @@ export async function dbBackfillRepo(opts: DbBackfillOptions): Promise<DbBackfil
 							// the step this sweep's wall clock is made of. A bootstrap has an
 							// empty set and so still scans everything.
 							knownHashes,
+							// The branch-attribution read. Explicit, and not this checkout's
+							// own ambient fallback — see `indexStorage`.
+							storage: indexStorage,
 						});
 					} catch (err) {
 						// Not fatal for the repo: sessions and memories still import, and the
@@ -613,13 +660,24 @@ export async function dbBackfillRepo(opts: DbBackfillOptions): Promise<DbBackfil
 							merged.set(event.hash, event);
 							continue;
 						}
-						// Union the reachability; keep the first checkout's metadata, which
+						// Union the attribution; keep the first checkout's metadata, which
 						// is identical for a given hash apart from `branches`.
 						//
-						// ABSENT ON EITHER SIDE POISONS THE UNION. A checkout omits
-						// `branches` when its own branch scan was incomplete (a failed
-						// `for-each-ref`/`rev-list`, or a commit only branches past
-						// MAX_BRANCHES reach), and absent means "keep what is stored".
+						// The union is FULLY degenerate now and kept for its ABSENT
+						// handling alone: every checkout reads its attribution from the one
+						// `indexStorage` this pass resolved, so each contributes the same
+						// single recorded branch for a hash. (It used to be argued as
+						// earning its place across two CLONES holding different indexes;
+						// that stopped being true when the provider stopped being
+						// per-checkout, and the index was already treated as per-repo by
+						// the summaries cursor either way.)
+						//
+						// ABSENT ON EITHER SIDE POISONS THE UNION, and that half is NOT
+						// degenerate — one shared provider means the index either loads for
+						// every checkout or for none, but the "for none" case still has to
+						// come out absent. `branches` is omitted when the index could not
+						// be loaded at all (unreadable, or none written yet), and absent
+						// means "keep what is stored".
 						// Coercing that to `[]` and unioning turns two omissions into the
 						// CLAIM "no branch reaches this commit" — which the projection
 						// honours by deleting every `commit_branches` row for the commit —

--- a/cli/src/dashboard/SotSchema.ts
+++ b/cli/src/dashboard/SotSchema.ts
@@ -58,6 +58,44 @@ export const REORDER_OFFSET = 1_000_000;
  * Every repo association is `repo_id`, and every composite key and index leads
  * with it. The one exception is `commit_branches`, which carries no repo column
  * at all — see the note on `branches`.
+ *
+ * ## `commit_branches` no longer stores reachability — read this before touching it
+ *
+ * Its in-DDL comment still describes the per-ref `git rev-list` union it was
+ * built for, and that comment is FROZEN: this constant is `MIGRATIONS[0]`, whose
+ * bytes every existing database has recorded and now byte-compares on every
+ * writable open (see `DashboardDb`'s drift check and `MigrationFingerprints`).
+ * Editing a character in there makes every database in the wild refuse to open.
+ * So the current behaviour is documented here, outside the frozen text.
+ *
+ * **What it holds now: exactly ONE row per commit — the branch the commit was
+ * committed on** (`CommitCreatedEvent.branches` as a one-element list, sourced
+ * from the summary's recorded branch in `DashboardCollector`).
+ *
+ * **Why the union was removed.** It came from `for-each-ref --sort=-committerdate`
+ * capped at 50, and that window reshuffles whenever any branch gains a commit —
+ * while `DbBackfill`'s `unchangedCommitEvent` compares `branches` for exact set
+ * equality. On a repo past the cap every commit the window reached was re-projected
+ * on every pass and never converged: measured on a 350-branch repo, 11,953 commits
+ * re-enqueued per shift and 24.6 MB of duplicate `events_raw` rows. Worse, the
+ * field is replace-when-present, so a branch dropping out of the window DELETED its
+ * rows — stored attribution was a moving target under the one query that reads it.
+ * A recorded branch is a historical fact about one commit and cannot reshuffle.
+ *
+ * It is also the better answer for that query (per-PR cost): under reachability
+ * every commit on `main` counted under every feature branch based off it, which is
+ * the only reason the reader needed an apportioning division at all. What is lost
+ * is "which branches can see this commit NOW", checked against what the dashboard
+ * asks (cost per PR, cost per commit) and needed by neither.
+ *
+ * **Why both tables survive with a degenerate use — do NOT drop them.** Released
+ * clients still JOIN them for the per-branch series, and the rule here is to keep
+ * compatibility with shipped clients rather than delete tables or columns. An older
+ * client reading a database this build wrote gets one row per commit, so its
+ * `COUNT(*) OVER (PARTITION BY hash)` divisor becomes 1 and it stops apportioning —
+ * fixed by this change, not degraded. Dropping them (or removing the CREATE, which
+ * is the same thing for every database created afterwards) would make that client
+ * fail with `no such table` instead.
  */
 export const ACTIVITY_DDL = `
 -- ── Metadata ────────────────────────────────────────────────────────────────

--- a/cli/src/dashboard/StatsWriter.ts
+++ b/cli/src/dashboard/StatsWriter.ts
@@ -733,9 +733,16 @@ function projectCommit(db: DashboardDbHandle, event: CommitCreatedEvent): void {
 		event.deletions ?? null,
 	);
 
-	// `branches` is authoritative when present — replacing the set is what prunes
-	// a branch the commit is no longer reachable from. `undefined` means "not
-	// observed this time" and leaves the existing rows alone.
+	// `branches` is authoritative when present — replacing the set is what drops an
+	// attribution the commit no longer carries. `undefined` means "could not tell"
+	// (the collector loaded no summary index) and leaves the existing rows alone.
+	//
+	// The guard MUST stay a plain truthiness test on the array itself: `[]` is
+	// truthy, and that is exactly what lets an empty list reach the DELETE and clear
+	// the rows. Rewriting it as `event.branches?.length` or `.length > 0` looks
+	// equivalent and silently inverts the meaning of `[]` into `undefined`'s —
+	// which, on a database still holding the old N-row reachability sets, leaves
+	// those commits carrying stale attribution forever. See `CommitCreatedEvent.branches`.
 	const commitId = resolveCommitId(db, eventId);
 	if (event.branches) {
 		db.prepare("DELETE FROM commit_branches WHERE commit_id = ?").run(commitId);
@@ -789,6 +796,42 @@ function projectCommitSummary(db: DashboardDbHandle, event: CommitSummaryEvent):
 		   branch        = COALESCE(excluded.branch, commits.branch),
 		   message       = COALESCE(excluded.message, commits.message)`,
 	).run(commitEventId, repoId, event.hash, event.branch ?? null, event.message ?? null, event.committedAtMs);
+
+	// `commit_branches` too, and NOT just the `commits.branch` column above.
+	//
+	// Attribution is the branch the commit was COMMITTED ON, and its source is
+	// this very summary — so this event carries the whole fact and must project it
+	// into the table the branch axis actually reads (`buildSeries` joins
+	// `commit_branches`; nothing reads `commits.branch` for that axis).
+	//
+	// Writing only the column left a gap no later pass closes on its own. The
+	// commit tier is gated on `checkoutFingerprint`, which hashes HEAD plus
+	// `refs/heads` MINUS Jolli's own refs — so the orphan branch moving under a
+	// late-arriving memory does not move that cursor, `collectCommitEvents` is
+	// skipped, and the commit keeps whatever attribution it had when it was last
+	// swept: `[]` for one whose summary did not exist yet, since an index that
+	// loads WITHOUT the entry is the "no recorded branch" answer. The rows then
+	// stay wrong until some unrelated ref happens to move.
+	// `recordCommitsFromWorker` hides this for the ordinary local commit — it
+	// writes the current branch at drain time — which is exactly why the hole only
+	// shows for the paths that skip it: a live write that failed (and was
+	// swallowed, by contract), a regeneration outside the queue, and a database
+	// whose sweep ran between the commit and its summary.
+	//
+	// Same replace-when-present contract as `commit.created`'s `branches`, and the
+	// absent side is load-bearing in the same way: `branch` is present-gated by
+	// `summaryEventFromCommitSummary`, so a summary recording none leaves the
+	// stored rows ALONE rather than clearing them. Only `commit.created` may say
+	// "no branch reaches this commit", because only it can tell an unreadable
+	// index from one that simply does not list the hash.
+	if (event.branch) {
+		const commitId = resolveCommitId(db, commitEventId);
+		db.prepare("DELETE FROM commit_branches WHERE commit_id = ?").run(commitId);
+		db.prepare(
+			`INSERT INTO commit_branches (commit_id, branch_id) VALUES (?, ?)
+			 ON CONFLICT(commit_id, branch_id) DO NOTHING`,
+		).run(commitId, resolveBranchId(db, repoId, event.branch));
+	}
 
 	if (event.sessionLinks) {
 		const seedSession = db.prepare(

--- a/cli/src/dashboard/assets/js/shell.js
+++ b/cli/src/dashboard/assets/js/shell.js
@@ -11,10 +11,12 @@ window.JD = window.JD || {};
 		var ranged = JD.ranged(model);
 		var range = "range" in o ? o.range : ranged ? ranged.range : undefined;
 		/* Falls back to the dimension the SERVER says it used, not to undefined.
-		   `JD.dimension` is only ever set by a chip click, so before the first click
-		   a deep-linked `?dimension=branch` was absent from every rebuilt URL and
-		   the 30 s poll silently re-asked for the default — the chart axis changed
-		   under the reader. */
+		   `JD.dimension` is only set by the Tokens card's split tabs, so for every
+		   other axis it is undefined — and a deep-linked `?dimension=branch` was
+		   then absent from every rebuilt URL while the 30 s poll silently re-asked
+		   for the default, changing the chart axis under the reader. Deep links are
+		   the ONLY way to reach the branch/ticket/category axes: the server accepts
+		   them (see `parseDimension`) but nothing renders a control for them. */
 		var served = model.stats && model.stats.seriesDimension;
 		var dimension = "dimension" in o ? o.dimension : JD.dimension || served;
 		/* Bounds ride along ONLY with range=custom, so switching to a preset drops

--- a/cli/src/dashboard/assets/js/stats.js
+++ b/cli/src/dashboard/assets/js/stats.js
@@ -10,27 +10,6 @@ window.JD = window.JD || {};
 		return RANGE_SUB[stats.range] || stats.rangeFrom + " → " + stats.rangeTo;
 	}
 
-	/* The mockup's group-by axes. `lockTier: 1` reads the memory-enriched commit
-	   columns; `project` is unlocked here because repo grouping needs no memory. */
-	var GROUPS = [
-		{ key: "model", label: "Model", memoryOnly: false },
-		{ key: "agent", label: "Agent", memoryOnly: false },
-		{ key: "project", label: "Project", memoryOnly: false },
-		{ key: "branch", label: "Branch", memoryOnly: true },
-		{ key: "ticket", label: "Ticket", memoryOnly: true },
-		{ key: "category", label: "Work category", memoryOnly: true },
-	];
-
-	/* Per-axis footnote, quoting the mockup's own wording where it applies. */
-	var AXIS_NOTE = {
-		model: "Token coverage: <b>Claude ✓</b> · Codex, Cursor, Copilot report sessions only until usage parsing lands.",
-		agent: "Sessions and tokens per agent. Cost shown where the transcript reports usage.",
-		project: "Tokens per repository, across every agent.",
-		branch: "A commit reachable from several branches counts on each — the axis answers where spend landed.",
-		ticket: "Commits with no ticket are grouped as <span class=\"mono\">(no ticket)</span>.",
-		category: "Work category is the dominant topic category of each commit's memory.",
-	};
-
 	/* Totals per series key, for the ranked-bar axes. */
 	function rankRows(stats) {
 		/* Prototype-less, same reason as memoryActivityCard's grouping: series keys
@@ -1108,8 +1087,9 @@ window.JD = window.JD || {};
 	var TOK_VIEW_LABEL = { model: "Model", project: "Project" };
 
 	/* Split-by tabs, inside the card and nowhere else. Picking "By model"/"By
-	   repo" re-fetches exactly the way Cost & tokens' own group-by chips do,
-	   because both read `JD.dimension`. */
+	   repo" writes `JD.dimension` and re-fetches, because the axis is a
+	   server-side query. These are the only controls that set it — the generic
+	   group-by chips they used to be described as matching were never rendered. */
 	function tokensViewChips(view) {
 		return (
 			'<div class="chips" role="group" aria-label="Split by" style="margin-top:10px">' +
@@ -1373,15 +1353,6 @@ window.JD = window.JD || {};
 		html += feedCard(model);
 
 		document.getElementById("app").innerHTML = html;
-
-		/* Group-by chips: re-fetch the model along the picked axis (the axis is a
-		   server-side query, so it needs a round trip). */
-		document.querySelectorAll(".chips .chip[data-dim]").forEach((chip) => {
-			chip.onclick = () => {
-				JD.dimension = chip.getAttribute("data-dim");
-				JD.refreshNow(JD.renderPage);
-			};
-		});
 
 		/* Card tabs and the table toggle are pure view state over the SAME model,
 		   so they re-render locally instead of re-querying. */


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

The dashboard's per-branch cost chart had a self-reinforcing write loop on repositories with many branches. A background sweep sorted branches by most-recently-committed and took the top 50, then compared that window against what was stored — but any commit on any branch reshuffled the sort order, so the comparison never matched and every commit the window covered was rewritten on every sweep. On a 350-branch repository this produced over 11,000 re-processed commits per sweep and 24.6 MB of accumulating duplicate data, with the numbers shown in the chart changing from sweep to sweep.

The fix replaces the reachability window entirely. Each commit now records the single branch it was committed on — a historical fact that cannot change — and the per-branch cost chart reflects that stable record. Already-shipped clients that read the same database tables find one row per commit and their numbers align with the new behavior automatically, with no forced upgrade and no cross-surface coordination required.

A second bug was discovered during this work: the guard that decided whether to clear or preserve stored branch rows was checking for a thrown exception, but the index reader almost never throws — it converts disk errors and malformed files into a null return. One unreadable index therefore caused every commit's branch data to be deleted in a single pass, leaving the per-branch cost chart completely blank with no error surfaced to the user. The guard was corrected to key on whether the index actually loaded, treating both failure shapes as "could not determine" and preserving stored rows in both cases.

A third issue was also resolved: documentation had been added inside the SQL string that defines the baseline database schema, whose exact bytes are recorded in every existing database and compared on every open. Editing even a comment character inside that string caused every existing database to report a drift error. The documentation was moved outside the frozen string, restoring the original bytes and leaving all existing databases intact.

---

## E2E Test (2)
<details>
<summary><strong>1. Per-branch cost chart stays populated after a background refresh</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository connected to Jolli Memory that already has some per-branch cost data visible in the dashboard (at least one branch with recorded cost history).

**Steps:**
1. Open the Jolli Memory dashboard and navigate to the per-branch cost chart.
2. Note which branches are shown and that the chart displays cost data for them.
3. Wait for a background refresh to complete (or trigger one by switching away and back to the dashboard).
4. Check the per-branch cost chart again.
5. Repeat steps 3–4 two or three more times to confirm the chart remains stable across multiple refreshes.

**Expected Results:**
- The per-branch cost chart continues to show the same branches and cost data after every refresh — it does not go blank or lose previously displayed information.
- No error message appears indicating that branch data could not be loaded.

</blockquote>
</details>
<details>
<summary><strong>2. Per-branch cost chart stabilises on a repository with many branches</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with more than 50 local branches connected to Jolli Memory, and allow the dashboard to run at least two background sweeps.

**Steps:**
1. Open the Jolli Memory dashboard and go to the per-branch cost chart.
2. Note which branches appear and what cost values are shown for each.
3. Wait for a second background sweep to finish (allow a minute or two, or check again after the app has been open for a while).
4. Compare the branch list and cost values to what you noted in step 2.

**Expected Results:**
- The branches shown in the chart and their associated cost figures remain the same between sweeps — no branches appear, disappear, or swap positions unexpectedly.
- The chart does not accumulate duplicate entries or show wildly changing totals on each refresh.
- Each commit is attributed to the single branch it was originally committed on, not a growing or shifting list of branches.

</blockquote>
</details>

---

## Topics (5)
<details>
<summary><strong>01 · Fix silent data wipe when branch history index is unreadable</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After switching branch attribution from a live git scan to a value recorded in the summary index, a subtle guard bug caused every commit's stored branch data to be deleted whenever the index could not be read, leaving the per-branch cost chart completely blank with no error surfaced to the user.

**💡 Decisions Behind the Code**

- **Treating unreadable and absent indexes identically**: The index reader's own contract states that callers must read a null return as "nothing to read, not nothing went wrong." Distinguishing the two cases would require changing the storage layer's interface, adding complexity with no safety gain. Keeping unreadable rows is harmless; wiping live attribution is immediately visible and slow to recover.
- **No database migration needed**: The fix is entirely in the collection path. The stored data model is unchanged, and the corrected behavior is backward-compatible with any existing database state.

**✅ What Was Implemented**

- `DashboardCollector.ts`: removed the `indexReadable` flag and replaced the exception-based guard with a direct null-check on the loaded index object. Both a thrown error and a resolved null are now treated as "could not determine" — preserving stored rows — and an empty list (which clears rows) is only emitted when the index actually loaded and recorded nothing for that commit.
- `DashboardCollector.test.ts`: the test that previously asserted a resolved-null index emits an empty branch list was inverted to assert no branch property at all; an explanatory comment block was added documenting the regression and the asymmetry between the two null shapes.
- `DashboardModel.ts`, `StatsWriter.ts`, `DbBackfill.ts`, `DbBackfill.test.ts`: inline documentation updated to reflect corrected semantics — "no index loaded" replaces "index unreadable" as the description of the absent case, and references to the old reachability scan were removed as no-longer-valid reasons for absence.

**📁 FILES**
- `cli/src/dashboard/DashboardCollector.ts`
- `cli/src/dashboard/DashboardModel.ts`
- `cli/src/dashboard/DbBackfill.ts`
- `cli/src/dashboard/StatsWriter.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Replace unstable branch reachability window with recorded branch attribution</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

On repositories with more than 50 local branches, the dashboard's per-branch cost chart never settled: every time any branch received a new commit, the sorted window of "top 50 branches" reshuffled, causing thousands of commits to be re-processed on every background sweep. A 350-branch repository was measured accumulating 24.6 MB of duplicate database entries with no end in sight, and the branch attribution shown in charts was a moving target rather than a stable historical record.

**💡 Decisions Behind the Code**

- **Rewrite the stored value rather than stop writing it**: Simply stopping writes would leave older clients seeing missing data for new commits. Writing a single recorded branch instead of a reachability union means older clients automatically get a corrected result — their apportioning divisor becomes 1 and their per-branch cost numbers align with the new client — at no compatibility cost.
- **No schema change required**: Dropping the tables or bumping the schema version would force every installed client to upgrade before the database could be opened again. The fix is purely in what values are written, so it ships as a code-only change with no forced upgrade and no cross-surface coordination.
- **Recorded branch over reachability for per-PR cost**: The reachability model counted every commit on a base branch under every feature branch derived from it, requiring an apportioning division whose denominator was proven to be drifting. The recorded branch answers "what did the work on this branch cost" directly and correctly, which is the actual question the chart exists to answer. The ability to ask "which branches can see this commit today" is lost, but was confirmed to be needed by neither of the dashboard's two cost questions.

**✅ What Was Implemented**

- The entire per-branch reachability scan was removed from `DashboardCollector.ts`: the `for-each-ref` call, the per-branch `rev-list` loop (up to 350 subprocess calls per sweep), the 50-branch cap constant, and the truncation/failure tracking variables. Branch attribution is now read directly from the summary index entry for each commit — a single stable value rather than a set computed from the current state of all branches.
- The emit logic in `DashboardCollector.ts` was rewritten to distinguish three cases: index not loaded (leave stored rows alone), index loaded with a branch recorded (write a one-element list), and index loaded with no branch recorded (write an empty list to actively clear stale rows). A key correctness detail — that an empty array is truthy in JavaScript and therefore triggers the projection's delete path — was pinned with comments in `DashboardCollector.ts`, `StatsWriter.ts`, and `DashboardModel.ts` to prevent a future "simplification" from silently inverting the semantics.
- `SotSchema.ts` and `DashboardQuery.ts` were updated with detailed notes explaining why the `commit_branches` and `branches` tables are retained despite now holding only one row per commit: released clients still join them, and dropping the tables would cause those clients to crash. The apportioning division in the branch series query is also kept as a transition safeguard for databases written by older clients.

**📋 Future Enhancements**

Verify squash-merge scenarios: when a PR is squash-merged, the original commits carry the feature branch while the squash commit lands on the base branch. The consolidation pipeline is expected to handle this, but a real squash merge should be used to confirm the per-PR numbers are not double-counted.

**📁 FILES**
- `cli/src/dashboard/DashboardCollector.ts`
- `cli/src/dashboard/SotSchema.ts`
- `cli/src/dashboard/DashboardModel.ts`
- `cli/src/dashboard/DashboardQuery.ts`
- `cli/src/dashboard/StatsWriter.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Restore frozen schema DDL bytes broken by documentation edit</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A documentation comment was added inside the SQL DDL string that defines the baseline database schema. That string's exact bytes are recorded in every existing database and compared on every writable open to detect schema drift, so editing even a comment character inside it causes every existing database to report a drift error and refuse to open.

**💡 Decisions Behind the Code**

Moving documentation rather than updating the fingerprint was the correct fix. Updating the fingerprint would require a new migration entry and would still invalidate every database that had recorded the old bytes. The frozen DDL comment is now intentionally stale — it describes the old reachability behavior — but the live documentation immediately above it explains the current behavior and why the DDL text cannot be changed.

**✅ What Was Implemented**

- `SotSchema.ts`: moved the new explanatory documentation out of the frozen DDL template string and into a TypeScript module-level comment above it, restoring the DDL bytes to their original fingerprint-verified form.
- The DDL itself reverts the `commit_branches` table comment back to its original reachability-era wording (which is frozen), while the accurate current-behavior documentation lives in the unfrozen TypeScript docstring above the constant.

**📁 FILES**
- `cli/src/dashboard/SotSchema.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Add convergence and late-memory tests for branch attribution</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The switch to recorded branch attribution needed test coverage for two scenarios the old tests did not address: that the new approach actually stops re-processing commits when the branch list changes, and that a commit whose memory arrives after the commit itself eventually gets its branch filled in.

**💡 Decisions Behind the Code**

- **Test written before fix, confirmed red first**: A test written after a fix cannot prove the fix was necessary, only that the current code passes. Writing the convergence test first and confirming it failed directly reproduces the measured churn and validates the fix was needed.
- **Dedicated late-memory test guards a specific regression risk**: The old churn was continuously refreshing branch data as a side effect, and removing it narrows the window during which a commit's branch can be filled in. The late-memory test ensures this narrowed window still covers the full lifecycle correctly.

**✅ What Was Implemented**

- Added a convergence regression test in `DashboardCollector.test.ts` that simulates a branch window reshuffle (one branch entering, one leaving) and asserts the emitted branch value is identical across both sweeps. This test was confirmed to be red before the fix was applied, directly reproducing the measured churn.
- Added a "memory arrived late" integration test in `DbBackfill.test.ts` covering the full lifecycle: commit stored with no branch, memory arrives, branch fills in on the next sweep, and subsequent sweeps emit nothing new. The test also asserts exactly one row exists in the branch table after convergence, and that the branch column on the commit record is populated.

**📁 FILES**
- `cli/src/dashboard/DashboardCollector.test.ts`
- `cli/src/dashboard/DbBackfill.test.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Relocate internal-ref classification tests to the owning module</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The test guarding the rule that distinguishes Jolli's internal storage branch from user branches with similar names lived inside the commit collector's test file. Removing the reachability scan would have deleted that test along with the scan code, leaving the underlying classification function — still used elsewhere — without any coverage.

**💡 Decisions Behind the Code**

Moving the tests to the file that owns the function makes the coverage durable regardless of which callers exist at any given time. The original location tested the rule only indirectly through the collector, so any future refactor of the collector could silently drop the guard; a direct test on the function itself cannot be accidentally removed by changes to its callers.

**✅ What Was Implemented**

Created `cli/src/core/JolliRefs.test.ts` with direct tests for the internal-ref classification function and the exclude-glob constant. The tests pin both the namespace-vs-prefix distinction (a branch named similarly to the internal namespace must not be excluded) and the exact string form of the glob (the `refs/heads/`-prefixed form was measured to silently match nothing, so the correct relative form is asserted explicitly).

**📁 FILES**
- `cli/src/core/JolliRefs.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 13, 2026 at 8:48 PM · via Anthropic*
<!-- jollimemory-summary-end -->