### PR TITLE
Add per-agent call breakdown to dashboard tool usage rows

### DIFF
--- a/cli/src/dashboard/DashboardModel.ts
+++ b/cli/src/dashboard/DashboardModel.ts
@@ -1141,6 +1141,34 @@ export interface StandupModel {
 	readonly insights?: ReadonlyArray<StandupInsight>;
 }
 
+/**
+ * One agent's share of a single skill / tool / server row — which of Claude
+ * Code, Codex, … actually made those calls.
+ *
+ * CALLS ONLY, deliberately. A session belongs to exactly one source, so calls
+ * and session counts both partition cleanly by agent at the grouping they were
+ * counted at — but a session count does not survive being RE-SUMMED at a
+ * coarser level, and this shape appears at three of them. A session that called
+ * two of a server's tools is one session for the server and two rows in the
+ * per-tool grouping, which is the same trap {@link ToolUsage.servers}' own
+ * query exists to avoid (see `buildToolUsage`). Carrying a number that is exact
+ * on the skill rows and a double count on the server rows would be worse than
+ * carrying none. The per-kind totals in {@link ToolUsage.skillAgents} /
+ * {@link ToolUsage.mcpAgents} do carry sessions, because they come from their
+ * own `COUNT(DISTINCT …)` grouping rather than from a re-sum.
+ */
+export interface ToolUsageAgentShare {
+	/** `sessions.source` — the raw `claude` / `codex` tag every other axis shows. */
+	readonly source: string;
+	readonly calls: number;
+}
+
+/** One agent's whole-window footprint for a tool kind, counted by its own grouping. */
+export interface ToolUsageAgentTotal extends ToolUsageAgentShare {
+	/** Distinct sessions of this agent with at least one call of that kind. */
+	readonly sessions: number;
+}
+
 /** One tool, skill or MCP server, aggregated over the window. */
 export interface ToolUsageRow {
 	/** `Bash`, `linear.list_issues`, `code-review`. */
@@ -1149,6 +1177,8 @@ export interface ToolUsageRow {
 	/** Sessions that called it — the adoption figure, not the volume figure. */
 	readonly sessions: number;
 	readonly calls: number;
+	/** Which agents made those calls, most calls first — see {@link ToolUsageAgentShare}. */
+	readonly agents: ReadonlyArray<ToolUsageAgentShare>;
 }
 
 /** One MCP server, rolled up across all of its tools. */
@@ -1159,10 +1189,51 @@ export interface McpServerRow {
 	readonly calls: number;
 	/** Distinct tools of that server actually called. */
 	readonly tools: number;
+	/** Which agents called it, most calls first — see {@link ToolUsageAgentShare}. */
+	readonly agents: ReadonlyArray<ToolUsageAgentShare>;
 }
 
-/** How many rows the skill and server lists carry. */
+/**
+ * How many rows ONE PAGE of a skill / server / MCP-tool list carries.
+ *
+ * Not a cap any more: it is the page size, applied as `LIMIT` in SQL (see
+ * `buildToolUsage`), and the card's "Show more" button asks
+ * `/api/tool-usage` for the next page of the same size. It stayed 8 because
+ * that is the height the card is laid out for — past the first page the list
+ * scrolls inside the card rather than growing it, so the page size is also the
+ * number of rows visible without scrolling.
+ *
+ * The client has a copy of this number (`TOOL_PAGE_SIZE` in `assets/js/stats.js`)
+ * for the scroll cap alone; the paging itself is driven by the server's
+ * `*Total` counts below, never by the client re-deriving the page size.
+ */
 export const TOOL_ROWS_LIMIT = 8;
+
+/** Which of the three tool-usage lists a page request is for. */
+export type ToolUsageList = "skill" | "server" | "tool";
+
+/**
+ * One page of a tool-usage list — the `/api/tool-usage` answer.
+ *
+ * `totalCount` is re-read per page rather than remembered from the first
+ * render: the window keeps gaining rows while the dashboard is open, so the
+ * client's "is there more" test must be against a total as fresh as the rows
+ * it just received.
+ */
+export type ToolUsagePage =
+	| {
+			readonly list: "skill" | "tool";
+			/** Row index the page starts at — what the caller asked for, echoed back. */
+			readonly offset: number;
+			readonly rows: ReadonlyArray<ToolUsageRow>;
+			readonly totalCount: number;
+	  }
+	| {
+			readonly list: "server";
+			readonly offset: number;
+			readonly rows: ReadonlyArray<McpServerRow>;
+			readonly totalCount: number;
+	  };
 
 /**
  * `server.tool` name recorded for the recall feature's own MCP tool — the
@@ -1262,21 +1333,75 @@ export const RECALL_SKILL_NAMES: ReadonlyArray<string> = [RECALL_SKILL_NAME, "jo
  * dashboard states the limitation in the card's footnote instead.
  */
 export interface ToolUsage {
-	/** Skills, most-adopted first. */
-	readonly skills: ReadonlyArray<ToolUsageRow>;
-	/** MCP servers, most-adopted first. */
-	readonly servers: ReadonlyArray<McpServerRow>;
-	/** Individual MCP tools (name already `server.tool`), most-adopted first — the "by tool" split of `servers`. */
-	readonly mcpTools: ReadonlyArray<ToolUsageRow>;
 	/**
-	 * The recall feature's own row (`jollimemory.recall`), pulled out of `mcpTools`
-	 * before that array is truncated to TOOL_ROWS_LIMIT — recall can rank outside
-	 * the top 8 MCP tools by adoption even when it has real volume, so this must
-	 * not be derived from `mcpTools` client-side. `undefined` when the window has
-	 * no matching row (misses bare `jolli recall` CLI runs and the skill's
-	 * non-MCP fallback too — those never produce an `mcp`-kind row at all).
+	 * Skills, most-adopted first — ranked by {@link ToolUsageRow.sessions}, not by
+	 * volume, so one session that ran `/simplify` 200 times does not outrank a
+	 * skill three separate sessions reached for.
+	 *
+	 * This is the ONE list that ranks by a figure its rows do not print (they
+	 * print runs). That mismatch is why `rankedList` must size its bars against
+	 * the list's true maximum rather than its first row — and why an appended
+	 * page cannot be spliced into the rendered list in place: a later page can
+	 * carry MORE runs than the top row, which moves the bar denominator.
+	 *
+	 * ONE PAGE — the first {@link TOOL_ROWS_LIMIT} rows. The rest are fetched
+	 * per click from `/api/tool-usage?list=skill`, so anything derived from the
+	 * whole set must come off a `*Total` field or its own grouping, never off
+	 * this array.
+	 */
+	readonly skills: ReadonlyArray<ToolUsageRow>;
+	/** Distinct skills in the window — the paging total behind `skills`, and the "N skills" the card prints. */
+	readonly skillsTotal: number;
+	/** Every skill run in the window, including rows past the first page. */
+	readonly skillCallsTotal: number;
+	/**
+	 * MCP servers, busiest first — ranked by {@link McpServerRow.calls}, with
+	 * sessions as the tiebreak.
+	 *
+	 * Volume rather than adoption because this is the figure the card prints and
+	 * bars: ranking by sessions put 149 calls below 68 and made the two cards
+	 * disagree about what "first" meant, for no reading the numbers on screen
+	 * could explain. A server's adoption is still on the row (`sessions` rides in
+	 * the "by tool" split's meta slot) — it just does not order the list.
+	 *
+	 * ONE PAGE, like {@link skills} — see {@link serversTotal}.
+	 */
+	readonly servers: ReadonlyArray<McpServerRow>;
+	/** Distinct MCP servers called in the window — the paging total behind `servers`. */
+	readonly serversTotal: number;
+	/** Every MCP call in the window that carries a server, including rows past the first page. */
+	readonly serverCallsTotal: number;
+	/**
+	 * Individual MCP tools (name already `server.tool`), busiest first — the "by
+	 * tool" split of `servers`, same rule, and ONE PAGE like the other two.
+	 */
+	readonly mcpTools: ReadonlyArray<ToolUsageRow>;
+	/** Distinct MCP tools called in the window — the paging total behind `mcpTools`. */
+	readonly mcpToolsTotal: number;
+	/**
+	 * The recall feature's own row (`jollimemory.recall`), from its OWN query
+	 * rather than out of `mcpTools` — recall can rank outside the first page of
+	 * MCP tools on a busy machine even when its own volume is worth reporting, so
+	 * this must not be derived from `mcpTools` client-side (that held under the
+	 * old adoption ranking, holds under volume, and holds harder now that the
+	 * array is one page of a paged list: the reader may never click far enough to
+	 * load the row). `undefined` when the window has no matching row (misses bare
+	 * `jolli recall` CLI runs and the skill's non-MCP fallback too — those never
+	 * produce an `mcp`-kind row at all).
 	 */
 	readonly recallCalls?: ToolUsageRow;
+	/**
+	 * Agents that ran a skill in the window, most calls first.
+	 *
+	 * Its own grouping over EVERY row in the window, not a roll-up of
+	 * {@link skills} — that array is one page of {@link TOOL_ROWS_LIMIT}, so
+	 * deriving this client-side would under-report every agent whose skills all
+	 * rank outside the loaded pages, and would have to re-sum session counts (see
+	 * {@link ToolUsageAgentShare}).
+	 */
+	readonly skillAgents: ReadonlyArray<ToolUsageAgentTotal>;
+	/** Agents that called an MCP tool in the window, most calls first — same rule as {@link skillAgents}. */
+	readonly mcpAgents: ReadonlyArray<ToolUsageAgentTotal>;
 	/** Sessions with at least one recorded tool call. */
 	readonly sessionsWithTools: number;
 	/** Sessions in the window, regardless of whether tools could be read. */

--- a/cli/src/dashboard/DashboardQuery.test.ts
+++ b/cli/src/dashboard/DashboardQuery.test.ts
@@ -3,11 +3,19 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { withDashboardDb } from "./DashboardDb.js";
-import type { DashboardScope, SessionUpsertedEvent, StatsEventEnvelope, StatsModel } from "./DashboardModel.js";
+import type {
+	DashboardScope,
+	McpServerRow,
+	SessionUpsertedEvent,
+	StatsEventEnvelope,
+	StatsModel,
+	ToolUsageRow,
+} from "./DashboardModel.js";
 import { TOOL_ROWS_LIMIT } from "./DashboardModel.js";
 import {
 	addLocalDays,
 	buildDashboardModel,
+	buildToolUsagePage,
 	computeStreak,
 	localDayKey,
 	localHour,
@@ -826,8 +834,20 @@ describe("buildDashboardModel — tool usage", () => {
 			{ producerKind: "cli", dbPath },
 		);
 		const result = await usage();
-		expect(result?.skills[0]).toEqual({ name: "code-review", kind: "skill", sessions: 3, calls: 4 });
-		expect(result?.skills[1]).toEqual({ name: "simplify", kind: "skill", sessions: 1, calls: 200 });
+		expect(result?.skills[0]).toEqual({
+			name: "code-review",
+			kind: "skill",
+			sessions: 3,
+			calls: 4,
+			agents: [{ source: "claude", calls: 4 }],
+		});
+		expect(result?.skills[1]).toEqual({
+			name: "simplify",
+			kind: "skill",
+			sessions: 1,
+			calls: 200,
+			agents: [{ source: "claude", calls: 200 }],
+		});
 	});
 
 	it("rolls MCP tools up to their server and counts its distinct tools", async () => {
@@ -845,17 +865,17 @@ describe("buildDashboardModel — tool usage", () => {
 		const result = await usage();
 		expect(result?.servers).toEqual([
 			// One session using two of the server's tools is ONE session, never two.
-			{ server: "linear", sessions: 1, calls: 5, tools: 2 },
-			{ server: "github", sessions: 1, calls: 1, tools: 1 },
+			{ server: "linear", sessions: 1, calls: 5, tools: 2, agents: [{ source: "claude", calls: 5 }] },
+			{ server: "github", sessions: 1, calls: 1, tools: 1, agents: [{ source: "claude", calls: 1 }] },
 		]);
 	});
 
-	it("splits the same MCP rows by individual tool, ranked by adoption", async () => {
+	it("splits the same MCP rows by individual tool, ranked by call volume", async () => {
 		await applySummaryEvents(
 			[
 				repoEvent,
 				sessionWith("s1", [
-					{ name: "linear.list_issues", kind: "mcp", server: "linear", calls: 3 },
+					{ name: "linear.list_issues", kind: "mcp", server: "linear", calls: 9 },
 					{ name: "linear.get_issue", kind: "mcp", server: "linear", calls: 2 },
 				]),
 				sessionWith("s2", [{ name: "linear.get_issue", kind: "mcp", server: "linear", calls: 1 }]),
@@ -863,12 +883,42 @@ describe("buildDashboardModel — tool usage", () => {
 			{ producerKind: "cli", dbPath },
 		);
 		const result = await usage();
-		// linear.get_issue reached across two sessions outranks list_issues' one,
-		// even though list_issues has more raw calls — same adoption-first rule
-		// as skills.
+		// The two rules disagree here on purpose — list_issues has the volume (9 vs
+		// 3) and get_issue has the adoption (2 sessions vs 1) — because the fixture
+		// this replaced tied at 3 calls each and so passed under either one, leaving
+		// the rule it named untested. Volume wins: unlike skills, both MCP lists
+		// print calls and size their bars by calls.
 		expect(result?.mcpTools).toEqual([
-			{ name: "linear.get_issue", kind: "mcp", sessions: 2, calls: 3 },
-			{ name: "linear.list_issues", kind: "mcp", sessions: 1, calls: 3 },
+			{
+				name: "linear.list_issues",
+				kind: "mcp",
+				sessions: 1,
+				calls: 9,
+				agents: [{ source: "claude", calls: 9 }],
+			},
+			{ name: "linear.get_issue", kind: "mcp", sessions: 2, calls: 3, agents: [{ source: "claude", calls: 3 }] },
+		]);
+	});
+
+	it("ranks servers by call volume, not by the sessions that reached for them", async () => {
+		await applySummaryEvents(
+			[
+				repoEvent,
+				// The shape of the real bug: a widely-adopted server with modest volume
+				// above a narrowly-used one that dominates the calls. Ranking by
+				// sessions printed 149 below 68 on a live database, and `rankedList`
+				// sizes its bars against the top row, so the busier server's bar
+				// overflowed to 100% and read as equal rather than as bigger.
+				sessionWith("s1", [{ name: "jollimemory.recall", kind: "mcp", server: "jollimemory", calls: 1 }]),
+				sessionWith("s2", [{ name: "jollimemory.recall", kind: "mcp", server: "jollimemory", calls: 1 }]),
+				sessionWith("s3", [{ name: "jollimemory.recall", kind: "mcp", server: "jollimemory", calls: 1 }]),
+				sessionWith("s4", [{ name: "codegraph.explore", kind: "mcp", server: "codegraph", calls: 30 }]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		expect((await usage())?.servers.map((row) => [row.server, row.sessions, row.calls])).toEqual([
+			["codegraph", 1, 30],
+			["jollimemory", 3, 3],
 		]);
 	});
 
@@ -882,7 +932,13 @@ describe("buildDashboardModel — tool usage", () => {
 			{ producerKind: "cli", dbPath },
 		);
 		const result = await usage();
-		expect(result?.recallCalls).toEqual({ name: "jollimemory.recall", kind: "mcp", sessions: 2, calls: 4 });
+		expect(result?.recallCalls).toEqual({
+			name: "jollimemory.recall",
+			kind: "mcp",
+			sessions: 2,
+			calls: 4,
+			agents: [{ source: "claude", calls: 4 }],
+		});
 	});
 
 	it("still finds recall's row once it is pushed out of mcpTools' top slots", async () => {
@@ -894,9 +950,10 @@ describe("buildDashboardModel — tool usage", () => {
 		}));
 		const events = [
 			repoEvent,
-			// Each busier tool is reached from two separate sessions — strictly
-			// outranking recall's single session by adoption — while recall itself
-			// is only called once.
+			// Each busier tool is reached from two separate sessions with one call
+			// each, so it outranks recall's single call on volume as well as on
+			// adoption — the cut is TOOL_ROWS_LIMIT rows whichever figure orders
+			// them, which is the property `recallCalls` has to survive.
 			...busierTools.flatMap((tool, i) => [sessionWith(`busyA${i}`, [tool]), sessionWith(`busyB${i}`, [tool])]),
 			sessionWith("recall-session", [
 				{ name: "jollimemory.recall", kind: "mcp", server: "jollimemory", calls: 1 },
@@ -906,7 +963,13 @@ describe("buildDashboardModel — tool usage", () => {
 		const result = await usage();
 		expect(result?.mcpTools).toHaveLength(TOOL_ROWS_LIMIT);
 		expect(result?.mcpTools.some((row) => row.name === "jollimemory.recall")).toBe(false);
-		expect(result?.recallCalls).toEqual({ name: "jollimemory.recall", kind: "mcp", sessions: 1, calls: 1 });
+		expect(result?.recallCalls).toEqual({
+			name: "jollimemory.recall",
+			kind: "mcp",
+			sessions: 1,
+			calls: 1,
+			agents: [{ source: "claude", calls: 1 }],
+		});
 	});
 
 	it("leaves recallCalls undefined when recall was never called", async () => {
@@ -927,7 +990,111 @@ describe("buildDashboardModel — tool usage", () => {
 			{ producerKind: "cli", dbPath },
 		);
 		// Two sessions, one tool each: the per-tool max was 1 and undercounted by half.
-		expect((await usage())?.servers).toEqual([{ server: "linear", sessions: 2, calls: 2, tools: 2 }]);
+		expect((await usage())?.servers).toEqual([
+			{ server: "linear", sessions: 2, calls: 2, tools: 2, agents: [{ source: "claude", calls: 2 }] },
+		]);
+	});
+
+	it("names the agents behind one skill, most calls first, without losing the row's own totals", async () => {
+		await applySummaryEvents(
+			[
+				repoEvent,
+				sessionWith("s1", [{ name: "code-review", kind: "skill", calls: 2 }], "claude"),
+				sessionWith("s2", [{ name: "code-review", kind: "skill", calls: 5 }], "codex"),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		// The SQL groups by source as well now, so the row itself is a fold of two
+		// buckets. A session has exactly one source, so both totals survive it
+		// exactly — that is the property the split relies on.
+		expect((await usage())?.skills).toEqual([
+			{
+				name: "code-review",
+				kind: "skill",
+				sessions: 2,
+				calls: 7,
+				agents: [
+					{ source: "codex", calls: 5 },
+					{ source: "claude", calls: 2 },
+				],
+			},
+		]);
+	});
+
+	it("splits a server by agent from the per-tool rows, leaving its tool count undoubled", async () => {
+		await applySummaryEvents(
+			[
+				repoEvent,
+				sessionWith("s1", [{ name: "linear.get_issue", kind: "mcp", server: "linear", calls: 3 }], "claude"),
+				// The SAME tool from a second agent: `tools` must stay 1, which is why
+				// the split rides on the per-tool rows instead of a `source` column
+				// added to the server query's own GROUP BY.
+				sessionWith("s2", [{ name: "linear.get_issue", kind: "mcp", server: "linear", calls: 1 }], "codex"),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		expect((await usage())?.servers).toEqual([
+			{
+				server: "linear",
+				sessions: 2,
+				calls: 4,
+				tools: 1,
+				agents: [
+					{ source: "claude", calls: 3 },
+					{ source: "codex", calls: 1 },
+				],
+			},
+		]);
+	});
+
+	it("counts each agent's sessions distinctly in the per-kind totals", async () => {
+		await applySummaryEvents(
+			[
+				repoEvent,
+				// One session, two of the server's tools. Re-summing the per-tool rows
+				// would report claude with 2 sessions; its own grouping reports 1.
+				sessionWith(
+					"s1",
+					[
+						{ name: "linear.get_issue", kind: "mcp", server: "linear", calls: 1 },
+						{ name: "linear.list_issues", kind: "mcp", server: "linear", calls: 1 },
+					],
+					"claude",
+				),
+				sessionWith("s2", [{ name: "github.list_prs", kind: "mcp", server: "github", calls: 5 }], "codex"),
+				sessionWith("s3", [{ name: "code-review", kind: "skill", calls: 1 }], "codex"),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		const result = await usage();
+		expect(result?.mcpAgents).toEqual([
+			{ source: "codex", sessions: 1, calls: 5 },
+			{ source: "claude", sessions: 1, calls: 2 },
+		]);
+		// Kinds are separate groupings: the codex session that ran a skill is not
+		// in `mcpAgents`, and its MCP session is not in `skillAgents`.
+		expect(result?.skillAgents).toEqual([{ source: "codex", sessions: 1, calls: 1 }]);
+	});
+
+	it("keeps the agent split on rows that rank outside the visible list", async () => {
+		const many = Array.from({ length: TOOL_ROWS_LIMIT + 2 }, (_, i) =>
+			sessionWith(`s${i}`, [{ name: `srv${i}.t`, kind: "mcp", server: `srv${i}`, calls: 1 }], "claude"),
+		);
+		await applySummaryEvents(
+			[
+				repoEvent,
+				...many,
+				// One codex call, on a server that cannot make the top TOOL_ROWS_LIMIT.
+				sessionWith("sx", [{ name: "tail.t", kind: "mcp", server: "tail", calls: 1 }], "codex"),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		const result = await usage();
+		expect(result?.servers).toHaveLength(TOOL_ROWS_LIMIT);
+		// `mcpAgents` comes from its own untruncated grouping, so codex is still
+		// named even though no visible row carries it.
+		expect(result?.servers.some((row) => row.agents.some((a) => a.source === "codex"))).toBe(false);
+		expect(result?.mcpAgents).toContainEqual({ source: "codex", sessions: 1, calls: 1 });
 	});
 
 	it("reports coverage from all sessions and names the sources it cannot see inside", async () => {
@@ -992,7 +1159,9 @@ describe("buildDashboardModel — tool usage", () => {
 			{ producerKind: "cli", dbPath },
 		);
 		const result = await usage();
-		expect(result?.skills).toEqual([{ name: "code-review", kind: "skill", sessions: 1, calls: 4 }]);
+		expect(result?.skills).toEqual([
+			{ name: "code-review", kind: "skill", sessions: 1, calls: 4, agents: [{ source: "claude", calls: 4 }] },
+		]);
 		expect(result?.sessionsInWindow).toBe(1);
 		expect(result?.sessionsWithTools).toBe(1);
 	});
@@ -1051,9 +1220,203 @@ describe("buildDashboardModel — tool usage", () => {
 			skills: [],
 			mcpTools: [],
 			servers: [],
+			skillsTotal: 0,
+			serversTotal: 0,
+			mcpToolsTotal: 0,
+			skillCallsTotal: 0,
+			serverCallsTotal: 0,
 			sessionsWithTools: 0,
 			sessionsInWindow: 1,
 		});
+	});
+
+	/**
+	 * A page row's identity, whichever list it came from.
+	 *
+	 * `ToolUsagePage` is a union discriminated on `list`, and a caller that knows
+	 * which list it asked for still has to say so — the discriminant is on the
+	 * page, not inferred from the argument. Spelled once here rather than narrowed
+	 * at each assertion.
+	 */
+	const rowKey = (row: ToolUsageRow | McpServerRow): string => ("name" in row ? row.name : row.server);
+
+	/** `TOOL_ROWS_LIMIT + 4` skills, each reached from a distinct number of sessions. */
+	const manySkillEvents = (): ReadonlyArray<StatsEventEnvelope> => {
+		const events: StatsEventEnvelope[] = [repoEvent];
+		// Skills rank by ADOPTION, so the session count is what decides the order:
+		// skill00 is reached from the most sessions, skill11 from one.
+		for (let i = 0; i !== TOOL_ROWS_LIMIT + 4; i += 1) {
+			const name = `skill${String(i).padStart(2, "0")}`;
+			for (let s = 0; s !== TOOL_ROWS_LIMIT + 4 - i; s += 1) {
+				events.push(sessionWith(`${name}-s${s}`, [{ name, kind: "skill", calls: 1 }]));
+			}
+		}
+		return events;
+	};
+
+	it("carries the whole window's totals beside the first page, not the page's own sums", async () => {
+		await applySummaryEvents(manySkillEvents(), { producerKind: "cli", dbPath });
+		const result = await usage();
+		// The page is 8 rows; the card's header line states 12 skills and every run
+		// they made. Summing the rows on screen — what it used to do — would print
+		// "8 skills" and a run count that grew with every Show more click.
+		expect(result?.skills).toHaveLength(TOOL_ROWS_LIMIT);
+		expect(result?.skillsTotal).toBe(TOOL_ROWS_LIMIT + 4);
+		// Runs are 12 + 11 + … + 1 across every skill, of which the first page holds
+		// only 12 + 11 + … + 5.
+		expect(result?.skillCallsTotal).toBe(78);
+		expect(result?.skills.reduce((n, row) => n + row.calls, 0)).toBe(68);
+	});
+
+	it("pages a skills list in SQL, partitioning it exactly across offsets", async () => {
+		await applySummaryEvents(manySkillEvents(), { producerKind: "cli", dbPath });
+		const page = async (offset: number) =>
+			await withDashboardDb(
+				(db) =>
+					buildToolUsagePage(db, { scope: { kind: "all" }, list: "skill", offset, timeZone: "UTC", nowMs }),
+				{ dbPath },
+			);
+		const first = await page(0);
+		const second = await page(TOOL_ROWS_LIMIT);
+		expect(first.rows).toHaveLength(TOOL_ROWS_LIMIT);
+		expect(second.rows).toHaveLength(4);
+		expect(second.offset).toBe(TOOL_ROWS_LIMIT);
+		// `totalCount` travels with every page — it is the client's "there is more"
+		// test, and the window keeps gaining rows while the dashboard is open.
+		expect(second.totalCount).toBe(TOOL_ROWS_LIMIT + 4);
+		// The two pages together are the list, with nothing repeated and nothing
+		// dropped: the property OFFSET paging only has while the ORDER BY is total.
+		const names = [...first.rows, ...second.rows].map(rowKey);
+		expect(new Set(names).size).toBe(TOOL_ROWS_LIMIT + 4);
+		expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)));
+	});
+
+	it("partitions rows tied on both counts, rather than repeating one and dropping another", async () => {
+		// Every row here has the same sessions and the same calls, so the ranking
+		// keys cannot separate them and only the name tiebreak can. Without it two
+		// pages could each hand back the same row and neither the one it displaced.
+		const tied = Array.from({ length: TOOL_ROWS_LIMIT + 2 }, (_, i) => `tied${String(i).padStart(2, "0")}`);
+		await applySummaryEvents(
+			[repoEvent, ...tied.map((name) => sessionWith(`${name}-s`, [{ name, kind: "skill", calls: 1 }]))],
+			{ producerKind: "cli", dbPath },
+		);
+		const rows = async (offset: number) =>
+			(
+				await withDashboardDb(
+					(db) =>
+						buildToolUsagePage(db, {
+							scope: { kind: "all" },
+							list: "skill",
+							offset,
+							timeZone: "UTC",
+							nowMs,
+						}),
+					{ dbPath },
+				)
+			).rows.map(rowKey);
+		expect([...(await rows(0)), ...(await rows(TOOL_ROWS_LIMIT))]).toEqual(tied);
+	});
+
+	it("pages the server roll-up too, keeping each row's tool count and agent split", async () => {
+		await applySummaryEvents(
+			[
+				repoEvent,
+				sessionWith("s1", [
+					{ name: "linear.list_issues", kind: "mcp", server: "linear", calls: 9 },
+					{ name: "linear.get_issue", kind: "mcp", server: "linear", calls: 2 },
+				]),
+				sessionWith("s2", [{ name: "github.list_prs", kind: "mcp", server: "github", calls: 4 }], "codex"),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		const page = await withDashboardDb(
+			(db) =>
+				buildToolUsagePage(db, {
+					scope: { kind: "all" },
+					list: "server",
+					offset: 1,
+					limit: 1,
+					timeZone: "UTC",
+					nowMs,
+				}),
+			{ dbPath },
+		);
+		// The agent split is its own query over the page's keys, so it has to survive
+		// arriving at a nonzero offset — a fold over "every row in the window" would
+		// have attributed the row that was skipped.
+		expect(page).toEqual({
+			list: "server",
+			offset: 1,
+			totalCount: 2,
+			rows: [{ server: "github", sessions: 1, calls: 4, tools: 1, agents: [{ source: "codex", calls: 4 }] }],
+		});
+	});
+
+	it("answers an offset past the end with an empty page rather than an error", async () => {
+		await applySummaryEvents([repoEvent, sessionWith("s1", [{ name: "code-review", kind: "skill", calls: 1 }])], {
+			producerKind: "cli",
+			dbPath,
+		});
+		const page = await withDashboardDb(
+			(db) =>
+				buildToolUsagePage(db, { scope: { kind: "all" }, list: "skill", offset: 99, timeZone: "UTC", nowMs }),
+			{ dbPath },
+		);
+		expect(page).toEqual({ list: "skill", offset: 99, rows: [], totalCount: 1 });
+	});
+
+	it("floors a negative or fractional offset onto the first page", async () => {
+		await applySummaryEvents([repoEvent, sessionWith("s1", [{ name: "code-review", kind: "skill", calls: 1 }])], {
+			producerKind: "cli",
+			dbPath,
+		});
+		// A position has a nearest sane answer, unlike a list name — so this is
+		// clamped where an unknown `list` is a 400 (see DashboardServer).
+		const page = await withDashboardDb(
+			(db) =>
+				buildToolUsagePage(db, { scope: { kind: "all" }, list: "skill", offset: -5.7, timeZone: "UTC", nowMs }),
+			{ dbPath },
+		);
+		expect(page.offset).toBe(0);
+		expect(page.rows).toHaveLength(1);
+	});
+
+	it("honours the page's repo scope and window, so an appended page matches the card", async () => {
+		await applySummaryEvents(
+			[
+				repoEvent,
+				sessionWith("in-window", [{ name: "code-review", kind: "skill", calls: 1 }]),
+				{
+					producerKind: "cli",
+					event: {
+						type: "session.upserted",
+						repoIdentity: "repo-1",
+						source: "claude",
+						sessionId: "months-ago",
+						updatedAtMs: nowMs - 3_600_000,
+						tools: [{ name: "ancient", kind: "skill", calls: 1, lastCallAtMs: nowMs - 120 * 86_400_000 }],
+					},
+				},
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		const page = await withDashboardDb(
+			(db) =>
+				buildToolUsagePage(db, {
+					scope: { kind: "all" },
+					list: "skill",
+					offset: 0,
+					range: "week",
+					timeZone: "UTC",
+					nowMs,
+				}),
+			{ dbPath },
+		);
+		// Windowed by the CALL's own time, exactly as the inlined first page is: a
+		// page counted over a different window would append rows the card's totals
+		// know nothing about.
+		expect(page.rows.map(rowKey)).toEqual(["code-review"]);
+		expect(page.totalCount).toBe(1);
 	});
 });
 
@@ -1459,7 +1822,9 @@ describe("buildDashboardModel — recall usage", () => {
 			(db) => buildDashboardModel(db, { view: "stats", scope: { kind: "all" }, timeZone: "UTC", nowMs }),
 			{ dbPath },
 		);
-		expect(model.stats?.toolUsage.skills).toEqual([{ name: "jolli-recall", kind: "skill", sessions: 1, calls: 1 }]);
+		expect(model.stats?.toolUsage.skills).toEqual([
+			{ name: "jolli-recall", kind: "skill", sessions: 1, calls: 1, agents: [{ source: "claude", calls: 1 }] },
+		]);
 		expect(model.stats?.recallUsage.skillInvocations).toBe(1);
 	});
 

--- a/cli/src/dashboard/DashboardQuery.ts
+++ b/cli/src/dashboard/DashboardQuery.ts
@@ -56,6 +56,10 @@ import type {
 	StatsModel,
 	TokenBreakdown,
 	ToolUsage,
+	ToolUsageAgentShare,
+	ToolUsageAgentTotal,
+	ToolUsageList,
+	ToolUsagePage,
 	ToolUsageRow,
 } from "./DashboardModel.js";
 import {
@@ -1361,93 +1365,210 @@ function withModel(summary: CommitSummary): { model?: string } {
 
 // ── Tool / skill / MCP usage ────────────────────────────────────────────────
 
+/** Most calls first, then by source, so equal-volume agents order deterministically. */
+function sortAgents<T extends ToolUsageAgentShare>(agents: ReadonlyArray<T>): T[] {
+	return [...agents].sort((a, b) => b.calls - a.calls || a.source.localeCompare(b.source));
+}
+
 /**
- * Skills, MCP servers and the tool mix over the window.
+ * The WHERE clause every query in this section shares — the window, applied to
+ * the CALL's own time, plus the page's repo scope.
  *
- * Every figure here is Claude-only by construction, so the coverage numbers are
- * computed from `sessions` — the full population — and never from the join.
- * `uncoveredSources` names the agents that contributed sessions but no tool
- * records, because "linear: 3 sessions" is a very different statement depending
- * on whether the other 40 sessions could have been counted and were not.
+ * Windowed by the CALL, like the Recall card — see {@link TOOL_CALL_TIME_SQL}.
+ * The two panels report the same rows from the same table, so a `jolli-recall`
+ * bucket landing on one day here and another day there is a contradiction the
+ * reader has no way to resolve.
  *
- * Adoption (`sessions`) leads the ranking over volume (`calls`) deliberately: a
- * single session that hammered one tool 200 times is not evidence that the tool
- * matters, whereas a tool reached for across many separate sessions is.
+ * Built once and threaded into each query rather than re-derived per query: the
+ * three lists, their totals, the per-row agent splits and the recall row must
+ * all be answering about the same set of rows, and `scopeToRepoId` is a lookup
+ * this section would otherwise repeat six times.
  */
-function buildToolUsage(db: DashboardDbHandle, scope: DashboardScope, window: ResolvedWindow): ToolUsage {
+function toolUsageWhere(
+	db: DashboardDbHandle,
+	scope: DashboardScope,
+	window: ResolvedWindow,
+): { sql: string; params: unknown[] } {
 	const filter = scopeFilter(scopeToRepoId(db, scope), "s.repo_id");
+	return {
+		sql: `${TOOL_CALL_TIME_SQL} >= ? AND ${TOOL_CALL_TIME_SQL} < ?${filter.sql}`,
+		params: [window.startMs, window.endMs, ...filter.params],
+	};
+}
+
+/** `session_tool_use.kind` each list is drawn from — two of the three share one. */
+const TOOL_LIST_KIND: Readonly<Record<ToolUsageList, string>> = { skill: "skill", tool: "mcp", server: "mcp" };
+
+/**
+ * `ORDER BY` per list — the ranking, and the tiebreak that makes it pageable.
+ *
+ * A ranked list must be ordered by the figure its rows PRINT, or the card
+ * contradicts itself twice over. Both MCP lists print calls and size their bars
+ * by calls, so ranking them by sessions was wrong in a way that read as a
+ * rendering fault rather than a sort one: measured on a real database, the
+ * servers card came out jollimemory (32 sessions / 68 calls), codegraph
+ * (27 / 149), dbhub (9 / 76) — descending sessions, visibly unsorted calls — and
+ * because `rankedList` sizes every bar against the FIRST row, codegraph asked
+ * for 219% and dbhub for 112%, both clamped by `.rl-bar`'s `overflow: hidden`,
+ * so three different volumes all rendered as one full-width bar. Skills ranks by
+ * ADOPTION deliberately: one session hammering /simplify 200 times should not
+ * outrank /code-review reached from three, and that card's own doc comment is
+ * the authority for its list.
+ *
+ * The trailing name is not decoration. `LIMIT`/`OFFSET` only partition a list
+ * cleanly when the order is TOTAL: two rows tied on both counts may come back in
+ * either order per query, so an untiebroken sort can hand the same row to two
+ * pages and never hand over the one it displaced. The un-paged version leaned on
+ * SQLite's own row order for ties, which was good enough while every row was
+ * read exactly once.
+ */
+const TOOL_LIST_ORDER: Readonly<Record<ToolUsageList, string>> = {
+	skill: "session_count DESC, call_count DESC, t.tool_name ASC",
+	tool: "call_count DESC, session_count DESC, t.tool_name ASC",
+	server: "call_count DESC, session_count DESC, t.server ASC",
+};
+
+/**
+ * How many rows a list has in the window, and how many calls they account for.
+ *
+ * Both figures are what a card's header line prints, and both must come from
+ * here rather than from the page it renders: a client summing the rows it holds
+ * says "8 servers · 61 calls" on a machine with 15 servers and 375 calls, and
+ * says something different after every click. `totalCount` is also the client's
+ * "there is another page" test, so it travels with every page — see
+ * {@link ToolUsagePage}.
+ */
+function toolListTotals(
+	db: DashboardDbHandle,
+	where: { sql: string; params: unknown[] },
+	list: ToolUsageList,
+): { totalCount: number; callsTotal: number } {
+	const keyColumn = list === "server" ? "t.server" : "t.tool_name";
+	const row = db
+		.prepare(
+			`SELECT COUNT(DISTINCT ${keyColumn}) AS row_count,
+			        COALESCE(SUM(t.calls), 0) AS call_count
+			   FROM session_tool_use t
+			   JOIN sessions s ON s.event_id = t.session_event_id
+			  WHERE ${where.sql}
+			    AND t.kind = ?${list === "server" ? " AND t.server IS NOT NULL" : ""}`,
+		)
+		.get(...where.params, TOOL_LIST_KIND[list]) as { row_count: number; call_count: number } | undefined;
+	return { totalCount: row?.row_count ?? 0, callsTotal: row?.call_count ?? 0 };
+}
+
+/**
+ * The per-agent split for the rows of ONE page, keyed by whatever identifies a
+ * row in that list (`tool_name`, or `server` for the roll-up).
+ *
+ * Its own query restricted to the page's keys, rather than a fold over every row
+ * in the window: that fold is what the un-paged version did, and keeping it
+ * would defeat the `LIMIT` it now sits behind — reading the agent split of 42
+ * MCP tools to render 8 of them.
+ *
+ * Only CALLS come from here, never sessions. A session belongs to exactly one
+ * source, so per-source call buckets sum back exactly; a per-source SESSION
+ * count does not survive being re-summed at a coarser grouping, which is what a
+ * server row's split would be — see {@link ToolUsageAgentShare}.
+ */
+function toolRowAgents(
+	db: DashboardDbHandle,
+	where: { sql: string; params: unknown[] },
+	list: ToolUsageList,
+	keys: ReadonlyArray<string>,
+): Map<string, ToolUsageAgentShare[]> {
+	const byKey = new Map<string, ToolUsageAgentShare[]>();
+	// `IN ()` is a syntax error, and an empty page has nothing to attribute.
+	if (keys.length === 0) return byKey;
+	const keyColumn = list === "server" ? "t.server" : "t.tool_name";
 	const rows = db
 		.prepare(
-			// Windowed by the CALL, like the Recall card — see TOOL_CALL_TIME_SQL. The
-			// two panels report the same rows from the same table, so a `jolli-recall`
-			// bucket landing on one day here and another day there is a contradiction
-			// the reader has no way to resolve.
-			`SELECT t.tool_name, t.kind, t.server,
+			`SELECT ${keyColumn} AS row_key, s.source,
+			        COALESCE(SUM(t.calls), 0) AS call_count
+			   FROM session_tool_use t
+			   JOIN sessions s ON s.event_id = t.session_event_id
+			  WHERE ${where.sql}
+			    AND t.kind = ? AND ${keyColumn} IN (${placeholders(keys.length)})
+			  GROUP BY ${keyColumn}, s.source`,
+		)
+		.all(...where.params, TOOL_LIST_KIND[list], ...keys) as ReadonlyArray<{
+		row_key: string;
+		source: string;
+		call_count: number;
+	}>;
+	for (const row of rows) {
+		byKey.set(row.row_key, [...(byKey.get(row.row_key) ?? []), { source: row.source, calls: row.call_count }]);
+	}
+	for (const [key, agents] of byKey) byKey.set(key, sortAgents(agents));
+	return byKey;
+}
+
+/** One page of the Skills list, or of the MCPs card's "by tool" split. */
+function toolNameRowsPage(
+	db: DashboardDbHandle,
+	where: { sql: string; params: unknown[] },
+	list: "skill" | "tool",
+	offset: number,
+	limit: number,
+): ToolUsageRow[] {
+	const kind = TOOL_LIST_KIND[list];
+	const rows = db
+		.prepare(
+			// Grouped by name alone: the kind is already pinned by the WHERE, so this
+			// is the same bucket the old `(kind, tool_name)` grouping produced, and
+			// COUNT(DISTINCT) over the whole group is the same number as the sum of
+			// its per-source counts (a session has exactly one source).
+			`SELECT t.tool_name,
 			        COUNT(DISTINCT t.session_event_id) AS session_count,
 			        COALESCE(SUM(t.calls), 0) AS call_count
 			   FROM session_tool_use t
 			   JOIN sessions s ON s.event_id = t.session_event_id
-			  WHERE ${TOOL_CALL_TIME_SQL} >= ? AND ${TOOL_CALL_TIME_SQL} < ?${filter.sql}
-			  GROUP BY t.kind, t.tool_name, t.server`,
+			  WHERE ${where.sql} AND t.kind = ?
+			  GROUP BY t.tool_name
+			  ORDER BY ${TOOL_LIST_ORDER[list]}
+			  LIMIT ? OFFSET ?`,
 		)
-		.all(window.startMs, window.endMs, ...filter.params) as ReadonlyArray<{
+		.all(...where.params, kind, limit, offset) as ReadonlyArray<{
 		tool_name: string;
-		kind: string;
-		server: string | null;
 		session_count: number;
 		call_count: number;
 	}>;
+	const agents = toolRowAgents(
+		db,
+		where,
+		list,
+		rows.map((row) => row.tool_name),
+	);
+	return rows.map((row) => ({
+		name: row.tool_name,
+		kind: list === "skill" ? ("skill" as const) : ("mcp" as const),
+		sessions: row.session_count,
+		calls: row.call_count,
+		agents: agents.get(row.tool_name) ?? [],
+	}));
+}
 
-	const skills: ToolUsageRow[] = rows
-		.filter((row) => row.kind === "skill")
-		.map((row) => ({
-			name: row.tool_name,
-			kind: "skill" as const,
-			sessions: row.session_count,
-			calls: row.call_count,
-		}));
-
-	// The same rows already carry a per-tool breakdown for MCP calls (tool_name
-	// is `server.tool`, see TranscriptParser) — this is the "by tool" split of
-	// `servers` below, not a second query.
-	const mcpTools: ToolUsageRow[] = rows
-		.filter((row) => row.kind === "mcp")
-		.map((row) => ({
-			name: row.tool_name,
-			kind: "mcp" as const,
-			sessions: row.session_count,
-			calls: row.call_count,
-		}));
-
-	// Pulled from the untruncated `rows`, not from `mcpTools` below — recall can
-	// rank outside the top TOOL_ROWS_LIMIT tools by adoption even with real
-	// volume, and filtering the truncated array would silently drop it.
-	//
-	// Matched against EVERY spelling of the tool (see RECALL_MCP_TOOL_NAMES): a
-	// plugin-registered server namespaces the row, and an equality test on the
-	// bare name reported "no recall calls" forever on those installs. Reported
-	// under the canonical name — the row is about the recall feature, not about
-	// which manifest registered the server.
-	const recallRows = rows.filter((row) => row.kind === "mcp" && isRecallMcpToolName(row.tool_name));
-	const recallCalls: ToolUsageRow | undefined = recallRows.length
-		? {
-				name: RECALL_MCP_TOOL_NAME,
-				kind: "mcp",
-				// Summed across spellings. A session that used two of them counts twice,
-				// which needs the same server registered under two namespaces at once —
-				// pathological, and not worth a second query to be exact about.
-				sessions: recallRows.reduce((n, row) => n + row.session_count, 0),
-				calls: recallRows.reduce((n, row) => n + row.call_count, 0),
-			}
-		: undefined;
-
-	// Servers get their OWN grouping rather than a roll-up of the per-tool rows
-	// above. Session counts there are per tool, so neither combining rule is
-	// right: summing double-counts a session that called two of a server's tools,
-	// and the max — what this used to do — undercounts two sessions that each
-	// called a different one. `COUNT(DISTINCT session_event_id)` grouped by server
-	// is the figure the UI already presents this as.
-	const serverRows = db
+/**
+ * One page of the MCP-server roll-up.
+ *
+ * Servers get their OWN grouping rather than a roll-up of the per-tool rows.
+ * Session counts there are per tool, so neither combining rule is right:
+ * summing double-counts a session that called two of a server's tools, and the
+ * max — what this used to do — undercounts two sessions that each called a
+ * different one. `COUNT(DISTINCT session_event_id)` grouped by server is the
+ * figure the UI already presents this as.
+ *
+ * `tool_count` is also why the agent split cannot just be an `s.source` column
+ * added here: `COUNT(DISTINCT tool_name)` per source double-counts a tool called
+ * from two agents once the buckets are summed back together.
+ */
+function serverRowsPage(
+	db: DashboardDbHandle,
+	where: { sql: string; params: unknown[] },
+	offset: number,
+	limit: number,
+): McpServerRow[] {
+	const rows = db
 		.prepare(
 			`SELECT t.server,
 			        COUNT(DISTINCT t.session_event_id) AS session_count,
@@ -1455,19 +1576,188 @@ function buildToolUsage(db: DashboardDbHandle, scope: DashboardScope, window: Re
 			        COUNT(DISTINCT t.tool_name) AS tool_count
 			   FROM session_tool_use t
 			   JOIN sessions s ON s.event_id = t.session_event_id
-			  WHERE ${TOOL_CALL_TIME_SQL} >= ? AND ${TOOL_CALL_TIME_SQL} < ?${filter.sql}
+			  WHERE ${where.sql}
 			    AND t.kind = 'mcp' AND t.server IS NOT NULL
-			  GROUP BY t.server`,
+			  GROUP BY t.server
+			  ORDER BY ${TOOL_LIST_ORDER.server}
+			  LIMIT ? OFFSET ?`,
 		)
-		.all(window.startMs, window.endMs, ...filter.params) as ReadonlyArray<{
+		.all(...where.params, limit, offset) as ReadonlyArray<{
 		server: string;
 		session_count: number;
 		call_count: number;
 		tool_count: number;
 	}>;
+	const agents = toolRowAgents(
+		db,
+		where,
+		"server",
+		rows.map((row) => row.server),
+	);
+	return rows.map((row) => ({
+		server: row.server,
+		sessions: row.session_count,
+		calls: row.call_count,
+		tools: row.tool_count,
+		agents: agents.get(row.server) ?? [],
+	}));
+}
 
-	const byAdoption = <T extends { sessions: number; calls: number }>(a: T, b: T) =>
-		b.sessions - a.sessions || b.calls - a.calls;
+/**
+ * The recall tool's own row, from its own query.
+ *
+ * Never filtered out of the MCP-tool page: recall can rank outside the first
+ * page on a busy machine even with real volume of its own, and now that the page
+ * is one of several, the reader may never load the one carrying it.
+ *
+ * Matched against EVERY spelling of the tool (see {@link isRecallMcpToolName}):
+ * a plugin-registered server namespaces the row, and an equality test on the
+ * bare name reported "no recall calls" forever on those installs. SQL narrows
+ * with a suffix `LIKE` and the JS predicate decides — the pattern is derived
+ * from the canonical name, which carries no `_` or `%` and so needs no `ESCAPE`,
+ * and a name that merely ends in the same letters is rejected in JS rather than
+ * counted. Reported under the canonical name: the row is about the recall
+ * feature, not about which manifest registered the server.
+ */
+function recallToolRow(db: DashboardDbHandle, where: { sql: string; params: unknown[] }): ToolUsageRow | undefined {
+	const rows = db
+		.prepare(
+			`SELECT t.tool_name, s.source,
+			        COUNT(DISTINCT t.session_event_id) AS session_count,
+			        COALESCE(SUM(t.calls), 0) AS call_count
+			   FROM session_tool_use t
+			   JOIN sessions s ON s.event_id = t.session_event_id
+			  WHERE ${where.sql}
+			    AND t.kind = 'mcp' AND t.tool_name LIKE ?
+			  GROUP BY t.tool_name, s.source`,
+		)
+		.all(...where.params, `%${RECALL_MCP_TOOL_NAME}`) as ReadonlyArray<{
+		tool_name: string;
+		source: string;
+		session_count: number;
+		call_count: number;
+	}>;
+	const matched = rows.filter((row) => isRecallMcpToolName(row.tool_name));
+	if (matched.length === 0) return undefined;
+	const agents = new Map<string, number>();
+	for (const row of matched) agents.set(row.source, (agents.get(row.source) ?? 0) + row.call_count);
+	return {
+		name: RECALL_MCP_TOOL_NAME,
+		kind: "mcp",
+		// Summed across spellings. A session that used two of them counts twice,
+		// which needs the same server registered under two namespaces at once —
+		// pathological, and not worth a second query to be exact about.
+		sessions: matched.reduce((n, row) => n + row.session_count, 0),
+		calls: matched.reduce((n, row) => n + row.call_count, 0),
+		agents: sortAgents([...agents].map(([source, calls]) => ({ source, calls }))),
+	};
+}
+
+/** What one `/api/tool-usage` request names: a list, a position, and the page's window. */
+export interface ToolUsagePageOptions {
+	readonly scope: DashboardScope;
+	readonly list: ToolUsageList;
+	/** Row index to start at. Negative or fractional input is floored to a valid one. */
+	readonly offset: number;
+	/** Rows per page. Defaults to {@link TOOL_ROWS_LIMIT}, the size the first page rode in at. */
+	readonly limit?: number;
+	readonly range?: DashboardRange;
+	readonly customFrom?: string;
+	readonly customTo?: string;
+	readonly timeZone?: string;
+	readonly nowMs?: number;
+}
+
+/**
+ * ONE page of one tool-usage list — the `/api/tool-usage` answer behind a card's
+ * "Show more" button.
+ *
+ * Paged in SQL rather than by slicing a full read: the un-paged version grouped
+ * every `session_tool_use` row in the window, folded the per-agent split for all
+ * of them, and then kept 8 — so a machine with 42 MCP tools paid for 42 to
+ * render 8, and the other 34 were unreachable no matter what the reader did.
+ * Every figure a card states about the whole set now comes from a COUNT/SUM (see
+ * {@link toolListTotals}) instead of from the rows on screen.
+ *
+ * OFFSET rather than a cursor, unlike the Memories tree: what this pages over is
+ * an aggregate the query recomputes, not a list git can shorten under the reader,
+ * so the only movement is new calls arriving mid-browse — which shifts a row by
+ * one slot at worst. The client dedupes by row identity for that case, and
+ * {@link TOOL_LIST_ORDER}'s name tiebreak is what keeps the partition clean
+ * otherwise.
+ */
+export function buildToolUsagePage(db: DashboardDbHandle, opts: ToolUsagePageOptions): ToolUsagePage {
+	const timeZone = opts.timeZone ?? machineTimeZone();
+	const window = resolveWindow(opts.range, opts.customFrom, opts.customTo, opts.nowMs ?? Date.now(), timeZone);
+	const where = toolUsageWhere(db, opts.scope, window);
+	// Floored, not rejected: an offset is a position in a list, and a bad one has
+	// a nearest sane answer (the first page). The LIMIT is ours, never the
+	// caller's — see DashboardServer's route.
+	const offset = Math.max(0, Math.trunc(opts.offset) || 0);
+	const limit = opts.limit ?? TOOL_ROWS_LIMIT;
+	const { totalCount } = toolListTotals(db, where, opts.list);
+	if (opts.list === "server") {
+		return { list: "server", offset, rows: serverRowsPage(db, where, offset, limit), totalCount };
+	}
+	return { list: opts.list, offset, rows: toolNameRowsPage(db, where, opts.list, offset, limit), totalCount };
+}
+
+/**
+ * Skills, MCP servers and the tool mix over the window, each row carrying the
+ * agents that produced it — the FIRST page of each of the three lists, plus the
+ * totals they page against.
+ *
+ * Not every agent's transcripts can be read for tool calls, so the coverage
+ * numbers are computed from `sessions` — the full population — and never from
+ * the join. `uncoveredSources` names the agents that contributed sessions but no
+ * tool records, because "linear: 3 sessions" is a very different statement
+ * depending on whether the other 40 sessions could have been counted and were
+ * not.
+ *
+ * Adoption (`sessions`) leads the Skills ranking over volume (`calls`)
+ * deliberately: a single session that hammered one tool 200 times is not
+ * evidence that the tool matters, whereas a tool reached for across many
+ * separate sessions is. The per-agent splits are ordered by volume instead —
+ * they answer "who ran this", where the count IS the point. See
+ * {@link TOOL_LIST_ORDER}.
+ */
+function buildToolUsage(db: DashboardDbHandle, scope: DashboardScope, window: ResolvedWindow): ToolUsage {
+	const where = toolUsageWhere(db, scope, window);
+	const skillTotals = toolListTotals(db, where, "skill");
+	const serverTotals = toolListTotals(db, where, "server");
+	const mcpToolTotals = toolListTotals(db, where, "tool");
+	const skills = toolNameRowsPage(db, where, "skill", 0, TOOL_ROWS_LIMIT);
+	const mcpTools = toolNameRowsPage(db, where, "tool", 0, TOOL_ROWS_LIMIT);
+	const servers = serverRowsPage(db, where, 0, TOOL_ROWS_LIMIT);
+	const recallCalls = recallToolRow(db, where);
+
+	// Per-kind agent totals, from their own grouping so `sessions` is a real
+	// COUNT(DISTINCT) rather than a re-sum of the pages above — and over EVERY row
+	// in the window, so an agent whose every skill ranks past the first page still
+	// shows up in the card's header line.
+	const agentRows = db
+		.prepare(
+			`SELECT t.kind, s.source,
+			        COUNT(DISTINCT t.session_event_id) AS session_count,
+			        COALESCE(SUM(t.calls), 0) AS call_count
+			   FROM session_tool_use t
+			   JOIN sessions s ON s.event_id = t.session_event_id
+			  WHERE ${where.sql}
+			    AND t.kind IN ('skill','mcp')
+			  GROUP BY t.kind, s.source`,
+		)
+		.all(...where.params) as ReadonlyArray<{
+		kind: string;
+		source: string;
+		session_count: number;
+		call_count: number;
+	}>;
+	const agentTotals = (kind: string): ToolUsageAgentTotal[] =>
+		sortAgents(
+			agentRows
+				.filter((row) => row.kind === kind)
+				.map((row) => ({ source: row.source, sessions: row.session_count, calls: row.call_count })),
+		);
 
 	// Coverage from the FULL session population, never from the join above — and
 	// windowed by the SESSION's own time OR by any call it made, which is the
@@ -1522,20 +1812,17 @@ function buildToolUsage(db: DashboardDbHandle, scope: DashboardScope, window: Re
 	}>;
 
 	return {
-		skills: skills.sort(byAdoption).slice(0, TOOL_ROWS_LIMIT),
-		mcpTools: mcpTools.sort(byAdoption).slice(0, TOOL_ROWS_LIMIT),
+		skills,
+		skillsTotal: skillTotals.totalCount,
+		skillCallsTotal: skillTotals.callsTotal,
+		mcpTools,
+		mcpToolsTotal: mcpToolTotals.totalCount,
 		recallCalls,
-		servers: serverRows
-			.map(
-				(row): McpServerRow => ({
-					server: row.server,
-					sessions: row.session_count,
-					calls: row.call_count,
-					tools: row.tool_count,
-				}),
-			)
-			.sort(byAdoption)
-			.slice(0, TOOL_ROWS_LIMIT),
+		servers,
+		serversTotal: serverTotals.totalCount,
+		serverCallsTotal: serverTotals.callsTotal,
+		skillAgents: agentTotals("skill"),
+		mcpAgents: agentTotals("mcp"),
 		sessionsWithTools: sessionRows.reduce((sum, row) => sum + row.with_tools, 0),
 		sessionsInWindow: sessionRows.reduce((sum, row) => sum + row.total, 0),
 		// "No tool rows" and "cannot have tool rows" are different facts, and only

--- a/cli/src/dashboard/DashboardServer.test.ts
+++ b/cli/src/dashboard/DashboardServer.test.ts
@@ -1450,6 +1450,65 @@ describe("defaultModelBuilder (no injected buildModel)", () => {
 		expect((await get(port, "/api/memories?afterRepo=repo-1")).status).toBe(400);
 	});
 
+	// The Skills / MCPs cards' "Show more" fetch. Paged in SQL, so this route
+	// opens the database itself rather than going through buildModel — the page
+	// past the first one is not part of any page payload.
+	it("serves one page of a tool-usage list, and rejects a list or offset it cannot page", async () => {
+		const dbPath = join(dir, "tool-usage-page.db");
+		const configDir = join(dir, "config-tools");
+		await applyStatsEvents(
+			[
+				{
+					producerKind: "cli",
+					event: {
+						type: "repo.enabled",
+						repoIdentity: "repo-1",
+						repoName: "jolli",
+						worktreeRoot: "/w/jolli",
+						enabledAt: "t",
+					},
+				},
+				{
+					producerKind: "cli",
+					event: {
+						type: "session.upserted",
+						repoIdentity: "repo-1",
+						source: "claude",
+						sessionId: "s1",
+						updatedAtMs: Date.now() - 3_600_000,
+						tools: [
+							{ name: "linear.list_issues", kind: "mcp", server: "linear", calls: 9 },
+							{ name: "github.list_prs", kind: "mcp", server: "github", calls: 4 },
+						],
+					},
+				},
+			],
+			{ producerKind: "cli", dbPath },
+		);
+
+		const port = await listen(createDashboardServer({ port: 0, assetsDir, dbPath, configDir }));
+
+		const second = await get(port, "/api/tool-usage?list=server&offset=1");
+		expect(second.status).toBe(200);
+		expect(await second.json()).toMatchObject({
+			list: "server",
+			offset: 1,
+			totalCount: 2,
+			rows: [{ server: "github", calls: 4 }],
+		});
+
+		// An unknown list is a 400, never a fallback to the first one: the answer
+		// would be a page of the WRONG list, which the client appends to the one it
+		// asked about.
+		expect((await get(port, "/api/tool-usage?list=servers")).status).toBe(400);
+		expect((await get(port, "/api/tool-usage")).status).toBe(400);
+		// A non-numeric offset would otherwise be read as 0 and answer a "Show more"
+		// click with the page the client already holds — a button that does nothing.
+		expect((await get(port, "/api/tool-usage?list=server&offset=abc")).status).toBe(400);
+		// Absent means the first page, which is the one case a default is right.
+		expect((await get(port, "/api/tool-usage?list=skill")).status).toBe(200);
+	});
+
 	// The Context dialog's fetch. A read like every other GET here — no token —
 	// and it opens the database itself rather than going through buildModel,
 	// because a document body is not part of any page payload.

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -116,8 +116,9 @@ import {
 	type DashboardScope,
 	type DashboardView,
 	type SeriesDimension,
+	type ToolUsageList,
 } from "./DashboardModel.js";
-import { buildDashboardModel, type QueryOptions } from "./DashboardQuery.js";
+import { buildDashboardModel, buildToolUsagePage, type QueryOptions } from "./DashboardQuery.js";
 import { projectRepoRegistryState } from "./DbBackfill.js";
 import { getDecisionGist } from "./DecisionGist.js";
 import { buildGraphViewerDocument } from "./GraphViewerDocument.js";
@@ -1034,6 +1035,16 @@ const VIEW_TOKENS: ReadonlySet<string> = new Set<DashboardView>([
 ]);
 
 /**
+ * Valid `?list=` tokens for `/api/tool-usage`.
+ *
+ * An unrecognized one is a 400, NOT a fallback to the first list. Every other
+ * enum on this router degrades to a default because the answer is still a page
+ * the reader can read — here the answer would be a page of the WRONG list,
+ * appended by the client to the one it asked about.
+ */
+const TOOL_USAGE_LISTS: ReadonlyArray<ToolUsageList> = ["skill", "server", "tool"];
+
+/**
  * New destinations that redirect to Repositories when nothing is enabled yet
  * — mirrors the mockup's nav gating ("nothing for any of them to read" before
  * a repo is set up). `/repositories` is deliberately absent — it is the row
@@ -1361,6 +1372,62 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 			} catch (err) {
 				log.warn("memories page read failed: %s", errMsg(err));
 				sendJson(res, 500, { error: "could not read that page of memories" });
+			}
+			return;
+		}
+
+		// One page of a Skills / MCPs list, behind those cards' "Show more" button.
+		// Same shape as `/api/memories` above and for the same reason: the model is
+		// inlined into the page HTML, so only the first page can ride there. A read
+		// like every other GET here — no token.
+		//
+		// The window params ride along (`range`/`from`/`to`) because the rows are
+		// an aggregate OVER a window: paging with a different one than the card was
+		// rendered under would append rows counted from a different set. The client
+		// sends them from the same `JD.query` builder every other fetch uses.
+		//
+		// `limit` is deliberately NOT a parameter. The page size is the height the
+		// card is laid out for, so it is ours to pick; accepting one would let a
+		// browser-reachable route ask for an unbounded scan.
+		if (url.pathname === "/api/tool-usage") {
+			const requested = url.searchParams.get("list") ?? "";
+			const list = TOOL_USAGE_LISTS.find((known) => known === requested);
+			if (!list) {
+				sendJson(res, 400, { error: `list must be one of ${TOOL_USAGE_LISTS.join("|")}` });
+				return;
+			}
+			// A non-numeric offset is the caller's bug, not a position to guess at:
+			// treating it as 0 would answer a "Show more" click with the page the
+			// client already holds, which its dedupe drops — a button that visibly
+			// does nothing. (A negative or fractional NUMBER is floored instead; see
+			// `buildToolUsagePage`.)
+			const rawOffset = url.searchParams.get("offset") ?? "0";
+			const offset = Number(rawOffset);
+			if (!Number.isFinite(offset)) {
+				sendJson(res, 400, { error: "offset must be a number" });
+				return;
+			}
+			// Spelled out rather than spread from `parseWindow`: that helper also
+			// carries the series axis and the Memories view's `hash`/`detailRepo`,
+			// none of which this route has any business receiving.
+			const requestedWindow = parseWindow(url);
+			try {
+				const page = await withReadonlyDashboardDb(
+					(db) =>
+						buildToolUsagePage(db, {
+							scope: parseScope(url),
+							list,
+							offset,
+							...(requestedWindow.range ? { range: requestedWindow.range } : {}),
+							...(requestedWindow.customFrom ? { customFrom: requestedWindow.customFrom } : {}),
+							...(requestedWindow.customTo ? { customTo: requestedWindow.customTo } : {}),
+						}),
+					{ ...(options.dbPath ? { dbPath: options.dbPath } : {}) },
+				);
+				sendJson(res, 200, page);
+			} catch (err) {
+				log.warn("tool usage page read failed: %s", errMsg(err));
+				sendJson(res, 500, { error: "could not read that page of tool usage" });
 			}
 			return;
 		}

--- a/cli/src/dashboard/FeedCardAsset.test.ts
+++ b/cli/src/dashboard/FeedCardAsset.test.ts
@@ -115,12 +115,26 @@ function model(over: Record<string, unknown> = {}, statsOver: Record<string, unk
 			range: "month",
 			rangeFrom: "2026-07-01",
 			rangeTo: "2026-07-30",
+			// Field-for-field with `ToolUsage`. Nothing type-checks that: this builder
+			// returns `unknown` on purpose (the asset scripts are plain JS), so the
+			// fixture had drifted to a `sourcesWithoutToolData` key no renderer has
+			// read since that field was renamed `uncoveredSources`, and was missing
+			// `mcpTools` outright. A renderer reading a field the server always sends
+			// is right to do so unguarded — the fixture is what has to keep up.
 			toolUsage: {
 				skills: [],
+				skillsTotal: 0,
+				skillCallsTotal: 0,
 				servers: [],
+				serversTotal: 0,
+				serverCallsTotal: 0,
+				mcpTools: [],
+				mcpToolsTotal: 0,
+				skillAgents: [],
+				mcpAgents: [],
 				sessionsWithTools: 0,
 				sessionsInWindow: 0,
-				sourcesWithoutToolData: [],
+				uncoveredSources: [],
 			},
 			recallUsage: {
 				usedCalls: 0,
@@ -498,6 +512,79 @@ describe("Recall card", () => {
 			daily: [{ date: "2026-07-30", used: 2, setAside: 0 }],
 		});
 		expect(html).not.toContain("more often than recall");
+	});
+});
+
+/** The MCPs / Skills card markup, for one `toolUsage` override. */
+function usageHtml(label: string, toolUsage: Record<string, unknown>): string {
+	app.innerHTML = "";
+	JD.renderStats(
+		model(
+			{},
+			{
+				toolUsage: {
+					skills: [],
+					servers: [],
+					mcpTools: [],
+					skillAgents: [],
+					mcpAgents: [],
+					sessionsWithTools: 1,
+					sessionsInWindow: 1,
+					uncoveredSources: [],
+					...toolUsage,
+				},
+			},
+		),
+	);
+	const html = app.innerHTML;
+	const start = html.indexOf(`aria-label="${label}"`);
+	expect(start).toBeGreaterThan(-1);
+	return html.slice(start, html.indexOf("</section>", start));
+}
+
+/** Every `width:N%` a ranked list emitted, in row order. */
+function barWidths(html: string): ReadonlyArray<number> {
+	return [...html.matchAll(/width:(\d+)%/g)].map((m) => Number(m[1]));
+}
+
+describe("ranked list bars", () => {
+	// The bug this pins is a two-layer one, and the renderer owns the second layer:
+	// the server ranks the MCP lists by calls now, but `rankedList` used `rows[0]`
+	// as the denominator, so ANY list whose order is not its bar metric painted
+	// widths above 100% — which `.rl-bar`'s `overflow: hidden` clamps into a
+	// full bar instead of showing as broken.
+	it("sizes MCP server bars against the busiest row, proportionally", () => {
+		const html = usageHtml("MCPs", {
+			servers: [
+				{ server: "codegraph", sessions: 27, calls: 150, tools: 1, agents: [{ source: "codex", calls: 150 }] },
+				{ server: "dbhub", sessions: 9, calls: 75, tools: 7, agents: [{ source: "codex", calls: 75 }] },
+				{ server: "jollimemory", sessions: 32, calls: 30, tools: 3, agents: [{ source: "claude", calls: 30 }] },
+			],
+			mcpAgents: [{ source: "codex", sessions: 2, calls: 225 }],
+		});
+		expect(barWidths(html)).toEqual([100, 50, 20]);
+		expect(html.indexOf("codegraph")).toBeLessThan(html.indexOf("jollimemory"));
+	});
+
+	it("never emits a bar past 100% when rank order and bar metric disagree", () => {
+		// Skills deliberately ranks by adoption while printing runs, so its first row
+		// is not its biggest value — the case that produced 219%-wide bars.
+		const html = usageHtml("Skills", {
+			skills: [
+				{ name: "code-review", kind: "skill", sessions: 3, calls: 4, agents: [{ source: "claude", calls: 4 }] },
+				{
+					name: "simplify",
+					kind: "skill",
+					sessions: 1,
+					calls: 200,
+					agents: [{ source: "claude", calls: 200 }],
+				},
+			],
+			skillAgents: [{ source: "claude", sessions: 4, calls: 204 }],
+		});
+		const widths = barWidths(html);
+		expect(Math.max(...widths)).toBe(100);
+		expect(widths).toEqual([2, 100]);
 	});
 });
 

--- a/cli/src/dashboard/ToolUsagePagingAsset.test.ts
+++ b/cli/src/dashboard/ToolUsagePagingAsset.test.ts
@@ -1,0 +1,503 @@
+/**
+ * Runtime test for the Skills / MCPs cards' "Show more" paging in `stats.js`.
+ *
+ * These lists are the one thing on the stats page that pages in SQL: the model
+ * carries {@link TOOL_ROWS_LIMIT} rows plus the whole window's totals, and every
+ * row past that comes from `/api/tool-usage`. Three behaviours have no other
+ * cover, and each one fails silently in the browser:
+ *
+ *   - the footer must appear only while `rows.length < *Total`, and print the
+ *     SERVER's totals rather than a sum of the rows on screen;
+ *   - a fetched page must be appended and deduped (an offset can repeat a row
+ *     that shifted across the boundary, never invent one);
+ *   - past the first page the list must scroll INSIDE the card — a measured
+ *     `max-height` — while a list still on its first page gets no cap and so no
+ *     scrollbar.
+ *
+ * `assets/js/*.js` is plain JavaScript served verbatim, so tsc never sees it;
+ * this drives the real IIFEs against a stub document, following the same pattern
+ * as `FeedCardAsset.test.ts`.
+ */
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { TOOL_ROWS_LIMIT } from "./DashboardModel.js";
+
+interface FakeStyle {
+	maxHeight?: string;
+	[key: string]: string | undefined;
+}
+
+/** A ranked-list <ul> stub: laid-out children, a class list and a scroll position. */
+interface FakeList {
+	readonly children: ReadonlyArray<{ offsetTop: number; offsetHeight: number }>;
+	readonly style: FakeStyle;
+	readonly classes: string[];
+	classList: { add: (name: string) => void };
+	scrollTop: number;
+}
+
+interface FakeButton {
+	getAttribute: (name: string) => string | null;
+	onclick?: () => void;
+}
+
+interface Harness {
+	// biome-ignore lint/suspicious/noExplicitAny: the asset scripts are plain JS; the model is deliberately untyped.
+	readonly JD: any;
+	/** #app's innerHTML after the last render. */
+	html: () => string;
+	/** Renders, and returns the wired "Show more" buttons keyed by list. */
+	render: (model: unknown) => Map<string, FakeButton>;
+	/** The <ul> stub `capToolLists` / `revealToolRows` will find for one list. */
+	list: (name: string) => FakeList;
+	/** Every URL `JD.getJson` was asked for, in order. */
+	readonly fetched: string[];
+	/** Replaces the browser's current model, as `JD.refreshNow` does after a poll. */
+	setCurrentModel: (model: unknown) => void;
+}
+
+/**
+ * One row of laid-out geometry per loaded row, so the measured cap is
+ * predictable: row i sits at `i * 50` and is 40 tall, making eight rows
+ * `7 * 50 + 40 = 390`.
+ */
+const ROW_PITCH = 50;
+const ROW_HEIGHT = 40;
+
+function loadHarness(rowCounts: Record<string, number> = {}): Harness {
+	const fetched: string[] = [];
+	const lists = new Map<string, FakeList>();
+	for (const [name, count] of Object.entries(rowCounts)) {
+		const children = Array.from({ length: count }, (_, i) => ({
+			offsetTop: i * ROW_PITCH,
+			offsetHeight: ROW_HEIGHT,
+		}));
+		const classes: string[] = [];
+		const style: FakeStyle = {};
+		lists.set(name, {
+			children,
+			style,
+			classes,
+			classList: { add: (cls: string) => classes.push(cls) },
+			scrollTop: 0,
+		});
+	}
+	let buttons = new Map<string, FakeButton>();
+
+	const element = () => ({
+		innerHTML: "",
+		style: {} as Record<string, string>,
+		querySelectorAll: () => [] as ReadonlyArray<never>,
+		querySelector: () => null,
+		addEventListener: () => undefined,
+	});
+	const elements = new Map<string, ReturnType<typeof element>>();
+	const doc = {
+		getElementById: (id: string) => {
+			if (!elements.has(id)) elements.set(id, element());
+			return elements.get(id);
+		},
+		// Only the two selectors this test is about are answered; every other
+		// wiring query in renderStats gets an empty list, as it does in
+		// FeedCardAsset's harness.
+		querySelectorAll: (selector: string) => {
+			if (selector === "[data-toollist]") return [...lists.values()];
+			if (selector === "[data-toolmore]") {
+				buttons = new Map();
+				// Built from the rendered HTML, so a card that stopped emitting its
+				// footer stops producing a button here too.
+				for (const match of (elements.get("app")?.innerHTML ?? "").matchAll(/data-toolmore="([a-z]+)"/g)) {
+					const list = match[1] as string;
+					buttons.set(list, { getAttribute: (name) => (name === "data-toolmore" ? list : null) });
+				}
+				return [...buttons.values()];
+			}
+			return [] as ReadonlyArray<never>;
+		},
+		querySelector: (selector: string) => {
+			const hit = /^\[data-toollist="([a-z]+)"\]$/.exec(selector);
+			return hit ? (lists.get(hit[1] as string) ?? null) : null;
+		},
+		addEventListener: () => undefined,
+		createElement: element,
+		body: element(),
+	};
+	const win = { JD: {}, document: doc, addEventListener: () => undefined, alert: () => undefined } as Record<
+		string,
+		unknown
+	>;
+	for (const file of ["format.js", "shell.js", "charts.js", "stats.js"]) {
+		const src = readFileSync(new URL(`./assets/js/${file}`, import.meta.url), "utf8");
+		new Function("window", "document", src)(win, doc);
+	}
+	// biome-ignore lint/suspicious/noExplicitAny: see the Harness comment.
+	const JD = win.JD as any;
+	JD.getJson = (path: string) => {
+		fetched.push(path);
+		return Promise.resolve({ rows: [], totalCount: 0 });
+	};
+	const render = (model: unknown): Map<string, FakeButton> => {
+		// `main.js` seeds this once at boot. Local re-renders keep the same object;
+		// only refreshNow replaces it, which the paging code detects by identity.
+		if (!("__JOLLI_DASHBOARD__" in win)) win.__JOLLI_DASHBOARD__ = model;
+		const app = doc.getElementById("app");
+		if (app) app.innerHTML = "";
+		JD.renderStats(model);
+		// `renderPage` is main.js's job in the browser; here it is the real
+		// re-render, which is what every paging handler ends in.
+		JD.renderPage = render;
+		return buttons;
+	};
+	JD.renderPage = render;
+	return {
+		JD,
+		html: () => doc.getElementById("app")?.innerHTML ?? "",
+		render,
+		list: (name: string) => {
+			const hit = lists.get(name);
+			if (!hit) throw new Error(`no list stub for ${name}`);
+			return hit;
+		},
+		fetched,
+		setCurrentModel: (model: unknown) => {
+			win.__JOLLI_DASHBOARD__ = model;
+		},
+	};
+}
+
+const skillRow = (i: number) => ({
+	name: `skill${String(i).padStart(2, "0")}`,
+	kind: "skill",
+	sessions: 20 - i,
+	calls: 20 - i,
+	agents: [{ source: "claude", calls: 20 - i }],
+});
+
+const serverRow = (i: number) => ({
+	server: `server${String(i).padStart(2, "0")}`,
+	sessions: 20 - i,
+	calls: 20 - i,
+	tools: 1,
+	agents: [{ source: "claude", calls: 20 - i }],
+});
+
+function model(toolUsageOver: Record<string, unknown> = {}): unknown {
+	return {
+		schemaVersion: 1,
+		view: "stats",
+		tier: "memory",
+		generatedAtMs: Date.parse("2026-07-30T12:00:00Z"),
+		timeZone: "UTC",
+		scope: { kind: "all" },
+		repos: [],
+		usage: { available: false },
+		stats: {
+			kpis: [],
+			series: [],
+			seriesKeys: [],
+			seriesDimension: "model",
+			heatmap: [],
+			hours: [],
+			fun: { legendarySessionMinutes: 0, biggestDayTokens: 0, nightOwlSharePct: 0 },
+			recentSessions: [],
+			memoryCards: [],
+			range: "month",
+			rangeFrom: "2026-07-01",
+			rangeTo: "2026-07-30",
+			toolUsage: {
+				skills: Array.from({ length: TOOL_ROWS_LIMIT }, (_, i) => skillRow(i)),
+				skillsTotal: TOOL_ROWS_LIMIT + 4,
+				skillCallsTotal: 200,
+				servers: Array.from({ length: TOOL_ROWS_LIMIT }, (_, i) => serverRow(i)),
+				serversTotal: TOOL_ROWS_LIMIT + 7,
+				serverCallsTotal: 375,
+				mcpTools: Array.from({ length: TOOL_ROWS_LIMIT }, (_, i) => ({ ...skillRow(i), kind: "mcp" })),
+				mcpToolsTotal: 42,
+				skillAgents: [{ source: "claude", sessions: 4, calls: 200 }],
+				mcpAgents: [{ source: "claude", sessions: 4, calls: 375 }],
+				sessionsWithTools: 4,
+				sessionsInWindow: 4,
+				uncoveredSources: [],
+				...toolUsageOver,
+			},
+			recallUsage: {
+				usedCalls: 0,
+				setAsideCalls: 0,
+				contextServedPct: 0,
+				distinctMemoriesUsed: 0,
+				staleMemoriesUsed: 0,
+				sessionsWithContext: 0,
+				callsWithoutSession: 0,
+				sessionsInWindow: 0,
+				bySurface: [],
+				skillInvocations: 0,
+				daily: [],
+			},
+			tokenBreakdown: { input: 0, output: 0, cached: 0, perDay: [] },
+		},
+	};
+}
+
+/** One microtask hop past the stubbed fetch, plus the render it ends in. */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("tool-usage lists — header totals", () => {
+	it("prints the window's totals, not a sum of the page on screen", () => {
+		const h = loadHarness();
+		h.render(model());
+		// The page holds 8 skills worth 116 runs; the window holds 12 worth 200.
+		// Summing the rows — what this used to do — made the header disagree with
+		// the footer and change on every Show more click.
+		expect(h.html()).toContain("200 runs · 12 skills");
+		expect(h.html()).toContain("15 servers · 375 calls");
+	});
+
+	it("keeps the singular/plural wording on a one-row window", () => {
+		const h = loadHarness();
+		h.render(
+			model({
+				skills: [skillRow(0)],
+				skillsTotal: 1,
+				skillCallsTotal: 1,
+				servers: [serverRow(0)],
+				serversTotal: 1,
+				serverCallsTotal: 1,
+			}),
+		);
+		expect(h.html()).toContain("1 run · 1 skill");
+		expect(h.html()).toContain("1 server · 1 call");
+	});
+});
+
+describe("tool-usage lists — the Show more footer", () => {
+	it("offers one page per click, naming what is loaded against the window's total", () => {
+		const h = loadHarness();
+		h.render(model());
+		expect(h.html()).toContain(`Showing ${TOOL_ROWS_LIMIT} of ${TOOL_ROWS_LIMIT + 4} skills`);
+		expect(h.html()).toContain('data-toolmore="skill"');
+		// Not JD.moreToggle's promise: this costs a round trip, so it never claims
+		// to finish the list in one click.
+		expect(h.html()).not.toContain(`Show all ${TOOL_ROWS_LIMIT + 4}`);
+		expect(h.html()).toContain("Show more");
+	});
+
+	it("shows nothing once every row is loaded", () => {
+		const h = loadHarness();
+		h.render(
+			model({
+				skillsTotal: TOOL_ROWS_LIMIT,
+				serversTotal: TOOL_ROWS_LIMIT,
+				mcpToolsTotal: TOOL_ROWS_LIMIT,
+			}),
+		);
+		// A footer that can only ever read "N of N" is noise on the common
+		// small-corpus page.
+		expect(h.html()).not.toContain("data-toolmore");
+		expect(h.html()).not.toContain("Showing");
+	});
+
+	it("pages the MCPs card along whichever split is on screen", () => {
+		const h = loadHarness();
+		h.JD.mcpSplitView = "server";
+		h.render(model());
+		expect(h.html()).toContain('data-toolmore="server"');
+		expect(h.html()).not.toContain('data-toolmore="tool"');
+
+		h.JD.mcpSplitView = "tool";
+		h.render(model());
+		expect(h.html()).toContain('data-toolmore="tool"');
+		expect(h.html()).toContain(`Showing ${TOOL_ROWS_LIMIT} of 42 tools`);
+		expect(h.html()).not.toContain('data-toolmore="server"');
+	});
+});
+
+describe("tool-usage lists — fetching a page", () => {
+	it("asks for the next offset, carrying the page's scope and range", async () => {
+		const h = loadHarness();
+		h.JD.getJson = (path: string) => {
+			h.fetched.push(path);
+			return Promise.resolve({ list: "skill", offset: TOOL_ROWS_LIMIT, rows: [skillRow(9)], totalCount: 9 });
+		};
+		const buttons = h.render(model());
+		buttons.get("skill")?.onclick?.();
+		await settle();
+		// The window params ride along because the rows are an aggregate OVER a
+		// window: paging with a different one would append rows counted from a
+		// different set.
+		expect(h.fetched).toEqual([`/api/tool-usage?range=month&dimension=model&list=skill&offset=${TOOL_ROWS_LIMIT}`]);
+	});
+
+	it("appends the page and moves the footer, keeping the card's other rows", async () => {
+		const h = loadHarness();
+		const fresh = [skillRow(9), skillRow(10)];
+		// `totalCount` is re-read per page, not remembered from the first render:
+		// the window keeps gaining rows while the dashboard is open.
+		h.JD.getJson = () => Promise.resolve({ list: "skill", offset: TOOL_ROWS_LIMIT, rows: fresh, totalCount: 13 });
+		const buttons = h.render(model());
+		buttons.get("skill")?.onclick?.();
+		await settle();
+		expect(h.html()).toContain(`Showing ${TOOL_ROWS_LIMIT + 2} of 13 skills`);
+		expect(h.html()).toContain("skill09");
+		expect(h.html()).toContain("skill10");
+		// The MCPs card is untouched — a click on one list must not reset another.
+		expect(h.html()).toContain('data-toolmore="server"');
+	});
+
+	it("does not confuse a prototype property with an already-loaded tool", async () => {
+		const h = loadHarness();
+		const special = { ...skillRow(9), name: "__proto__" };
+		h.JD.getJson = () =>
+			Promise.resolve({
+				list: "skill",
+				offset: TOOL_ROWS_LIMIT,
+				rows: [special],
+				totalCount: TOOL_ROWS_LIMIT + 1,
+			});
+		const buttons = h.render(model());
+		buttons.get("skill")?.onclick?.();
+		await settle();
+		expect(h.html()).toContain("/__proto__");
+	});
+
+	it("keeps the footer, count only, once the last page has landed", async () => {
+		const h = loadHarness();
+		h.JD.getJson = () =>
+			Promise.resolve({
+				list: "skill",
+				offset: TOOL_ROWS_LIMIT,
+				rows: [skillRow(9), skillRow(10), skillRow(11), skillRow(12)],
+				totalCount: TOOL_ROWS_LIMIT + 4,
+			});
+		const buttons = h.render(model());
+		buttons.get("skill")?.onclick?.();
+		await settle();
+		// The button is gone — there is nothing left to fetch — but the ROW stays, or
+		// the card visibly shrinks on the one click that was supposed to change
+		// nothing but its rows (measured in a real browser: 729px → 689px).
+		expect(h.html()).toContain(`Showing ${TOOL_ROWS_LIMIT + 4} of ${TOOL_ROWS_LIMIT + 4} skills`);
+		expect(h.html()).toContain('class="more-row is-done"');
+		expect(h.html()).not.toContain('data-toolmore="skill"');
+	});
+
+	it("drops a row the page repeats, and retires the footer when every row is a repeat", async () => {
+		const h = loadHarness();
+		// A call arriving mid-browse shifts a row across the offset boundary, so the
+		// next page can hand back one the client already holds. It can never invent
+		// one, which is why an all-repeats page means "nothing after this".
+		h.JD.getJson = () =>
+			Promise.resolve({ list: "skill", offset: TOOL_ROWS_LIMIT, rows: [skillRow(0)], totalCount: 99 });
+		const buttons = h.render(model());
+		buttons.get("skill")?.onclick?.();
+		await settle();
+		expect(h.html()).not.toContain('data-toolmore="skill"');
+		// Believe the rows over the total: offering a click that cannot add anything
+		// is a button that visibly does nothing.
+		expect(h.html()).not.toContain("of 99 skills");
+		// The row still holds its place, same as any other last page.
+		expect(h.html()).toContain(`Showing ${TOOL_ROWS_LIMIT} of ${TOOL_ROWS_LIMIT} skills`);
+	});
+
+	it("states a failed load next to the count it stopped from growing", async () => {
+		const h = loadHarness();
+		h.JD.getJson = () => Promise.reject(new Error("offline"));
+		const buttons = h.render(model());
+		buttons.get("skill")?.onclick?.();
+		await settle();
+		expect(h.html()).toContain("could not load more");
+		expect(h.html()).toContain("Try again");
+		// Still the same loaded count — the failure did not pretend to grow it.
+		expect(h.html()).toContain(`Showing ${TOOL_ROWS_LIMIT} of ${TOOL_ROWS_LIMIT + 4} skills`);
+	});
+
+	it("ignores a second click while the first is still in flight", async () => {
+		const h = loadHarness();
+		let calls = 0;
+		h.JD.getJson = () => {
+			calls += 1;
+			return new Promise(() => undefined);
+		};
+		const buttons = h.render(model());
+		const button = buttons.get("skill");
+		button?.onclick?.();
+		// The re-render disables the button, but the handler must hold the invariant
+		// itself — the disabled attribute is a hint, not the guard.
+		h.render(model());
+		button?.onclick?.();
+		await settle();
+		expect(calls).toBe(1);
+	});
+
+	it("does not repaint an old page response over a newer polled model", async () => {
+		const h = loadHarness();
+		let resolvePage: ((page: unknown) => void) | undefined;
+		h.JD.getJson = () =>
+			new Promise((resolve) => {
+				resolvePage = resolve;
+			});
+		const oldModel = model();
+		const buttons = h.render(oldModel);
+		buttons.get("skill")?.onclick?.();
+
+		// Mirror refreshNow: replace the global object before rendering the poll's
+		// fresh first page. The in-flight response still closes over `oldModel`.
+		const freshModel = model({ skillsTotal: TOOL_ROWS_LIMIT });
+		h.setCurrentModel(freshModel);
+		h.render(freshModel);
+		resolvePage?.({ list: "skill", offset: TOOL_ROWS_LIMIT, rows: [skillRow(9)], totalCount: TOOL_ROWS_LIMIT + 1 });
+		await settle();
+
+		expect(h.html()).not.toContain("skill09");
+		expect(h.html()).not.toContain('data-toolmore="skill"');
+	});
+});
+
+describe("tool-usage lists — the scroll cap", () => {
+	it("leaves a first-page list uncapped, so the default rows carry no scrollbar", () => {
+		const h = loadHarness({ skill: TOOL_ROWS_LIMIT });
+		h.render(model());
+		expect(h.list("skill").style.maxHeight).toBeUndefined();
+		expect(h.list("skill").classes).toEqual([]);
+	});
+
+	it("caps a grown list to the measured height of its first page", () => {
+		const h = loadHarness({ skill: TOOL_ROWS_LIMIT + 4 });
+		h.render(model());
+		// Measured off the real rows, never a CSS constant: a row is a line of
+		// variable-length text plus a bar, so its height is a font measurement.
+		expect(h.list("skill").style.maxHeight).toBe(`${(TOOL_ROWS_LIMIT - 1) * ROW_PITCH + ROW_HEIGHT}px`);
+		expect(h.list("skill").classes).toEqual(["rl-scroll"]);
+	});
+
+	it("leaves an unlaid-out list alone rather than capping it to zero", () => {
+		const h = loadHarness({ skill: TOOL_ROWS_LIMIT + 4 });
+		// A hidden card measures 0 — capping to that would hide every row, where
+		// staying uncapped only costs the card its fixed height until the next paint.
+		for (const child of h.list("skill").children as Array<{ offsetTop: number; offsetHeight: number }>) {
+			child.offsetTop = 0;
+			child.offsetHeight = 0;
+		}
+		h.render(model());
+		expect(h.list("skill").style.maxHeight).toBeUndefined();
+		expect(h.list("skill").classes).toEqual([]);
+	});
+
+	it("scrolls the rows a click just fetched into view, once", async () => {
+		const h = loadHarness({ skill: TOOL_ROWS_LIMIT + 1 });
+		h.JD.getJson = () =>
+			Promise.resolve({ list: "skill", offset: TOOL_ROWS_LIMIT, rows: [skillRow(9)], totalCount: 9 });
+		const buttons = h.render(model());
+		expect(h.list("skill").scrollTop).toBe(0);
+		buttons.get("skill")?.onclick?.();
+		await settle();
+		// The new rows start at the top of the visible window; without this the card
+		// looks unchanged and only the footer count moves.
+		expect(h.list("skill").scrollTop).toBe(TOOL_ROWS_LIMIT * ROW_PITCH);
+
+		// And not again on the next repaint — a sticky reveal would yank the reader
+		// back to that row on every 30 s model poll.
+		h.list("skill").scrollTop = 120;
+		h.render(model({ skills: Array.from({ length: TOOL_ROWS_LIMIT + 1 }, (_, i) => skillRow(i)) }));
+		expect(h.list("skill").scrollTop).toBe(120);
+	});
+});

--- a/cli/src/dashboard/assets/js/stats.js
+++ b/cli/src/dashboard/assets/js/stats.js
@@ -618,12 +618,102 @@ window.JD = window.JD || {};
 		);
 	}
 
+	/* Page size for every ranked tool list — mirrors TOOL_ROWS_LIMIT in
+	   DashboardModel.ts. Used for the SCROLL CAP only: how many rows exist and
+	   whether another page can be fetched are the server's `*Total` counts, never
+	   this number, so the two going out of step costs a slightly wrong cap height
+	   and nothing else. */
+	var TOOL_PAGE_SIZE = 8;
+
+	/* The three pageable ranked lists, and everything that differs between them:
+	   which array on `toolUsage` holds the loaded rows, which count they page
+	   against, what identifies a row (for the append dedupe) and the noun the
+	   footer prints. Table-driven because the Skills and MCPs cards would
+	   otherwise each spell the same four decisions out, and only one of them would
+	   get fixed. */
+	var TOOL_LISTS = {
+		skill: { rows: "skills", total: "skillsTotal", key: (r) => r.name, noun: "skills" },
+		server: { rows: "servers", total: "serversTotal", key: (r) => r.server, noun: "servers" },
+		tool: { rows: "mcpTools", total: "mcpToolsTotal", key: (r) => r.name, noun: "tools" },
+	};
+
+	/* Per-list paging state — in flight, failed, and which row index a click just
+	   grew the list from.
+
+	   Kept ON `toolUsage`, never on JD: the 30 s `/api/model` poll replaces that
+	   object with a fresh FIRST page, and the paging state has to reset with it. A
+	   module-level flag would survive the swap and either strand the new payload
+	   at page 1 or scroll it to a row index the new list does not have. */
+	function toolPaging(usage, list) {
+		usage.paging = usage.paging || {};
+		usage.paging[list] = usage.paging[list] || {};
+		return usage.paging[list];
+	}
+
+	/* "Showing 8 of 15 servers" plus the button that fetches the next page.
+
+	   Deliberately NOT `JD.moreToggle`, for the same reason the Memories tree's
+	   footer is not: that one expands rows the server already sent, so it can
+	   promise "Show all N" and offer "Show fewer". This costs a round trip per
+	   click, so it says only what one click will do.
+
+	   Absent entirely on a list that has never paged and never could — a footer
+	   that can only ever read "N of N" is noise on the far more common
+	   small-corpus page. But once a click HAS grown the list it stays, count only,
+	   because the card's height is part of the layout: the three cards share one
+	   equal-third band, and dropping a 40px row the moment the last page lands
+	   made the card visibly shrink under the reader on the one click that was
+	   supposed to change nothing but the rows (measured in a real browser). It is
+	   also the only place the reader is told they have reached the end. */
+	function toolMoreRow(usage, list) {
+		var spec = TOOL_LISTS[list];
+		var shown = (usage[spec.rows] || []).length;
+		var total = usage[spec.total] || 0;
+		var state = toolPaging(usage, list);
+		if (!shown) return "";
+		var count =
+			'<span class="more-count">Showing ' +
+			shown +
+			" of " +
+			total +
+			" " +
+			spec.noun +
+			/* The failure belongs next to the count it stopped from growing, not in a
+			   toast: this button still being here IS the reason it matters. */
+			(state.error && !state.loading ? " — could not load more" : "") +
+			"</span>";
+		if (shown >= total) return state.grown ? '<div class="more-row is-done">' + count + "</div>" : "";
+		var label = state.loading ? "Loading…" : state.error ? "Try again" : "Show more";
+		return (
+			'<div class="more-row">' +
+			count +
+			'<button type="button" class="cta ghost sm" data-toolmore="' +
+			JD.esc(list) +
+			'"' +
+			(state.loading ? " disabled" : "") +
+			">" +
+			label +
+			"</button></div>"
+		);
+	}
+
 	/* Ranked rows shared by Skills and MCP servers: label (+ optional kind),
-	   value, a bare colour bar underneath sized against the top row. */
-	function rankedList(rows, colorVar, valueOf, labelOf, kindOf, unit) {
+	   value, a bare colour bar underneath sized against the top row. `list` names
+	   which pageable list this is, so `capToolLists` can find the <ul> again after
+	   the render. */
+	function rankedList(rows, colorVar, valueOf, labelOf, kindOf, unit, list) {
 		if (rows.length === 0) return "";
-		var top = valueOf(rows[0]) || 1;
-		var html = '<ul class="ranklist">';
+		// The real maximum, not `rows[0]` — that is only the biggest value when the
+		// list's rank order happens to be the metric the bars measure, and Skills
+		// deliberately ranks by adoption while printing runs (see `byAdoption` in
+		// DashboardQuery). Row 0 as the denominator therefore produced widths past
+		// 100%, which `.rl-bar`'s `overflow: hidden` clamps rather than reveals:
+		// measured on the MCPs card at 68 calls in row 0, codegraph's 149 asked for
+		// 219% and dbhub's 76 for 112%, so three distinct volumes all painted as one
+		// full bar. A too-wide bar is the failure that hides itself; a short bar in
+		// row 0 is the honest signal that rank and volume disagree.
+		var top = rows.reduce((max, row) => Math.max(max, valueOf(row)), 0) || 1;
+		var html = '<ul class="ranklist"' + (list ? ' data-toollist="' + JD.esc(list) + '"' : "") + ">";
 		rows.forEach((row) => {
 			var value = valueOf(row);
 			// The name truncates with an ellipsis (see .rl-name), so the full text
@@ -651,9 +741,58 @@ window.JD = window.JD || {};
 		return html + "</ul>";
 	}
 
+	/* Which agents are behind one ranked row — `claude`, or `codex · claude` when
+	   more than one contributed. The names are `sessions.source` verbatim, the
+	   same tag the Tokens chart's Agent axis prints, so the two panels can be
+	   read against each other without a mapping in the reader's head.
+
+	   Counts are deliberately left OFF the per-row tag: the row already prints
+	   its own total beside the name, and a second set of numbers at that size
+	   reads as noise. The split WITH volume lives on the card's header line. */
+	function agentTag(agents) {
+		if (!agents || agents.length === 0) return "";
+		return agents.map((a) => a.source).join(" · ");
+	}
+
+	/* Append the agent tag to a row's existing meta slot without losing it —
+	   the MCP lists already spend that slot on tool/session counts. */
+	function withAgents(metaOf) {
+		return (row) => {
+			var tag = agentTag(row.agents);
+			var meta = metaOf ? metaOf(row) : "";
+			return meta && tag ? meta + " · " + tag : meta || tag;
+		};
+	}
+
+	/* The card's per-agent header line: who produced everything below, with
+	   volume. Built from the server's own untruncated grouping (`skillAgents` /
+	   `mcpAgents`), never from the visible rows — those are cut to 8, so summing
+	   them would quietly under-report an agent whose tools all rank lower. */
+	function agentLine(agents) {
+		if (!agents || agents.length === 0) return "";
+		var parts = agents.map((a) => '<b class="num">' + a.calls + "</b> " + JD.esc(a.source));
+		return '<div class="sub" style="margin-top:2px">by agent · ' + parts.join(" · ") + "</div>";
+	}
+
+	/* The "…so this list is not everything" caveat, shared by both cards.
+	   `uncoveredSources` is a PARSER capability the server computed, not "these
+	   agents happened to call nothing" — see ToolUsage in DashboardModel. */
+	function uncoveredNote(usage, noun) {
+		if (usage.uncoveredSources.length === 0) return "";
+		return (
+			" · <b>" +
+			JD.esc(usage.uncoveredSources.join(", ")) +
+			"</b> record no tool calls, so " +
+			noun +
+			" used only from those agents will not appear here"
+		);
+	}
+
 	/* Skills (span6) — split out of the old combined "Skills & tools" card so
 	   each half gets its own icon, stat line and footer, matching jolli-design's
-	   per-card anatomy. Claude-only by construction, like the card it replaces. */
+	   per-card anatomy. Every row names the agents that ran it; which agents can
+	   be read at all is the footer's `uncoveredSources` caveat, not a fixed list
+	   here (it was hard-coded to Claude and went stale the day Codex landed). */
 	function skillsCard(model) {
 		var usage = model.stats.toolUsage;
 		var icon = widgetIcon(
@@ -667,27 +806,36 @@ window.JD = window.JD || {};
 		if (usage.skills.length === 0) {
 			return (
 				html +
-				'<div class="empty-note">No skill invocations recorded in this window. Only Claude transcripts ' +
-				"carry them.</div></section>"
+				'<div class="empty-note">No skill invocations recorded in this window.' +
+				uncoveredNote(usage, "a skill") +
+				"</div></section>"
 			);
 		}
 
-		var totalRuns = usage.skills.reduce((sum, r) => sum + r.calls, 0);
+		/* Both figures come off the server's own COUNT/SUM, never off the rows on
+		   screen: `usage.skills` is ONE PAGE, so summing it read "12 runs · 8
+		   skills" on a machine with 30 skills — and changed every time the reader
+		   clicked Show more, which is the kind of wrong a header line cannot be. */
+		var totalRuns = usage.skillCallsTotal;
+		var totalSkills = usage.skillsTotal;
 		html +=
 			'<div class="sub" style="margin-top:2px">' +
 			totalRuns +
 			(totalRuns === 1 ? " run · " : " runs · ") +
-			usage.skills.length +
-			(usage.skills.length === 1 ? " skill</div>" : " skills</div>");
+			totalSkills +
+			(totalSkills === 1 ? " skill</div>" : " skills</div>");
+		html += agentLine(usage.skillAgents);
 
 		html += rankedList(
 			usage.skills,
 			"--s2",
 			(r) => r.calls,
 			(r) => "/" + r.name,
-			null,
+			withAgents(null),
 			"run",
+			"skill",
 		);
+		html += toolMoreRow(usage, "skill");
 
 		return (
 			html +
@@ -696,7 +844,9 @@ window.JD = window.JD || {};
 			"</b> of " +
 			usage.sessionsInWindow +
 			(usage.sessionsInWindow === 1 ? " session</b>" : " sessions") +
-			" in this window</span></div></section>"
+			" in this window" +
+			uncoveredNote(usage, "a skill") +
+			"</span></div></section>"
 		);
 	}
 
@@ -721,33 +871,41 @@ window.JD = window.JD || {};
 	function mcpViewList(usage, view) {
 		if (view === "tool") {
 			if (usage.mcpTools.length === 0) return '<div class="empty-note">No individual MCP tool calls recorded in this window.</div>';
-			return rankedList(
-				usage.mcpTools,
-				"--s1",
-				(r) => r.calls,
-				(r) => r.name,
-				(r) => r.sessions + (r.sessions === 1 ? " session" : " sessions"),
-				"call",
+			return (
+				rankedList(
+					usage.mcpTools,
+					"--s1",
+					(r) => r.calls,
+					(r) => r.name,
+					withAgents((r) => r.sessions + (r.sessions === 1 ? " session" : " sessions")),
+					"call",
+					"tool",
+				) + toolMoreRow(usage, "tool")
 			);
 		}
-		return rankedList(
-			usage.servers,
-			"--s1",
-			(r) => r.calls,
-			(r) => r.server,
-			(r) => r.tools + (r.tools === 1 ? " tool" : " tools"),
-			"call",
+		return (
+			rankedList(
+				usage.servers,
+				"--s1",
+				(r) => r.calls,
+				(r) => r.server,
+				withAgents((r) => r.tools + (r.tools === 1 ? " tool" : " tools")),
+				"call",
+				"server",
+			) + toolMoreRow(usage, "server")
 		);
 	}
 
-	/* MCP servers (span6). Claude-only by construction, so the coverage line
-	   is mandatory: without it, "3 sessions" reads as 3 of everything rather
-	   than 3 of the sessions this build can actually see inside. Deliberately
-	   no "N of M servers called" figure — that needs the full registered-server
-	   list, which lives in MCP registration config, not in captured tool calls;
-	   see ToolUsage in DashboardModel. */
+	/* MCP servers (span6). Only some agents' transcripts can be read for tool
+	   calls, so the coverage line is mandatory: without it, "3 sessions" reads
+	   as 3 of everything rather than 3 of the sessions this build can actually
+	   see inside. Each row also names the agents behind it, which is the finer
+	   version of the same honesty — "codegraph · codex" answers a question the
+	   whole-card caveat cannot. Deliberately no "N of M servers called" figure:
+	   that needs the full registered-server list, which lives in MCP
+	   registration config, not in captured tool calls; see ToolUsage in
+	   DashboardModel. */
 	function mcpCard(model) {
-		var esc = JD.esc;
 		var usage = model.stats.toolUsage;
 		var icon = widgetIcon(
 			"--s1",
@@ -760,18 +918,25 @@ window.JD = window.JD || {};
 		if (usage.servers.length === 0) {
 			return (
 				html +
-				'<div class="empty-note">No MCP calls recorded in this window. Only Claude transcripts carry them.' +
+				'<div class="empty-note">No MCP calls recorded in this window.' +
+				uncoveredNote(usage, "a server") +
 				"</div></section>"
 			);
 		}
 
-		var totalCalls = usage.servers.reduce((sum, r) => sum + r.calls, 0);
+		/* Server and call totals for the WHOLE window, from the server's own
+		   COUNT/SUM — see the same note on the Skills card. Measured on a real
+		   database: 15 servers and 375 calls, of which the first page can account
+		   for 8 and 61. */
+		var totalCalls = usage.serverCallsTotal;
+		var totalServers = usage.serversTotal;
 		html +=
 			'<div class="sub" style="margin-top:2px">' +
-			usage.servers.length +
-			(usage.servers.length === 1 ? " server · " : " servers · ") +
+			totalServers +
+			(totalServers === 1 ? " server · " : " servers · ") +
 			totalCalls +
 			(totalCalls === 1 ? " call</div>" : " calls</div>");
+		html += agentLine(usage.mcpAgents);
 
 		if (usage.recallCalls) {
 			html +=
@@ -790,12 +955,7 @@ window.JD = window.JD || {};
 		html += mcpViewList(usage, view);
 
 		var note = "from <b>" + usage.sessionsWithTools + "</b> of " + usage.sessionsInWindow + " sessions in this window";
-		if (usage.uncoveredSources.length > 0) {
-			note +=
-				" · <b>" +
-				esc(usage.uncoveredSources.join(", ")) +
-				"</b> record no tool calls, so a server used only from those agents will not appear here";
-		}
+		note += uncoveredNote(usage, "a server");
 		if (usage.recallCalls) {
 			note +=
 				" · recall count is MCP-tool calls only — a bare <code>jolli recall</code> run or the skill's CLI " +
@@ -804,6 +964,138 @@ window.JD = window.JD || {};
 		note +=
 			" · older activity is reconstructed from commits and stored summaries; recent sessions are exact";
 		return html + '<div class="w-foot"><span class="w-measure mcp-card-note">ⓘ ' + note + "</span></div></section>";
+	}
+
+	/* Past its first page a ranked list scrolls INSIDE the card rather than
+	   growing it. The three cards sit in one equal-third band, so a list that
+	   grows re-flows the two beside it and pushes everything below the fold — the
+	   card's size is part of the layout, not a consequence of its contents.
+
+	   The cap is MEASURED off the rendered rows (the height of exactly
+	   TOOL_PAGE_SIZE of them) rather than written as a CSS length: a row is a line
+	   of variable-length text plus a bar, so its height is a font measurement, not
+	   a constant, and a hard-coded one would either clip row 8 or leave a scrollbar
+	   under a list that has nothing to scroll.
+
+	   A list still on its first page gets NO cap at all — that is what keeps the
+	   default 8 rows free of a scrollbar, which a `max-height` set unconditionally
+	   would not (a cap equal to the content still arms the scroll container, and a
+	   sub-pixel row height rounds the wrong way). */
+	function capToolLists() {
+		document.querySelectorAll("[data-toollist]").forEach((list) => {
+			var items = list.children;
+			if (!items || items.length <= TOOL_PAGE_SIZE) return;
+			var first = items[0];
+			var last = items[TOOL_PAGE_SIZE - 1];
+			var height = last.offsetTop + last.offsetHeight - first.offsetTop;
+			/* 0 while the card has no layout yet (a hidden tab, a detached render).
+			   Capping to 0 would hide every row; leaving it uncapped only costs the
+			   card its fixed height until the next repaint. */
+			if (!height) return;
+			list.style.maxHeight = height + "px";
+			list.classList.add("rl-scroll");
+		});
+	}
+
+	/* Scrolls a just-grown list so the rows the click actually fetched are at the
+	   top of the visible window. Without it the card looks unchanged: the new rows
+	   are there but below the fold, and the only visible difference is the footer
+	   count — which reads as a button that half-worked. */
+	function revealToolRows(usage) {
+		if (!usage || !usage.paging) return;
+		Object.keys(TOOL_LISTS).forEach((list) => {
+			var state = usage.paging[list];
+			if (!state || state.revealFrom == null) return;
+			var at = state.revealFrom;
+			/* Cleared whether or not the scroll lands — it describes ONE click, and a
+			   sticky value would re-scroll the reader on every 30 s repaint. */
+			state.revealFrom = null;
+			var el = document.querySelector('[data-toollist="' + list + '"]');
+			if (!el) return;
+			var items = el.children;
+			if (at <= 0 || at >= items.length) return;
+			el.scrollTop = items[at].offsetTop - items[0].offsetTop;
+		});
+	}
+
+	/**
+	 * Fetches ONE more page of a ranked tool list and appends it.
+	 *
+	 * The paging is SQL-side (`/api/tool-usage` → `buildToolUsagePage`), so this
+	 * is the only way past the first page: the model carries 8 rows and the
+	 * totals, never the rest of the list.
+	 *
+	 * Re-renders the whole stats page rather than splicing the new rows into the
+	 * existing <ul>. A ranked list's bars are sized against the list's true
+	 * maximum, and a later page can carry a BIGGER value than the top row — Skills
+	 * ranks by adoption while printing runs (see `rankedList`) — so appending in
+	 * place would leave every bar already on screen measured against a denominator
+	 * that had moved.
+	 *
+	 * Never chained or auto-fired: one click, one page. The first page is already
+	 * a working card, and anything past it earns its round trip when asked for.
+	 */
+	function loadMoreToolRows(model, list) {
+		var spec = TOOL_LISTS[list];
+		var usage = model.stats && model.stats.toolUsage;
+		if (!spec || !usage) return;
+		var state = toolPaging(usage, list);
+		if (state.loading) return;
+		var rows = usage[spec.rows] || [];
+		if (rows.length >= (usage[spec.total] || 0)) return;
+		state.loading = true;
+		state.error = false;
+		JD.renderPage(model);
+		JD.getJson(JD.withParams("/api/tool-usage" + JD.query(model, {}), { list: list, offset: String(rows.length) }))
+			.then((page) => {
+				/* A 30 s model refresh can finish while this page is in flight. That
+				   refresh replaces the global model and deliberately resets every tool
+				   list to its fresh first page; an older response must not repaint the
+				   superseded model over it. Identity is enough because refreshNow replaces
+				   the object rather than mutating it. */
+				if (window.__JOLLI_DASHBOARD__ !== model) return;
+				state.loading = false;
+				var incoming = (page && page.rows) || [];
+				/* Re-read per page, not remembered from the first render: the window
+				   keeps gaining calls while the dashboard is open, so "is there more"
+				   has to be asked against a total as fresh as the rows beside it. */
+				usage[spec.total] = page.totalCount;
+				/* Deduped by row identity. An offset can repeat a row — a call arriving
+				   mid-browse shifts one across the page boundary — but it can never
+				   invent one, so a repeat is dropped and an all-repeats page is the
+				   "nothing new" case below. */
+				/* Null-prototype because tool names are data. `__proto__` and
+				   `constructor` are valid strings, not inherited rows that should be
+				   treated as already loaded. */
+				var seen = Object.create(null);
+				rows.forEach((row) => {
+					seen[spec.key(row)] = true;
+				});
+				var fresh = incoming.filter((row) => !seen[spec.key(row)]);
+				if (fresh.length === 0) {
+					/* Nothing past this offset that we do not already hold, whatever the
+					   total says. Believe the rows: pin the total to what is loaded, so
+					   the footer loses its button rather than offering a click that cannot
+					   add anything — but keeps its row, so the card does not resize on a
+					   click that found nothing. */
+					usage[spec.total] = rows.length;
+					state.grown = true;
+					JD.renderPage(model);
+					return;
+				}
+				state.revealFrom = rows.length;
+				/* Sticky for the life of this payload: it is what keeps the footer (and
+				   so the card's height) in place once the last page lands. */
+				state.grown = true;
+				usage[spec.rows] = rows.concat(fresh);
+				JD.renderPage(model);
+			})
+			.catch(() => {
+				if (window.__JOLLI_DASHBOARD__ !== model) return;
+				state.loading = false;
+				state.error = true;
+				JD.renderPage(model);
+			});
 	}
 
 	/* Where your tokens went (span4) — input/output/cache, day-bucketed. Reuses
@@ -1149,5 +1441,15 @@ window.JD = window.JD || {};
 			};
 		}
 
+		/* The Skills / MCPs lists are the one thing on this page that pages in SQL,
+		   so their "Show more" is a fetch rather than a view toggle. Capped first
+		   (both run on every repaint, so a list grown by an earlier click keeps its
+		   height and its scrollbar), then the reveal, which needs the cap in place
+		   to have anything to scroll. */
+		capToolLists();
+		revealToolRows(stats.toolUsage);
+		document.querySelectorAll("[data-toolmore]").forEach((button) => {
+			button.onclick = () => loadMoreToolRows(model, button.getAttribute("data-toolmore"));
+		});
 	};
 })(window.JD);

--- a/cli/src/dashboard/assets/styles/main.css
+++ b/cli/src/dashboard/assets/styles/main.css
@@ -518,6 +518,12 @@ body {
   .more-row { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-top: 14px; }
   .more-count { font-size: 11.5px; color: var(--muted); }
   .more-row .cta { margin-left: auto; }
+  /* The tool-usage footer keeps its row after the last page lands, with the count
+     and no button (see `toolMoreRow`) — so the row has to hold the height the
+     button was giving it, or the card resizes on that one click. `.cta.sm` is
+     12px/1.2 text plus 5px padding and a 1px border each side, so 26px is the
+     button's own box; the two are pinned together deliberately. */
+  .more-row.is-done { min-height: 26px; }
 
   /* ---------- outcome tag (M6 do next) ---------- */
   .tag.outc { border-color: transparent; background: var(--accent-soft); color: var(--accent); font-weight: 600; }
@@ -967,6 +973,26 @@ body {
   .ranklist .rl-val { margin-left: auto; color: var(--ink-2); white-space: nowrap; flex: none; }
   .ranklist .rl-bar { height: 10px; margin-top: 10px; border-radius: 5px; background: var(--heat-track); overflow: hidden; }
   .ranklist .rl-bar i { display: block; height: 100%; }
+  /* Added by `capToolLists` once a list has been grown past its first page, and
+     never before: the three cards share one equal-third band, so a list that got
+     taller would re-flow its neighbours, but a list still showing its default 8
+     rows must have no scrollbar at all. The `max-height` that arms this is set
+     inline, measured off the real rows — a length here could not know the row
+     height. `overscroll-behavior: contain` keeps a flick inside the card instead
+     of scrolling the page on once the list bottoms out. */
+  .ranklist.rl-scroll {
+    overflow-y: auto; overscroll-behavior: contain;
+    scrollbar-width: thin; scrollbar-color: color-mix(in srgb, var(--muted) 42%, transparent) transparent;
+  }
+  .ranklist.rl-scroll::-webkit-scrollbar { width: 10px; }
+  .ranklist.rl-scroll::-webkit-scrollbar-track { background: transparent; }
+  .ranklist.rl-scroll::-webkit-scrollbar-thumb {
+    background: color-mix(in srgb, var(--muted) 38%, transparent); border-radius: 999px;
+    border: 3px solid transparent; background-clip: padding-box;
+  }
+  .ranklist.rl-scroll:hover::-webkit-scrollbar-thumb {
+    background: color-mix(in srgb, var(--muted) 55%, transparent); background-clip: padding-box;
+  }
 
   /* Memory Activity's two views share the same rows, but their grouping answers
      different questions: branches cluster work streams; time preserves the

--- a/package-lock.json
+++ b/package-lock.json
@@ -3782,6 +3782,7 @@
 			"resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
 			"integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=16.9.0"
 			}
@@ -6476,6 +6477,7 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -7143,6 +7145,7 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
 			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Context (2)

- Search
- Recall

## Quick recap

The dashboard's Skills and MCP cards now show which coding assistant produced the activity they report. Each card carries a "by agent" line under its headline stats covering Claude Code, Codex, and any other assistant active in the selected window, and every individual skill, tool, and server row is tagged with the agents behind it. The counts are drawn from existing session records, and the database is unchanged.

Readers can also reach every recorded tool, not just the first eight. Each panel keeps its default eight rows and gains a "Show more" button that pulls the next batch from the database on demand; the extra rows scroll inside the card, which holds a constant height throughout, and the default view stays free of a scrollbar. Once the whole list has loaded, the footer remains and reports the loaded count against the window total.

The panel headings now state the true figures for the selected time window. A machine with fifteen connected servers and several hundred calls previously saw a heading built only from the eight visible rows; the heading now reports the full counts and stays steady as more rows load. The MCP lists are ordered by the call counts printed beside each name, with the coloured bars scaled against the largest value in the list, so a busy server appears at the top with a full bar and quieter ones are drawn in proportion. The Skills panel continues to rank by how many separate sessions reached for each skill.

Both cards' footnotes were corrected as well. The note about which assistants contribute tool data is now generated from the set of sources the dashboard can actually read, covering all nine supported agents, and the Skills card carries the same caveat the MCP card already had. Readers get an accurate statement of what the list can and cannot include.

---

## Topics (2)
<details>
<summary><strong>01 · Per-agent breakdown and on-demand paging for dashboard Skills and MCP usage cards</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The dashboard's Skills and MCP cards showed usage totals but not which coding assistant produced them, so Claude Code activity could not be told apart from Codex activity, and the user wanted this without any database schema change. The cards also showed only the first eight entries, leaving everything beyond that permanently unreachable, and their headline counts described only those visible rows.

**💡 Decisions Behind the Code**

- **Two agent shapes instead of one**: Per-row breakdowns carry only call counts, while card-level totals carry both calls and sessions. Call counts can be re-added at any grouping level and stay correct, but session counts cannot — one session touching two tools of the same server would be counted twice when rolled up, inflating adoption figures. Reporting a number exact in one place and doubled in another was judged worse than reporting none.
- **Card headers computed server-side over all data, not summed from visible rows**: Each card shows only eight rows by default, so an agent or server ranking lower would vanish from a client-side roll-up. Dedicated counts guarantee the header names every contributing agent and the true totals, which also fixed a case where a machine with fifteen servers and 389 calls was reported as "8 servers · 61 calls".
- **Fetch one page per click from the database over slicing a full read**: The earlier approach read and folded every tool row in the window just to display eight, costing the full scan on every dashboard load while leaving the rest invisible. Paging in the database bounds the work to what is displayed and makes the remaining rows reachable.
- **Rank each list by the number it actually prints, keeping Skills on adoption**: The MCP panels printed and barred call counts while ordering by session count, and bars sized against the first row clamped so three different volumes looked identical. Both MCP lists now order by calls with sessions as tiebreak; Skills deliberately keeps adoption ordering, since one session hammering a skill two hundred times should not outrank a skill three separate sessions reached for.
- **Hold the card's height fixed by measuring the first eight rows**: The three cards share one equal-height band, so a growing list would reflow its neighbours and push content below the fold. The cap is measured from rendered rows because row height depends on text and font, the first page gets no cap so the default view has no scrollbar, and the footer stays after the last page since dropping it made the card visibly shrink.

**✅ What Was Implemented**

- Reworked the tool usage read in `DashboardQuery.ts` into `buildToolUsagePage`: each list is a `LIMIT`/`OFFSET` query with a total-order `ORDER BY`, the per-row agent split is a second query restricted to the page's keys via `IN (...)`, and headline figures come from dedicated `COUNT(DISTINCT …)`/`SUM(calls)` queries surfaced as `skillsTotal`, `skillCallsTotal`, `serversTotal`, `serverCallsTotal` and `mcpToolsTotal`. A separate `(kind, source)` grouping supplies whole-window per-agent totals with real distinct session counts, and the recall row moved to its own query so it survives ranking outside the first page.
- Added `ToolUsageAgentShare` (calls only) and `ToolUsageAgentTotal` (calls plus sessions) to `DashboardModel.ts`, hung an `agents` array on skill rows, MCP tool rows, server rows and the recall row, and added `skillAgents` / `mcpAgents` to the tool usage payload.
- Added the `/api/tool-usage?list=skill|server|tool&offset=N` route in `DashboardServer.ts`, carrying range/repo scope so an appended page is counted over the same window as the inlined first page; an unknown list or non-numeric offset returns 400 and `limit` is deliberately not client-controllable.
- Rewrote the card rendering in `assets/js/stats.js` around a table-driven list spec: a "by agent" header line under each stat line, agent names in each row's meta slot, a footer row with a Show more button, per-list paging state stored on the payload so the 30-second poll resets it, append-with-dedupe via a null-prototype seen map, an in-flight identity guard against stale responses, a measured `max-height` scroll cap applied only past the first page, and a scroll-to-new-rows reveal.
- Replaced the hard-coded "Claude only" footnotes on both cards with a note generated from the server's own list of agent sources whose transcripts carry no tool records, and ordered both MCP lists by call volume with bars sized against the list's true maximum.

**📋 Future Enhancements**

- Position-based paging can let a newly busy row jump from a later page to an earlier one, and client-side deduplication can only drop repeats, not recover a row that skipped past the reader's position; fixing this needs a different paging protocol.
- The Skills card still ranks by adoption while printing run counts — unifying it means either reordering by calls or changing what it prints.
- Per-memory detail pages could also show skills and MCP usage; the data is already in the payload, awaiting the user's call.
- One existing commit on the branch is missing its sign-off line and will be rejected by continuous integration until the history is amended.
- The slower test suites and the full check script were not run and should be executed before shipping.

**📁 FILES**
- `cli/src/dashboard/DashboardQuery.ts`
- `cli/src/dashboard/DashboardServer.ts`
- `cli/src/dashboard/DashboardModel.ts`
- `cli/src/dashboard/assets/js/stats.js`
- `cli/src/dashboard/assets/styles/main.css`

</blockquote>
</details>
<details>
<summary><strong>02 · Explaining why dashboard code changes need a manual service restart</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After rebuilding and reinstalling, the user still saw the old ordering in the MCP panel while the bar widths had visibly updated, and asked how to restart the dashboard service by hand.

**💡 Decisions Behind the Code**

Restarting stays an explicit stop-then-start rather than gaining a dedicated restart option; the reuse behaviour is intentional so that repeated launches attach to the existing service instead of spawning duplicates, and the state file makes the running instance inspectable when a stale build is suspected.

**✅ What Was Implemented**

No code change: diagnosed that the running dashboard process had been started before the build and was serving in-memory code, while the page's inline stylesheet and script assets are re-read from disk on every request — producing the half-updated appearance. Documented that restarting is a stop followed by a start, that the service reuses a live process recorded in the local state file, and listed the available options for the dashboard command.

</blockquote>
</details>

---

*Generated by Jolli Memory · August 13, 2026 at 9:11 PM · via Local agent - Claude Code*
<!-- jollimemory-summary-end -->