### PR TITLE
Extend session backfill to a 7-day disk scan with summary line

### DIFF
--- a/cli/src/commands/DashboardCommand.test.ts
+++ b/cli/src/commands/DashboardCommand.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { StartedDashboardServer } from "../dashboard/DashboardServer.js";
-import type { DbBackfillProgress } from "../dashboard/DbBackfill.js";
+import type { DbBackfillProgress, DbBackfillResult } from "../dashboard/DbBackfill.js";
 import type { RegisteredRepo } from "../dashboard/RepoRegistry.js";
 
 vi.mock("../dashboard/DbBackfill.js", () => ({
@@ -53,7 +53,7 @@ import { maybeAutoCutover } from "../dashboard/AutoCutover.js";
 import { opportunisticSnapshot } from "../dashboard/Backup.js";
 import { canUseDashboardDb } from "../dashboard/DashboardDb.js";
 import { DASHBOARD_HEALTH_SERVICE } from "../dashboard/DashboardServer.js";
-import { dbBackfillRepos } from "../dashboard/DbBackfill.js";
+import { dbBackfillRepos, type SessionTierSummary } from "../dashboard/DbBackfill.js";
 import { listActiveRepos, registerRepo } from "../dashboard/RepoRegistry.js";
 import {
 	createDeferredWriter,
@@ -62,6 +62,7 @@ import {
 	executeDashboard,
 	identifyDashboardHealth,
 	importDashboardHistory,
+	printSessionSummary,
 	registerDashboardCommand,
 	resolveServerCwd,
 	startForegroundDashboard,
@@ -944,6 +945,204 @@ describe("createProgressPrinter", () => {
 			"  Reading AI sessions…",
 		]);
 		expect(lines.filter((l) => l.includes("can take a few minutes"))).toHaveLength(1);
+	});
+
+	it("keeps two same-named repos apart, because the name is not unique", () => {
+		// `deriveRepoName` is the last path/URL segment, so two clones of one project
+		// (or two unrelated `app` directories) collide. A name-keyed reset never fires
+		// on the collision: the second repo printed no heading, no phase labels, and
+		// its whole run appeared under the FIRST repo's heading.
+		const lines: string[] = [];
+		const printer = createProgressPrinter({ log: (line) => lines.push(line) });
+		for (const repoIndex of [1, 2] as const) {
+			printer.onProgress(event({ repoName: "app", repoIndex, repoTotal: 2, kind: "sessions", done: 0 }));
+		}
+		expect(lines).toEqual(["  app (1/2)", "  Reading AI sessions…", "  app (2/2)", "  Reading AI sessions…"]);
+	});
+
+	it("prints the per-agent breakdown when the session tier ends", () => {
+		const lines: string[] = [];
+		const printer = createProgressPrinter({ log: (line) => lines.push(line) });
+		printer.onProgress(event({ kind: "sessions", done: 0, total: undefined }));
+		printer.onProgress(
+			event({
+				kind: "sessions",
+				// Nonzero, which is exactly why the breakdown branch must run before the
+				// commit-only counter rule that would otherwise drop this event.
+				done: 18,
+				total: undefined,
+				sessionBreakdown: {
+					claude: { discovered: 18, processed: 14, skipped: 4 },
+					codex: { discovered: 6, processed: 4, skipped: 2 },
+				},
+			}),
+		);
+		expect(lines).toEqual([
+			"  Reading AI sessions…",
+			"      claude  18 found, 14 processed, 4 skipped",
+			"      codex    6 found,  4 processed, 2 skipped",
+		]);
+	});
+
+	it("adds no breakdown lines for a repo whose window turned up nothing", () => {
+		const lines: string[] = [];
+		const printer = createProgressPrinter({ log: (line) => lines.push(line) });
+		printer.onProgress(event({ kind: "sessions", done: 0, total: undefined }));
+		printer.onProgress(event({ kind: "sessions", done: 0, total: undefined, sessionBreakdown: {} }));
+		expect(lines).toEqual(["  Reading AI sessions…"]);
+	});
+});
+
+describe("printSessionSummary", () => {
+	const result = (sessions?: SessionTierSummary): DbBackfillResult => ({
+		mode: "recovered",
+		eventsApplied: 0,
+		repoName: "jolliai",
+		...(sessions ? { sessions } : {}),
+	});
+
+	/** Shorthand for one agent's row: found / processed / skipped. */
+	const agent = (discovered: number, processed: number, skipped: number) => ({ discovered, processed, skipped });
+
+	/**
+	 * Builds one repo's tier summary from per-agent counts.
+	 *
+	 * The summary carries conversation IDENTITIES alongside the counts, because the
+	 * report merges by conversation rather than by adding the repos' numbers — so a
+	 * fixture has to name its conversations. Ids are synthesised per agent as
+	 * `<source><tag>-<n>` from 1, with the processed set taken off the front and the
+	 * skipped set immediately after it; any remainder is discovered-but-neither, which
+	 * is the undateable session the totals must not derive by subtraction.
+	 *
+	 * `tag` is what decides whether two repos claim the SAME conversations (same tag —
+	 * the coarse-attribution case the merge has to collapse) or different ones.
+	 */
+	function tier(bySource: Record<string, ReturnType<typeof agent>>, tag = ""): SessionTierSummary {
+		const keys = { discovered: [] as string[], processed: [] as string[], skipped: [] as string[] };
+		let discovered = 0;
+		let processed = 0;
+		let skipped = 0;
+		for (const [source, counts] of Object.entries(bySource)) {
+			const ids = Array.from({ length: counts.discovered }, (_, i) => `${source}:${source}${tag}-${i + 1}`);
+			keys.discovered.push(...ids);
+			keys.processed.push(...ids.slice(0, counts.processed));
+			keys.skipped.push(...ids.slice(counts.processed, counts.processed + counts.skipped));
+			discovered += counts.discovered;
+			processed += counts.processed;
+			skipped += counts.skipped;
+		}
+		return { discovered, processed, skipped, bySource, keys };
+	}
+
+	/** Returns every line the summary printed. */
+	function render(results: ReadonlyArray<DbBackfillResult>): string[] {
+		const lines: string[] = [];
+		const log = vi.spyOn(console, "log").mockImplementation((line?: unknown) => {
+			lines.push(String(line ?? ""));
+		});
+		try {
+			printSessionSummary(results);
+		} finally {
+			log.mockRestore();
+		}
+		return lines;
+	}
+
+	it("states both counts outright, then all three per agent", () => {
+		const lines = render([result(tier({ claude: agent(18, 14, 4), codex: agent(6, 4, 2) }))]);
+		// Numbers right-padded into columns: the reader is comparing agents against each
+		// other, which ragged numbers turn into a per-line parse.
+		expect(lines).toEqual([
+			"  ✓ 24 AI conversations in the last 7 days: 18 processed, 6 skipped",
+			"      claude  18 found, 14 processed, 4 skipped",
+			"      codex    6 found,  4 processed, 2 skipped",
+		]);
+	});
+
+	it("uses the same sentence on a converged run, with a zero in it", () => {
+		// A silent branch makes a converged re-run look identical to a run that never
+		// happened; a DIFFERENT sentence would read as a different kind of event.
+		// The agent still appears: "24 found, 0 processed" is what says the tier looked
+		// and found nothing new, which an omitted row would spell as "codex absent".
+		const lines = render([result(tier({ codex: agent(24, 0, 24) }))]);
+		expect(lines).toEqual([
+			"  ✓ 24 AI conversations in the last 7 days: 0 processed, 24 skipped",
+			"      codex  24 found, 0 processed, 24 skipped",
+		]);
+	});
+
+	it("does not derive the skip count by subtraction", () => {
+		// A session with an unparseable instant is neither processed nor skipped, so
+		// `discovered - processed` would overstate the skips. Reporting the real count.
+		const lines = render([result(tier({ claude: agent(10, 4, 3) }))]);
+		expect(lines[0]).toContain("4 processed, 3 skipped");
+		expect(lines[1]).toContain("10 found, 4 processed, 3 skipped");
+	});
+
+	it("uses the singular for one conversation", () => {
+		const lines = render([result(tier({ claude: agent(1, 1, 0) }))]);
+		expect(lines[0]).toContain("1 AI conversation in the last 7 days");
+	});
+
+	it("adds up repos that turned up different conversations, busiest agent first", () => {
+		// Alphabetical order would bury the agent the user actually works in. All three
+		// numbers merge, not just the processed one — otherwise a reader cannot tell a
+		// converged agent from one whose transcripts could not be read.
+		const lines = render([
+			result(tier({ codex: agent(3, 2, 1), claude: agent(7, 4, 3) }, "-a")),
+			result(tier({ claude: agent(11, 7, 4), kimi: agent(3, 2, 1) }, "-b")),
+		]);
+		expect(lines).toEqual([
+			"  ✓ 24 AI conversations in the last 7 days: 15 processed, 9 skipped",
+			"      claude  18 found, 11 processed, 7 skipped",
+			"      codex    3 found,  2 processed, 1 skipped",
+			"      kimi     3 found,  2 processed, 1 skipped",
+		]);
+	});
+
+	it("counts a conversation once when several repos claim it", () => {
+		// Cursor's global store records no workspace for a composer, so every in-window
+		// composer is claimed by every repo Cursor has a workspace for — and two clones of
+		// one project claim an identical set outright. Adding the repos' counts reported
+		// one conversation once per registered repo, so the headline grew with how many
+		// repos the user had registered and was only ever wrong on their own machine.
+		const claimed = () => result(tier({ cursor: agent(5, 5, 0) }));
+		const lines = render([claimed(), claimed(), claimed()]);
+		expect(lines).toEqual([
+			"  ✓ 5 AI conversations in the last 7 days: 5 processed, 0 skipped",
+			"      cursor  5 found, 5 processed, 0 skipped",
+		]);
+	});
+
+	it("reports a shared conversation as processed when any repo read it", () => {
+		// The same conversation read here and already-current there is a conversation this
+		// run read. Taking the last repo's answer instead would make the headline depend
+		// on registry order.
+		const lines = render([result(tier({ claude: agent(1, 1, 0) })), result(tier({ claude: agent(1, 0, 1) }))]);
+		expect(lines).toEqual([
+			"  ✓ 1 AI conversation in the last 7 days: 1 processed, 0 skipped",
+			"      claude  1 found, 1 processed, 0 skipped",
+		]);
+	});
+
+	it("breaks an agent tie alphabetically, so the block is stable across runs", () => {
+		const lines = render([result(tier({ kimi: agent(2, 2, 0), claude: agent(2, 2, 0) }))]);
+		expect(lines.slice(1)).toEqual([
+			"      claude  2 found, 2 processed, 0 skipped",
+			"      kimi    2 found, 2 processed, 0 skipped",
+		]);
+	});
+
+	it("prints the headline alone when the window turned up nothing", () => {
+		// An empty split is not a reason to withhold the headline: the run still
+		// happened, and a list of zeroes for absent tools says less than no list.
+		const lines = render([result(tier({}))]);
+		expect(lines).toEqual(["  ✓ 0 AI conversations in the last 7 days: 0 processed, 0 skipped"]);
+	});
+
+	it("says nothing when no repo reached the session tier", () => {
+		expect(render([result(undefined)])).toEqual([]);
+		expect(render([])).toEqual([]);
 	});
 });
 

--- a/cli/src/commands/DashboardCommand.ts
+++ b/cli/src/commands/DashboardCommand.ts
@@ -34,8 +34,10 @@ import type { Command } from "commander";
 import { getProjectRootDir } from "../core/GitOps.js";
 import { readManualDisableFlagSync } from "../core/RepoProfile.js";
 import { getGlobalConfigDir } from "../core/SessionTracker.js";
+import { BACKFILL_SESSION_WINDOW_MS } from "../core/SessionWindow.js";
 import { maybeAutoCutover } from "../dashboard/AutoCutover.js";
 import { opportunisticSnapshot } from "../dashboard/Backup.js";
+import { sourceOfSessionPassKey } from "../dashboard/DashboardCollector.js";
 import { canUseDashboardDb, DASHBOARD_SQLITE_MIN_VERSION, ensureDashboardDbExists } from "../dashboard/DashboardDb.js";
 import {
 	DASHBOARD_HEALTH_SERVICE,
@@ -43,7 +45,12 @@ import {
 	type StartedDashboardServer,
 	startDashboardServer,
 } from "../dashboard/DashboardServer.js";
-import { type DbBackfillProgress, dbBackfillRepos } from "../dashboard/DbBackfill.js";
+import {
+	type DbBackfillProgress,
+	type DbBackfillResult,
+	dbBackfillRepos,
+	type SessionSourceTotals,
+} from "../dashboard/DbBackfill.js";
 import { listActiveRepos, registerRepo } from "../dashboard/RepoRegistry.js";
 import { type ServerTelemetryHandle, startServerTelemetry } from "../dashboard/ServerTelemetry.js";
 import { createLogger, errMsg } from "../Logger.js";
@@ -790,6 +797,15 @@ async function runHistoryImport(deps: DashboardDeps): Promise<void> {
 		//
 		// The counts are MEMORIES, not events: events are the activity tier, and
 		// this whole line is about the thing the user was told was migrating.
+		// The session tier's own line, printed ahead of the memory one and on the same
+		// terms: directly, not through the deferred writer. It has to be its own line
+		// because the progress block's reveal rule deliberately excludes `sessions`, so
+		// on a converged re-run — where git and memories are both cursor-gated into
+		// silence — the tier that DID the 7-day back-fill was the one tier with no
+		// output at all. A run that pulled in eighteen previously unreachable
+		// conversations printed exactly what a run that did nothing printed.
+		printSessionSummary(worked);
+
 		const migrated = worked.reduce((sum, r) => sum + (r.sotImport?.nodes ?? 0), 0);
 		const bootstrapped = worked.filter((r) => r.mode === "bootstrapped").length;
 		const newMemories = worked.reduce((sum, r) => sum + (r.sotImport?.updated ?? 0), 0);
@@ -808,6 +824,95 @@ async function runHistoryImport(deps: DashboardDeps): Promise<void> {
 	} catch (err) {
 		output.error(`  Warning: memory migration failed: ${errMsg(err)}\n`);
 	}
+}
+
+/**
+ * One line for the AI-conversation tier: how far back it looked, how many it read,
+ * how many it skipped, and which agents the read ones came from.
+ *
+ * Both counts are stated outright rather than as "18 of 24", which asks the reader to
+ * subtract — and would give them the wrong answer if they did. `processed` and
+ * `skipped` need not add up to `discovered`: a session with an unparseable instant is
+ * neither (see {@link SessionTierSummary}). So the two numbers a reader would act on
+ * are the two that are printed, and `discovered` is stated as the window's reach — the
+ * figure that shows a 7-day scan doing something a 48-hour one could not.
+ *
+ * ONE format for both outcomes, including the converged run where `processed` is 0.
+ * A separate "nothing to do" sentence would read as a different kind of event; the
+ * same sentence with a zero in it reads as the same event with nothing in it.
+ *
+ * It prints at all — rather than staying silent when nothing changed — for the reason
+ * the memory line does: silence makes a converged re-run indistinguishable from a run
+ * that never happened, which is the complaint that produced all of this.
+ *
+ * Silent only when no repo reached the tier — there is nothing to report then, not
+ * even a zero.
+ *
+ * ## Merged by CONVERSATION, never by adding the repos' counts
+ *
+ * Every number here is a count of distinct {@link SessionTierSummary.keys} entries,
+ * because one conversation is routinely claimed by several repos and adding the
+ * per-repo counts therefore reports it several times. Cursor is the clearest case —
+ * its global store records no workspace for a composer, so every in-window composer
+ * belongs to every repo Cursor has a workspace for — and two clones of one project do
+ * it outright. Summing inflated the headline by roughly the number of registered
+ * repos, and only on a machine with several of them, which is why it read as
+ * plausible. The per-repo counts stay correct as per-repo facts; they are simply not
+ * addable, and this is the reader that has to know it.
+ */
+export function printSessionSummary(worked: ReadonlyArray<DbBackfillResult>): void {
+	const tiers = worked.map((r) => r.sessions).filter((s): s is NonNullable<typeof s> => s !== undefined);
+	if (tiers.length === 0) return;
+
+	// One entry per conversation, holding the strongest outcome any repo reported for
+	// it. Processed outranks skipped, and skipped outranks "discovered but neither" —
+	// a conversation this run actually read is a read conversation, however many other
+	// repos already held it. Without that ranking the merge would be arrival-ordered,
+	// and the headline would then depend on which repo the registry happened to list
+	// first.
+	const outcome = new Map<string, 0 | 1 | 2>();
+	const mark = (keys: ReadonlyArray<string>, rank: 0 | 1 | 2): void => {
+		for (const key of keys) {
+			const seen = outcome.get(key);
+			if (seen === undefined || rank > seen) outcome.set(key, rank);
+		}
+	};
+	for (const tier of tiers) {
+		mark(tier.keys.discovered, 0);
+		mark(tier.keys.skipped, 1);
+		mark(tier.keys.processed, 2);
+	}
+
+	// Both totals and the per-agent split come from the SAME deduped map, so the two
+	// can never disagree — the agent lines add up to the headline by construction
+	// rather than by two loops agreeing. The agent is read off the key, which is where
+	// the collector put it.
+	const bySource = new Map<string, { discovered: number; processed: number; skipped: number }>();
+	let discovered = 0;
+	let processed = 0;
+	let skipped = 0;
+	for (const [key, rank] of outcome) {
+		const source = sourceOfSessionPassKey(key);
+		const total = bySource.get(source) ?? { discovered: 0, processed: 0, skipped: 0 };
+		discovered++;
+		total.discovered++;
+		if (rank === 2) {
+			processed++;
+			total.processed++;
+		} else if (rank === 1) {
+			skipped++;
+			total.skipped++;
+		}
+		bySource.set(source, total);
+	}
+
+	const days = Math.round(BACKFILL_SESSION_WINDOW_MS / 86_400_000);
+	const noun = discovered === 1 ? "conversation" : "conversations";
+	// The headline keeps the run-wide totals and drops the agent names it used to
+	// carry inline: the per-agent lines below say the same thing with the two numbers
+	// the inline form had no room for.
+	console.log(`  ✓ ${discovered} AI ${noun} in the last ${days} days: ${processed} processed, ${skipped} skipped`);
+	for (const line of formatSessionBreakdown(Object.fromEntries(bySource))) console.log(line);
 }
 
 /**
@@ -878,18 +983,33 @@ export function createProgressPrinter(deps: { readonly log?: (line: string) => v
 	let lastCommitQuarter = 0;
 	let warnedSlow = false;
 	let announcedResume = false;
-	let currentRepo: string | null = null;
+	let currentRepo: number | null = null;
 	const labelled = new Set<string>();
 	return {
 		onProgress: (progress) => {
-			if (progress.repoName !== currentRepo) {
-				currentRepo = progress.repoName;
+			// Keyed on the INDEX, not the name. `deriveRepoName` is the last path or URL
+			// segment and is not unique — two clones of one project, two worktrees of it,
+			// or two unrelated repos whose directory is called `app` all collide. On a
+			// collision a name test never fires, so the second repo printed no header, no
+			// phase labels (`labelled` was never cleared) and quarter marks continued from
+			// the previous repo's high-water: its whole run appeared UNDER the first
+			// repo's header, attributed to the wrong repo. `repoIndex` is 1-based and
+			// assigned per position, so it cannot collide.
+			if (progress.repoIndex !== currentRepo) {
+				currentRepo = progress.repoIndex;
 				lastQuarter = 0;
 				lastCommitQuarter = 0;
 				announcedResume = false;
 				labelled.clear();
 				if (progress.repoTotal > 1)
 					write(`  ${progress.repoName} (${progress.repoIndex}/${progress.repoTotal})`);
+			}
+			// Before the phase-start branch below: this marker carries a nonzero `done`
+			// on any repo that read something, so it would otherwise fall through to the
+			// commit-only counter rule and be dropped.
+			if (progress.sessionBreakdown) {
+				for (const line of formatSessionBreakdown(progress.sessionBreakdown)) write(line);
+				return;
 			}
 			// The scans before the migration. These are where the wall clock
 			// actually goes — measured 64 s of scanning against 3 s of migrating —
@@ -986,6 +1106,44 @@ const PHASE_LABELS: Record<"commits" | "summaries" | "sessions", string> = {
 	summaries: "Indexing stored memories…",
 	sessions: "Reading AI sessions…",
 };
+
+/**
+ * One indented line per agent: what the window turned up for it, how much was read,
+ * how much was already current.
+ *
+ * Sorted busiest-first and name-ordered on a tie, matching the run-wide summary — with
+ * up to a dozen possible agents, alphabetical order buries the one the user works in,
+ * and an unstable order makes two runs over the same data look different.
+ *
+ * Names are left-padded and each number right-padded to its own column, so the block
+ * reads as a table — which is the whole point of splitting it up: the reader is
+ * comparing agents against each other, and ragged numbers make that a per-line parse.
+ * Every width is computed per call rather than fixed at the widest possible value
+ * (`copilot-chat`, five-digit counts), because a machine running two agents should not
+ * be indented for ten it does not have.
+ *
+ * Returns EMPTY for a repo whose window turned up nothing — the phase label above it
+ * has already said the tier ran, and a list of zeroes for absent tools says less than
+ * no list at all. Sources are kept even when everything was skipped: "51 found, 0
+ * processed" is the case this breakdown exists to show.
+ */
+export function formatSessionBreakdown(bySource: Readonly<Record<string, SessionSourceTotals>>): string[] {
+	const rows = Object.entries(bySource).filter(([, counts]) => counts.discovered > 0);
+	if (rows.length === 0) return [];
+	rows.sort((a, b) => b[1].discovered - a[1].discovered || a[0].localeCompare(b[0]));
+	const nameWidth = Math.max(...rows.map(([source]) => source.length));
+	const widthOf = (pick: (c: SessionSourceTotals) => number): number =>
+		Math.max(...rows.map(([, counts]) => String(pick(counts)).length));
+	const foundWidth = widthOf((c) => c.discovered);
+	const processedWidth = widthOf((c) => c.processed);
+	const skippedWidth = widthOf((c) => c.skipped);
+	return rows.map(
+		([source, c]) =>
+			`      ${source.padEnd(nameWidth)}  ${String(c.discovered).padStart(foundWidth)} found` +
+			`, ${String(c.processed).padStart(processedWidth)} processed` +
+			`, ${String(c.skipped).padStart(skippedWidth)} skipped`,
+	);
+}
 
 /**
  * Registers this repo and runs {@link runHistoryImport} — the server-free

--- a/cli/src/core/AntigravitySessionDiscoverer.test.ts
+++ b/cli/src/core/AntigravitySessionDiscoverer.test.ts
@@ -6,7 +6,7 @@ import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it, vi } from "vitest";
 
 // Two of the discoverer's guards protect against a TOCTOU race — the file or db
-// disappearing between the existsSync/statSync probe and the read. The
+// disappearing between the discoverer's `stat` probe and the read. The
 // filesystem cannot be made to lose that race on demand, so the two holders
 // below inject the exact error the race would produce. Both default to
 // `undefined`, i.e. fully real behaviour.
@@ -37,10 +37,12 @@ vi.mock("./SqliteHelpers.js", async (importOriginal) => {
 
 import { buildMetadataBlob, createAntigravityConvo, REAL_TRANSCRIPT_FULL } from "../testUtils/antigravityFixture.js";
 import { symlinksSupported } from "../testUtils/symlinkSupport.js";
+import { getAntigravityVariants } from "./AntigravityDetector.js";
 import {
 	discoverAntigravitySessions,
 	extractWorkspacePath,
 	scanAntigravitySessions,
+	scanAntigravitySessionsOnDisk,
 } from "./AntigravitySessionDiscoverer.js";
 import { hasNodeSqliteSupport } from "./SqliteHelpers.js";
 
@@ -241,8 +243,9 @@ sqliteOnly("AntigravitySessionDiscoverer", () => {
 				transcriptLines: REAL_TRANSCRIPT_FULL,
 			});
 		// Relative to now so the conversations stay inside the 48h window whenever
-		// the suite runs. antigravity-ide is newest → kept; -cli is oldest → the
-		// `>=` guard skips its SQLite open; antigravity is replaced when -ide wins.
+		// the suite runs. antigravity-ide is newest → kept; the other two lose. The
+		// winner is picked from the complete stat set BEFORE any database is opened,
+		// so the answer cannot depend on which stat finished first.
 		const now = Date.now();
 		const at = (hoursAgo: number) => {
 			const d = new Date(now - hoursAgo * 3600_000);
@@ -255,6 +258,67 @@ sqliteOnly("AntigravitySessionDiscoverer", () => {
 		const sessions = await discoverAntigravitySessions(ws, home);
 		expect(sessions).toHaveLength(1);
 		expect(sessions[0].transcriptPath).toContain("antigravity-ide");
+	});
+
+	it("falls back to an older variant's copy when the newest one yields nothing", async () => {
+		// Newest-wins decides the ORDER, not the outcome. A copy can still fail to produce
+		// a session — here the newest variant has no transcript written yet — and dropping
+		// the conversation on that evidence loses a conversation an older copy can answer
+		// for in full.
+		const home = freshDir("agy-home-");
+		const ws = freshDir("repo-");
+		const older = createAntigravityConvo(home, {
+			convId: "fallback",
+			variant: "antigravity",
+			workspacePath: ws,
+			transcriptLines: REAL_TRANSCRIPT_FULL,
+		});
+		const newest = createAntigravityConvo(home, {
+			convId: "fallback",
+			variant: "antigravity-ide",
+			workspacePath: ws,
+			transcriptLines: [],
+			writeTranscript: false,
+		});
+		const now = Date.now();
+		const at = (hoursAgo: number) => {
+			const d = new Date(now - hoursAgo * 3600_000);
+			return [d, d] as const;
+		};
+		utimesSync(older.dbPath, ...at(2));
+		utimesSync(newest.dbPath, ...at(1));
+
+		const sessions = await discoverAntigravitySessions(ws, home);
+
+		expect(sessions).toHaveLength(1);
+		expect(sessions[0].transcriptPath).toBe(older.transcriptPath);
+	});
+
+	it("breaks an mtime tie by variant order, not by whichever stat landed first", async () => {
+		// Equal mtimes are reachable (two copies written in the same millisecond, or a
+		// filesystem with coarse timestamps). The winner must be the first variant in
+		// `getAntigravityVariants` order — a deterministic answer, which is precisely
+		// what the sequential "consult the map while filling it" version stopped being
+		// able to promise once the scan fanned out.
+		const home = freshDir("agy-home-");
+		const ws = freshDir("repo-");
+		const mk = (variant: string) =>
+			createAntigravityConvo(home, {
+				convId: "tie",
+				variant,
+				workspacePath: ws,
+				transcriptLines: REAL_TRANSCRIPT_FULL,
+			});
+		const same = new Date(Date.now() - 3600_000);
+		utimesSync(mk("antigravity").dbPath, same, same);
+		utimesSync(mk("antigravity-ide").dbPath, same, same);
+		utimesSync(mk("antigravity-cli").dbPath, same, same);
+
+		const sessions = await discoverAntigravitySessions(ws, home);
+
+		expect(sessions).toHaveLength(1);
+		const [first] = getAntigravityVariants(home);
+		expect(sessions[0].transcriptPath.startsWith(first.brainDir)).toBe(true);
 	});
 
 	it("skips a conversation whose db was last touched more than 48h ago", async () => {
@@ -270,10 +334,30 @@ sqliteOnly("AntigravitySessionDiscoverer", () => {
 		expect(await discoverAntigravitySessions(ws, home)).toHaveLength(0);
 	});
 
+	it("admits a conversation older than 48h when an explicit wider window is passed", async () => {
+		const home = freshDir("agy-home-");
+		const ws = freshDir("repo-");
+		const { dbPath } = createAntigravityConvo(home, {
+			convId: "old-but-in-window",
+			workspacePath: ws,
+			transcriptLines: REAL_TRANSCRIPT_FULL,
+		});
+		// 72h ago — outside the 48h default, inside the 7-day window the dashboard
+		// back-fill passes.
+		const old = new Date(Date.now() - 72 * 3600_000);
+		utimesSync(dbPath, old, old);
+
+		// Omitted window: stale, as QueueWorker requires.
+		expect(await discoverAntigravitySessions(ws, home)).toHaveLength(0);
+
+		const widened = await discoverAntigravitySessions(ws, home, 7 * 24 * 3600_000);
+		expect(widened.map((s) => s.sessionId)).toEqual(["old-but-in-window"]);
+	});
+
 	it("skips a variant whose conversations path is not a directory", async () => {
-		// existsSync() is happy with a FILE at conversations/, so the variant is
-		// listed; readdirSync then fails with ENOTDIR and the variant is skipped
-		// rather than aborting the whole scan.
+		// The detector's existsSync() is happy with a FILE at conversations/, so the
+		// variant is listed; the scanner's readdir then fails with ENOTDIR and the
+		// variant is skipped rather than aborting the whole scan.
 		const home = freshDir("agy-home-");
 		const ws = freshDir("repo-");
 		mkdirSync(join(home, ".gemini", "antigravity-cli"), { recursive: true });
@@ -297,8 +381,8 @@ sqliteOnly("AntigravitySessionDiscoverer", () => {
 			workspacePath: ws,
 			transcriptLines: REAL_TRANSCRIPT_FULL,
 		});
-		// Self-referential symlink — readdirSync lists it, statSync chases the link
-		// into itself and throws ELOOP. Models the real race where a conversation
+		// Self-referential symlink — readdir lists it, the staleness stat chases the
+		// link into itself and throws ELOOP. Models the real race where a conversation
 		// is deleted between the listing and the stat.
 		const loop = join(dbPath, "..", "loop.db");
 		symlinkSync(loop, loop, "file");
@@ -321,7 +405,7 @@ sqliteOnly("AntigravitySessionDiscoverer", () => {
 		expect(error).toBeDefined();
 	});
 
-	// The db passed statSync but was gone by the time SQLite opened it (the user
+	// The db passed the staleness stat but was gone by the time SQLite opened it (the user
 	// deleted the conversation mid-scan). classifyScanError returns null for
 	// ENOENT, so this is benign: skip the conversation, surface NO error.
 	it("silently skips a conversation whose db vanished between the stat and the open", async () => {
@@ -406,7 +490,7 @@ sqliteOnly("AntigravitySessionDiscoverer titles", () => {
 		expect(sessions[0].title).toBeUndefined();
 	});
 
-	// The transcript passed existsSync but was gone by the time the stream opened.
+	// The transcript passed the existence stat but was gone by the time the stream opened.
 	// ENOENT is the expected shape of that race, so readTitle stays silent (no
 	// debug log) and the session still surfaces — just without a title.
 	it("leaves the title undefined, without logging, when the transcript vanished mid-scan", async () => {
@@ -424,7 +508,7 @@ sqliteOnly("AntigravitySessionDiscoverer titles", () => {
 	});
 
 	it("leaves the title undefined when the transcript path is unreadable", async () => {
-		// A DIRECTORY named transcript_full.jsonl: existsSync() passes the
+		// A DIRECTORY named transcript_full.jsonl: the existence stat passes the
 		// materialization gate, then the read stream fails with EISDIR — a
 		// non-ENOENT error, so readTitle logs and degrades to no title.
 		const { ws, home, transcriptPath } = convoWithRawTranscript("");
@@ -433,5 +517,86 @@ sqliteOnly("AntigravitySessionDiscoverer titles", () => {
 		const sessions = await discoverAntigravitySessions(ws, home);
 		expect(sessions).toHaveLength(1);
 		expect(sessions[0].title).toBeUndefined();
+	});
+});
+
+sqliteOnly("scanAntigravitySessionsOnDisk — the already-recorded skip", () => {
+	function oneConvo(convId = "1bbaa61e"): { home: string; ws: string; dbPath: string } {
+		const home = freshDir("agy-home-");
+		const ws = freshDir("repo-");
+		const { dbPath } = createAntigravityConvo(home, {
+			convId,
+			workspacePath: ws,
+			transcriptLines: REAL_TRANSCRIPT_FULL,
+		});
+		return { home, ws, dbPath };
+	}
+
+	it("scans normally when nothing is recorded", async () => {
+		const { home } = oneConvo();
+
+		const { sessions } = await scanAntigravitySessionsOnDisk(home, undefined, { alreadyRecorded: () => false });
+
+		expect(sessions).toHaveLength(1);
+		expect(sessions[0].session.sessionId).toBe("1bbaa61e");
+		// The machine-wide scan carries no title: reading one streams a transcript, and
+		// doing it here meant doing it for every conversation on the machine. It is read
+		// after the match instead — see `antigravitySessionsForRepo`, and the title suite
+		// above, which asserts through the repo-scoped entry point.
+		expect(sessions[0].session.title).toBeUndefined();
+	});
+
+	it("drops a recorded conversation rather than opening its database", async () => {
+		// Unlike Claude, there is no cheap way to learn the workspace here — it lives in
+		// the protobuf blob inside the database — so a skipped conversation cannot be
+		// attributed and is left out. Safe because the skip only fires when every repo
+		// holding a row for it is already current.
+		const { home } = oneConvo();
+		race.sqliteError = new Error("the db must not be opened for a recorded conversation");
+		try {
+			const { sessions, error } = await scanAntigravitySessionsOnDisk(home, undefined, {
+				alreadyRecorded: () => true,
+			});
+			expect(sessions).toEqual([]);
+			expect(error).toBeUndefined();
+		} finally {
+			race.sqliteError = undefined;
+		}
+	});
+
+	it("asks with the conversation id from the filename and the instant from its mtime", async () => {
+		const { home } = oneConvo("abc123");
+		const asked: Array<[string, string, number]> = [];
+
+		await scanAntigravitySessionsOnDisk(home, undefined, {
+			alreadyRecorded: (source, sessionId, updatedAtMs) => {
+				asked.push([source, sessionId, updatedAtMs]);
+				return false;
+			},
+		});
+
+		expect(asked).toHaveLength(1);
+		expect(asked[0][0]).toBe("antigravity");
+		expect(asked[0][1]).toBe("abc123");
+		expect(Number.isFinite(asked[0][2])).toBe(true);
+	});
+
+	it("does not ask about a conversation outside the window", async () => {
+		// The staleness stat runs first, so a stale conversation is dropped either way
+		// and must not be reported as one this run discovered.
+		const { home, dbPath } = oneConvo();
+		const old = new Date(Date.now() - 60_000);
+		utimesSync(dbPath, old, old);
+		let asked = 0;
+
+		const { sessions } = await scanAntigravitySessionsOnDisk(home, 1_000, {
+			alreadyRecorded: () => {
+				asked++;
+				return true;
+			},
+		});
+
+		expect(asked).toBe(0);
+		expect(sessions).toEqual([]);
 	});
 });

--- a/cli/src/core/AntigravitySessionDiscoverer.ts
+++ b/cli/src/core/AntigravitySessionDiscoverer.ts
@@ -13,22 +13,37 @@
  * direct per-db comparison against projectDir.
  *
  * The db is WAL-mode; reads go through `withSqliteDb` (node:sqlite, WAL-aware).
+ *
+ * ## Every filesystem call here is async, and that is a hard rule
+ *
+ * This scanner used `readdirSync` / `statSync` / `existsSync`, two of them inside
+ * the per-conversation loop. A synchronous call blocks the whole event loop, so it
+ * does not merely make THIS scan serial — it freezes every other scan running
+ * concurrently, including the Claude transcript fan-out. On a machine with a long
+ * Antigravity history that turned the entire concurrent discovery phase back into
+ * a serial one, from the outside indistinguishable from "the disk is slow".
+ *
+ * Antigravity was the only discoverer doing this. Do not reintroduce a `*Sync`
+ * filesystem call in any of them.
  */
 
-import { createReadStream, existsSync, readdirSync, statSync } from "node:fs";
+import { createReadStream } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
 import { createLogger, errMsg, isEnoent } from "../Logger.js";
 import type { SessionInfo } from "../Types.js";
+import { mapWithConcurrency, withIoBudget } from "../util/Concurrency.js";
 import { getAntigravityVariants } from "./AntigravityDetector.js";
 import { unwrapUserRequest } from "./AntigravityTranscriptReader.js";
+import { type AlreadyCurrent, type DiskSession, sessionsForRepo } from "./DiskSessionScan.js";
 import { listWorktrees } from "./GitOps.js";
 import { sessionDirBelongsToRepo } from "./SessionDirMatch.js";
 import { classifyScanError, hasNodeSqliteSupport, type SqliteScanError, withSqliteDb } from "./SqliteHelpers.js";
 
 const log = createLogger("AntigravityDiscoverer");
 
-/** Conversations older than 48 hours are considered stale (matches other sources). */
+/** Default window: conversations older than 48 hours are considered stale (matches other sources). */
 const SESSION_STALE_MS = 48 * 60 * 60 * 1000;
 
 const TRANSCRIPT_RELPATH = [".system_generated", "logs", "transcript_full.jsonl"] as const;
@@ -118,7 +133,7 @@ async function readTitle(transcriptPath: string): Promise<string | undefined> {
 			stream.destroy();
 		}
 	} catch (err) {
-		// ENOENT: transcript vanished between the caller's existsSync guard
+		// ENOENT: transcript vanished between the caller's existence `stat`
 		// and this open — a race that's fundamentally untestable without
 		// invasive fs mocking. Narrowed from the previous `v8 ignore next`
 		// covering the whole `if (!isEnoent(err)) log.debug(...)` line
@@ -157,8 +172,99 @@ async function resolveWorktreeRoots(projectDir: string): Promise<ReadonlySet<str
 	return roots;
 }
 
-/** Discovers Antigravity conversations relevant to the given project directory. */
-export async function scanAntigravitySessions(projectDir: string, home?: string): Promise<AntigravityScanResult> {
+/**
+ * Discovers Antigravity conversations relevant to the given project directory.
+ *
+ * @param windowMs Optional staleness window, in milliseconds. Defaults to
+ * `SESSION_STALE_MS` (48h), the window shared by every discovery-based source.
+ * The dashboard's history back-fill passes a wider one (7 days) so it can reach
+ * further into the past. Callers that must NOT widen simply omit it: the VS Code
+ * / IntelliJ "Active Conversations" sidebar, `jolli status`, and above all the
+ * post-commit summary generation in `hooks/QueueWorker.ts`, which uses this
+ * session set to decide which conversations belong to the commit being
+ * summarised. Widening it there folds week-old unrelated conversations into that
+ * commit's stored memory, which is written to the git orphan branch and is
+ * persistent — and it fails invisibly, with no error, just wrong content.
+ */
+export async function scanAntigravitySessions(
+	projectDir: string,
+	home?: string,
+	windowMs?: number,
+): Promise<AntigravityScanResult> {
+	const { sessions, error } = await scanAntigravitySessionsOnDisk(home, windowMs);
+	const mine = await antigravitySessionsForRepo(sessions, projectDir);
+	log.debug("Discovered %d Antigravity session(s) for %s", mine.length, projectDir);
+	return error ? { sessions: mine, error } : { sessions: mine };
+}
+
+/** A machine-wide Antigravity scan: every in-window conversation, plus the first failure. */
+export interface AntigravityDiskScanResult {
+	readonly sessions: ReadonlyArray<DiskSession>;
+	readonly error?: SqliteScanError;
+}
+
+export interface ScanAntigravityOptions {
+	/**
+	 * Lets the scan skip the two expensive steps — the SQLite open and the streaming
+	 * title read — for a conversation the database already holds at or past its
+	 * recorded instant.
+	 *
+	 * Applicable here for the same reason it is applicable to Claude, and only
+	 * because of an ordering accident worth stating: this scanner learns the
+	 * conversation's id from the FILENAME and its instant from the staleness `stat`,
+	 * both of which happen before anything expensive. So the skip has everything it
+	 * needs at exactly the point where acting on it saves the most.
+	 *
+	 * What it gives up is the workspace path, which lives in the protobuf blob inside
+	 * the database — so a skipped conversation cannot be attributed to a repo and is
+	 * dropped from this scan's result. That is not the loss it looks like: the skip
+	 * only fires when every repo holding a row for the conversation is already
+	 * current, so no repo had anything to write. The visible effect is that such a
+	 * conversation is not counted among the run's discovered ones. Claude takes the
+	 * other branch — it keeps the session using the directories the tail already gave
+	 * it — because there the cheap read happens to carry a usable answer; here there
+	 * is no cheap way to learn the workspace at all.
+	 *
+	 * Omitted means "read everything properly", which is what every non-back-fill
+	 * caller wants.
+	 */
+	readonly alreadyRecorded?: AlreadyCurrent;
+}
+
+/**
+ * Scans every Antigravity conversation database on this machine once and returns the
+ * in-window ones, each carrying the workspace path its metadata blob recorded.
+ *
+ * MACHINE-WIDE and repo-agnostic on purpose. `~/.gemini/<variant>/conversations/`
+ * holds one SQLite file per conversation with no repo in its name, so attributing any
+ * of them means opening the database and decoding a protobuf blob — work a
+ * repo-scoped scan repeated for every registered repo. Callers scan once and narrow
+ * with {@link antigravitySessionsForRepo}.
+ *
+ * ## One cost moved, one deliberately not
+ *
+ * The repo-scoped version checked for the transcript file and read its title only
+ * AFTER the workspace matched. The TITLE read has moved back behind the match — it now
+ * happens in {@link antigravitySessionsForRepo}, which is free for the back-fill and
+ * restores the single-repo callers' old cost; see that function for why it is sound
+ * here and would not be for Claude.
+ *
+ * The transcript `stat` stays, and cannot move: a conversation with no
+ * `transcript_full.jsonl` yet is DROPPED, so the check decides what the scan returns
+ * rather than decorating it. It is one `stat` on a conversation that already passed
+ * the staleness gate and already cost a database open.
+ *
+ * That database open is the cost nobody can amortise away, and it is structural rather
+ * than accepted-out-of-laziness: unlike Cursor's workspace lookup there is no cheap
+ * test for "this repo claims nothing here", because the workspace path lives inside
+ * the protobuf blob — so the database has to be opened before attribution can be
+ * decided at all, by a machine-wide scan and a repo-scoped one alike.
+ */
+export async function scanAntigravitySessionsOnDisk(
+	home?: string,
+	windowMs?: number,
+	opts: ScanAntigravityOptions = {},
+): Promise<AntigravityDiskScanResult> {
 	// A runtime below the Node floor cannot load node:sqlite. Gate up front (like
 	// the detector) so the aggregator's 60s tick on such a VS Code host degrades
 	// silently instead of logging a scan failure for every conversation db. The
@@ -168,102 +274,244 @@ export async function scanAntigravitySessions(projectDir: string, home?: string)
 	if (!hasNodeSqliteSupport()) return { sessions: [] };
 	/* v8 ignore stop */
 
-	const worktreeRoots = await resolveWorktreeRoots(projectDir);
-	const cutoffMs = Date.now() - SESSION_STALE_MS;
-	// Keyed by conversation id. The same convId can exist under multiple variants
-	// (a user who migrated between `antigravity` / `antigravity-ide` / `-cli`
-	// keeps the id), which would otherwise surface the conversation once per
-	// variant. Keep the most-recently-touched copy.
-	const byConvId = new Map<string, { transcriptPath: string; mtimeMs: number }>();
-	let firstError: SqliteScanError | undefined;
+	const staleMs = windowMs ?? SESSION_STALE_MS;
+	const cutoffMs = Date.now() - staleMs;
 
-	for (const variant of getAntigravityVariants(home)) {
-		let dbFiles: string[];
+	// ## Phase 1 — list and stat, then RANK each conversation's variant copies
+	//
+	// The variant dedupe is why this is a phase of its own rather than a check inside
+	// the expensive loop. The same convId can exist under several variants (a user who
+	// migrated between `antigravity` / `antigravity-ide` / `-cli` keeps the id), and the
+	// newest copy is tried first. That used to be decided by consulting a map WHILE filling it,
+	// which is only correct while the loop is sequential: run the same test concurrently
+	// and the answer depends on which `stat` happened to land first, so a run could open
+	// the older copy's database, or both. Deciding it up front from the complete stat
+	// set makes the result independent of scheduling — which is the precondition for
+	// fanning out phase 2 at all.
+	const listed = await mapWithConcurrency(getAntigravityVariants(home), async (variant) => {
 		try {
-			dbFiles = readdirSync(variant.conversationsDir).filter((f) => f.endsWith(".db"));
+			return (await withIoBudget(0, () => readdir(variant.conversationsDir)))
+				.filter((f) => f.endsWith(".db"))
+				.map((dbFile) => ({ variant, dbFile }));
 		} catch (err) {
 			log.debug("Cannot list %s: %s", variant.conversationsDir, errMsg(err));
-			continue;
+			return [];
 		}
+	});
 
-		for (const dbFile of dbFiles) {
-			const convId = dbFile.slice(0, -3);
-			const dbPath = join(variant.conversationsDir, dbFile);
+	const statted = await mapWithConcurrency(listed.flat(), async ({ variant, dbFile }) => {
+		// Cheap staleness gate first — a `stat` avoids opening SQLite for conversations
+		// last touched outside the window (the common case for users with a long
+		// Antigravity history).
+		const dbPath = join(variant.conversationsDir, dbFile);
+		try {
+			const mtimeMs = (await withIoBudget(0, () => stat(dbPath))).mtimeMs;
+			if (mtimeMs < cutoffMs) return null;
+			return { convId: dbFile.slice(0, -3), variant, dbPath, mtimeMs };
+		} catch {
+			return null;
+		}
+	});
+	const stats = statted.filter((entry): entry is NonNullable<typeof entry> => entry !== null);
 
-			// Cheap staleness gate first — a `stat` avoids opening SQLite for
-			// conversations last touched > 48h ago (the common case for users
-			// with a long Antigravity history).
-			let mtimeMs: number;
-			try {
-				mtimeMs = statSync(dbPath).mtimeMs;
-			} catch {
-				continue;
-			}
-			if (mtimeMs < cutoffMs) continue;
+	// Every copy of each conversation, NEWEST FIRST. Not just the newest one: a copy can
+	// still fail to yield a session — an unreadable database, a blob with no workspace in
+	// it, a `brain/` directory whose transcript has not been written yet — and the
+	// sequential version this replaced fell through to an older variant's copy when that
+	// happened, because it only recorded a winner once one had actually produced a
+	// session. Keeping the runners-up restores that: phase 2 walks the list in order and
+	// takes the first copy that answers, so a broken newest copy costs the conversation
+	// nothing instead of dropping it.
+	//
+	// The ORDER is fixed here rather than discovered during the scan, which is what makes
+	// the outcome independent of scheduling — the precondition for fanning out phase 2 at
+	// all. `stats` is in `getAntigravityVariants` order and the sort is stable, so a tie
+	// keeps the first variant, exactly as the sequential version reported it.
+	const byConvId = new Map<string, Array<(typeof stats)[number]>>();
+	for (const entry of stats) {
+		const copies = byConvId.get(entry.convId);
+		if (copies) copies.push(entry);
+		else byConvId.set(entry.convId, [entry]);
+	}
+	for (const copies of byConvId.values()) copies.sort((a, b) => b.mtimeMs - a.mtimeMs);
 
-			// Skip the SQLite open + blob parse when a newer variant of this same
-			// conversation was already accepted.
-			const existing = byConvId.get(convId);
-			if (existing && existing.mtimeMs >= mtimeMs) continue;
-
-			let workspacePath: string | undefined;
-			try {
-				workspacePath = await withSqliteDb(dbPath, (db) => {
+	/** Reads ONE copy of a conversation into a session, or explains why it could not. */
+	const readCopy = async ({
+		convId,
+		variant,
+		dbPath,
+		mtimeMs,
+	}: (typeof stats)[number]): Promise<{ session: DiskSession | null; error?: SqliteScanError }> => {
+		let workspacePath: string | undefined;
+		try {
+			workspacePath = await withIoBudget(0, () =>
+				withSqliteDb(dbPath, (db) => {
 					const row = db
 						.prepare("SELECT data FROM trajectory_metadata_blob WHERE id = 'main' LIMIT 1")
 						.get() as { data?: Uint8Array } | undefined;
 					return row?.data ? extractWorkspacePath(row.data) : undefined;
-				});
-			} catch (err) {
-				const scanError = classifyScanError(err);
-				if (scanError) {
-					log.warn("Antigravity db scan failed (%s) at %s: %s", scanError.kind, dbPath, scanError.message);
-					firstError ??= scanError;
-				}
-				continue;
+				}),
+			);
+		} catch (err) {
+			const scanError = classifyScanError(err);
+			if (scanError) {
+				log.warn("Antigravity db scan failed (%s) at %s: %s", scanError.kind, dbPath, scanError.message);
+				return { session: null, error: scanError };
 			}
-
-			// Prefix/containment match (shared `sessionDirBelongsToRepo`, like the
-			// other hookless sources): a workspace recorded in a *subdirectory* of a
-			// worktree still belongs to the repo (JOLLI-2015), while a nested git
-			// repo / submodule inside it is excluded via the helper's `.git` walk.
-			if (!workspacePath || ![...worktreeRoots].some((root) => sessionDirBelongsToRepo(workspacePath, root)))
-				continue;
-
-			const transcriptPath = join(variant.brainDir, convId, ...TRANSCRIPT_RELPATH);
-			if (!existsSync(transcriptPath)) {
-				log.debug("Antigravity convo %s matches %s but has no transcript_full.jsonl yet", convId, projectDir);
-				continue;
-			}
-
-			byConvId.set(convId, { transcriptPath, mtimeMs });
+			// `classifyScanError` returns null for a benign cause (ENOENT — the user
+			// deleted the conversation mid-scan), which is a skip, not a failure.
+			return { session: null };
 		}
-	}
 
-	// Read titles only for the survivors (one per conversation), not per variant.
-	const out: SessionInfo[] = [];
-	for (const [convId, { transcriptPath, mtimeMs }] of byConvId) {
-		out.push({
-			sessionId: convId,
-			transcriptPath,
-			updatedAt: new Date(mtimeMs).toISOString(),
-			source: "antigravity",
-			title: await readTitle(transcriptPath),
-		});
-	}
+		// The workspace is CARRIED, not matched — `antigravitySessionsForRepo` does
+		// that. A conversation whose blob yields no workspace can never be
+		// attributed, so it is still dropped here.
+		if (!workspacePath) return { session: null };
 
-	log.debug("Discovered %d Antigravity session(s) for %s", out.length, projectDir);
+		// A conversation with no transcript yet is DROPPED, not merely left
+		// titleless, so the check is load-bearing and cannot be folded into
+		// `readTitle`'s own ENOENT handling. `stat` rather than `existsSync` for the
+		// event-loop reason in this module's header.
+		const transcriptPath = join(variant.brainDir, convId, ...TRANSCRIPT_RELPATH);
+		try {
+			await withIoBudget(0, () => stat(transcriptPath));
+		} catch {
+			log.debug("Antigravity convo %s has no transcript_full.jsonl yet", convId);
+			return { session: null };
+		}
+
+		// No `title`: it is read by {@link antigravitySessionsForRepo}, for the
+		// conversations a repo actually claims. See that function for why.
+		return {
+			session: {
+				session: {
+					sessionId: convId,
+					transcriptPath,
+					updatedAt: new Date(mtimeMs).toISOString(),
+					source: "antigravity",
+				},
+				dirs: [workspacePath],
+			},
+		};
+	};
+
+	// ## Phase 2 — the expensive half, one unit per surviving conversation
+	//
+	// A SQLite open plus a protobuf decode plus a streaming title read, each
+	// independent. This is the part whose cost scales with how much Antigravity history
+	// a user has, and it was entirely serial.
+	//
+	// The copies of ONE conversation are tried in order INSIDE the unit rather than
+	// fanned out: only the first one that answers is wanted, so trying them concurrently
+	// would open databases whose result is thrown away — and duplicates are the rare case
+	// anyway (a single-copy conversation is one attempt, exactly as before).
+	//
+	// Each unit reports its own failure rather than assigning to a shared
+	// `firstError`: `mapWithConcurrency` preserves INPUT order in its result but not in
+	// its completion order, so an assignment made inside the callback would record
+	// whichever database happened to fail first in wall-clock time. "The first failure"
+	// has to mean the first in conversation order, which is only decidable once every
+	// unit has answered — so it is picked out of the ordered result below. A copy that
+	// failed still reports its error even when a fallback copy then succeeded: the
+	// unreadable database is a real fact about this machine, and the sequential version
+	// surfaced it the same way.
+	const scanned = await mapWithConcurrency(
+		[...byConvId.values()],
+		async (copies): Promise<{ session: DiskSession | null; error?: SqliteScanError }> => {
+			// A conversation the database already holds — see
+			// {@link ScanAntigravityOptions.alreadyRecorded}. Placed after the staleness
+			// gate so the two cheap tests come first, and before everything expensive, and
+			// asked ONCE for the whole group: the answer is about the conversation, so a
+			// fallback copy of a skipped conversation must not be opened either.
+			const newest = copies[0];
+			if (opts.alreadyRecorded?.("antigravity", newest.convId, newest.mtimeMs)) {
+				log.debug("Antigravity convo %s already recorded -- skipping the db open", newest.convId);
+				return { session: null };
+			}
+
+			let firstError: SqliteScanError | undefined;
+			for (const copy of copies) {
+				const attempt = await readCopy(copy);
+				firstError ??= attempt.error;
+				if (attempt.session)
+					return firstError ? { session: attempt.session, error: firstError } : { session: attempt.session };
+			}
+			return firstError ? { session: null, error: firstError } : { session: null };
+		},
+	);
+	const out = scanned.map((r) => r.session).filter((session): session is DiskSession => session !== null);
+	const firstError = scanned.find((r) => r.error !== undefined)?.error;
+
+	log.debug("Antigravity disk scan: %d conversation(s) inside the window", out.length);
 	return firstError ? { sessions: out, error: firstError } : { sessions: out };
+}
+
+/**
+ * Narrows a machine-wide Antigravity scan to one repo.
+ *
+ * ASYNC, unlike every other source's narrowing, and that is inherent rather than
+ * incidental: Antigravity records the checkout the IDE was opened in, which is
+ * frequently a DIFFERENT worktree than the one committing, so the match runs against
+ * every worktree root of the repo — and enumerating those needs a `git worktree list`
+ * that no machine-wide scan can do on the repo's behalf. Resolving the roots is
+ * per-repo work by definition, so it belongs on this side.
+ *
+ * Prefix/containment match (shared `sessionDirBelongsToRepo`, like the other hookless
+ * sources): a workspace recorded in a *subdirectory* of a worktree still belongs to
+ * the repo (JOLLI-2015), while a nested git repo / submodule inside it is excluded
+ * via the helper's `.git` walk.
+ *
+ * ## The title is read HERE, which is the one place it costs nobody anything extra
+ *
+ * `readTitle` streams a transcript until the first user turn. Reading it during the
+ * machine-wide scan meant doing that for every in-window conversation on the machine,
+ * and the callers that lose by it are the ones with nothing to amortise across: the
+ * 60 s sidebar tick, `jolli status` and the post-commit summary all ask about ONE
+ * repo, so they paid a title read per conversation where the repo-scoped version they
+ * replaced paid one per conversation it claimed.
+ *
+ * Reading it after the match restores that for them and costs the multi-repo back-fill
+ * almost nothing, because an Antigravity conversation records exactly ONE workspace —
+ * so unlike Claude (27 of 64 real transcripts carry several directories), one
+ * conversation cannot fan out across a machine's repos by having touched them all.
+ *
+ * "Almost" rather than "nothing", because the match is against every WORKTREE of the
+ * repo: two registered entries that are two worktrees, or two clones, of one project
+ * resolve to overlapping root sets and both claim the same conversation, so its title
+ * is read once per such entry. That is bounded by how many checkouts of one project a
+ * user has registered, against a machine-wide read for every repo in the old shape.
+ *
+ * A title that cannot be read leaves the field ABSENT rather than empty, which is what
+ * lets `resolveSessionTitle` fall through to its own ladder instead of rendering a
+ * blank row.
+ */
+export async function antigravitySessionsForRepo(
+	scanned: ReadonlyArray<DiskSession>,
+	projectDir: string,
+): Promise<ReadonlyArray<SessionInfo>> {
+	const worktreeRoots = [...(await resolveWorktreeRoots(projectDir))];
+	const mine = sessionsForRepo(scanned, (dir) => worktreeRoots.some((root) => sessionDirBelongsToRepo(dir, root)));
+	return mapWithConcurrency(mine, async (session) => {
+		// Streams with an early exit on the first user turn, so it claims a slot and
+		// none of the byte allowance.
+		const title = await withIoBudget(0, () => readTitle(session.transcriptPath));
+		return title === undefined ? session : { ...session, title };
+	});
 }
 
 /**
  * Backwards-compatible wrapper that returns only the session array. Callers that
  * need to surface scan failures should call `scanAntigravitySessions` directly.
+ *
+ * `windowMs` is forwarded verbatim. QueueWorker itself must keep omitting it —
+ * see `scanAntigravitySessions` for why widening the post-commit window corrupts
+ * stored memory.
  */
 export async function discoverAntigravitySessions(
 	projectDir: string,
 	home?: string,
+	windowMs?: number,
 ): Promise<ReadonlyArray<SessionInfo>> {
-	const { sessions } = await scanAntigravitySessions(projectDir, home);
+	const { sessions } = await scanAntigravitySessions(projectDir, home, windowMs);
 	return sessions;
 }

--- a/cli/src/core/ClaudeAiTitleReader.test.ts
+++ b/cli/src/core/ClaudeAiTitleReader.test.ts
@@ -2,7 +2,27 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { readClaudeAiTitle, TAIL_SCAN_BYTES } from "./ClaudeAiTitleReader.js";
+import { aiTitleFromRecord, readClaudeAiTitle, TAIL_SCAN_BYTES } from "./ClaudeAiTitleReader.js";
+
+describe("aiTitleFromRecord", () => {
+	it("returns the title of an ai-title row", () => {
+		expect(aiTitleFromRecord({ type: "ai-title", aiTitle: "a title" })).toBe("a title");
+	});
+
+	it("declines a row of any other type", () => {
+		// Unreachable from the streaming reader, whose substring pre-filter has already
+		// established the type — but this function's other caller (the Claude disk scan)
+		// folds it over EVERY parsed record, so the check is what makes it safe there.
+		expect(aiTitleFromRecord({ type: "user", aiTitle: "not a title row" })).toBeUndefined();
+		expect(aiTitleFromRecord({})).toBeUndefined();
+	});
+
+	it("declines an ai-title row whose title is empty or not a string", () => {
+		expect(aiTitleFromRecord({ type: "ai-title", aiTitle: "" })).toBeUndefined();
+		expect(aiTitleFromRecord({ type: "ai-title", aiTitle: 42 })).toBeUndefined();
+		expect(aiTitleFromRecord({ type: "ai-title" })).toBeUndefined();
+	});
+});
 
 describe("readClaudeAiTitle", () => {
 	let dir: string;

--- a/cli/src/core/ClaudeAiTitleReader.ts
+++ b/cli/src/core/ClaudeAiTitleReader.ts
@@ -43,6 +43,27 @@ const AI_TITLE_FRAGMENT = '"type":"ai-title"';
  */
 export const TAIL_SCAN_BYTES = 4 * 1024 * 1024;
 
+/**
+ * The title carried by one already-parsed transcript record, if it carries one.
+ *
+ * The whole rule, in one place, so a caller that has already parsed the line does not
+ * have to restate it, and so {@link readClaudeAiTitle} below has exactly one
+ * definition of what a title row IS.
+ *
+ * The Claude disk scan used to be the other caller — it parses every line anyway, so
+ * folding this over those records saved it a second streaming pass of up to
+ * {@link TAIL_SCAN_BYTES}. That was reverted with the rest of the content handoff (see
+ * `acceptFacts` in `ClaudeSessionDiscoverer`), so the streaming reader is the only
+ * caller today. Kept exported because it is the rule, not a helper of that one loop.
+ *
+ * "Last one wins" is the caller's job, not this function's — it answers about one
+ * record. That is the same order the streaming loop below relies on.
+ */
+export function aiTitleFromRecord(raw: { readonly type?: unknown; readonly aiTitle?: unknown }): string | undefined {
+	if (raw.type !== "ai-title") return undefined;
+	return typeof raw.aiTitle === "string" && raw.aiTitle.length > 0 ? raw.aiTitle : undefined;
+}
+
 export async function readClaudeAiTitle(transcriptPath: string): Promise<string | undefined> {
 	let latest: string | undefined;
 	let parseSkipped = 0;
@@ -69,18 +90,18 @@ export async function readClaudeAiTitle(transcriptPath: string): Promise<string 
 					dropPartial = false;
 					continue;
 				}
-				// Pre-filter: skip lines that can't possibly be ai-title rows.
-				// The literal substring `"type":"ai-title"` (including the
-				// trailing closing quote) is exactly what Claude Code writes,
-				// and any line that passes this check also satisfies
-				// `obj.type === "ai-title"` once parsed — so an explicit
-				// `obj.type !== "ai-title"` check post-parse is redundant.
+				// Pre-filter: skip lines that can't possibly be ai-title rows, so the
+				// common line never reaches JSON.parse. The literal substring
+				// `"type":"ai-title"` (including the trailing closing quote) is exactly
+				// what Claude Code writes, so a line that passes this also satisfies the
+				// `type` test inside `aiTitleFromRecord` — the two agree by construction
+				// and the second one is what makes that function safe for a caller
+				// (the disk scan) that has no fragment pre-filter to lean on.
 				if (!line.includes(AI_TITLE_FRAGMENT)) continue;
 				try {
-					const obj = JSON.parse(line) as { aiTitle?: unknown };
-					if (typeof obj.aiTitle === "string" && obj.aiTitle.length > 0) {
-						latest = obj.aiTitle;
-					}
+					// `aiTitleFromRecord` owns what a title row IS; this loop owns only
+					// "the last one wins" and the tail-slice mechanics above.
+					latest = aiTitleFromRecord(JSON.parse(line) as Record<string, unknown>) ?? latest;
 				} catch {
 					// Skip malformed ai-title row but keep scanning so a
 					// later valid row still produces a title. Aggregate count

--- a/cli/src/core/ClaudeSessionDiscoverer.test.ts
+++ b/cli/src/core/ClaudeSessionDiscoverer.test.ts
@@ -1,0 +1,484 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	CLAUDE_DISK_SCAN_WINDOW_MS,
+	claudeProjectsRoot,
+	claudeSessionsForRepo,
+	scanClaudeSessionsOnDisk,
+} from "./ClaudeSessionDiscoverer.js";
+
+beforeAll(() => {
+	vi.spyOn(console, "log").mockImplementation(() => {});
+	vi.spyOn(console, "warn").mockImplementation(() => {});
+	vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+let projectsRoot: string;
+/** Fixed "now" so window assertions do not depend on wall-clock drift. */
+const NOW = Date.parse("2026-08-13T12:00:00.000Z");
+const now = () => NOW;
+
+beforeEach(async () => {
+	projectsRoot = await mkdtemp(join(tmpdir(), "claude-projects-"));
+});
+
+afterEach(async () => {
+	await rm(projectsRoot, { recursive: true, force: true });
+});
+
+const hoursAgo = (h: number): string => new Date(NOW - h * 3_600_000).toISOString();
+
+/** A conversation turn line — what the scan looks for. */
+const turn = (cwd: string, at: string, role = "user"): string =>
+	JSON.stringify({ type: role, cwd, timestamp: at, message: { role, content: "hi" } });
+
+/** A line the scan must NOT treat as a turn: no `message.role`. */
+const nonTurn = (cwd: string | undefined, at: string): string =>
+	JSON.stringify({ type: "queue-operation", ...(cwd ? { cwd } : {}), timestamp: at, operation: "enqueue" });
+
+async function writeTranscript(dir: string, sessionId: string, lines: ReadonlyArray<string>): Promise<string> {
+	const dirPath = join(projectsRoot, dir);
+	await mkdir(dirPath, { recursive: true });
+	const filePath = join(dirPath, `${sessionId}.jsonl`);
+	await writeFile(filePath, `${lines.join("\n")}\n`, "utf-8");
+	return filePath;
+}
+
+/** Enough non-turn filler to push a byte offset past `bytes`. */
+function filler(cwd: string, at: string, bytes: number): string[] {
+	const one = nonTurn(cwd, at);
+	return new Array(Math.ceil(bytes / (one.length + 1))).fill(one);
+}
+
+describe("scanClaudeSessionsOnDisk", () => {
+	it("reads a small transcript whole and reports its last turn", async () => {
+		await writeTranscript("-repo", "s1", [
+			nonTurn(undefined, hoursAgo(5)),
+			turn("/w/repo", hoursAgo(4)),
+			turn("/w/repo", hoursAgo(3)),
+			nonTurn("/w/repo", hoursAgo(1)),
+		]);
+
+		const found = await scanClaudeSessionsOnDisk({ projectsRoot, now });
+
+		expect(found).toHaveLength(1);
+		// The LAST turn, not the last line — the trailing non-turn must not win.
+		expect(found[0].updatedAt).toBe(hoursAgo(3));
+		expect(found[0].sessionId).toBe("s1");
+		expect(found[0].dirs).toEqual(["/w/repo"]);
+	});
+
+	it("takes the session id from the filename", async () => {
+		await writeTranscript("-repo", "0d8ec8ca-792d-4385-b1a7-0e8b160c2ff3", [turn("/w/repo", hoursAgo(1))]);
+
+		const found = await scanClaudeSessionsOnDisk({ projectsRoot, now });
+
+		expect(found[0].sessionId).toBe("0d8ec8ca-792d-4385-b1a7-0e8b160c2ff3");
+	});
+
+	it("finds the last turn in a large transcript via the tail read", async () => {
+		await writeTranscript("-repo", "big", [
+			turn("/w/repo", hoursAgo(9)),
+			...filler("/w/repo", hoursAgo(8), 200 * 1024),
+			turn("/w/repo", hoursAgo(2)),
+			...filler("/w/repo", hoursAgo(1), 4 * 1024),
+		]);
+
+		const found = await scanClaudeSessionsOnDisk({ projectsRoot, now });
+
+		expect(found).toHaveLength(1);
+		expect(found[0].updatedAt).toBe(hoursAgo(2));
+	});
+
+	it("escalates the tail window when the first slice holds no turn", async () => {
+		// The only turn sits behind ~300 KB of filler, so the first 64 KB tail slice
+		// cannot see it. Without escalation this session would be dropped entirely.
+		await writeTranscript("-repo", "escalate", [
+			...filler("/w/repo", hoursAgo(9), 32 * 1024),
+			turn("/w/repo", hoursAgo(6)),
+			...filler("/w/repo", hoursAgo(5), 300 * 1024),
+		]);
+
+		const found = await scanClaudeSessionsOnDisk({ projectsRoot, now });
+
+		expect(found).toHaveLength(1);
+		expect(found[0].updatedAt).toBe(hoursAgo(6));
+	});
+
+	it("excludes a transcript that holds no conversation turn at all", async () => {
+		await writeTranscript("-repo", "meta-only", [
+			nonTurn("/w/repo", hoursAgo(2)),
+			JSON.stringify({ type: "ai-title", aiTitle: "x", sessionId: "meta-only" }),
+			JSON.stringify({ type: "summary", lastPrompt: "x", leafUuid: "y", sessionId: "meta-only" }),
+		]);
+
+		await expect(scanClaudeSessionsOnDisk({ projectsRoot, now })).resolves.toEqual([]);
+	});
+
+	it("excludes a large transcript with no turn even after reading the whole file", async () => {
+		await writeTranscript("-repo", "big-meta-only", [...filler("/w/repo", hoursAgo(3), 300 * 1024)]);
+
+		await expect(scanClaudeSessionsOnDisk({ projectsRoot, now })).resolves.toEqual([]);
+	});
+
+	it("excludes an empty file", async () => {
+		const dirPath = join(projectsRoot, "-repo");
+		await mkdir(dirPath, { recursive: true });
+		await writeFile(join(dirPath, "empty.jsonl"), "", "utf-8");
+
+		await expect(scanClaudeSessionsOnDisk({ projectsRoot, now })).resolves.toEqual([]);
+	});
+
+	it("keeps a session just inside the window and drops one just outside", async () => {
+		const insideH = CLAUDE_DISK_SCAN_WINDOW_MS / 3_600_000 - 1;
+		const outsideH = CLAUDE_DISK_SCAN_WINDOW_MS / 3_600_000 + 1;
+		await writeTranscript("-a", "inside", [turn("/w/repo", hoursAgo(insideH))]);
+		await writeTranscript("-b", "outside", [turn("/w/repo", hoursAgo(outsideH))]);
+
+		const found = await scanClaudeSessionsOnDisk({ projectsRoot, now });
+
+		expect(found.map((s) => s.sessionId)).toEqual(["inside"]);
+	});
+
+	it("admits a session the 48 h window would have dropped", async () => {
+		await writeTranscript("-repo", "three-days", [turn("/w/repo", hoursAgo(72))]);
+
+		const narrow = await scanClaudeSessionsOnDisk({ projectsRoot, now, windowMs: 48 * 3_600_000 });
+		const wide = await scanClaudeSessionsOnDisk({ projectsRoot, now });
+
+		expect(narrow).toEqual([]);
+		expect(wide.map((s) => s.sessionId)).toEqual(["three-days"]);
+	});
+
+	it("drops a turn whose timestamp cannot be parsed", async () => {
+		await writeTranscript("-repo", "bad-ts", [
+			JSON.stringify({ type: "user", cwd: "/w/repo", timestamp: "not-a-date", message: { role: "user" } }),
+		]);
+
+		await expect(scanClaudeSessionsOnDisk({ projectsRoot, now })).resolves.toEqual([]);
+	});
+
+	it("collects every distinct working directory, in first-seen order", async () => {
+		await writeTranscript("-repo", "multi", [
+			turn("/w/repo", hoursAgo(5)),
+			turn("/w/repo/cli", hoursAgo(4)),
+			turn("/w/other", hoursAgo(3)),
+			turn("/w/repo", hoursAgo(2)),
+		]);
+
+		const found = await scanClaudeSessionsOnDisk({ projectsRoot, now });
+
+		expect(found[0].dirs).toEqual(["/w/repo", "/w/repo/cli", "/w/other"]);
+	});
+
+	it("ignores malformed lines and non-jsonl files rather than failing the scan", async () => {
+		const dirPath = join(projectsRoot, "-repo");
+		await mkdir(dirPath, { recursive: true });
+		await writeFile(join(dirPath, "notes.txt"), "not a transcript", "utf-8");
+		await writeTranscript("-repo", "s1", ["{ this is not json", turn("/w/repo", hoursAgo(1)), "}{"]);
+
+		const found = await scanClaudeSessionsOnDisk({ projectsRoot, now });
+
+		expect(found.map((s) => s.sessionId)).toEqual(["s1"]);
+	});
+
+	it("keeps scanning when one transcript is unreadable", async () => {
+		await writeTranscript("-a", "good", [turn("/w/repo", hoursAgo(1))]);
+		// A directory named like a transcript: opening it as a file fails.
+		await mkdir(join(projectsRoot, "-b", "broken.jsonl"), { recursive: true });
+
+		const found = await scanClaudeSessionsOnDisk({ projectsRoot, now });
+
+		expect(found.map((s) => s.sessionId)).toEqual(["good"]);
+	});
+
+	it("returns nothing when the projects root does not exist", async () => {
+		await expect(scanClaudeSessionsOnDisk({ projectsRoot: join(projectsRoot, "nope"), now })).resolves.toEqual([]);
+	});
+
+	it("returns nothing — but REPORTS it — when the root cannot be listed at all", async () => {
+		// A missing tree is a machine without Claude installed and stays silent. A root
+		// that exists and still cannot be listed is a real fault (here ENOTDIR, in the
+		// field a permission problem), and the two must not degrade the same way: both
+		// answer empty, only one says so.
+		const notADirectory = join(projectsRoot, "a-file");
+		await writeFile(notADirectory, "x", "utf-8");
+
+		await expect(scanClaudeSessionsOnDisk({ projectsRoot: notADirectory, now })).resolves.toEqual([]);
+	});
+
+	it("defaults to the real projects root when none is injected", async () => {
+		// The default every production caller takes. Asserted with a `now` far in the
+		// FUTURE, which makes the result empty whatever that machine's tree holds: every
+		// real transcript is then outside the window, and a machine without Claude
+		// installed has no tree to walk in the first place. So this pins the default
+		// without depending on the host — the one thing a test of a home-directory
+		// default must not do.
+		const farFuture = () => Date.parse("2099-01-01T00:00:00.000Z");
+
+		await expect(scanClaudeSessionsOnDisk({ now: farFuture })).resolves.toEqual([]);
+	});
+
+	it("uses the real clock when no `now` is injected", async () => {
+		// The default every production caller takes. A fixture written at the current
+		// instant is inside the window on any clock, so this pins the default without
+		// depending on wall-clock drift.
+		await writeTranscript("-repo", "sNow", [turn("/w/repo", new Date().toISOString())]);
+
+		const found = await scanClaudeSessionsOnDisk({ projectsRoot });
+
+		expect(found.map((s) => s.sessionId)).toEqual(["sNow"]);
+	});
+
+	it("skips entries under the root that are not directories", async () => {
+		await writeFile(join(projectsRoot, "stray-file"), "x", "utf-8");
+		await writeTranscript("-repo", "s1", [turn("/w/repo", hoursAgo(1))]);
+
+		const found = await scanClaudeSessionsOnDisk({ projectsRoot, now });
+
+		expect(found.map((s) => s.sessionId)).toEqual(["s1"]);
+	});
+
+	it("scans every project directory, not just the first", async () => {
+		await writeTranscript("-one", "s1", [turn("/w/one", hoursAgo(1))]);
+		await writeTranscript("-two", "s2", [turn("/w/two", hoursAgo(1))]);
+		await writeTranscript("-three", "s3", [turn("/w/three", hoursAgo(1))]);
+
+		const found = await scanClaudeSessionsOnDisk({ projectsRoot, now });
+
+		expect(found.map((s) => s.sessionId).sort()).toEqual(["s1", "s2", "s3"]);
+	});
+
+	it("keeps NO transcript content, however much it just parsed", async () => {
+		// The scan reads the whole file to collect the directories a `cd` scattered
+		// through it, and used to hand that parse to the collector so the transcript was
+		// opened once per run. It no longer does: a run held every in-window transcript
+		// resident at the same time, with nothing capping the total. The read is paid
+		// again where it is needed instead — see `acceptFacts`.
+		await writeTranscript("-repo", "rich", [
+			JSON.stringify({ type: "ai-title", aiTitle: "The session title", sessionId: "rich" }),
+			turn("/w/repo", hoursAgo(5)),
+			turn("/w/repo", hoursAgo(4), "assistant"),
+			turn("/w/repo", hoursAgo(3)),
+		]);
+
+		const found = await scanClaudeSessionsOnDisk({ projectsRoot, now });
+
+		expect(found[0].complete).toBe(true);
+		// The scanned record is the session's identity plus its directory evidence, and
+		// nothing that scales with the transcript's size.
+		expect(Object.keys(found[0]).sort()).toEqual(["complete", "dirs", "sessionId", "transcriptPath", "updatedAt"]);
+	});
+
+	it("honours a concurrency of 1", async () => {
+		await writeTranscript("-a", "s1", [turn("/w/repo", hoursAgo(1))]);
+		await writeTranscript("-b", "s2", [turn("/w/repo", hoursAgo(1))]);
+
+		const found = await scanClaudeSessionsOnDisk({ projectsRoot, now, concurrency: 1 });
+
+		expect(found.map((s) => s.sessionId).sort()).toEqual(["s1", "s2"]);
+	});
+});
+
+describe("scanClaudeSessionsOnDisk — the already-recorded skip", () => {
+	/**
+	 * A transcript whose EARLY directory is visible only to a whole-file read: the
+	 * first turn is in `/w/early`, then ~200 KB of filler, then the last turn in
+	 * `/w/late`. A full read reports both; the tail read reports only `/w/late`.
+	 */
+	async function twoDirTranscript(sessionId = "skippable"): Promise<void> {
+		await writeTranscript("-repo", sessionId, [
+			turn("/w/early", hoursAgo(9)),
+			...filler("/w/late", hoursAgo(8), 200 * 1024),
+			turn("/w/late", hoursAgo(2)),
+		]);
+	}
+
+	it("reads the whole file when nothing is recorded, reporting every directory", async () => {
+		await twoDirTranscript();
+
+		const found = await scanClaudeSessionsOnDisk({ projectsRoot, now, alreadyRecorded: () => false });
+
+		expect(found[0].dirs).toEqual(["/w/early", "/w/late"]);
+		expect(found[0].complete).toBe(true);
+	});
+
+	it("skips the whole-file read and falls back to the tail's own directories", async () => {
+		// The saving this exists for: the session is still reported (so the run's count
+		// of discovered conversations does not shrink on a converged pass) but the
+		// expensive read never happens. `/w/early` is the accepted loss — it can only
+		// matter to a repo that already holds this session at this instant.
+		await twoDirTranscript();
+
+		const found = await scanClaudeSessionsOnDisk({ projectsRoot, now, alreadyRecorded: () => true });
+
+		expect(found).toHaveLength(1);
+		expect(found[0].updatedAt).toBe(hoursAgo(2));
+		expect(found[0].dirs).toEqual(["/w/late"]);
+		expect(found[0].complete).toBe(false);
+	});
+
+	it("asks with the session id and the instant the tail found", async () => {
+		await twoDirTranscript("abc123");
+		const asked: Array<[string, string, number]> = [];
+
+		await scanClaudeSessionsOnDisk({
+			projectsRoot,
+			now,
+			alreadyRecorded: (source, sessionId, updatedAtMs) => {
+				asked.push([source, sessionId, updatedAtMs]);
+				return false;
+			},
+		});
+
+		expect(asked).toEqual([["claude", "abc123", Date.parse(hoursAgo(2))]]);
+	});
+
+	it("does not ask about a transcript small enough to be read whole anyway", async () => {
+		// Below the whole-file threshold the read the skip would avoid has already
+		// happened, so asking could only cost a round trip and lose directories.
+		await writeTranscript("-repo", "small", [turn("/w/early", hoursAgo(5)), turn("/w/late", hoursAgo(2))]);
+		let asked = 0;
+
+		const found = await scanClaudeSessionsOnDisk({
+			projectsRoot,
+			now,
+			alreadyRecorded: () => {
+				asked++;
+				return true;
+			},
+		});
+
+		expect(asked).toBe(0);
+		expect(found[0].dirs).toEqual(["/w/early", "/w/late"]);
+		expect(found[0].complete).toBe(true);
+	});
+
+	it("labels the cheap path's directory set as incomplete", async () => {
+		// The tail is not the conversation, so `dirs` may be missing a directory the
+		// session left earlier. `complete: false` is the honest label on that, and it is
+		// the only thing distinguishing the two paths' output now that neither carries
+		// any transcript content.
+		await twoDirTranscript();
+
+		const found = await scanClaudeSessionsOnDisk({ projectsRoot, now, alreadyRecorded: () => true });
+
+		expect(found[0].complete).toBe(false);
+	});
+
+	it("does not ask about a transcript outside the window", async () => {
+		// The window check comes first: a stale transcript is dropped either way, and
+		// asking about one would report it as discovered when it is not.
+		await writeTranscript("-repo", "stale", [
+			turn("/w/repo", hoursAgo(400)),
+			...filler("/w/repo", hoursAgo(400), 200 * 1024),
+			turn("/w/repo", hoursAgo(400)),
+		]);
+		let asked = 0;
+
+		const found = await scanClaudeSessionsOnDisk({
+			projectsRoot,
+			now,
+			alreadyRecorded: () => {
+				asked++;
+				return true;
+			},
+		});
+
+		expect(asked).toBe(0);
+		expect(found).toEqual([]);
+	});
+});
+
+describe("claudeProjectsRoot", () => {
+	it("points at the Claude transcript tree under the home directory", () => {
+		expect(claudeProjectsRoot().endsWith(join(".claude", "projects"))).toBe(true);
+	});
+});
+
+describe("claudeSessionsForRepo", () => {
+	let repoRoot: string;
+
+	beforeEach(async () => {
+		repoRoot = await mkdtemp(join(tmpdir(), "claude-repo-"));
+	});
+
+	afterEach(async () => {
+		await rm(repoRoot, { recursive: true, force: true });
+	});
+
+	// `complete: true` throughout: narrowing does not read the flag, and the honest
+	// default for a hand-built fixture is the whole-file read every non-skipped
+	// transcript actually gets.
+	const scanned = (dirs: ReadonlyArray<string>, sessionId = "s1") => [
+		{ sessionId, transcriptPath: `/t/${sessionId}.jsonl`, updatedAt: hoursAgo(1), dirs, complete: true },
+	];
+
+	it("claims a session whose working directory is the repo root", () => {
+		const mine = claudeSessionsForRepo(scanned([repoRoot]), repoRoot);
+
+		expect(mine).toHaveLength(1);
+		expect(mine[0].source).toBe("claude");
+		expect(mine[0].sessionId).toBe("s1");
+	});
+
+	it("claims a session started in a subdirectory of the repo", () => {
+		const mine = claudeSessionsForRepo(scanned([join(repoRoot, "cli", "src")]), repoRoot);
+
+		expect(mine).toHaveLength(1);
+	});
+
+	it("does NOT claim a sibling directory that merely shares the repo's name prefix", () => {
+		// `<repo>-figma-mcp` is a prefix match on the raw string but a different repo.
+		// A naive `startsWith` would claim it; `sessionDirBelongsToRepo` must not.
+		const mine = claudeSessionsForRepo(scanned([`${repoRoot}-figma-mcp`]), repoRoot);
+
+		expect(mine).toEqual([]);
+	});
+
+	it("does not claim an unrelated directory", () => {
+		const mine = claudeSessionsForRepo(scanned(["/somewhere/else"]), repoRoot);
+
+		expect(mine).toEqual([]);
+	});
+
+	it("claims a session when ANY of its directories matches", () => {
+		const mine = claudeSessionsForRepo(scanned(["/unrelated", join(repoRoot, "cli"), "/also-unrelated"]), repoRoot);
+
+		expect(mine).toHaveLength(1);
+	});
+
+	it("filters rather than partitions — two repos may each claim the same session", async () => {
+		const otherRoot = await mkdtemp(join(tmpdir(), "claude-repo2-"));
+		try {
+			const session = scanned([repoRoot, otherRoot]);
+
+			expect(claudeSessionsForRepo(session, repoRoot)).toHaveLength(1);
+			expect(claudeSessionsForRepo(session, otherRoot)).toHaveLength(1);
+		} finally {
+			await rm(otherRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("excludes a session that belongs to a nested repo inside this one", async () => {
+		const nested = join(repoRoot, "vendor", "inner");
+		await mkdir(join(nested, ".git"), { recursive: true });
+
+		const mine = claudeSessionsForRepo(scanned([join(nested, "src")]), repoRoot);
+
+		expect(mine).toEqual([]);
+	});
+
+	it("drops a session with no working directory at all", () => {
+		expect(claudeSessionsForRepo(scanned([]), repoRoot)).toEqual([]);
+	});
+
+	it("carries the last-turn instant through as updatedAt and drops dirs", () => {
+		const mine = claudeSessionsForRepo(scanned([repoRoot]), repoRoot);
+
+		expect(mine[0].updatedAt).toBe(hoursAgo(1));
+		expect("dirs" in mine[0]).toBe(false);
+	});
+});

--- a/cli/src/core/ClaudeSessionDiscoverer.ts
+++ b/cli/src/core/ClaudeSessionDiscoverer.ts
@@ -1,0 +1,504 @@
+/**
+ * Claude Session Discoverer — the on-disk scan for Claude Code conversations.
+ *
+ * Every other transcript source has a discoverer that reads its own store; Claude
+ * was the exception, reachable only through the per-project `sessions.json`
+ * registry the Stop hook writes. That registry is pruned at 48 h by
+ * `SessionTracker.pruneStale`, and the prune is a PHYSICAL delete — `saveSession`
+ * writes back only the live rows, and every Claude or Gemini turn triggers one. So
+ * an older conversation stopped existing as far as the dashboard was concerned even
+ * though its transcript sits under `~/.claude/projects/` indefinitely. Measured on
+ * a real machine: 3 sessions in `sessions.json` against 64 transcripts / 56 MB on
+ * disk, a 21x gap, and every one of those 61 invisible conversations carried skill
+ * and MCP call data the dashboard could not see.
+ *
+ * This module reads those files directly, so back-fill coverage is bounded by what
+ * is on disk rather than by what a hook happened to record in the last two days.
+ *
+ * ## Deliberately NOT wired into `ActiveSessionAggregator`
+ *
+ * The sidebar answers "what am I talking to right now", which the hook registry
+ * already answers from one small per-project file and with the right 48 h horizon.
+ * Wiring this in would make every 60 s sidebar tick walk the whole machine-global
+ * tree for an answer it already has. This scan exists for back-fill, where reading
+ * a 7-day window off disk is the entire point.
+ *
+ * It also does not REPLACE the `sessions.json` route: that route stays as this
+ * one's fallback (and as Gemini's only route at all). Keeping both costs nothing —
+ * the collector's existing dedupe merges the two views of one session — while
+ * dropping it would mean a failed disk scan leaves Claude completely invisible,
+ * where today it would still have 48 h of coverage.
+ *
+ * ## Why the time comes from the transcript, not from mtime
+ *
+ * `updatedAt` is the timestamp of the last real conversation turn. Measured over 64
+ * real transcripts, the file's mtime runs AHEAD of that by a median of 0.8 h and by
+ * as much as 42.8 h (26 of them by more than an hour), because Claude Code keeps
+ * appending non-conversational lines — `ai-title`, `queue-operation`, a trailing
+ * `lastPrompt`/`leafUuid` record — after the conversation itself has stopped. A
+ * window computed from mtime files a two-day-old session under today and stores an
+ * instant the session never had: at 48 h it admitted 44 transcripts where the true
+ * count was 33.
+ *
+ * mtime remains a SOUND coarse filter (it can only ever be at or after the last
+ * turn, so it never wrongly excludes) and is deliberately unused anyway: the
+ * precise value has to be read to be stored, and reading it costs 36 ms for the
+ * whole tree, so a separate coarse pass would buy nothing.
+ *
+ * This argument is about mtime ONLY. It does not transfer to the Stop hook's
+ * timestamp, which is the same instant plus the few seconds the hook took to fire
+ * (measured +3.9 s / +2.7 s / +2.5 s) — harmless for every bucket the dashboard
+ * draws.
+ *
+ * ## Why the read has two phases
+ *
+ * The two facts a scan needs have different cost models, and treating them as one is
+ * how an earlier version of this module got attribution wrong.
+ *
+ * The last turn's instant IS answerable from the tail — any later turn would also be
+ * in the tail — which is the same shape, for the same reason, as
+ * `ClaudeAiTitleReader`. Reading from byte 0 to find it re-parses thousands of
+ * tool-call lines: measured 464 ms against 36 ms over the same 64 files.
+ *
+ * The set of directories a session touched is NOT. A `cwd` recorded only in the
+ * middle of the file is invisible to a head+tail read, and the session then goes
+ * unattributed for that repo — measured, head+tail disagreed with a full read on 24
+ * of 64 transcripts. So the tail read is a GATE (is this file worth opening
+ * properly?) and the full read produces the facts, for in-window files only. Total
+ * cost therefore scales with recent activity rather than with total history.
+ *
+ * Neither phase re-states `parseTranscriptLine`'s notion of a conversation turn;
+ * both call it. See {@link scanSlice} for what a hand-rolled equivalent got wrong.
+ */
+
+import type { FileHandle } from "node:fs/promises";
+import { open, readdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
+import { createLogger, errMsg, isEnoent } from "../Logger.js";
+import type { SessionInfo } from "../Types.js";
+import { mapWithConcurrency, withIoBudget } from "../util/Concurrency.js";
+import type { AlreadyCurrent } from "./DiskSessionScan.js";
+import { sessionDirBelongsToRepo } from "./SessionDirMatch.js";
+import { BACKFILL_SESSION_WINDOW_MS } from "./SessionWindow.js";
+import { parseTranscriptLine } from "./TranscriptReader.js";
+
+const log = createLogger("ClaudeSessionDiscoverer");
+
+/**
+ * This scanner's default window, and deliberately NOT the other discoverers' 48 h
+ * `SESSION_STALE_MS`: its only caller is the history back-fill, so the back-fill's
+ * window IS its default. See {@link BACKFILL_SESSION_WINDOW_MS} for why the two
+ * horizons must stay separate constants.
+ */
+export const CLAUDE_DISK_SCAN_WINDOW_MS = BACKFILL_SESSION_WINDOW_MS;
+
+/** First tail slice scanned for the last conversation turn (phase 1, the gate). */
+const TAIL_SCAN_BYTES = 64 * 1024;
+/** Multiplier applied when a tail slice held no conversation line. */
+const TAIL_ESCALATION = 8;
+/** At or below this size the whole file is read — cheaper than two positioned reads. */
+const WHOLE_FILE_BYTES = 96 * 1024;
+
+/** One Claude transcript, as the scan understands it. */
+export interface ClaudeDiskSession {
+	readonly sessionId: string;
+	readonly transcriptPath: string;
+	/** ISO timestamp of the last real conversation turn. */
+	readonly updatedAt: string;
+	/**
+	 * Every distinct working directory the transcript recorded, in first-seen order.
+	 * COMPLETE: it comes from a full read, not from a slice — see
+	 * {@link readTranscriptFacts} for why a sampled set silently loses repos.
+	 *
+	 * Plural because a session follows the user across `cd`: measured, 27 of 64
+	 * transcripts carry more than one, 26 of those only subdirectories of the same
+	 * repo and one genuinely spanning unrelated trees.
+	 *
+	 * This field is why the scan has its own type instead of returning `SessionInfo`
+	 * directly. `SessionInfo` carries no working directory and has a hand-kept Kotlin
+	 * mirror, so adding one there would be a cross-language change for a value that
+	 * is consumed and discarded inside {@link claudeSessionsForRepo}.
+	 */
+	readonly dirs: ReadonlyArray<string>;
+	/**
+	 * False when {@link dirs} came from the tail alone because the database already
+	 * held this session — see {@link ScanClaudeSessionsOptions.alreadyRecorded}.
+	 *
+	 * Carried rather than kept private because it is the honest label on a
+	 * possibly-incomplete field: a consumer that cares whether attribution could have
+	 * missed a directory has no other way to ask.
+	 *
+	 * Nothing reads it in production today — the whole-file facts it used to gate
+	 * (tokens, tool calls, the transcript's own lines) are no longer carried out of the
+	 * scan at all; see {@link acceptFacts}. It stays because the caveat on `dirs` is
+	 * true whether or not anyone is currently acting on it.
+	 */
+	readonly complete: boolean;
+}
+
+export interface ScanClaudeSessionsOptions {
+	/** Override for `~/.claude/projects` (tests inject a temp dir). */
+	readonly projectsRoot?: string;
+	/** Defaults to {@link CLAUDE_DISK_SCAN_WINDOW_MS}. */
+	readonly windowMs?: number;
+	/** Injected clock, for window-boundary tests. */
+	readonly now?: () => number;
+	/** Bounded fan-out width; defaults to {@link mapWithConcurrency}'s. */
+	readonly concurrency?: number;
+	/**
+	 * Lets the scan skip PHASE 2 — the whole-file read — for a session the database
+	 * already holds at or past the instant phase 1 found.
+	 *
+	 * This is the difference between a converged re-run costing a 64 KB tail read per
+	 * transcript and costing a full read plus a full parse of each one, which is what
+	 * it cost when the only skip lived downstream of the scan. See
+	 * {@link AlreadyCurrent}, and {@link readTranscriptFacts} for what the cheap path
+	 * gives up.
+	 *
+	 * Omitted means "read everything properly", which is always correct and is what
+	 * every non-back-fill caller wants.
+	 */
+	readonly alreadyRecorded?: AlreadyCurrent;
+}
+
+/** Default root of Claude Code's per-project transcript tree. */
+export function claudeProjectsRoot(): string {
+	return join(homedir(), ".claude", "projects");
+}
+
+/** Reads `length` bytes at `position` as UTF-8. */
+async function readRange(handle: FileHandle, position: number, length: number): Promise<string> {
+	const buf = Buffer.allocUnsafe(length);
+	const { bytesRead } = await handle.read(buf, 0, length, position);
+	// A slice boundary can split a multi-byte character. That corrupts at most the
+	// one line it lands in, and a corrupted line fails `JSON.parse` and is dropped by
+	// `scanSlice` — which is why the boundary needs no special handling here.
+	return buf.subarray(0, bytesRead).toString("utf-8");
+}
+
+/**
+ * {@link readRange} under the shared I/O budget, claiming the bytes it will actually
+ * materialise.
+ *
+ * Per READ rather than per file, and that placement is the whole reason the claim is
+ * honest. A 64 KB tail read of a 50 MB transcript must claim 64 KB: claiming the file
+ * size instead would make the cheap path — the one a converged re-run takes for every
+ * transcript — hold the allowance a genuinely large read needs, which is the opposite
+ * of the intent. The cost of putting it here is that the file HANDLE is held across
+ * the gaps between reads without a slot, so the number of simultaneously open
+ * transcripts is bounded by the fan-out width rather than by the budget. That is the
+ * accepted half of the trade: an open descriptor costs almost nothing, whereas the
+ * bytes are what can take the process down.
+ *
+ * Never nest this inside another budget call — see {@link withIoBudget}.
+ */
+function budgetedRead(handle: FileHandle, position: number, length: number): Promise<string> {
+	return withIoBudget(length, () => readRange(handle, position, length));
+}
+
+/** What one slice of a transcript yielded. */
+interface SliceFacts {
+	/** Timestamp of the LAST conversation turn in the slice, if it held one. */
+	readonly lastTurnAt?: string;
+	readonly dirs: ReadonlyArray<string>;
+}
+
+/**
+ * Extracts the conversation facts from a slice of JSONL.
+ *
+ * The turn predicate is `parseTranscriptLine` ITSELF, not a restatement of it. That
+ * distinction is the whole point: a hand-rolled "has `message.role` and a timestamp"
+ * check looks equivalent and is not, because the real parser also drops compaction
+ * summaries (`isCompactSummary`), roles other than user/assistant, assistant messages
+ * whose content extracts to nothing, and user messages that are only tool results or
+ * an IDE/skill injection. Measured over 64 real transcripts, the loose check picked a
+ * different last line in 8 of them — and in all 8 the line it picked was one the real
+ * parser discards. Since that timestamp drives the window edge, the date bucket and
+ * the skip comparison, "close enough" is not a category that exists here.
+ *
+ * `cwd` is read off the RAW object instead, and must be: it rides on lines that are
+ * not conversation turns at all (`attachment`, `queue-operation`), so gating it on the
+ * parser would throw away most of the directories a session ever touched.
+ *
+ * Lines that fail to parse are dropped silently — they are either a partial line at a
+ * slice boundary or a record shape this build does not know, and neither is worth
+ * failing a scan for.
+ */
+function scanSlice(text: string, firstLineNo = 0): SliceFacts {
+	let lastTurnAt: string | undefined;
+	const dirs: string[] = [];
+	const lines = text.split("\n");
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i].trim();
+		if (!line.startsWith("{")) continue;
+		let raw: { message?: unknown; cwd?: unknown; type?: unknown };
+		try {
+			raw = JSON.parse(line) as typeof raw;
+		} catch {
+			continue;
+		}
+		if (typeof raw.cwd === "string" && raw.cwd.length > 0 && !dirs.includes(raw.cwd)) {
+			dirs.push(raw.cwd);
+		}
+		// Gate before re-parsing: `parseTranscriptLine` requires a `message` object as
+		// its own first real check, so a line without one cannot qualify and the second
+		// parse would be pure waste. The gate is a strict subset of the parser's
+		// condition, so it cannot change which line wins.
+		if (!raw.message || typeof raw.message !== "object") continue;
+		const entry = parseTranscriptLine(line, firstLineNo + i);
+		// A qualifying turn with no timestamp cannot date anything, so it is not a
+		// candidate — but it does not disqualify an earlier one either.
+		if (entry?.timestamp) lastTurnAt = entry.timestamp;
+	}
+	return {
+		...(lastTurnAt !== undefined ? { lastTurnAt } : {}),
+		dirs,
+	};
+}
+
+/** A transcript's scanned facts, or null when the file holds no conversation at all. */
+interface TranscriptFacts {
+	readonly lastTurnAt: string;
+	readonly dirs: ReadonlyArray<string>;
+	/**
+	 * True when `dirs` came from a whole-file read and is therefore the COMPLETE set.
+	 * False when the cheap path produced it from the tail alone — see
+	 * {@link readTranscriptFacts}.
+	 */
+	readonly complete: boolean;
+}
+
+/** True when `lastTurnAt` is a parseable instant inside the window. */
+function inWindow(lastTurnAt: string, windowMs: number, now: number): boolean {
+	const ms = Date.parse(lastTurnAt);
+	return Number.isFinite(ms) && now - ms <= windowMs;
+}
+
+/**
+ * Promotes a slice to a transcript's facts, or rejects it as undateable / too old.
+ *
+ * Only ever called on a WHOLE-FILE slice, which is what makes `complete` sound: the
+ * directory set really is every directory the session recorded.
+ *
+ * ## What this deliberately does NOT keep
+ *
+ * The bytes. An earlier version parsed them here and carried the result out — the
+ * entries, the token tallies and the transcript's own lines — so that the collector
+ * could write a session row without opening the file a second time. It was faster and
+ * it was unbounded: every in-window transcript stayed resident for the whole run,
+ * measured at over 100 MB against a 56 MB corpus, growing linearly with the window and
+ * with nothing to cap it. Recovering the memory means paying for the read again where
+ * it is needed, per session, which is what `sessionContentFor` now does.
+ *
+ * Do not reintroduce a carried payload here without a byte cap on the total. The scan
+ * has no idea how many transcripts are in the window, so "one file's parse" and "every
+ * file's parse at once" look identical from inside this function.
+ */
+function acceptFacts(facts: SliceFacts, windowMs: number, now: number): TranscriptFacts | null {
+	if (!facts.lastTurnAt || !inWindow(facts.lastTurnAt, windowMs, now)) return null;
+	return { lastTurnAt: facts.lastTurnAt, dirs: facts.dirs, complete: true };
+}
+
+/**
+ * Reads one transcript's facts, in two phases with different cost models.
+ *
+ * The two phases exist because the two facts are NOT equally cheap, and pretending
+ * they were is how this module got it wrong the first time. "When did this session
+ * last speak" is answerable from the tail, because any later turn would also be in the
+ * tail. "Which directories did this session touch" is not answerable from any slice: a
+ * `cwd` that appears only in the middle of the file is invisible to a head+tail read,
+ * and the session then goes unattributed for that repo. Measured over 64 real
+ * transcripts, head+tail produced a different directory set than a full read for 24 of
+ * them.
+ *
+ * So:
+ *
+ *  - **Phase 1, the gate.** Tail-read for the last turn, widening until one appears.
+ *    Rejects a file that holds no conversation at all (entirely `queue-operation` /
+ *    `ai-title` records — a normal outcome, not a failure) and one whose last turn is
+ *    outside the window. Cheap, and it is what keeps a long history off the phase-2
+ *    bill: a machine with years of transcripts pays a 64 KB read for each old one.
+ *  - **Phase 2, the facts.** Only for a file that survived the gate, read the whole
+ *    thing for the complete directory set. This is the expensive half, and it is now
+ *    bounded by recent activity rather than by total history.
+ *
+ * Phase 2 re-derives `lastTurnAt` and that value — not phase 1's — is the one
+ * returned. They agree by construction, and having exactly one authoritative producer
+ * is worth more than saving the re-scan.
+ */
+async function readTranscriptFacts(
+	path: string,
+	windowMs: number,
+	now: number,
+	sessionId: string,
+	alreadyRecorded?: AlreadyCurrent,
+): Promise<TranscriptFacts | null> {
+	const handle = await open(path, "r");
+	try {
+		const { size } = await handle.stat();
+		if (size === 0) return null;
+
+		// Below the threshold the two phases collapse: one read is cheaper than a tail
+		// read plus a full read of nearly the same bytes. No point consulting
+		// `alreadyRecorded` either — the read it would avoid has already happened.
+		if (size <= WHOLE_FILE_BYTES) {
+			const text = await budgetedRead(handle, 0, size);
+			return acceptFacts(scanSlice(text), windowMs, now);
+		}
+
+		// Phase 1 — the gate.
+		let gate: SliceFacts | undefined;
+		let window = TAIL_SCAN_BYTES;
+		for (;;) {
+			const start = Math.max(0, size - window);
+			const tail = scanSlice(await budgetedRead(handle, start, size - start));
+			if (tail.lastTurnAt) {
+				gate = tail;
+				break;
+			}
+			if (start === 0) return null; // whole file read, no conversation in it
+			window *= TAIL_ESCALATION;
+		}
+		const gateTurnAt = gate.lastTurnAt as string;
+		if (!inWindow(gateTurnAt, windowMs, now)) return null;
+
+		// The cheap path. Phase 1 has already established the session's identity and
+		// its instant, which is everything the database needs to say "I have this
+		// one" — so the whole-file read below buys nothing except a more complete
+		// directory set for a session nobody is going to write.
+		//
+		// The tail's OWN directories are used instead, and they may be incomplete —
+		// that is the trade, stated plainly. Claude stamps `cwd` on most lines, so the
+		// tail almost always carries the directory the session was last working in,
+		// and the one it MIGHT miss is a directory the session left earlier. The
+		// consequence of missing one is bounded to cosmetics: this path is only taken
+		// when every repo holding a row for this session is already current, so a repo
+		// that fails to recognise it had nothing to write anyway — its count of
+		// discovered conversations is one lower for the run and no row changes. The
+		// moment the session actually has a new turn, its instant moves past the
+		// stored one, this branch is not taken, and the full read produces the
+		// complete set again.
+		const gateMs = Date.parse(gateTurnAt);
+		if (alreadyRecorded?.("claude", sessionId, gateMs)) {
+			log.debug("claude %s already recorded at its last turn -- skipping the full read", sessionId);
+			return { lastTurnAt: gateTurnAt, dirs: gate.dirs, complete: false };
+		}
+
+		// Phase 2 — the facts.
+		const text = await budgetedRead(handle, 0, size);
+		return acceptFacts(scanSlice(text), windowMs, now);
+	} finally {
+		await handle.close();
+	}
+}
+
+/** Every `*.jsonl` under `<projectsRoot>/<dir>/`. */
+async function listTranscripts(projectsRoot: string): Promise<string[]> {
+	let dirs: string[];
+	try {
+		dirs = await readdir(projectsRoot);
+	} catch (err) {
+		// A machine with no Claude install has no tree; that is not a fault to report.
+		if (!isEnoent(err)) log.info("cannot list %s: %s", projectsRoot, errMsg(err));
+		return [];
+	}
+	const files: string[] = [];
+	for (const dir of dirs) {
+		try {
+			for (const entry of await readdir(join(projectsRoot, dir))) {
+				if (entry.endsWith(".jsonl")) files.push(join(projectsRoot, dir, entry));
+			}
+		} catch {
+			// not a directory, or unreadable — skip
+		}
+	}
+	return files;
+}
+
+/**
+ * Scans every Claude transcript on this machine and returns those whose last
+ * conversation turn falls inside the window.
+ *
+ * MACHINE-WIDE and repo-agnostic on purpose. `~/.claude/projects` is one global
+ * tree, so a repo-scoped scan run inside `dbBackfillRepos`' per-repo loop would walk
+ * the same files once per registered repo. Callers scan once and narrow with
+ * {@link claudeSessionsForRepo}.
+ *
+ * The encoded directory names under that root are deliberately not parsed. The
+ * encoding replaces path separators with `-` without escaping the `-` characters
+ * (and the `.` characters) already in the path, so it is lossy — `/Users/zf/.jolli`
+ * and `/Users/zf/-jolli` produce the same name — and one repo owns several of those
+ * directories anyway (measured: 11 directories holding 43 distinct working
+ * directories). The `cwd` recorded inside each file is the exact absolute path, so
+ * that is what attribution uses.
+ */
+export async function scanClaudeSessionsOnDisk(
+	opts: ScanClaudeSessionsOptions = {},
+): Promise<ReadonlyArray<ClaudeDiskSession>> {
+	const projectsRoot = opts.projectsRoot ?? claudeProjectsRoot();
+	const windowMs = opts.windowMs ?? CLAUDE_DISK_SCAN_WINDOW_MS;
+	const now = opts.now?.() ?? Date.now();
+	const files = await listTranscripts(projectsRoot);
+	if (files.length === 0) return [];
+
+	const scanned = await mapWithConcurrency(
+		files,
+		async (path): Promise<ClaudeDiskSession | null> => {
+			// The filename IS the session id, which is what lets the skip below decide
+			// whether the database already holds this session before the file is opened.
+			const sessionId = basename(path).replace(/\.jsonl$/, "");
+			try {
+				const facts = await readTranscriptFacts(path, windowMs, now, sessionId, opts.alreadyRecorded);
+				if (!facts) return null;
+				return {
+					sessionId,
+					transcriptPath: path,
+					updatedAt: facts.lastTurnAt,
+					dirs: facts.dirs,
+					complete: facts.complete,
+				};
+			} catch (err) {
+				// One unreadable transcript must not lose the other sixty.
+				log.debug("skipping unreadable transcript %s: %s", path, errMsg(err));
+				return null;
+			}
+		},
+		opts.concurrency,
+	);
+
+	const sessions = scanned.filter((s): s is ClaudeDiskSession => s !== null);
+	log.info("claude disk scan: %d of %d transcript(s) inside the window", sessions.length, files.length);
+	return sessions;
+}
+
+/**
+ * Narrows a machine-wide scan to one repo, as `SessionInfo`s the existing collector
+ * consumes unchanged.
+ *
+ * Attribution is `sessionDirBelongsToRepo` — shared with the codex / opencode /
+ * devin discoverers — so a session started in a SUBDIRECTORY still counts while a
+ * nested repo's own sessions do not, and Windows/macOS case folding is handled once.
+ *
+ * This FILTERS, it does not partition: a session is claimed whenever ANY of its
+ * directories matches, and the same scanned session may legitimately be claimed by
+ * two different repos. Assigning each session to exactly one repo would drop it from
+ * the other — measured, 27 of 64 transcripts carry more than one working directory,
+ * so that is a live case rather than a hypothetical one.
+ */
+export function claudeSessionsForRepo(
+	scanned: ReadonlyArray<ClaudeDiskSession>,
+	projectDir: string,
+): ReadonlyArray<SessionInfo> {
+	const mine: SessionInfo[] = [];
+	for (const session of scanned) {
+		if (!session.dirs.some((dir) => sessionDirBelongsToRepo(dir, projectDir))) continue;
+		mine.push({
+			sessionId: session.sessionId,
+			transcriptPath: session.transcriptPath,
+			updatedAt: session.updatedAt,
+			source: "claude",
+		});
+	}
+	return mine;
+}

--- a/cli/src/core/ClineCliSessionDiscoverer.test.ts
+++ b/cli/src/core/ClineCliSessionDiscoverer.test.ts
@@ -69,6 +69,19 @@ describe("scanClineCliSessions", () => {
 		expect(r.sessions.map((s) => s.sessionId)).toEqual(["s3"]);
 	});
 
+	it("drops a VALID sidecar that carries neither spelling of a workspace root", async () => {
+		// Distinct from the corrupt case above: this parses fine, it just cannot be
+		// attributed to any repo. Carrying it with an empty directory list would make it
+		// match nothing downstream anyway — dropping it here is what keeps the scan's own
+		// count honest rather than reporting a session no repo will ever claim.
+		await writeSession(sessionsDir, "sNoRoot", { session_id: "sNoRoot", metadata: { title: "orphan" } });
+		await writeSession(sessionsDir, "sOk", { session_id: "sOk", workspace_root: project });
+
+		const r = await scanClineCliSessions(project, sessionsDir);
+
+		expect(r.sessions.map((s) => s.sessionId)).toEqual(["sOk"]);
+	});
+
 	it("discoverClineCliSessions strips error channel", async () => {
 		const sessions = await discoverClineCliSessions(project);
 		expect(Array.isArray(sessions)).toBe(true);
@@ -91,6 +104,26 @@ describe("scanClineCliSessions", () => {
 		expect(r.sessions.map((s) => s.sessionId)).not.toContain("sOld");
 		// s5 should be skipped (no messages file)
 		expect(r.sessions.map((s) => s.sessionId)).not.toContain("s5");
+	});
+
+	// The dashboard's history back-fill widens the window explicitly; the sidebar,
+	// `jolli status` and the post-commit summary generation keep the 48h default by
+	// omitting the parameter.
+	it("admits a session outside the 48h default when an explicit wider window is passed", async () => {
+		const sevenDays = 7 * 24 * 60 * 60 * 1000;
+		await writeSession(sessionsDir, "sBackfill", { workspace_root: project });
+		const threeDaysAgo = new Date(Date.now() - 72 * 60 * 60 * 1000);
+		const messagesPath = join(sessionsDir, "sBackfill", "sBackfill.messages.json");
+		await utimes(messagesPath, threeDaysAgo, threeDaysAgo);
+
+		// The default 48h window excludes it…
+		expect((await scanClineCliSessions(project, sessionsDir)).sessions).toEqual([]);
+		// …a 7-day window admits it, and the QueueWorker wrapper forwards the value.
+		const wide = await scanClineCliSessions(project, sessionsDir, sevenDays);
+		expect(wide.sessions.map((s) => s.sessionId)).toEqual(["sBackfill"]);
+		detector.sessionsDir = sessionsDir;
+		const viaWrapper = await discoverClineCliSessions(project, sevenDays);
+		expect(viaWrapper.map((s) => s.sessionId)).toEqual(["sBackfill"]);
 	});
 
 	it("skips sessions from different workspace_root/cwd", async () => {

--- a/cli/src/core/ClineCliSessionDiscoverer.ts
+++ b/cli/src/core/ClineCliSessionDiscoverer.ts
@@ -4,6 +4,7 @@ import { createLogger } from "../Logger.js";
 import type { SessionInfo } from "../Types.js";
 import { getClineCliSessionsDir } from "./ClineCliDetector.js";
 import type { ClineScanError } from "./ClineTranscriptShared.js";
+import { type DiskSession, sessionsForRepo } from "./DiskSessionScan.js";
 import { normalizePathForCompare } from "./PathUtils.js";
 
 const log = createLogger("ClineCliDiscoverer");
@@ -24,10 +25,54 @@ interface ClineCliSidecar {
 	readonly metadata?: { readonly title?: string };
 }
 
+/**
+ * @param windowMs Optional session-staleness window in milliseconds, defaulting to
+ * the 48-hour {@link SESSION_STALE_MS}. Only the dashboard's history back-fill passes
+ * a wider one (7 days); every caller that must NOT widen simply omits it — the
+ * "Active Conversations" sidebar, `jolli status`, and above all the post-commit
+ * summary generation in `hooks/QueueWorker.ts`, which uses this window to decide
+ * which conversations belong to the commit being summarised. A wider window there
+ * would pull unrelated week-old conversations into that commit's stored memory,
+ * which is persisted to the git orphan branch and fails silently — no error, just
+ * wrong content.
+ */
 export async function scanClineCliSessions(
 	projectDir: string,
 	sessionsDir: string = getClineCliSessionsDir(),
+	windowMs?: number,
 ): Promise<ClineCliScanResult> {
+	const { sessions, error } = await scanClineCliSessionsOnDisk(sessionsDir, windowMs);
+	const mine = clineCliSessionsForRepo(sessions, projectDir);
+	return error ? { sessions: mine, error } : { sessions: mine };
+}
+
+/** A machine-wide Cline CLI scan: every in-window session, plus a genuine failure. */
+export interface ClineCliDiskScanResult {
+	readonly sessions: ReadonlyArray<DiskSession>;
+	readonly error?: ClineScanError;
+}
+
+/**
+ * Scans Cline CLI's sessions directory once and returns the in-window sessions, each
+ * carrying the workspace root its sidecar recorded.
+ *
+ * MACHINE-WIDE and repo-agnostic on purpose. `~/.cline/sessions/` holds every
+ * project's sessions in one flat directory keyed by session id, so the workspace root
+ * is only knowable by opening each sidecar JSON — which a repo-scoped scan then does
+ * again for the next repo. Callers scan once and narrow with
+ * {@link clineCliSessionsForRepo}.
+ *
+ * One cost moves rather than disappearing: the repo-scoped version `stat`ed a
+ * session's messages file only AFTER its workspace root matched, so this now stats
+ * sessions no repo will claim. It is one `stat` per session, paid once for the run
+ * instead of once per repo — cheaper from two repos on, marginally dearer with one.
+ * The single-repo callers still go through the wrapper above, which scans and narrows
+ * in one call exactly as before.
+ */
+export async function scanClineCliSessionsOnDisk(
+	sessionsDir: string = getClineCliSessionsDir(),
+	windowMs?: number,
+): Promise<ClineCliDiskScanResult> {
 	let ids: string[];
 	try {
 		ids = await readdir(sessionsDir);
@@ -37,9 +82,9 @@ export async function scanClineCliSessions(
 		return { sessions: [], error: { kind: "fs", message: (error as Error).message } };
 	}
 
-	const cutoffMs = Date.now() - SESSION_STALE_MS;
-	const target = normalizePathForCompare(projectDir);
-	const sessions: SessionInfo[] = [];
+	const staleMs = windowMs ?? SESSION_STALE_MS;
+	const cutoffMs = Date.now() - staleMs;
+	const sessions: DiskSession[] = [];
 
 	for (const id of ids) {
 		const sidecarPath = join(sessionsDir, id, `${id}.json`);
@@ -50,8 +95,10 @@ export async function scanClineCliSessions(
 			log.debug("Skipping %s: sidecar read/parse failed (%s)", id, (error as Error).message);
 			continue;
 		}
+		// A sidecar with no workspace root of either spelling can never be attributed,
+		// so it is dropped here rather than carried with an empty directory list.
 		const root = meta.workspace_root ?? meta.cwd;
-		if (typeof root !== "string" || normalizePathForCompare(root) !== target) continue;
+		if (typeof root !== "string") continue;
 		// Trust the sidecar's messages_path only when absolute — a relative value
 		// (or one synced from another machine) would stat against process.cwd() and
 		// silently drop a live session. Fall back to the canonical per-session path.
@@ -68,19 +115,48 @@ export async function scanClineCliSessions(
 		if (mtimeMs < cutoffMs) continue;
 		const title = meta.metadata?.title?.trim();
 		sessions.push({
-			sessionId: meta.session_id ?? id,
-			transcriptPath: messagesPath,
-			updatedAt: new Date(mtimeMs).toISOString(),
-			source: "cline-cli",
-			...(title ? { title } : {}),
+			session: {
+				sessionId: meta.session_id ?? id,
+				transcriptPath: messagesPath,
+				updatedAt: new Date(mtimeMs).toISOString(),
+				source: "cline-cli",
+				...(title ? { title } : {}),
+			},
+			dirs: [root],
 		});
 	}
 	return { sessions };
 }
 
-/** QueueWorker wrapper — strips the error channel. */
-export async function discoverClineCliSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>> {
-	const { sessions, error } = await scanClineCliSessions(projectDir);
+/**
+ * Narrows a machine-wide Cline CLI scan to one repo.
+ *
+ * Attribution is EXACT equality on the sidecar's `workspace_root` (falling back to
+ * `cwd`), verbatim from when it ran inside the scan — deliberately not the
+ * prefix/containment rule the SQLite-backed sources use. A session started from a
+ * subdirectory is NOT attributed; see this source's "subdirectory" contract test.
+ */
+export function clineCliSessionsForRepo(
+	scanned: ReadonlyArray<DiskSession>,
+	projectDir: string,
+): ReadonlyArray<SessionInfo> {
+	const target = normalizePathForCompare(projectDir);
+	return sessionsForRepo(scanned, (dir) => normalizePathForCompare(dir) === target);
+}
+
+/**
+ * QueueWorker wrapper — strips the error channel.
+ *
+ * @param windowMs Optional staleness window in milliseconds, forwarded verbatim; see
+ * {@link scanClineCliSessions} for the default and for who may widen it.
+ */
+export async function discoverClineCliSessions(
+	projectDir: string,
+	windowMs?: number,
+): Promise<ReadonlyArray<SessionInfo>> {
+	// `undefined` for sessionsDir so the scan applies its own detector default —
+	// spelling it here would duplicate that default at the call site.
+	const { sessions, error } = await scanClineCliSessions(projectDir, undefined, windowMs);
 	if (error) log.warn("Cline CLI scan error (%s): %s", error.kind, error.message);
 	return sessions;
 }

--- a/cli/src/core/ClineSessionDiscoverer.test.ts
+++ b/cli/src/core/ClineSessionDiscoverer.test.ts
@@ -73,6 +73,36 @@ describe("scanClineSessions", () => {
 		expect(r.sessions.map((s) => s.sessionId)).toEqual(["t2"]);
 	});
 
+	it("skips an out-of-range numeric timestamp without losing healthy tasks", async () => {
+		await writeHistory(sd, [
+			{ id: "bad", ts: 1e100, task: "bad date", cwdOnTaskInitialization: "/tmp/other" },
+			{ id: "ok", ts: Date.now(), task: "keeper", cwdOnTaskInitialization: project },
+		]);
+
+		const r = await scanClineSessions(project, [sd]);
+
+		expect(r.error).toBeUndefined();
+		expect(r.sessions.map((s) => s.sessionId)).toEqual(["ok"]);
+	});
+
+	// The dashboard's history back-fill widens the window explicitly; the sidebar,
+	// `jolli status` and the post-commit summary generation keep the 48h default by
+	// omitting the parameter.
+	it("admits a session outside the 48h default when an explicit wider window is passed", async () => {
+		const sevenDays = 7 * 24 * 60 * 60 * 1000;
+		const threeDaysAgo = Date.now() - 72 * 60 * 60 * 1000;
+		await writeHistory(sd, [{ id: "tOld", ts: threeDaysAgo, task: "backfill", cwdOnTaskInitialization: project }]);
+
+		// The default 48h window excludes it…
+		expect((await scanClineSessions(project, [sd])).sessions).toEqual([]);
+		// …a 7-day window admits it, and the QueueWorker wrapper forwards the value.
+		const wide = await scanClineSessions(project, [sd], sevenDays);
+		expect(wide.sessions.map((s) => s.sessionId)).toEqual(["tOld"]);
+		detector.dirs = [sd];
+		const viaWrapper = await discoverClineSessions(project, sevenDays);
+		expect(viaWrapper.map((s) => s.sessionId)).toEqual(["tOld"]);
+	});
+
 	// Valid JSON that is not an array — Cline rewrites taskHistory.json wholesale,
 	// so a half-migrated or hand-edited file can legitimately hold an object.
 	// Treat it as "no history" rather than letting `for…of` throw.

--- a/cli/src/core/ClineSessionDiscoverer.ts
+++ b/cli/src/core/ClineSessionDiscoverer.ts
@@ -4,6 +4,7 @@ import { createLogger } from "../Logger.js";
 import type { SessionInfo } from "../Types.js";
 import { getClineStorageDirs } from "./ClineDetector.js";
 import type { ClineScanError } from "./ClineTranscriptShared.js";
+import { type DiskSession, sessionsForRepo } from "./DiskSessionScan.js";
 import { normalizePathForCompare } from "./PathUtils.js";
 
 const log = createLogger("ClineDiscoverer");
@@ -23,7 +24,11 @@ interface TaskHistoryEntry {
 	readonly cwdOnTaskInitialization?: string;
 }
 
-async function scanFlavor(storageDir: string, target: string, cutoffMs: number): Promise<SessionInfo[]> {
+/**
+ * Reads one editor flavour's `taskHistory.json`, carrying each task's recorded
+ * directory rather than matching it — see {@link clineSessionsForRepo} for the match.
+ */
+async function scanFlavor(storageDir: string, cutoffMs: number): Promise<DiskSession[]> {
 	const historyPath = join(storageDir, "state", "taskHistory.json");
 	let entries: TaskHistoryEntry[];
 	try {
@@ -33,37 +38,82 @@ async function scanFlavor(storageDir: string, target: string, cutoffMs: number):
 		if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
 		throw error;
 	}
-	const out: SessionInfo[] = [];
+	const out: DiskSession[] = [];
 	for (const e of entries) {
 		if (typeof e.id !== "string" || typeof e.cwdOnTaskInitialization !== "string") continue;
-		if (normalizePathForCompare(e.cwdOnTaskInitialization) !== target) continue;
 		// `ts` is the task's updatedAt (always present in real taskHistory). Require
 		// it: an entry without a numeric ts has no basis to be judged fresh, so treat
 		// it as stale rather than surfacing it with a fabricated `Date.now()` stamp.
-		if (typeof e.ts !== "number" || e.ts < cutoffMs) continue;
+		if (typeof e.ts !== "number" || !Number.isFinite(e.ts) || e.ts < cutoffMs) continue;
+		// JSON accepts finite numbers far outside JavaScript Date's representable
+		// range. One such row must not make `toISOString()` throw and discard every
+		// healthy task in this editor flavour, especially now that the machine-wide
+		// scan reads unrelated projects in the same history file.
+		const updatedAt = new Date(e.ts);
+		if (!Number.isFinite(updatedAt.getTime())) continue;
 		const title = e.task?.trim();
 		out.push({
-			sessionId: e.id,
-			transcriptPath: join(storageDir, "tasks", e.id, "api_conversation_history.json"),
-			updatedAt: new Date(e.ts).toISOString(),
-			source: "cline",
-			...(title ? { title } : {}),
+			session: {
+				sessionId: e.id,
+				transcriptPath: join(storageDir, "tasks", e.id, "api_conversation_history.json"),
+				updatedAt: updatedAt.toISOString(),
+				source: "cline",
+				...(title ? { title } : {}),
+			},
+			dirs: [e.cwdOnTaskInitialization],
 		});
 	}
 	return out;
 }
 
+/**
+ * @param windowMs Optional session-staleness window in milliseconds, defaulting to
+ * the 48-hour {@link SESSION_STALE_MS}. Only the dashboard's history back-fill passes
+ * a wider one (7 days); every caller that must NOT widen simply omits it — the
+ * "Active Conversations" sidebar, `jolli status`, and above all the post-commit
+ * summary generation in `hooks/QueueWorker.ts`, which uses this window to decide
+ * which conversations belong to the commit being summarised. A wider window there
+ * would pull unrelated week-old conversations into that commit's stored memory,
+ * which is persisted to the git orphan branch and fails silently — no error, just
+ * wrong content.
+ */
 export async function scanClineSessions(
 	projectDir: string,
 	storageDirs: string[] = getClineStorageDirs(),
+	windowMs?: number,
 ): Promise<ClineScanResult> {
-	const target = normalizePathForCompare(projectDir);
-	const cutoffMs = Date.now() - SESSION_STALE_MS;
-	const sessions: SessionInfo[] = [];
+	const { sessions, error } = await scanClineSessionsOnDisk(storageDirs, windowMs);
+	const mine = clineSessionsForRepo(sessions, projectDir);
+	return error ? { sessions: mine, error } : { sessions: mine };
+}
+
+/** A machine-wide Cline scan: every in-window task, plus the first flavour failure. */
+export interface ClineDiskScanResult {
+	readonly sessions: ReadonlyArray<DiskSession>;
+	readonly error?: ClineScanError;
+}
+
+/**
+ * Scans every installed Cline flavour's task history once and returns the in-window
+ * tasks, each carrying the directory it was started in.
+ *
+ * MACHINE-WIDE and repo-agnostic on purpose. Each flavour keeps ONE
+ * `state/taskHistory.json` holding every project's tasks, so a repo-scoped scan
+ * re-reads and re-parses that whole file once per registered repo — and it is a
+ * single JSON parse of the user's entire Cline history, not a lazy store. Callers
+ * scan once and narrow with {@link clineSessionsForRepo}.
+ */
+export async function scanClineSessionsOnDisk(
+	storageDirs: string[] = getClineStorageDirs(),
+	windowMs?: number,
+): Promise<ClineDiskScanResult> {
+	const staleMs = windowMs ?? SESSION_STALE_MS;
+	const cutoffMs = Date.now() - staleMs;
+	const sessions: DiskSession[] = [];
 	let error: ClineScanError | undefined;
 	for (const dir of storageDirs) {
 		try {
-			sessions.push(...(await scanFlavor(dir, target, cutoffMs)));
+			sessions.push(...(await scanFlavor(dir, cutoffMs)));
 		} catch (err: unknown) {
 			log.warn("Cline flavor scan failed at %s: %s", dir, (err as Error).message);
 			// Malformed taskHistory.json throws a SyntaxError (parse); anything else
@@ -75,9 +125,36 @@ export async function scanClineSessions(
 	return error ? { sessions, error } : { sessions };
 }
 
-/** QueueWorker wrapper — strips the error channel. */
-export async function discoverClineSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>> {
-	const { sessions, error } = await scanClineSessions(projectDir);
+/**
+ * Narrows a machine-wide Cline scan to one repo.
+ *
+ * Attribution is EXACT equality on the task's `cwdOnTaskInitialization`, verbatim
+ * from when it ran inside the flavour scan — deliberately not the prefix/containment
+ * rule the SQLite-backed sources use. A task started from a subdirectory of the repo
+ * is NOT attributed to it; that is the known, intentional limitation this source's
+ * "subdirectory" contract test pins.
+ */
+export function clineSessionsForRepo(
+	scanned: ReadonlyArray<DiskSession>,
+	projectDir: string,
+): ReadonlyArray<SessionInfo> {
+	const target = normalizePathForCompare(projectDir);
+	return sessionsForRepo(scanned, (dir) => normalizePathForCompare(dir) === target);
+}
+
+/**
+ * QueueWorker wrapper — strips the error channel.
+ *
+ * @param windowMs Optional staleness window in milliseconds, forwarded verbatim; see
+ * {@link scanClineSessions} for the default and for who may widen it.
+ */
+export async function discoverClineSessions(
+	projectDir: string,
+	windowMs?: number,
+): Promise<ReadonlyArray<SessionInfo>> {
+	// `undefined` for storageDirs so the scan applies its own detector default —
+	// spelling it here would duplicate that default at the call site.
+	const { sessions, error } = await scanClineSessions(projectDir, undefined, windowMs);
 	if (error) log.warn("Cline scan error (%s): %s", error.kind, error.message);
 	return sessions;
 }

--- a/cli/src/core/CodexSessionDiscoverer.test.ts
+++ b/cli/src/core/CodexSessionDiscoverer.test.ts
@@ -39,7 +39,12 @@ function setPlatform(os: NodeJS.Platform): void {
 	Object.defineProperty(process, "platform", { value: os, configurable: true });
 }
 
-import { discoverCodexSessions, isCodexInstalled } from "./CodexSessionDiscoverer.js";
+import {
+	codexSessionsForRepo,
+	discoverCodexSessions,
+	isCodexInstalled,
+	scanCodexSessionsOnDisk,
+} from "./CodexSessionDiscoverer.js";
 
 let tempDir: string;
 
@@ -272,6 +277,18 @@ describe("discoverCodexSessions", () => {
 		expect(sessions).toHaveLength(0);
 	});
 
+	it("skips a session_meta row with an unparseable timestamp", async () => {
+		const now = new Date();
+		const year = String(now.getFullYear());
+		const month = String(now.getMonth() + 1).padStart(2, "0");
+		const day = String(now.getDate()).padStart(2, "0");
+		const dayDir = join(tempDir, ".codex", "sessions", year, month, day);
+
+		await createCodexSession(dayDir, "rollout-bad-time.jsonl", "/my/project", "sess-bad-time", "not-a-date");
+
+		await expect(discoverCodexSessions("/my/project")).resolves.toEqual([]);
+	});
+
 	it("falls back to file mtime when session_meta has no timestamp", async () => {
 		const now = new Date();
 		const year = String(now.getFullYear());
@@ -426,6 +443,173 @@ describe("Windows path case-insensitive matching", () => {
 
 		const sessions = await discoverCodexSessions("/MY/PROJECT");
 		expect(sessions).toHaveLength(0);
+	});
+});
+
+describe("discoverCodexSessions — staleness window", () => {
+	const DAY_MS = 24 * 60 * 60 * 1000;
+	const SEVEN_DAYS_MS = 7 * DAY_MS;
+
+	/**
+	 * The `YYYY/MM/DD` directory Codex would have written a session `daysAgo` days
+	 * back, built from LOCAL date parts — which is what the discoverer's own
+	 * traversal uses, and what Codex itself stamps into these names (a real capture
+	 * has `sessions/2026/08/11/rollout-2026-08-11T10-52-15-….jsonl` whose
+	 * `session_meta.timestamp` is `2026-08-11T02:53:24Z`, i.e. 10:53 local at UTC+8).
+	 */
+	function dayDirFor(daysAgo: number): string {
+		const d = new Date(Date.now() - daysAgo * DAY_MS);
+		return join(
+			tempDir,
+			".codex",
+			"sessions",
+			String(d.getFullYear()),
+			String(d.getMonth() + 1).padStart(2, "0"),
+			String(d.getDate()).padStart(2, "0"),
+		);
+	}
+
+	const isoDaysAgo = (daysAgo: number): string => new Date(Date.now() - daysAgo * DAY_MS).toISOString();
+
+	it("finds a four-day-old session when given a seven-day window", async () => {
+		// THIS is the test that pins the calendar-day traversal, not just the staleness
+		// check. A session four days back lives in a `YYYY/MM/DD` directory that the
+		// old hard-coded three-day range never entered, so it was unreachable no matter
+		// what window was asked for — the parameter would have been purely decorative,
+		// with no error and a plausible-looking empty result.
+		await createCodexSession(dayDirFor(4), "rollout-old.jsonl", "/my/project", "sess-4d", isoDaysAgo(4));
+
+		const sessions = await discoverCodexSessions("/my/project", SEVEN_DAYS_MS);
+
+		expect(sessions.map((s) => s.sessionId)).toEqual(["sess-4d"]);
+	});
+
+	it("does not find that session under the default 48-hour window", async () => {
+		await createCodexSession(dayDirFor(4), "rollout-old.jsonl", "/my/project", "sess-4d", isoDaysAgo(4));
+
+		await expect(discoverCodexSessions("/my/project")).resolves.toEqual([]);
+	});
+
+	it("reaches the oldest calendar day a seven-day window can touch", async () => {
+		// `ceil(7d / 1d) + 1 = 8` directories: a window that ends mid-day reaches into
+		// the eighth calendar day back. Six days is comfortably inside that.
+		await createCodexSession(dayDirFor(6), "rollout-six.jsonl", "/my/project", "sess-6d", isoDaysAgo(6));
+
+		const sessions = await discoverCodexSessions("/my/project", SEVEN_DAYS_MS);
+
+		expect(sessions.map((s) => s.sessionId)).toEqual(["sess-6d"]);
+	});
+
+	it("still rejects a session older than the widened window", async () => {
+		// Nine days back: outside the window AND outside the directory range.
+		await createCodexSession(dayDirFor(9), "rollout-ancient.jsonl", "/my/project", "sess-9d", isoDaysAgo(9));
+
+		await expect(discoverCodexSessions("/my/project", SEVEN_DAYS_MS)).resolves.toEqual([]);
+	});
+
+	it("applies the window to archived sessions, which are not date-partitioned", async () => {
+		// The archived half is a flat directory, so it needs no traversal change — only
+		// the staleness value reaches it. Worth pinning so a later edit does not assume
+		// the two halves work the same way.
+		const archived = join(tempDir, ".codex", "archived_sessions");
+		await createCodexSession(archived, "rollout-arch.jsonl", "/my/project", "sess-arch", isoDaysAgo(4));
+
+		await expect(discoverCodexSessions("/my/project")).resolves.toEqual([]);
+		const wide = await discoverCodexSessions("/my/project", SEVEN_DAYS_MS);
+		expect(wide.map((s) => s.sessionId)).toEqual(["sess-arch"]);
+	});
+});
+
+describe("scanCodexSessionsOnDisk / codexSessionsForRepo", () => {
+	/** Today's date directory, where a fresh rollout would land. */
+	function todayDir(): string {
+		const d = new Date();
+		return join(
+			tempDir,
+			".codex",
+			"sessions",
+			String(d.getFullYear()),
+			String(d.getMonth() + 1).padStart(2, "0"),
+			String(d.getDate()).padStart(2, "0"),
+		);
+	}
+
+	it("scans machine-wide and carries each rollout's working directory", async () => {
+		// Repo-agnostic on purpose: one scan serves every registered repo, instead of
+		// re-reading the first line of every rollout once per repo.
+		await createCodexSession(todayDir(), "a.jsonl", "/w/one", "sess-a");
+		await createCodexSession(todayDir(), "b.jsonl", "/w/two", "sess-b");
+
+		const scanned = await scanCodexSessionsOnDisk();
+
+		expect(scanned.map((s) => s.sessionId).sort()).toEqual(["sess-a", "sess-b"]);
+		expect(scanned.find((s) => s.sessionId === "sess-a")?.dirs).toEqual(["/w/one"]);
+	});
+
+	it("narrows a scan to one repo, including a rollout started in a subdirectory", async () => {
+		const repoRoot = await mkdtemp(join(realTmpdir(), "codex-repo-"));
+		try {
+			const scanned = [
+				{
+					sessionId: "root",
+					transcriptPath: "/t/root.jsonl",
+					updatedAt: "2026-08-13T00:00:00.000Z",
+					dirs: [repoRoot],
+				},
+				{
+					sessionId: "sub",
+					transcriptPath: "/t/sub.jsonl",
+					updatedAt: "2026-08-13T00:00:00.000Z",
+					dirs: [join(repoRoot, "cli", "src")],
+				},
+				{
+					sessionId: "elsewhere",
+					transcriptPath: "/t/elsewhere.jsonl",
+					updatedAt: "2026-08-13T00:00:00.000Z",
+					dirs: ["/somewhere/else"],
+				},
+				{
+					// A sibling sharing the repo's name prefix — a naive `startsWith` claims it.
+					sessionId: "sibling",
+					transcriptPath: "/t/sibling.jsonl",
+					updatedAt: "2026-08-13T00:00:00.000Z",
+					dirs: [`${repoRoot}-other`],
+				},
+			];
+
+			const mine = codexSessionsForRepo(scanned, repoRoot);
+
+			expect(mine.map((s) => s.sessionId).sort()).toEqual(["root", "sub"]);
+			expect(mine[0].source).toBe("codex");
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("excludes a rollout that belongs to a nested repo inside this one", async () => {
+		const repoRoot = await mkdtemp(join(realTmpdir(), "codex-repo-"));
+		try {
+			const nested = join(repoRoot, "vendor", "inner");
+			await mkdir(join(nested, ".git"), { recursive: true });
+			const scanned = [
+				{ sessionId: "n", transcriptPath: "/t/n.jsonl", updatedAt: "2026-08-13T00:00:00.000Z", dirs: [nested] },
+			];
+
+			expect(codexSessionsForRepo(scanned, repoRoot)).toEqual([]);
+		} finally {
+			await rm(repoRoot, { recursive: true, force: true });
+		}
+	});
+
+	it("gives the same answer as the wrapper that replaced it", async () => {
+		// `discoverCodexSessions` is now scan-then-filter; the split must not have moved
+		// any behaviour.
+		await createCodexSession(todayDir(), "c.jsonl", "/my/project", "sess-c");
+
+		const direct = await discoverCodexSessions("/my/project");
+		const split = codexSessionsForRepo(await scanCodexSessionsOnDisk(), "/my/project");
+
+		expect(split).toEqual(direct);
 	});
 });
 

--- a/cli/src/core/CodexSessionDiscoverer.ts
+++ b/cli/src/core/CodexSessionDiscoverer.ts
@@ -29,6 +29,7 @@ import { join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { createLogger } from "../Logger.js";
 import type { SessionInfo } from "../Types.js";
+import { mapWithConcurrency, withIoBudget } from "../util/Concurrency.js";
 import { sessionDirBelongsToRepo } from "./SessionDirMatch.js";
 
 const log = createLogger("CodexDiscoverer");
@@ -43,28 +44,97 @@ const CODEX_DIR_NAME = ".codex";
  * Discovers Codex sessions relevant to the given project directory.
  * Scans ~/.codex/sessions/ for JSONL files whose session_meta.cwd matches
  * the project directory. Only returns sessions updated within the staleness
- * window (48 hours).
+ * window (48 hours by default).
  *
  * @param projectDir - The git repository root to match sessions against
+ * @param windowMs - Staleness window; defaults to {@link SESSION_STALE_MS}.
+ *   The dashboard's history back-fill passes a wider one (7 days). Every caller
+ *   that must keep the 48 h horizon simply omits it — the sidebar's Active
+ *   Conversations, `jolli status`, and (the one that matters) `QueueWorker`'s
+ *   post-commit summary, which decides which conversations belong to the commit
+ *   being summarised. Widening THAT would write week-old unrelated conversations
+ *   into a commit's stored memory, persistently and with no error anywhere, which
+ *   is why the constant above stays a default and never becomes the knob.
  * @returns Array of matching sessions with source="codex"
  */
-export async function discoverCodexSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>> {
+export async function discoverCodexSessions(
+	projectDir: string,
+	windowMs?: number,
+): Promise<ReadonlyArray<SessionInfo>> {
+	return codexSessionsForRepo(await scanCodexSessionsOnDisk(windowMs), projectDir);
+}
+
+/** One Codex rollout, as the machine-wide scan understands it. */
+export interface CodexDiskSession {
+	readonly sessionId: string;
+	readonly transcriptPath: string;
+	readonly updatedAt: string;
+	/**
+	 * The working directory `session_meta` recorded. An array for symmetry with the
+	 * other disk scans (Claude collects several per transcript, Devin has a primary
+	 * plus an attached list); Codex records exactly one, so it always holds one entry.
+	 */
+	readonly dirs: ReadonlyArray<string>;
+}
+
+/**
+ * Scans every Codex rollout on this machine and returns those inside the window,
+ * each carrying the working directory it recorded.
+ *
+ * MACHINE-WIDE and repo-agnostic on purpose. `~/.codex/sessions/` is one global tree
+ * keyed by DATE, not by project, so a repo-scoped scan re-reads the first line of
+ * every rollout once per registered repo — measured on this machine, 68 ms per repo
+ * and 201 ms across three, all of it pure repetition. Callers scan once and narrow
+ * with {@link codexSessionsForRepo}.
+ */
+export async function scanCodexSessionsOnDisk(windowMs?: number): Promise<ReadonlyArray<CodexDiskSession>> {
 	const codexBase = join(homedir(), CODEX_DIR_NAME);
-	const resolvedProject = resolve(projectDir);
-	const sessions: SessionInfo[] = [];
+	const staleMs = windowMs ?? SESSION_STALE_MS;
+	const sessions: CodexDiskSession[] = [];
 
 	// Scan active sessions in date-organized directories
 	const sessionsDir = join(codexBase, "sessions");
-	const activeSessions = await scanSessionsDirectory(sessionsDir, resolvedProject);
-	sessions.push(...activeSessions);
+	sessions.push(...(await scanSessionsDirectory(sessionsDir, staleMs)));
 
-	// Scan archived sessions (flat directory)
+	// Scan archived sessions (flat directory). Unlike the active half this is not
+	// date-partitioned, so it needs no directory-range change — only the staleness
+	// window reaches it.
 	const archivedDir = join(codexBase, "archived_sessions");
-	const archivedSessions = await scanFlatDirectory(archivedDir, resolvedProject);
-	sessions.push(...archivedSessions);
+	sessions.push(...(await scanFlatDirectory(archivedDir, staleMs)));
 
-	log.debug("Discovered %d Codex session(s)", sessions.length);
+	log.debug("Codex disk scan: %d rollout(s) inside the window", sessions.length);
 	return sessions;
+}
+
+/**
+ * Narrows a machine-wide Codex scan to one repo.
+ *
+ * Attribution is `sessionDirBelongsToRepo`, unchanged from when it ran inside the
+ * scan: prefix/containment with case folding plus the nested-repo exclusion, so a
+ * rollout started in a SUBDIRECTORY still counts (the exact-equality match this
+ * replaced silently dropped every one of those — JOLLI-2015).
+ *
+ * FILTERS rather than partitions: nested-repo exclusion aside, the same rollout may
+ * legitimately be claimed by two registered repos that are two checkouts of one
+ * project.
+ */
+export function codexSessionsForRepo(
+	scanned: ReadonlyArray<CodexDiskSession>,
+	projectDir: string,
+): ReadonlyArray<SessionInfo> {
+	const resolvedProject = resolve(projectDir);
+	const mine: SessionInfo[] = [];
+	for (const session of scanned) {
+		if (!session.dirs.some((dir) => sessionDirBelongsToRepo(resolve(dir), resolvedProject))) continue;
+		mine.push({
+			sessionId: session.sessionId,
+			transcriptPath: session.transcriptPath,
+			updatedAt: session.updatedAt,
+			source: "codex",
+		});
+	}
+	log.debug("Discovered %d Codex session(s) for %s", mine.length, projectDir);
+	return mine;
 }
 
 /**
@@ -85,9 +155,9 @@ export async function isCodexInstalled(): Promise<boolean> {
  * Scans the date-organized ~/.codex/sessions/YYYY/MM/DD/ directory structure.
  * Only traverses date directories within the 48h staleness window.
  */
-async function scanSessionsDirectory(sessionsDir: string, resolvedProject: string): Promise<SessionInfo[]> {
-	const results: SessionInfo[] = [];
-	const recentDates = getRecentDateDirs();
+async function scanSessionsDirectory(sessionsDir: string, staleMs: number): Promise<CodexDiskSession[]> {
+	const results: CodexDiskSession[] = [];
+	const recentDates = getRecentDateDirs(staleMs);
 
 	let yearDirs: string[];
 	try {
@@ -132,7 +202,7 @@ async function scanSessionsDirectory(sessionsDir: string, resolvedProject: strin
 				}
 
 				const dayPath = join(monthPath, day);
-				const daySessions = await scanFlatDirectory(dayPath, resolvedProject);
+				const daySessions = await scanFlatDirectory(dayPath, staleMs);
 				results.push(...daySessions);
 			}
 		}
@@ -145,37 +215,35 @@ async function scanSessionsDirectory(sessionsDir: string, resolvedProject: strin
  * Scans a flat directory for .jsonl files and checks each for cwd match.
  * Used for both day directories (active sessions) and archived_sessions.
  */
-async function scanFlatDirectory(dirPath: string, resolvedProject: string): Promise<SessionInfo[]> {
-	const results: SessionInfo[] = [];
-
+async function scanFlatDirectory(dirPath: string, staleMs: number): Promise<CodexDiskSession[]> {
 	let files: string[];
 	try {
 		files = await readdir(dirPath);
 	} catch {
-		return results;
+		return [];
 	}
 
-	for (const file of files) {
-		if (!file.endsWith(".jsonl")) {
-			continue;
-		}
-
-		const filePath = join(dirPath, file);
-		const session = await tryParseSessionMeta(filePath, resolvedProject);
-		if (session) {
-			results.push(session);
-		}
-	}
-
-	return results;
+	// One rollout per file, so the cost of this scan is the number of rollouts a user
+	// has — which on a heavy Codex machine is thousands. Fanned out rather than looped
+	// because each file is an independent first-line read. Each one takes a slot from
+	// the shared budget (see `withIoBudget` inside `tryParseSessionMeta`), so this
+	// running alongside eleven other scans still cannot exceed the process-wide total.
+	const scanned = await mapWithConcurrency(
+		files.filter((file) => file.endsWith(".jsonl")),
+		(file) => tryParseSessionMeta(join(dirPath, file), staleMs),
+	);
+	return scanned.filter((session): session is CodexDiskSession => session !== null);
 }
 
 /**
  * Reads only the first line of a Codex JSONL file to extract session_meta.
- * Returns a SessionInfo if the session's cwd matches the project directory
- * and the session is within the staleness window.
+ * Returns the rollout's facts when it is within the staleness window, or null.
+ *
+ * Repo attribution is deliberately NOT done here: it belongs to
+ * {@link codexSessionsForRepo}, so one scan of this global tree can serve every
+ * registered repo instead of being re-run per repo.
  */
-async function tryParseSessionMeta(filePath: string, resolvedProject: string): Promise<SessionInfo | null> {
+async function tryParseSessionMeta(filePath: string, staleMs: number): Promise<CodexDiskSession | null> {
 	let firstLine: string;
 	try {
 		firstLine = await readFirstLine(filePath);
@@ -209,34 +277,34 @@ async function tryParseSessionMeta(filePath: string, resolvedProject: string): P
 			return null;
 		}
 
-		// Match cwd against the project directory via `sessionDirBelongsToRepo`
-		// (shared with Devin/OpenCode/Copilot): prefix/containment with separator +
-		// case folding (handling the Windows "e:\foo" vs "E:\foo" drive-letter drift)
-		// plus the nested-repo exclusion. It replaced the exact `resolvedCwd ===
-		// resolvedProject` match, which silently dropped every session run from a
-		// subdirectory of the repo (JOLLI-2015).
-		if (!sessionDirBelongsToRepo(resolve(cwd), resolvedProject)) {
-			return null;
-		}
-
 		// Determine session freshness from timestamp or file mtime
 		const updatedAt = timestamp ?? (await getFileMtime(filePath));
 		if (!updatedAt) {
 			return null;
 		}
 
-		// Check staleness
-		const age = Date.now() - new Date(updatedAt).getTime();
-		if (age > SESSION_STALE_MS) {
+		// Check parseability before staleness. `NaN > staleMs` is false, so an invalid
+		// timestamp otherwise looks fresh and escapes the scan with an undateable
+		// `SessionInfo`; downstream then counts it as discovered but cannot project it.
+		const updatedAtMs = Date.parse(updatedAt);
+		if (!Number.isFinite(updatedAtMs)) return null;
+		const age = Date.now() - updatedAtMs;
+		if (age > staleMs) {
 			log.debug("Stale Codex session %s (age: %dh)", id, Math.round(age / 3600000));
 			return null;
 		}
 
+		// The cwd is carried, not matched. `codexSessionsForRepo` does the matching
+		// through `sessionDirBelongsToRepo` (shared with Devin/OpenCode/Copilot):
+		// prefix/containment with separator + case folding (handling the Windows
+		// "e:\foo" vs "E:\foo" drive-letter drift) plus the nested-repo exclusion. That
+		// replaced an exact `resolvedCwd === resolvedProject` match, which silently
+		// dropped every session run from a subdirectory of the repo (JOLLI-2015).
 		return {
 			sessionId: id,
 			transcriptPath: filePath,
 			updatedAt,
-			source: "codex",
+			dirs: [cwd],
 		};
 	} catch (error: unknown) {
 		log.debug("Failed to parse session_meta from %s: %s", filePath, (error as Error).message);
@@ -249,6 +317,12 @@ async function tryParseSessionMeta(filePath: string, resolvedProject: string): P
  * Closes the stream immediately after reading one line.
  */
 function readFirstLine(filePath: string): Promise<string> {
+	// Zero bytes claimed: this reads one line, not the file, so it needs a slot (to
+	// bound how many rollouts are open at once) and none of the byte allowance.
+	return withIoBudget(0, () => readFirstLineUnbudgeted(filePath));
+}
+
+function readFirstLineUnbudgeted(filePath: string): Promise<string> {
 	return new Promise((resolve, reject) => {
 		const stream = createReadStream(filePath, { encoding: "utf-8" });
 		const rl = createInterface({ input: stream, crlfDelay: Number.POSITIVE_INFINITY });
@@ -290,16 +364,45 @@ async function getFileMtime(filePath: string): Promise<string | null> {
 	}
 }
 
+/** One calendar day in ms — the step between Codex's `YYYY/MM/DD` directories. */
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
 /**
- * Returns date directory paths (YYYY/MM/DD format) for the last 3 days.
- * The 48h window may span up to 3 calendar days (today, yesterday, day before).
+ * How many `YYYY/MM/DD` directories a staleness window can reach into.
+ *
+ * `+1` because a window almost never ends at midnight: 48 h measured from noon
+ * today reaches back to noon two days ago, which is the THIRD calendar day
+ * (today, yesterday, the day before). Dropping the `+1` silently truncates the
+ * oldest day of every window.
+ *
+ * This is the second half of widening the window, and the half that is easy to
+ * miss: the staleness check alone is not enough, because a session four days old
+ * lives in a directory this traversal would never enter. Passing a 7-day window
+ * without widening the range here leaves the parameter purely decorative — with no
+ * error, no warning, and a plausible-looking empty result.
  */
-function getRecentDateDirs(): string[] {
+function calendarDaySpan(staleMs: number): number {
+	return Math.ceil(Math.max(0, staleMs) / ONE_DAY_MS) + 1;
+}
+
+/**
+ * Returns date directory paths (YYYY/MM/DD format) covering `staleMs`.
+ *
+ * The parts come from the LOCAL date, which matches how Codex names these
+ * directories: a real capture has `~/.codex/sessions/2026/08/11/` holding
+ * `rollout-2026-08-11T10-52-15-…jsonl` whose `session_meta.timestamp` is
+ * `2026-08-11T02:53:24.548Z` — 02:53 UTC is 10:53 in the machine's UTC+8, so the
+ * name is stamped in local time. (Inferred from the filename rather than proven
+ * directly: the machine that capture came from had no session spanning a date
+ * boundary, so UTC and local dates agreed for every sample.)
+ */
+function getRecentDateDirs(staleMs: number): string[] {
 	const dates: string[] = [];
 	const now = new Date();
+	const days = calendarDaySpan(staleMs);
 
-	for (let i = 0; i < 3; i++) {
-		const d = new Date(now.getTime() - i * 24 * 60 * 60 * 1000);
+	for (let i = 0; i < days; i++) {
+		const d = new Date(now.getTime() - i * ONE_DAY_MS);
 		const year = String(d.getFullYear());
 		const month = String(d.getMonth() + 1).padStart(2, "0");
 		const day = String(d.getDate()).padStart(2, "0");

--- a/cli/src/core/Concurrency.ts
+++ b/cli/src/core/Concurrency.ts
@@ -6,30 +6,43 @@
  * `onError(item, err)` instead of rejecting the whole batch — callers that want
  * per-item degradation (e.g. the ingest reconcile fan-out) pass it. Without
  * `onError`, the first thrown error rejects the returned promise.
+ *
+ * ## Why this is a wrapper and not a second worker pool
+ *
+ * `util/Concurrency.ts` owns the pool. This module is the OTHER call signature —
+ * `(items, limit, task)` with an explicit limit and an `onError` seam, against
+ * that one's `(items, fn, limit?)` with the shared I/O budget's width as the
+ * default. Both spellings have live callers, and neither reads naturally as the
+ * other, so the two survive as signatures rather than as implementations: the
+ * pool logic (worker count, order preservation, the shared `next` cursor) exists
+ * once, where a fix to it reaches both.
+ *
+ * Do not "unify" these by editing call sites to the other signature. The
+ * argument orders are transposed — `limit` sits where `fn` does in the other —
+ * so a moved call site that type-checks by coincidence would pass a number where
+ * a function belongs, and the compiler is not guaranteed to catch every shape.
  */
+
+import { mapWithConcurrency as mapWithPool } from "../util/Concurrency.js";
+
 export async function mapWithConcurrency<T, R>(
 	items: readonly T[],
 	limit: number,
 	task: (item: T, index: number) => Promise<R>,
 	onError?: (item: T, err: unknown, index: number) => R,
 ): Promise<R[]> {
-	const results = new Array<R>(items.length);
-	let next = 0;
-	const workerCount = Math.min(Math.max(1, limit), items.length || 1);
-
-	async function worker(): Promise<void> {
-		while (next < items.length) {
-			const index = next++;
-			const item = items[index];
+	return mapWithPool(
+		items,
+		async (item, index) => {
+			// Without `onError` the rejection propagates verbatim, which is what abandons
+			// the remaining items — the pool's own documented behaviour, unchanged.
+			if (!onError) return task(item, index);
 			try {
-				results[index] = await task(item, index);
+				return await task(item, index);
 			} catch (err) {
-				if (!onError) throw err;
-				results[index] = onError(item, err, index);
+				return onError(item, err, index);
 			}
-		}
-	}
-
-	await Promise.all(Array.from({ length: workerCount }, () => worker()));
-	return results;
+		},
+		limit,
+	);
 }

--- a/cli/src/core/CopilotChatSessionDiscoverer.test.ts
+++ b/cli/src/core/CopilotChatSessionDiscoverer.test.ts
@@ -256,6 +256,66 @@ describe("scanCopilotChatSessions", () => {
 		const result = await scanCopilotChatSessions(projectDir);
 		expect(result.sessions).toHaveLength(2);
 	});
+
+	// ─── Staleness window override (windowMs) ──────────────────────────────────
+	it("windowMs: an explicit wider window admits 72h-old sessions from BOTH scans", async () => {
+		// One session per scan, each 72h old — outside the 48h default, inside the
+		// 7-day window the dashboard back-fill passes.
+		makeSessionStateEntry({ sid: "old-a", folderPath: projectDir, ageHours: 72 });
+		const ws = makeWorkspace("ws1", nativePathToFileUri(projectDir));
+		makeChatSessionsFile(ws, "old-b.jsonl", 72);
+		const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+		const { scanCopilotChatSessions } = await import("./CopilotChatSessionDiscoverer.js");
+
+		// Default (omitted) window: both are stale, as QueueWorker requires.
+		expect((await scanCopilotChatSessions(projectDir)).sessions).toEqual([]);
+
+		// Widened: Scan A and Scan B each compute their OWN cutoff, so asserting the
+		// full pair is what catches a regression where only one of the two sites
+		// reads windowMs — a half-widened scan returns exactly one id and no error,
+		// which every other assertion here would happily accept.
+		const widened = await scanCopilotChatSessions(projectDir, sevenDaysMs);
+		expect(widened.error).toBeUndefined();
+		expect(widened.sessions.map((s) => s.sessionId).sort()).toEqual(["old-a", "old-b"]);
+	});
+
+	// ─── The machine-wide entry point ──────────────────────────────────────────
+	it("scans EVERY workspace when no repo directs it, unlike the repo-scoped call", async () => {
+		// The two entry points share one loop and differ only in whether Scan B is
+		// directed at one folder. This is the undirected half, which the multi-repo
+		// back-fill uses: a workspace this repo does not own still has to come back,
+		// because some OTHER registered repo may claim it.
+		const mine = makeWorkspace("ws-mine", nativePathToFileUri(projectDir));
+		const theirs = makeWorkspace("ws-theirs", nativePathToFileUri(join(tmpRoot, "someone-else")));
+		makeChatSessionsFile(mine, "s-mine.jsonl", 1);
+		makeChatSessionsFile(theirs, "s-theirs.jsonl", 1);
+
+		const { scanCopilotChatSessions, scanCopilotChatSessionsOnDisk } = await import(
+			"./CopilotChatSessionDiscoverer.js"
+		);
+		const everything = await scanCopilotChatSessionsOnDisk();
+		const directed = await scanCopilotChatSessions(projectDir);
+
+		// The machine-wide half yields `DiskSession`s — each carrying the workspace folder
+		// that decides ownership — while the repo-scoped one has already narrowed to
+		// `SessionInfo`. That shape difference IS the split.
+		expect(everything.sessions.map((s) => s.session.sessionId).sort()).toEqual(["s-mine", "s-theirs"]);
+		expect(directed.sessions.map((s) => s.sessionId)).toEqual(["s-mine"]);
+	});
+
+	it("forwards a widened window to the machine-wide scan", async () => {
+		// The back-fill's 7-day horizon has to reach both halves; on the 48 h default this
+		// session is stale and must not come back.
+		const ws = makeWorkspace("ws-old", nativePathToFileUri(projectDir));
+		makeChatSessionsFile(ws, "s-old.jsonl", 72);
+
+		const { scanCopilotChatSessionsOnDisk } = await import("./CopilotChatSessionDiscoverer.js");
+
+		expect((await scanCopilotChatSessionsOnDisk()).sessions).toEqual([]);
+		expect(
+			(await scanCopilotChatSessionsOnDisk(7 * 24 * 3600 * 1000)).sessions.map((s) => s.session.sessionId),
+		).toEqual(["s-old"]);
+	});
 });
 
 describe("scanCopilotChatSessions error precedence", () => {
@@ -313,7 +373,8 @@ describe("scanCopilotChatSessions error precedence", () => {
 		);
 		writeFileSync(join(sessionDir, "events.jsonl"), JSON.stringify({ type: "session.start", data: {} }));
 
-		// Build a workspaceStorage entry so findVscodeWorkspaceHash matches; mock readdir to fail on chatSessions.
+		// Build a workspaceStorage entry so Scan B's workspace listing finds it and
+		// attributes it to projectDir; mock readdir to fail on chatSessions.
 		const ws = join(tmpRoot, "Library", "Application Support", "Code", "User", "workspaceStorage", "ws-b-error");
 		mkdirSync(join(ws, "chatSessions"), { recursive: true });
 		writeFileSync(join(ws, "workspace.json"), JSON.stringify({ folder: nativePathToFileUri(projectDir) }));

--- a/cli/src/core/CopilotChatSessionDiscoverer.ts
+++ b/cli/src/core/CopilotChatSessionDiscoverer.ts
@@ -11,8 +11,9 @@
  *     <userDataDir>/User/workspaceStorage/<wsHash>/chatSessions/<sid>.jsonl
  *     wsHash resolved via VscodeWorkspaceLocator from projectDir
  *
- * Sessions older than 48h are excluded (matches every other discovery-based
- * source: OpenCode / Cursor / Copilot CLI). The deprecated .json snapshot
+ * Sessions older than 48h are excluded by default (matches every other
+ * discovery-based source: OpenCode / Cursor / Copilot CLI); a caller may widen
+ * that with the optional `windowMs` argument. The deprecated .json snapshot
  * format is explicitly NOT read — see spec for rationale.
  *
  * The standalone `copilot` source (CopilotSessionDiscoverer reading
@@ -25,10 +26,12 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { createLogger } from "../Logger.js";
 import type { SessionInfo } from "../Types.js";
+import { mapWithConcurrency, withIoBudget } from "../util/Concurrency.js";
 import type { CopilotChatScanError } from "./CopilotChatTranscriptReader.js";
+import { type DiskSession, sessionsForRepo } from "./DiskSessionScan.js";
 import {
-	findVscodeWorkspaceHash,
 	getVscodeWorkspaceStorageDir,
+	listVscodeWorkspaceFolders,
 	normalizePathForMatch,
 } from "./VscodeWorkspaceLocator.js";
 
@@ -48,11 +51,19 @@ interface VscodeMetadata {
 }
 
 /**
- * Scan A: ~/.copilot/session-state/<sid>/events.jsonl gated by folderPath.
- * Returns sessions and an optional error when readdir of the root fails for
- * non-ENOENT reasons.
+ * Scan A: ~/.copilot/session-state/<sid>/events.jsonl, carrying each session's
+ * recorded `workspaceFolder.folderPath`. Returns sessions and an optional error when
+ * readdir of the root fails for non-ENOENT reasons.
+ *
+ * Machine-wide, so this `stat`s the events file of sessions no repo will claim — the
+ * repo-scoped version checked the folder first. One `stat` per session, paid once for
+ * the run rather than once per repo.
+ *
+ * `windowMs` overrides the staleness window — see `scanCopilotChatSessions` for
+ * what may and may not widen it. Scan B has its own copy of this gate; both must
+ * honour the override or half the discovery silently stays at 48h.
  */
-async function scanSessionState(projectDir: string): Promise<CopilotChatScanResult> {
+async function scanSessionState(windowMs?: number): Promise<CopilotChatDiskScanResult> {
 	const root = join(homedir(), ".copilot", "session-state");
 	let entries: string[];
 	try {
@@ -64,117 +75,258 @@ async function scanSessionState(projectDir: string): Promise<CopilotChatScanResu
 		return { sessions: [], error: { kind: "fs", message: (error as Error).message } };
 	}
 
-	const cutoffMs = Date.now() - SESSION_STALE_MS;
-	const target = normalizePathForMatch(projectDir);
-	const sessions: SessionInfo[] = [];
+	const staleMs = windowMs ?? SESSION_STALE_MS;
+	const cutoffMs = Date.now() - staleMs;
 
-	for (const sid of entries) {
+	// One metadata read plus one `stat` per session, all independent — fanned out
+	// rather than looped, each unit taking a slot from the shared budget so this cannot
+	// widen the process-wide total on its own.
+	const scanned = await mapWithConcurrency(entries, async (sid): Promise<DiskSession | null> => {
 		const sessionDir = join(root, sid);
 		const metaPath = join(sessionDir, "vscode.metadata.json");
 		const eventsPath = join(sessionDir, "events.jsonl");
 
 		let meta: VscodeMetadata;
 		try {
-			meta = JSON.parse(await readFile(metaPath, "utf8")) as VscodeMetadata;
+			meta = JSON.parse(await withIoBudget(0, () => readFile(metaPath, "utf8"))) as VscodeMetadata;
 		} catch (error: unknown) {
 			log.debug("Skipping %s: vscode.metadata.json read/parse failed (%s)", sid, (error as Error).message);
-			continue;
+			return null;
 		}
 
+		// The folder is CARRIED, not matched. A session that records none can never be
+		// attributed, so it is still dropped here.
 		const folderPath = meta.workspaceFolder?.folderPath;
-		if (typeof folderPath !== "string" || folderPath.length === 0) continue;
-		if (normalizePathForMatch(folderPath) !== target) continue;
+		if (typeof folderPath !== "string" || folderPath.length === 0) return null;
 
 		let mtimeMs: number;
 		try {
-			mtimeMs = (await stat(eventsPath)).mtimeMs;
+			mtimeMs = (await withIoBudget(0, () => stat(eventsPath))).mtimeMs;
 		} catch (error: unknown) {
 			log.debug("Skipping %s: events.jsonl stat failed (%s)", sid, (error as Error).message);
-			continue;
+			return null;
 		}
-		if (mtimeMs < cutoffMs) continue;
+		if (mtimeMs < cutoffMs) return null;
 
-		sessions.push({
-			sessionId: sid,
-			transcriptPath: eventsPath,
-			updatedAt: new Date(mtimeMs).toISOString(),
-			source: "copilot-chat",
-		});
-	}
+		return {
+			session: {
+				sessionId: sid,
+				transcriptPath: eventsPath,
+				updatedAt: new Date(mtimeMs).toISOString(),
+				source: "copilot-chat",
+			},
+			dirs: [folderPath],
+		};
+	});
 
-	return { sessions };
+	return { sessions: scanned.filter((session): session is DiskSession => session !== null) };
 }
 
 /**
- * Scan B: <wsHash>/chatSessions/<sid>.jsonl. Skips .json snapshot files
- * (deprecated). Returns sessions and an optional error on non-ENOENT readdir
- * failure.
+ * Scan B: every workspace's `<wsHash>/chatSessions/<sid>.jsonl`, each session
+ * carrying the folder that workspace opens. Skips `.json` snapshot files
+ * (deprecated). Returns sessions and the first non-ENOENT readdir failure.
+ *
+ * This is the half that had to be INVERTED to become machine-wide. It used to
+ * resolve one `wsHash` from `projectDir` and read that single directory — an
+ * approach that can only ever answer for the repo you already hold, so serving N
+ * repos meant re-reading every `workspace.json` on the machine N times. Listing the
+ * workspaces once and carrying each one's folder gives every repo its answer from the
+ * same pass.
+ *
+ * ## `onlyFolder` is the repo-scoped callers' way back to their old cost
+ *
+ * Reading every workspace is right for the back-fill and pure loss for a caller that
+ * holds one repo — the 60 s sidebar tick, `jolli status`, the post-commit summary. Each
+ * of those used to resolve its own `wsHash` and `readdir` one `chatSessions/`; without
+ * this parameter they instead pay a `readdir` per workspace plus a `stat` per session
+ * file, machine-wide, on every tick.
+ *
+ * It is a FILTER on the same loop rather than a second code path, which is what keeps
+ * the two answers from drifting: `normalizePathForMatch` equality is the attribution
+ * rule either way, the same one {@link copilotChatSessionsForRepo} applies afterwards,
+ * so a directed scan returns exactly the subset the machine-wide one would have been
+ * narrowed to. Note it is deliberately NOT `findVscodeWorkspaceHash`, which stops at
+ * the FIRST match — a folder opened under two workspace entries (routine: VS Code mints
+ * a new one per window identity) would have lost the second one's sessions.
+ *
+ * Every `workspace.json` is still read even when directed; that is what the folder is
+ * matched against, and it is a tiny JSON file. What the filter removes is the
+ * `readdir` + per-file `stat` for workspaces this repo does not own.
+ *
+ * `windowMs` overrides the staleness window — the second of this file's two cutoff
+ * sites; see `scanSessionState` for the first.
  */
-async function scanChatSessions(projectDir: string): Promise<CopilotChatScanResult> {
-	const wsHash = await findVscodeWorkspaceHash("Code", projectDir);
-	if (wsHash === null) {
-		log.debug("No vscode workspace matched %s", projectDir);
-		return { sessions: [] };
-	}
-	const dir = join(getVscodeWorkspaceStorageDir("Code"), wsHash, "chatSessions");
+async function scanChatSessions(windowMs?: number, onlyFolder?: string): Promise<CopilotChatDiskScanResult> {
+	const workspaces = await listVscodeWorkspaceFolders("Code");
+	const storageDir = getVscodeWorkspaceStorageDir("Code");
+	const staleMs = windowMs ?? SESSION_STALE_MS;
+	const cutoffMs = Date.now() - staleMs;
+	const target = onlyFolder === undefined ? undefined : normalizePathForMatch(onlyFolder);
+	let error: CopilotChatScanError | undefined;
 
-	let entries: string[];
-	try {
-		entries = await readdir(dir);
-	} catch (error: unknown) {
-		const code = (error as NodeJS.ErrnoException).code;
-		if (code === "ENOENT") return { sessions: [] };
-		log.error("readdir %s failed (%s): %s", dir, code ?? "unknown", (error as Error).message);
-		return { sessions: [], error: { kind: "fs", message: (error as Error).message } };
-	}
+	// The workspace listing stays SEQUENTIAL: it is one `readdir` per workspace, and it
+	// is where `error` is decided — "the first failure" has to mean the first in
+	// workspace order, which a fan-out would make depend on scheduling instead.
+	const candidates: Array<{ readonly path: string; readonly sessionId: string; readonly folderPath: string }> = [];
+	for (const ws of workspaces) {
+		if (target !== undefined && normalizePathForMatch(ws.folderPath) !== target) continue;
+		const dir = join(storageDir, ws.hash, "chatSessions");
 
-	const cutoffMs = Date.now() - SESSION_STALE_MS;
-	const sessions: SessionInfo[] = [];
-
-	for (const entry of entries) {
-		if (!entry.endsWith(".jsonl")) continue; // skip .json snapshots and other suffixes
-		const path = join(dir, entry);
-		let mtimeMs: number;
+		let entries: string[];
 		try {
-			mtimeMs = (await stat(path)).mtimeMs;
-		} catch (error: unknown) {
-			log.debug("Skipping %s: stat failed (%s)", entry, (error as Error).message);
+			entries = await readdir(dir);
+		} catch (err: unknown) {
+			const code = (err as NodeJS.ErrnoException).code;
+			// A workspace with no chat sessions yet has no chatSessions/ — routine, and
+			// now the common case rather than the exception, since every workspace on the
+			// machine is visited instead of just the one that matched a repo.
+			if (code === "ENOENT") continue;
+			log.error("readdir %s failed (%s): %s", dir, code ?? "unknown", (err as Error).message);
+			// One unreadable workspace must not lose the others: record the first failure
+			// and keep scanning, the way the Cline flavour loop already does.
+			error = error ?? { kind: "fs", message: (err as Error).message };
 			continue;
 		}
-		if (mtimeMs < cutoffMs) continue;
-		const sessionId = entry.slice(0, -".jsonl".length);
-		sessions.push({
-			sessionId,
-			transcriptPath: path,
-			updatedAt: new Date(mtimeMs).toISOString(),
-			source: "copilot-chat",
-		});
+
+		for (const entry of entries) {
+			if (!entry.endsWith(".jsonl")) continue; // skip .json snapshots and other suffixes
+			candidates.push({
+				path: join(dir, entry),
+				sessionId: entry.slice(0, -".jsonl".length),
+				folderPath: ws.folderPath,
+			});
+		}
 	}
 
-	return { sessions };
+	// The per-session `stat`s ARE fanned out, and across every workspace at once rather
+	// than per workspace: session counts are lopsided, so a per-workspace fan-out would
+	// leave the busiest one running alone. Order is preserved, so the result is
+	// identical to what the nested loops produced.
+	const scanned = await mapWithConcurrency(
+		candidates,
+		async ({ path, sessionId, folderPath }): Promise<DiskSession | null> => {
+			let mtimeMs: number;
+			try {
+				mtimeMs = (await withIoBudget(0, () => stat(path))).mtimeMs;
+			} catch (err: unknown) {
+				log.debug("Skipping %s: stat failed (%s)", sessionId, (err as Error).message);
+				return null;
+			}
+			if (mtimeMs < cutoffMs) return null;
+			return {
+				session: {
+					sessionId,
+					transcriptPath: path,
+					updatedAt: new Date(mtimeMs).toISOString(),
+					source: "copilot-chat" as const,
+				},
+				dirs: [folderPath],
+			};
+		},
+	);
+	const sessions = scanned.filter((session): session is DiskSession => session !== null);
+
+	return error ? { sessions, error } : { sessions };
 }
 
 /**
  * Runs Scan A then Scan B; concatenates sessions; returns the first error
  * encountered (subsequent are debug-logged).
+ *
+ * @param windowMs Optional staleness window, in milliseconds. Defaults to
+ * `SESSION_STALE_MS` (48h), the window shared by every discovery-based source.
+ * The dashboard's history back-fill passes a wider one (7 days) so it can reach
+ * further into the past. Callers that must NOT widen simply omit it: the VS Code
+ * / IntelliJ "Active Conversations" sidebar, `jolli status`, and above all the
+ * post-commit summary generation in `hooks/QueueWorker.ts`, which uses this
+ * session set to decide which conversations belong to the commit being
+ * summarised. Widening it there folds week-old unrelated conversations into that
+ * commit's stored memory, which is written to the git orphan branch and is
+ * persistent — and it fails invisibly, with no error, just wrong content.
+ *
+ * Both scans receive it: a change that widens only one leaves half the discovery
+ * at 48h with nothing to signal it.
  */
-export async function scanCopilotChatSessions(projectDir: string): Promise<CopilotChatScanResult> {
-	const a = await scanSessionState(projectDir);
-	const b = await scanChatSessions(projectDir);
+export async function scanCopilotChatSessions(projectDir: string, windowMs?: number): Promise<CopilotChatScanResult> {
+	// Scan B is DIRECTED at this repo's own workspaces — see `scanChatSessions`'s
+	// `onlyFolder`. Scan A cannot be: its sessions live under `~/.copilot/session-state/`,
+	// keyed by session id, so every one has to be read before its recorded folder is
+	// known. That half was machine-wide before this change too, so nothing regressed
+	// there.
+	const { sessions, error } = await scanBothHalves(windowMs, projectDir);
+	const mine = copilotChatSessionsForRepo(sessions, projectDir);
+	if (mine.length > 0) {
+		log.debug("Discovered %d Copilot Chat session(s) for %s", mine.length, projectDir);
+	}
+	return { sessions: mine, error };
+}
+
+/** A machine-wide Copilot Chat scan: both halves' sessions, plus the first failure. */
+export interface CopilotChatDiskScanResult {
+	readonly sessions: ReadonlyArray<DiskSession>;
+	readonly error?: CopilotChatScanError;
+}
+
+/**
+ * Runs both scans and concatenates them, each session carrying the workspace folder it
+ * belongs to. Returns the first error encountered.
+ *
+ * `onlyFolder` directs Scan B at one repo's workspaces; omitting it scans the machine.
+ * Shared by the two entry points below so the merge, the error precedence and the
+ * "both failed" log line exist once.
+ */
+async function scanBothHalves(windowMs?: number, onlyFolder?: string): Promise<CopilotChatDiskScanResult> {
+	const a = await scanSessionState(windowMs);
+	const b = await scanChatSessions(windowMs, onlyFolder);
 	const sessions = [...a.sessions, ...b.sessions];
 	const error = a.error ?? b.error;
 	if (a.error && b.error) {
 		log.debug("Both scans errored; reporting Scan A's, dropped Scan B's: %s", b.error.message);
 	}
-	if (sessions.length > 0) {
-		log.debug("Discovered %d Copilot Chat session(s) for %s", sessions.length, projectDir);
-	}
-	return { sessions, error };
+	return error ? { sessions, error } : { sessions };
 }
 
-/** Convenience wrapper used by QueueWorker — strips the error channel. */
-export async function discoverCopilotChatSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>> {
-	const { sessions, error } = await scanCopilotChatSessions(projectDir);
+/**
+ * Runs both scans machine-wide and concatenates them, each session carrying the
+ * workspace folder it belongs to. Returns the first error encountered.
+ *
+ * MACHINE-WIDE and repo-agnostic on purpose — see {@link scanChatSessions} for why
+ * the second half had to be inverted to get here. Callers scan once and narrow with
+ * {@link copilotChatSessionsForRepo}.
+ */
+export async function scanCopilotChatSessionsOnDisk(windowMs?: number): Promise<CopilotChatDiskScanResult> {
+	return scanBothHalves(windowMs);
+}
+
+/**
+ * Narrows a machine-wide Copilot Chat scan to one repo.
+ *
+ * Attribution is exact equality under `normalizePathForMatch` — the VS Code family's
+ * own normalisation, and the same comparison both halves used before: Scan A against
+ * the session's recorded `folderPath`, Scan B against the folder its workspace opens
+ * (which `findVscodeWorkspaceHash` used to compare with the identical call).
+ */
+export function copilotChatSessionsForRepo(
+	scanned: ReadonlyArray<DiskSession>,
+	projectDir: string,
+): ReadonlyArray<SessionInfo> {
+	const target = normalizePathForMatch(projectDir);
+	return sessionsForRepo(scanned, (dir) => normalizePathForMatch(dir) === target);
+}
+
+/**
+ * Convenience wrapper used by QueueWorker — strips the error channel.
+ *
+ * `windowMs` is forwarded verbatim. QueueWorker itself must keep omitting it —
+ * see `scanCopilotChatSessions` for why widening the post-commit window corrupts
+ * stored memory.
+ */
+export async function discoverCopilotChatSessions(
+	projectDir: string,
+	windowMs?: number,
+): Promise<ReadonlyArray<SessionInfo>> {
+	const { sessions, error } = await scanCopilotChatSessions(projectDir, windowMs);
 	if (error) {
 		log.warn("Copilot Chat scan error (%s) — sessions excluded from this run: %s", error.kind, error.message);
 	}

--- a/cli/src/core/CopilotSessionDiscoverer.test.ts
+++ b/cli/src/core/CopilotSessionDiscoverer.test.ts
@@ -179,6 +179,22 @@ describe("scanCopilotSessions", () => {
 		expect(sessions.map((s) => s.sessionId)).toEqual(["fresh"]);
 	});
 
+	// The dashboard's history back-fill passes a wider window than the 48h default.
+	// Same fixture, two calls: the default rejects the row, the explicit window admits
+	// it — which is the whole point of the parameter being opt-in.
+	it("admits a session outside the 48h window when an explicit wider window is passed", async () => {
+		const SEVENTY_TWO_HOURS_MS = 72 * 60 * 60 * 1000;
+		const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+		await withFixture([{ id: "old", cwd: platformPath("/p"), updated_at: isoFromNow(SEVENTY_TWO_HOURS_MS) }]);
+		const { scanCopilotSessions } = await import("./CopilotSessionDiscoverer.js");
+
+		const withDefaultWindow = await scanCopilotSessions(platformPath("/p"));
+		expect(withDefaultWindow.sessions).toEqual([]);
+
+		const withWiderWindow = await scanCopilotSessions(platformPath("/p"), SEVEN_DAYS_MS);
+		expect(withWiderWindow.sessions.map((s) => s.sessionId)).toEqual(["old"]);
+	});
+
 	it("returns empty silently when the DB file is missing", async () => {
 		const detector = await import("./CopilotDetector.js");
 		vi.spyOn(detector, "getCopilotDbPath").mockReturnValue(join(tmpdir(), "copilot-disc-missing", "x.db"));

--- a/cli/src/core/CopilotSessionDiscoverer.ts
+++ b/cli/src/core/CopilotSessionDiscoverer.ts
@@ -15,6 +15,7 @@ import { resolve } from "node:path";
 import { createLogger } from "../Logger.js";
 import type { SessionInfo } from "../Types.js";
 import { getCopilotDbPath } from "./CopilotDetector.js";
+import { type DiskSession, sessionsForRepo } from "./DiskSessionScan.js";
 import { sessionDirBelongsToRepo } from "./SessionDirMatch.js";
 import { classifyScanError, type SqliteScanError, withSqliteDb } from "./SqliteHelpers.js";
 
@@ -32,10 +33,46 @@ function normalizeCwd(p: string): string {
 	return resolve(p);
 }
 
-export async function scanCopilotSessions(projectDir: string): Promise<CopilotScanResult> {
+/**
+ * Discovers Copilot CLI sessions belonging to the given project directory.
+ *
+ * @param projectDir - The git repository root to filter sessions by
+ * @param windowMs - Optional staleness window in milliseconds. Defaults to
+ *   {@link SESSION_STALE_MS} (48 h). The dashboard's history back-fill passes a wider
+ *   window (7 d) to recover conversations the database never recorded. Callers that
+ *   must NOT widen it omit the argument entirely: the "Active Conversations" sidebar,
+ *   `jolli status`, and — the one that matters — the post-commit summary in
+ *   `QueueWorker`, which uses this window to decide which conversations belong to the
+ *   commit being summarised. That summary is written to the git orphan branch and
+ *   kept, so a wider window there quietly attaches week-old unrelated conversations
+ *   to a commit's stored memory with no error anywhere.
+ */
+export async function scanCopilotSessions(projectDir: string, windowMs?: number): Promise<CopilotScanResult> {
+	const { sessions, error } = await scanCopilotSessionsOnDisk(windowMs);
+	const mine = copilotSessionsForRepo(sessions, projectDir);
+	return error ? { sessions: mine, error } : { sessions: mine };
+}
+
+/** A machine-wide Copilot CLI scan: every in-window session, plus a genuine failure. */
+export interface CopilotDiskScanResult {
+	readonly sessions: ReadonlyArray<DiskSession>;
+	readonly error?: SqliteScanError;
+}
+
+/**
+ * Scans Copilot CLI's global session store once and returns every session inside the
+ * window, each carrying the `cwd` its row recorded.
+ *
+ * MACHINE-WIDE and repo-agnostic on purpose. `~/.copilot/session-store.db` is ONE
+ * database for every project, and its `updated_at` is TEXT with no usable SQL cutoff
+ * — so the query is already a full-table scan. Running that once per registered repo
+ * re-reads and re-parses every session row N times over. Callers scan once and narrow
+ * with {@link copilotSessionsForRepo}.
+ */
+export async function scanCopilotSessionsOnDisk(windowMs?: number): Promise<CopilotDiskScanResult> {
 	const dbPath = getCopilotDbPath();
-	const normalized = normalizeCwd(projectDir);
-	const cutoffMs = Date.now() - SESSION_STALE_MS;
+	const staleMs = windowMs ?? SESSION_STALE_MS;
+	const cutoffMs = Date.now() - staleMs;
 
 	try {
 		await stat(dbPath);
@@ -57,13 +94,13 @@ export async function scanCopilotSessions(projectDir: string): Promise<CopilotSc
 
 	try {
 		const sessions = await withSqliteDb(dbPath, (db) => {
-			// The directory match runs in JS via `sessionDirBelongsToRepo` (shared with
-			// Devin/OpenCode): prefix/containment with separator + case folding plus the
-			// nested-repo exclusion. It replaced the SQL `cwd = :cwd` (and its win32/darwin
-			// LOWER() variant), which silently dropped every session run from a
-			// subdirectory of the repo (JOLLI-2015). updated_at is TEXT with no clean SQL
-			// cutoff, so the staleness filter is already JS-side below — the directory
-			// filter joins it there.
+			// The cwd is CARRIED, not matched — `copilotSessionsForRepo` does that through
+			// `sessionDirBelongsToRepo` (shared with Devin/OpenCode): prefix/containment
+			// with separator + case folding plus the nested-repo exclusion. That replaced
+			// the SQL `cwd = :cwd` (and its win32/darwin LOWER() variant), which silently
+			// dropped every session run from a subdirectory of the repo (JOLLI-2015).
+			// updated_at is TEXT with no clean SQL cutoff, so the staleness filter stays
+			// JS-side below; it is repo-independent, so it belongs in this scan.
 			const rows = db
 				.prepare(
 					// No ORDER BY: every row passing the directory + staleness filters below is
@@ -73,10 +110,7 @@ export async function scanCopilotSessions(projectDir: string): Promise<CopilotSc
 					 FROM sessions`,
 				)
 				.all() as ReadonlyArray<{ id: string; cwd: string; updated_at: string; summary: unknown }>;
-			return rows.flatMap((row): SessionInfo[] => {
-				if (!sessionDirBelongsToRepo(row.cwd, normalized)) {
-					return [];
-				}
+			return rows.flatMap((row): DiskSession[] => {
 				const ms = Date.parse(row.updated_at);
 				if (!Number.isFinite(ms)) {
 					log.warn("Skipping Copilot session %s: non-finite updated_at", row.id);
@@ -89,17 +123,22 @@ export async function scanCopilotSessions(projectDir: string): Promise<CopilotSc
 				if (ms < cutoffMs) return [];
 				return [
 					{
-						sessionId: String(row.id),
-						transcriptPath: `${dbPath}#${row.id}`,
-						updatedAt: new Date(ms).toISOString(),
-						source: "copilot",
-						title:
-							typeof row.summary === "string" && row.summary.trim().length > 0 ? row.summary : undefined,
+						session: {
+							sessionId: String(row.id),
+							transcriptPath: `${dbPath}#${row.id}`,
+							updatedAt: new Date(ms).toISOString(),
+							source: "copilot",
+							title:
+								typeof row.summary === "string" && row.summary.trim().length > 0
+									? row.summary
+									: undefined,
+						},
+						dirs: [row.cwd],
 					},
 				];
 			});
 		});
-		log.debug("Discovered %d Copilot session(s) for %s", sessions.length, normalized);
+		log.debug("Copilot disk scan: %d session(s) inside the window", sessions.length);
 		return { sessions };
 	} catch (error: unknown) {
 		const scanError = classifyScanError(error);
@@ -114,9 +153,34 @@ export async function scanCopilotSessions(projectDir: string): Promise<CopilotSc
 	}
 }
 
-/** Convenience wrapper without the error channel — used by QueueWorker. */
-export async function discoverCopilotSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>> {
-	const { sessions, error } = await scanCopilotSessions(projectDir);
+/**
+ * Narrows a machine-wide Copilot CLI scan to one repo.
+ *
+ * Attribution is `sessionDirBelongsToRepo` against the RESOLVED project dir — the
+ * `normalizeCwd` call is kept on this side because that is exactly where it ran
+ * before, on the project argument only and never on the row's own cwd.
+ */
+export function copilotSessionsForRepo(
+	scanned: ReadonlyArray<DiskSession>,
+	projectDir: string,
+): ReadonlyArray<SessionInfo> {
+	const normalized = normalizeCwd(projectDir);
+	const mine = sessionsForRepo(scanned, (dir) => sessionDirBelongsToRepo(dir, normalized));
+	log.debug("Discovered %d Copilot session(s) for %s", mine.length, normalized);
+	return mine;
+}
+
+/**
+ * Convenience wrapper without the error channel — used by QueueWorker.
+ *
+ * @param windowMs - Forwarded to {@link scanCopilotSessions}; see that function for why
+ *   the post-commit caller leaves it unset.
+ */
+export async function discoverCopilotSessions(
+	projectDir: string,
+	windowMs?: number,
+): Promise<ReadonlyArray<SessionInfo>> {
+	const { sessions, error } = await scanCopilotSessions(projectDir, windowMs);
 	if (error) {
 		log.warn("Copilot scan error (%s) — sessions excluded from this run: %s", error.kind, error.message);
 	}

--- a/cli/src/core/CursorCliSessionDiscoverer.test.ts
+++ b/cli/src/core/CursorCliSessionDiscoverer.test.ts
@@ -56,6 +56,30 @@ describe("scanCursorCliSessions", () => {
 		expect(r).toEqual({ sessions: [] });
 	});
 
+	it("drops a chat whose meta.json records no cwd", async () => {
+		// The cwd is what the narrowing matches on, so a chat without one can never be
+		// attributed to any repo. It is dropped at scan time rather than carried with an
+		// empty directory list, which keeps the scan's own count honest.
+		//
+		// Only the surviving chat gets a transcript, and that is deliberate rather than
+		// lazy: the cwd test runs BEFORE the transcript lookup, so `uNo` is dropped for
+		// the reason this case is about, while a chat with no JSONL would be dropped
+		// later for an unrelated one — which would make the case pass without ever
+		// reaching the branch it names.
+		await writeChat(chatsDir, "hNo", "uNo", { updatedAtMs: now, title: "no cwd" });
+		await writeChat(chatsDir, "hOk", "uOk", { cwd: project, updatedAtMs: now });
+		await writeTranscript(
+			projectsDir,
+			"Users-x-proj-a",
+			"uOk",
+			'{"role":"user","message":{"content":[{"type":"text","text":"hi"}]}}\n',
+		);
+
+		const r = await scanCursorCliSessions(project, chatsDir, projectsDir);
+
+		expect(r.sessions.map((s) => s.sessionId)).toEqual(["uOk"]);
+	});
+
 	it("attributes by meta.cwd, sets source/title/updatedAt, resolves JSONL by uuid", async () => {
 		await writeChat(chatsDir, "h1", "u1", { cwd: project, updatedAtMs: now, title: "Hello There" });
 		const jsonl1 = '{"role":"user","message":{"content":[{"type":"text","text":"hi"}]}}\n';
@@ -111,6 +135,20 @@ describe("scanCursorCliSessions", () => {
 		await writeTranscript(projectsDir, "e", "u3", "{}\n");
 		const r = await scanCursorCliSessions(project, chatsDir, projectsDir);
 		expect(r.sessions).toHaveLength(0);
+	});
+
+	it("admits a session older than 48h when an explicit wider window is passed", async () => {
+		// 72h ago — outside the 48h default, inside the 7-day window the dashboard
+		// back-fill passes.
+		await writeChat(chatsDir, "hw", "uw", { cwd: project, updatedAtMs: now - 72 * 60 * 60 * 1000 });
+		await writeTranscript(projectsDir, "Users-x-proj-a", "uw", "{}\n");
+
+		// Omitted window: stale, as QueueWorker requires.
+		const dflt = await scanCursorCliSessions(project, chatsDir, projectsDir);
+		expect(dflt.sessions).toHaveLength(0);
+
+		const widened = await scanCursorCliSessions(project, chatsDir, projectsDir, 7 * 24 * 60 * 60 * 1000);
+		expect(widened.sessions.map((s) => s.sessionId)).toEqual(["uw"]);
 	});
 
 	it("falls back to createdAtMs when updatedAtMs missing; skips non-finite timestamp", async () => {

--- a/cli/src/core/CursorCliSessionDiscoverer.ts
+++ b/cli/src/core/CursorCliSessionDiscoverer.ts
@@ -22,6 +22,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { createLogger } from "../Logger.js";
 import type { SessionInfo } from "../Types.js";
+import { type DiskSession, sessionsForRepo } from "./DiskSessionScan.js";
 import { normalizePathForCompare } from "./PathUtils.js";
 
 const log = createLogger("CursorCliDiscoverer");
@@ -100,11 +101,65 @@ async function resolveTranscriptPath(
 	return undefined;
 }
 
+/**
+ * Scans ~/.cursor/chats for cursor-agent sessions attributed to `projectDir`.
+ *
+ * @param windowMs Optional staleness window, in milliseconds. Defaults to
+ * `SESSION_STALE_MS` (48h), the window shared by every discovery-based source.
+ * The dashboard's history back-fill passes a wider one (7 days) so it can reach
+ * further into the past. Callers that must NOT widen simply omit it: the VS Code
+ * / IntelliJ "Active Conversations" sidebar, `jolli status`, and above all the
+ * post-commit summary generation in `hooks/QueueWorker.ts`, which uses this
+ * session set to decide which conversations belong to the commit being
+ * summarised. Widening it there folds week-old unrelated conversations into that
+ * commit's stored memory, which is written to the git orphan branch and is
+ * persistent — and it fails invisibly, with no error, just wrong content.
+ */
 export async function scanCursorCliSessions(
 	projectDir: string,
 	chatsDir: string = getCursorCliChatsDir(),
 	projectsDir: string = getCursorCliProjectsDir(),
+	windowMs?: number,
 ): Promise<CursorCliScanResult> {
+	const { sessions, error } = await scanCursorCliSessionsOnDisk(chatsDir, projectsDir, windowMs);
+	const mine = cursorCliSessionsForRepo(sessions, projectDir);
+	return error ? { sessions: mine, error } : { sessions: mine };
+}
+
+/** A machine-wide cursor-agent scan: every in-window session, plus a genuine failure. */
+export interface CursorCliDiskScanResult {
+	readonly sessions: ReadonlyArray<DiskSession>;
+	readonly error?: CursorCliScanError;
+}
+
+/**
+ * Scans `~/.cursor/chats` once and returns every in-window cursor-agent session, each
+ * carrying the `cwd` its `meta.json` recorded.
+ *
+ * MACHINE-WIDE and repo-agnostic on purpose. The `chats/<md5(cwd)>/` buckets cannot
+ * be derived from a repo path (the hash input is not part of cursor-agent's
+ * contract), so every bucket has to be opened and every `meta.json` parsed — once per
+ * registered repo, under the old repo-scoped shape. Callers scan once and narrow with
+ * {@link cursorCliSessionsForRepo}.
+ *
+ * ## One cost moved rather than removed
+ *
+ * The repo-scoped version resolved a session's transcript path only AFTER the cwd
+ * matched, so a machine-wide scan does that lookup for sessions no repo will claim.
+ * It is bounded — `resolveTranscriptPath` tries the remembered bucket first, and
+ * every session under one `chats/<hash>` shares a cwd and therefore a bucket, so the
+ * lookup stays O(1) after the first hit in each bucket — and it is paid ONCE for the
+ * run instead of once per repo. With two or more registered repos this is strictly
+ * cheaper; with exactly one it does more `stat` calls than before. That trade is
+ * deliberate: the back-fill is the multi-repo caller, and the single-repo path
+ * (`discoverCursorCliSessions`, the post-commit hook) still goes through the wrapper
+ * above, which scans and narrows in one call just as it always did.
+ */
+export async function scanCursorCliSessionsOnDisk(
+	chatsDir: string = getCursorCliChatsDir(),
+	projectsDir: string = getCursorCliProjectsDir(),
+	windowMs?: number,
+): Promise<CursorCliDiskScanResult> {
 	let hashes: string[];
 	try {
 		hashes = await readdir(chatsDir);
@@ -114,9 +169,9 @@ export async function scanCursorCliSessions(
 		return { sessions: [], error: { kind: "fs", message: (error as Error).message } };
 	}
 
-	const cutoffMs = Date.now() - SESSION_STALE_MS;
-	const target = normalizePathForCompare(projectDir);
-	const sessions: SessionInfo[] = [];
+	const staleMs = windowMs ?? SESSION_STALE_MS;
+	const cutoffMs = Date.now() - staleMs;
+	const sessions: DiskSession[] = [];
 
 	// Read the projects/ listing once — resolveTranscriptPath reuses it for every
 	// matching session. A MISSING projects/ dir (ENOENT) is benign: chats can exist
@@ -137,8 +192,9 @@ export async function scanCursorCliSessions(
 		}
 		projectBuckets = [];
 	}
-	// The target repo's sessions all share one bucket; remember it once resolved and
-	// try it first for the rest (see resolveTranscriptPath).
+	// Every session under one chats/<hash> shares a cwd and therefore one projects/
+	// bucket, so remembering the last resolved bucket keeps the lookup O(1) within a
+	// hash. Carried across hashes too — a miss just falls through to the full sweep.
 	let preferredBucket: string | undefined;
 
 	for (const hash of hashes) {
@@ -156,7 +212,9 @@ export async function scanCursorCliSessions(
 				log.debug("Skipping %s: meta.json read/parse failed (%s)", uuid, (error as Error).message);
 				continue;
 			}
-			if (typeof meta.cwd !== "string" || normalizePathForCompare(meta.cwd) !== target) continue;
+			// The cwd is CARRIED, not matched — `cursorCliSessionsForRepo` does that. A
+			// session without one can never be attributed, so it is still dropped here.
+			if (typeof meta.cwd !== "string") continue;
 			const updatedAtMs = meta.updatedAtMs ?? meta.createdAtMs;
 			if (typeof updatedAtMs !== "number" || !Number.isFinite(updatedAtMs)) {
 				log.warn("Skipping Cursor CLI session %s: non-finite updatedAtMs", uuid);
@@ -171,20 +229,51 @@ export async function scanCursorCliSessions(
 			preferredBucket = resolved.bucket;
 			const title = meta.title?.trim();
 			sessions.push({
-				sessionId: uuid,
-				transcriptPath: resolved.path,
-				updatedAt: new Date(updatedAtMs).toISOString(),
-				source: "cursor-cli",
-				...(title ? { title } : {}),
+				session: {
+					sessionId: uuid,
+					transcriptPath: resolved.path,
+					updatedAt: new Date(updatedAtMs).toISOString(),
+					source: "cursor-cli",
+					...(title ? { title } : {}),
+				},
+				dirs: [meta.cwd],
 			});
 		}
 	}
 	return { sessions };
 }
 
-/** QueueWorker wrapper — strips the error channel. */
-export async function discoverCursorCliSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>> {
-	const { sessions, error } = await scanCursorCliSessions(projectDir);
+/**
+ * Narrows a machine-wide cursor-agent scan to one repo.
+ *
+ * Attribution is EXACT equality on `meta.cwd`, verbatim from when it ran inside the
+ * scan — mirroring Devin/OpenCode/Cline CLI's spelling but NOT the prefix/containment
+ * rule: a session started from a repo *subdirectory* is not attributed to the root.
+ * That is the known, intentional hookless limitation — see the "subdirectory"
+ * contract test.
+ */
+export function cursorCliSessionsForRepo(
+	scanned: ReadonlyArray<DiskSession>,
+	projectDir: string,
+): ReadonlyArray<SessionInfo> {
+	const target = normalizePathForCompare(projectDir);
+	return sessionsForRepo(scanned, (dir) => normalizePathForCompare(dir) === target);
+}
+
+/**
+ * QueueWorker wrapper — strips the error channel.
+ *
+ * `windowMs` is forwarded verbatim. QueueWorker itself must keep omitting it —
+ * see `scanCursorCliSessions` for why widening the post-commit window corrupts
+ * stored memory.
+ */
+export async function discoverCursorCliSessions(
+	projectDir: string,
+	windowMs?: number,
+): Promise<ReadonlyArray<SessionInfo>> {
+	// The two `undefined`s keep the ~/.cursor chats/projects defaults; only the
+	// trailing staleness window is being overridden here.
+	const { sessions, error } = await scanCursorCliSessions(projectDir, undefined, undefined, windowMs);
 	if (error) log.warn("Cursor CLI scan error (%s): %s", error.kind, error.message);
 	return sessions;
 }

--- a/cli/src/core/CursorSessionDiscoverer.test.ts
+++ b/cli/src/core/CursorSessionDiscoverer.test.ts
@@ -36,7 +36,13 @@ vi.mock("node:os", async (importOriginal) => {
 });
 
 import { symlinksSupported } from "../testUtils/symlinkSupport.js";
-import { discoverCursorSessions, scanCursorSessions } from "./CursorSessionDiscoverer.js";
+import {
+	type CursorDiskComposer,
+	cursorSessionsForRepo,
+	discoverCursorSessions,
+	scanCursorComposersOnDisk,
+	scanCursorSessions,
+} from "./CursorSessionDiscoverer.js";
 
 // The non-ENOENT-stat case is driven by a self-referential symlink (ELOOP).
 // symlink() throws EPERM on a non-elevated Windows account, so skip it there.
@@ -205,6 +211,24 @@ describe("discoverCursorSessions", () => {
 
 		const sessions = await discoverCursorSessions(toNativePath("/Users/flyer/work/proj-a"));
 		expect(sessions).toEqual([]);
+	});
+
+	// The dashboard's history back-fill passes a wider window than the 48h default.
+	// `pointers: null` keeps the composer out of the anchor set, so the window is the
+	// only thing that can admit it: the default call rejects it, the explicit one keeps it.
+	it("admits a composer outside the 48h window when an explicit wider window is passed", async () => {
+		const stale = Date.now() - 72 * 60 * 60 * 1000;
+		await setupCursorHome(tmpHome, {
+			globalComposers: [{ composerId: "stale-1", createdAtMs: stale, lastUpdatedAtMs: stale }],
+			workspaces: [{ folder: toFileUri("/Users/flyer/work/proj-a"), pointers: null }],
+		});
+		const projectDir = toNativePath("/Users/flyer/work/proj-a");
+
+		const withDefaultWindow = await scanCursorSessions(projectDir);
+		expect(withDefaultWindow.sessions).toEqual([]);
+
+		const withWiderWindow = await scanCursorSessions(projectDir, 7 * 24 * 60 * 60 * 1000);
+		expect(withWiderWindow.sessions.map((s) => s.sessionId)).toEqual(["stale-1"]);
 	});
 
 	it("skips composerData rows with malformed JSON without crashing", async () => {
@@ -781,5 +805,75 @@ describe("discoverCursorSessions", () => {
 		expect(result.sessions).toEqual([]);
 		expect(result.error).toBeDefined();
 		expect(["corrupt", "permission", "unknown"]).toContain(result.error?.kind);
+	});
+});
+
+/**
+ * The scan/narrow split the multi-repo back-fill uses: one machine-wide scan, narrowed
+ * per repo. Exercised directly because that is the only caller — `scanCursorSessions`
+ * settles the workspace lookup itself, precisely so a repo Cursor has no workspace for
+ * never pays for the scan.
+ */
+describe("cursorSessionsForRepo", () => {
+	let tmpHome: string;
+
+	beforeEach(async () => {
+		tmpHome = await mkdtemp(join(tmpdir(), "cursor-narrow-"));
+		mockHomedir.mockReturnValue(tmpHome);
+		mockPlatform.mockReturnValue("darwin");
+	});
+
+	afterEach(async () => {
+		await rm(tmpHome, { recursive: true, force: true });
+	});
+
+	it("claims nothing for a repo Cursor has no workspace for", async () => {
+		// The composer is inside the window, so only the missing workspace can exclude it.
+		// This is the coarse-attribution rule's one limit: with no workspace, a repo is not
+		// a Cursor project at all and claims none of the store.
+		await setupCursorHome(tmpHome, {
+			globalComposers: [{ composerId: "fresh-1", createdAtMs: Date.now(), lastUpdatedAtMs: Date.now() }],
+			workspaces: [{ folder: toFileUri("/Users/flyer/work/proj-a"), pointers: null }],
+		});
+		const { composers } = await scanCursorComposersOnDisk();
+		expect(composers.map((c) => c.session.sessionId)).toEqual(["fresh-1"]);
+
+		const mine = await cursorSessionsForRepo(composers, toNativePath("/Users/flyer/work/proj-b"));
+		expect(mine).toEqual([]);
+	});
+
+	it("narrows one machine-wide scan to the repo whose workspace anchors it", async () => {
+		// Anchored well outside the window, so only the anchor can admit it — the property
+		// that stops the scan from pre-filtering by time.
+		const ancient = Date.now() - 365 * 24 * 60 * 60 * 1000;
+		await setupCursorHome(tmpHome, {
+			globalComposers: [{ composerId: "anchor-1", createdAtMs: ancient, lastUpdatedAtMs: ancient }],
+			workspaces: [
+				{
+					folder: toFileUri("/Users/flyer/work/proj-a"),
+					pointers: { lastFocusedComposerIds: ["anchor-1"] },
+				},
+			],
+		});
+		const { composers } = await scanCursorComposersOnDisk();
+
+		const mine = await cursorSessionsForRepo(composers, toNativePath("/Users/flyer/work/proj-a"));
+		expect(mine.map((s) => s.sessionId)).toEqual(["anchor-1"]);
+	});
+
+	it("applies the caller's window rather than the 48h default", async () => {
+		// The back-fill's 7-day window is passed per repo, at narrow time, because the scan
+		// cannot apply it without dropping anchored composers.
+		const stale = Date.now() - 72 * 60 * 60 * 1000;
+		await setupCursorHome(tmpHome, {
+			globalComposers: [{ composerId: "stale-1", createdAtMs: stale, lastUpdatedAtMs: stale }],
+			workspaces: [{ folder: toFileUri("/Users/flyer/work/proj-a"), pointers: null }],
+		});
+		const { composers }: { composers: ReadonlyArray<CursorDiskComposer> } = await scanCursorComposersOnDisk();
+		const projectDir = toNativePath("/Users/flyer/work/proj-a");
+
+		expect(await cursorSessionsForRepo(composers, projectDir)).toEqual([]);
+		const wider = await cursorSessionsForRepo(composers, projectDir, 7 * 24 * 60 * 60 * 1000);
+		expect(wider.map((s) => s.sessionId)).toEqual(["stale-1"]);
 	});
 });

--- a/cli/src/core/CursorSessionDiscoverer.ts
+++ b/cli/src/core/CursorSessionDiscoverer.ts
@@ -62,19 +62,105 @@ export interface CursorScanResult {
  * composers updated within the last 48 h (time window), deduped.
  *
  * @param projectDir - The git repository root to filter sessions by
+ * @param windowMs - Optional staleness window in milliseconds. Defaults to
+ *   {@link SESSION_STALE_MS} (48 h). The dashboard's history back-fill passes a wider
+ *   window (7 d) to recover conversations the database never recorded. Callers that
+ *   must NOT widen it omit the argument entirely: the "Active Conversations" sidebar,
+ *   `jolli status`, and — the one that matters — the post-commit summary in
+ *   `QueueWorker`, which uses this window to decide which conversations belong to the
+ *   commit being summarised. That summary is written to the git orphan branch and
+ *   kept, so a wider window there quietly attaches week-old unrelated conversations
+ *   to a commit's stored memory with no error anywhere. Workspace anchors are
+ *   unaffected — they bypass the window by design.
  * @returns { sessions, error? } — sessions is always an array; if `error` is
  *   present, callers should surface it to the user rather than silently reporting
  *   "0 sessions" (which is indistinguishable from a genuinely-empty scan).
  */
-export async function scanCursorSessions(projectDir: string): Promise<CursorScanResult> {
-	const globalDbPath = getCursorGlobalDbPath();
-
-	// Step 1: Workspace lookup — find which workspace hash corresponds to projectDir.
+export async function scanCursorSessions(projectDir: string, windowMs?: number): Promise<CursorScanResult> {
+	// Step 1 runs BEFORE the disk scan, and that order is this caller's whole cost
+	// model. A repo Cursor has no workspace for claims nothing at all (see
+	// {@link cursorSessionsForRepo}), and settling that costs a few `workspace.json`
+	// reads — while the scan below is `LIKE 'composerData:%'` plus a `JSON.parse` of
+	// every matching blob, i.e. a full pass over the user's entire Cursor history.
+	// Scanning first and narrowing afterwards would put that full pass on the 60 s
+	// sidebar tick, on every post-commit and on every `jolli status` of a repo Cursor
+	// was never opened in, where the answer is provably empty before any blob is read.
+	//
+	// The multi-repo back-fill hoists the scan on purpose (see
+	// {@link scanCursorComposersOnDisk}) — that caller pays the full pass once for N
+	// repos, which is the opposite trade. This one has exactly one repo to answer for.
 	const wsHash = await findCursorWorkspaceHash(projectDir);
 	if (wsHash === null) {
 		log.debug("No Cursor workspace found matching %s", projectDir);
 		return { sessions: [] };
 	}
+	const { composers, error } = await scanCursorComposersOnDisk();
+	const mine = await narrowToCursorWorkspace(composers, projectDir, wsHash, windowMs);
+	return error ? { sessions: mine, error } : { sessions: mine };
+}
+
+/** One Cursor composer from the global store, with the timestamp the window judges. */
+export interface CursorDiskComposer {
+	readonly session: SessionInfo;
+	/** `lastUpdatedAt` in epoch ms — already validated finite by the scan. */
+	readonly lastUpdatedAt: number;
+}
+
+/** A machine-wide Cursor composer scan: every composer in the global store. */
+export interface CursorDiskScanResult {
+	readonly composers: ReadonlyArray<CursorDiskComposer>;
+	readonly error?: SqliteScanError;
+}
+
+/**
+ * Reads every composer out of Cursor's GLOBAL store, once.
+ *
+ * MACHINE-WIDE and repo-agnostic on purpose — and this is the source where that
+ * split is least obvious, so it is worth stating what does and does not move here.
+ *
+ * There is no "this composer belongs to this workspace" pointer in the global store
+ * (see this file's header), so a composer carries no directory and this scan cannot
+ * narrow anything. What it CAN do is stop repeating the expensive half: the query is
+ * `LIKE 'composerData:%'` over `cursorDiskKV` followed by a `JSON.parse` of every
+ * matching blob — a full scan of the user's entire Cursor history, which the
+ * repo-scoped shape ran once per registered repo.
+ *
+ * The cheap, genuinely per-repo half stays in {@link cursorSessionsForRepo}: the
+ * workspace-hash lookup and the single-row anchor read. That is the right cut. The
+ * anchor read is one `SELECT … LIMIT 1` against a per-workspace database, so hoisting
+ * it would mean opening EVERY workspace's `state.vscdb` on the machine — more work
+ * than it saves as soon as a user has more Cursor workspaces than registered repos,
+ * which is the normal case.
+ *
+ * The staleness window is deliberately NOT applied here either: anchors bypass it by
+ * design, so a composer outside the window can still be claimed by the workspace that
+ * points at it. Filtering here would silently drop those.
+ *
+ * ## KNOWN, DEFERRED: this returns the user's ENTIRE Cursor history
+ *
+ * Not a defect to report again. The repo-scoped shape this replaced ran the same query
+ * and the same `JSON.parse` per blob, but decided anchor-or-window INSIDE the loop, so
+ * it only ever kept the composers one repo could claim. This keeps every composer in
+ * the global store, because the decision moved to {@link cursorSessionsForRepo} — and
+ * for a multi-repo run that is the point, since each repo answers it differently.
+ *
+ * What that costs is one small record per composer (id, synthetic path, instant, title)
+ * held for the length of the run — single-digit megabytes for a heavy user, not a
+ * transcript each. It is bounded by how much Cursor history exists, which does not grow
+ * with the number of registered repos.
+ *
+ * It cannot be filtered here without breaking attribution, and the reason is worth
+ * knowing before someone tries: a composer is claimed by anchor OR by window, and the
+ * anchor set lives in the per-workspace `state.vscdb`, one database per workspace. To
+ * know the anchors at scan time this would have to open EVERY workspace database on the
+ * machine — measured above as more work than it saves once a user has more Cursor
+ * workspaces than registered repos, which is the normal case. Applying the window alone
+ * is not a safe subset either: that is exactly what silently drops an anchored composer
+ * the user is actively working in. If this ever has to shrink, the shape to reach for is
+ * a lazy handle (id plus enough to re-read the blob on demand), not a filter.
+ */
+export async function scanCursorComposersOnDisk(): Promise<CursorDiskScanResult> {
+	const globalDbPath = getCursorGlobalDbPath();
 
 	// Pre-flight: distinguish "global DB missing" (silent) from "DB unreadable" (genuine failure)
 	// before calling DatabaseSync, which surfaces both as the same error message.
@@ -87,24 +173,17 @@ export async function scanCursorSessions(projectDir: string): Promise<CursorScan
 			const scanError = classifyScanError(error);
 			if (scanError) {
 				log.error("Cursor global DB stat failed (%s): %s", scanError.kind, scanError.message);
-				return { sessions: [], error: scanError };
+				return { composers: [], error: scanError };
 			}
-			return { sessions: [] };
+			return { composers: [] };
 		}
 		/* v8 ignore stop */
 		log.debug("Cursor global DB not present at %s — treating as not installed", globalDbPath);
-		return { sessions: [] };
+		return { composers: [] };
 	}
 
-	// Step 2: Anchor extraction — read the per-workspace composer pointer IDs.
-	const anchorIds = await readCursorAnchorComposerIds(wsHash);
-	const anchorSet = new Set(anchorIds);
-
-	// Step 3: Time-window scan — compute cutoff and open the global DB.
-	const cutoffMs = Date.now() - SESSION_STALE_MS;
-
 	try {
-		const out: SessionInfo[] = [];
+		const out: CursorDiskComposer[] = [];
 		const seenIds = new Set<string>();
 
 		await withSqliteDb(globalDbPath, (db) => {
@@ -155,15 +234,9 @@ export async function scanCursorSessions(projectDir: string): Promise<CursorScan
 					continue;
 				}
 
-				const inAnchor = anchorSet.has(composerId);
-				const inWindow = lastUpdatedAt >= cutoffMs;
-
-				// Step 4: Union — include if in anchor set OR within time window.
-				if (!inAnchor && !inWindow) {
-					continue;
-				}
-
-				// Dedupe: each composerId appears at most once.
+				// Dedupe: each composerId appears at most once. The anchor / window
+				// decision is NOT made here — it is per-repo, and lives in
+				// `cursorSessionsForRepo`.
 				if (seenIds.has(composerId)) {
 					continue;
 				}
@@ -173,38 +246,106 @@ export async function scanCursorSessions(projectDir: string): Promise<CursorScan
 				const title = nameRaw.length > 0 ? nameRaw : undefined;
 
 				out.push({
-					sessionId: composerId,
-					// Synthetic path: global DB path + composer discriminator (matches OpenCode pattern)
-					transcriptPath: `${globalDbPath}#${composerId}`,
-					updatedAt: new Date(lastUpdatedAt).toISOString(),
-					source: "cursor",
-					title,
+					session: {
+						sessionId: composerId,
+						// Synthetic path: global DB path + composer discriminator (matches OpenCode pattern)
+						transcriptPath: `${globalDbPath}#${composerId}`,
+						updatedAt: new Date(lastUpdatedAt).toISOString(),
+						source: "cursor",
+						title,
+					},
+					lastUpdatedAt,
 				});
 			}
 		});
 
-		log.debug("Discovered %d Cursor session(s) for %s", out.length, projectDir);
-		return { sessions: out };
+		log.debug("Cursor disk scan: %d composer(s) in the global store", out.length);
+		return { composers: out };
 	} catch (error: unknown) {
 		const scanError = classifyScanError(error);
 		/* v8 ignore start -- TOCTOU race: the DB passed stat() but vanished or became unreadable before DatabaseSync opened it. Requires a filesystem-level mock; classifier behavior is covered by classifyScanError unit tests. */
 		if (scanError === null) {
 			log.debug("Cursor global DB disappeared between detection and scan: %s", (error as Error).message);
-			return { sessions: [] };
+			return { composers: [] };
 		}
 		/* v8 ignore stop */
 		log.error("Cursor scan failed (%s): %s", scanError.kind, scanError.message);
-		return { sessions: [], error: scanError };
+		return { composers: [], error: scanError };
 	}
+}
+
+/**
+ * Narrows a machine-wide Cursor composer scan to one repo — the β′ algorithm's
+ * per-repo half.
+ *
+ * ASYNC and NOT built on `DiskSession`, because Cursor's attribution is not a
+ * directory comparison at all. The global store records no workspace for a composer,
+ * so a repo claims one of two ways:
+ *
+ *  1. **Anchor** — the repo's own workspace database points at it
+ *     (`lastFocusedComposerIds` / `selectedComposerIds`). Anchors bypass the staleness
+ *     window by design, which is why the scan must not pre-filter by time.
+ *  2. **Time window** — the composer was updated recently.
+ *
+ * The second is deliberately coarse: with no workspace pointer in the global store,
+ * every recent composer is claimed by every repo Cursor has a workspace for. That is
+ * pre-existing behaviour, unchanged here — a repo with NO Cursor workspace still
+ * claims nothing, which is what the early return preserves.
+ */
+export async function cursorSessionsForRepo(
+	composers: ReadonlyArray<CursorDiskComposer>,
+	projectDir: string,
+	windowMs?: number,
+): Promise<ReadonlyArray<SessionInfo>> {
+	// Step 1: Workspace lookup — find which workspace hash corresponds to projectDir.
+	const wsHash = await findCursorWorkspaceHash(projectDir);
+	if (wsHash === null) {
+		log.debug("No Cursor workspace found matching %s", projectDir);
+		return [];
+	}
+	return narrowToCursorWorkspace(composers, projectDir, wsHash, windowMs);
+}
+
+/**
+ * Steps 2-4 of the β′ algorithm, given a workspace hash step 1 already resolved.
+ *
+ * Split out so the single-repo entry point can settle step 1 BEFORE paying for the
+ * disk scan without resolving the same hash twice — see {@link scanCursorSessions}.
+ * Not exported: a caller with no hash belongs in {@link cursorSessionsForRepo},
+ * which is the function that knows a missing hash means "claims nothing".
+ */
+async function narrowToCursorWorkspace(
+	composers: ReadonlyArray<CursorDiskComposer>,
+	projectDir: string,
+	wsHash: string,
+	windowMs?: number,
+): Promise<ReadonlyArray<SessionInfo>> {
+	// Step 2: Anchor extraction — read the per-workspace composer pointer IDs.
+	const anchorSet = new Set(await readCursorAnchorComposerIds(wsHash));
+
+	// Step 3/4: window cutoff, then union with the anchors.
+	const cutoffMs = Date.now() - (windowMs ?? SESSION_STALE_MS);
+	const out = composers
+		.filter(({ session, lastUpdatedAt }) => anchorSet.has(session.sessionId) || lastUpdatedAt >= cutoffMs)
+		.map(({ session }) => session);
+
+	log.debug("Discovered %d Cursor session(s) for %s", out.length, projectDir);
+	return out;
 }
 
 /**
  * Backwards-compatible wrapper around `scanCursorSessions` that only returns
  * the session array. Callers that need to surface scan failures to the user
  * should call `scanCursorSessions` directly.
+ *
+ * @param windowMs - Forwarded to {@link scanCursorSessions}; see that function for why
+ *   the post-commit caller leaves it unset.
  */
-export async function discoverCursorSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>> {
-	const { sessions } = await scanCursorSessions(projectDir);
+export async function discoverCursorSessions(
+	projectDir: string,
+	windowMs?: number,
+): Promise<ReadonlyArray<SessionInfo>> {
+	const { sessions } = await scanCursorSessions(projectDir, windowMs);
 	return sessions;
 }
 

--- a/cli/src/core/DevinSessionDiscoverer.test.ts
+++ b/cli/src/core/DevinSessionDiscoverer.test.ts
@@ -25,6 +25,7 @@ import {
 	isDevinPresent,
 	scanDevinSessions,
 	scanDevinSessionsAt,
+	scanDevinSessionsOnDisk,
 } from "./DevinSessionDiscoverer.js";
 
 describe("DevinSessionDiscoverer", () => {
@@ -176,6 +177,26 @@ describe("DevinSessionDiscoverer", () => {
 		});
 	});
 
+	describe("scanDevinSessionsOnDisk", () => {
+		it("resolves its own DB path and carries every session's directory, unfiltered", async () => {
+			// The machine-wide half, and the one the multi-repo back-fill calls: it resolves
+			// `getDevinSessionsDbPath()` itself rather than taking a path, and it does NOT
+			// narrow — a session belonging to some other repo still comes back, because
+			// which repo claims it is `devinSessionsForRepo`'s question.
+			const nowSec = Math.floor(Date.now() / 1000);
+			await createDevinDb(join(fakeDataHome, "devin", "cli"), [
+				{ id: "mine", workingDirectory: projectDir, lastActivityAt: nowSec - 10 },
+				{ id: "theirs", workingDirectory: "/tmp/other-project", lastActivityAt: nowSec - 20 },
+			]);
+
+			const result = await scanDevinSessionsOnDisk();
+
+			expect(result.error).toBeUndefined();
+			expect(result.sessions.map((s) => s.session.sessionId).sort()).toEqual(["mine", "theirs"]);
+			expect(result.sessions.find((s) => s.session.sessionId === "mine")?.dirs).toContain(projectDir);
+		});
+	});
+
 	describe("scanDevinSessions / discoverDevinSessions", () => {
 		it("discovers the session matching its working_directory", async () => {
 			const dbDir = join(fakeDataHome, "devin", "cli");
@@ -225,6 +246,27 @@ describe("DevinSessionDiscoverer", () => {
 			const sessions = await discoverDevinSessions(projectDir);
 
 			expect(sessions.map((s) => s.sessionId)).toEqual(["fresh"]);
+		});
+
+		// The dashboard's history back-fill widens the window explicitly; the sidebar,
+		// `jolli status` and the post-commit summary generation keep the 48h default
+		// by omitting the parameter.
+		it("admits a stale session when an explicit wider window is passed", async () => {
+			const dbDir = join(fakeDataHome, "devin", "cli");
+			const nowSec = Math.floor(Date.now() / 1000);
+			const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+			const dbPath = await createDevinDb(dbDir, [
+				{ id: "backfill", workingDirectory: projectDir, lastActivityAt: nowSec - 72 * 60 * 60 },
+			]);
+
+			// The default 48h window excludes it…
+			expect(await discoverDevinSessions(projectDir)).toEqual([]);
+			// …a 7-day window admits it, through the wrapper and through the
+			// explicit-DB-path variant alike.
+			const viaWrapper = await discoverDevinSessions(projectDir, sevenDaysMs);
+			expect(viaWrapper.map((s) => s.sessionId)).toEqual(["backfill"]);
+			const at = await scanDevinSessionsAt(dbPath, projectDir, sevenDaysMs);
+			expect(at.sessions.map((s) => s.sessionId)).toEqual(["backfill"]);
 		});
 
 		it("filters out hidden sessions", async () => {

--- a/cli/src/core/DevinSessionDiscoverer.ts
+++ b/cli/src/core/DevinSessionDiscoverer.ts
@@ -18,6 +18,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { createLogger } from "../Logger.js";
 import type { SessionInfo } from "../Types.js";
+import { type DiskSession, sessionsForRepo } from "./DiskSessionScan.js";
 import { sessionDirBelongsToRepo } from "./SessionDirMatch.js";
 import { classifyScanError, hasNodeSqliteSupport, type SqliteScanError, withSqliteDb } from "./SqliteHelpers.js";
 
@@ -50,28 +51,23 @@ function parseWorkspaceDirs(raw: string | null): string[] {
 }
 
 /**
- * A Devin session belongs to `repoRoot` when its primary `working_directory` OR
- * any of its additional `workspace_dirs` is inside the repo worktree. Sessions
- * started from an attached workspace/worktree surface only through
- * `workspace_dirs`, so matching on `working_directory` alone silently drops them.
+ * Every directory a Devin session recorded: its primary `working_directory` first,
+ * then each of its additional `workspace_dirs`.
  *
- * Matching is prefix/containment via {@link sessionDirBelongsToRepo}, shared with
- * the other hookless directory-scoped sources (OpenCode, Copilot): a session
- * started from a *subdirectory* of the repo — common in a monorepo, e.g.
- * `cd packages/foo && devin …` — IS attributed to the repo (JOLLI-2015).
- * Sessions living in a nested git repo / submodule inside the worktree are
- * excluded so they aren't double-captured by both repos — the helper's docstring
- * has the full rationale.
+ * Both halves matter. A session started from an attached workspace/worktree surfaces
+ * ONLY through `workspace_dirs`, so a caller that looked at `working_directory` alone
+ * would silently drop it. Collecting them into one list is what lets the ordinary
+ * "does any recorded directory belong to this repo" rule cover both — see
+ * {@link devinSessionsForRepo} for the match itself.
+ *
+ * A null `working_directory` contributes nothing rather than a null entry: the
+ * column is nullable (a session started outside any project), and every consumer
+ * downstream expects real strings.
  */
-function sessionMatchesDir(
-	workingDirectory: string | null,
-	workspaceDirsRaw: string | null,
-	repoRoot: string,
-): boolean {
-	if (typeof workingDirectory === "string" && sessionDirBelongsToRepo(workingDirectory, repoRoot)) {
-		return true;
-	}
-	return parseWorkspaceDirs(workspaceDirsRaw).some((dir) => sessionDirBelongsToRepo(dir, repoRoot));
+function sessionDirs(workingDirectory: string | null, workspaceDirsRaw: string | null): string[] {
+	const dirs = typeof workingDirectory === "string" ? [workingDirectory] : [];
+	dirs.push(...parseWorkspaceDirs(workspaceDirsRaw));
+	return dirs;
 }
 
 function getDevinCliDir(home?: string): string {
@@ -161,16 +157,65 @@ export interface DevinScanResult {
 	readonly error?: SqliteScanError;
 }
 
-/** Discover Devin sessions for the given project directory (production entrypoint). */
-export async function scanDevinSessions(projectDir: string): Promise<DevinScanResult> {
-	return scanDevinSessionsAt(getDevinSessionsDbPath(), projectDir);
+/**
+ * Discover Devin sessions for the given project directory (production entrypoint).
+ *
+ * @param windowMs Optional session-staleness window in milliseconds, defaulting to
+ * the 48-hour {@link SESSION_STALE_MS}. Only the dashboard's history back-fill passes
+ * a wider one (7 days); every caller that must NOT widen simply omits it — the
+ * "Active Conversations" sidebar, `jolli status`, and above all the post-commit
+ * summary generation in `hooks/QueueWorker.ts`, which uses this window to decide
+ * which conversations belong to the commit being summarised. A wider window there
+ * would pull unrelated week-old conversations into that commit's stored memory,
+ * which is persisted to the git orphan branch and fails silently — no error, just
+ * wrong content.
+ */
+export async function scanDevinSessions(projectDir: string, windowMs?: number): Promise<DevinScanResult> {
+	return scanDevinSessionsAt(getDevinSessionsDbPath(), projectDir, windowMs);
 }
 
 /**
  * Discover Devin sessions from an explicit DB path. Split out so tests can point
  * at a fixture DB; production callers use `scanDevinSessions`.
+ *
+ * @param windowMs Optional staleness window in milliseconds; see
+ * {@link scanDevinSessions} for the default and for who may widen it.
  */
-export async function scanDevinSessionsAt(dbPath: string, projectDir: string): Promise<DevinScanResult> {
+export async function scanDevinSessionsAt(
+	dbPath: string,
+	projectDir: string,
+	windowMs?: number,
+): Promise<DevinScanResult> {
+	const { sessions, error } = await scanDevinSessionsOnDiskAt(dbPath, windowMs);
+	const mine = devinSessionsForRepo(sessions, projectDir);
+	return error ? { sessions: mine, error } : { sessions: mine };
+}
+
+/** A machine-wide Devin scan: every in-window session, plus a genuine failure. */
+export interface DevinDiskScanResult {
+	readonly sessions: ReadonlyArray<DiskSession>;
+	readonly error?: SqliteScanError;
+}
+
+/**
+ * Scans Devin's global session database once and returns every in-window session,
+ * each carrying the directories its row recorded.
+ *
+ * MACHINE-WIDE and repo-agnostic on purpose. `sessions.db` is ONE database for every
+ * project — the `working_directory` column is what scopes a row, not the file's
+ * location — so a repo-scoped scan opens it, queries it and re-parses every
+ * `workspace_dirs` JSON blob once per registered repo. Callers scan once and narrow
+ * with {@link devinSessionsForRepo}.
+ */
+export async function scanDevinSessionsOnDisk(windowMs?: number): Promise<DevinDiskScanResult> {
+	return scanDevinSessionsOnDiskAt(getDevinSessionsDbPath(), windowMs);
+}
+
+/**
+ * {@link scanDevinSessionsOnDisk} against an explicit DB path, so tests can point at
+ * a fixture database.
+ */
+export async function scanDevinSessionsOnDiskAt(dbPath: string, windowMs?: number): Promise<DevinDiskScanResult> {
 	// A runtime below the Node floor cannot load `node:sqlite`. Return a silent
 	// empty result — "not supported" is not a scan failure, so callers must not
 	// surface a partial-data / failed-source indicator.
@@ -179,7 +224,8 @@ export async function scanDevinSessionsAt(dbPath: string, projectDir: string): P
 		return { sessions: [] };
 	}
 
-	const cutoffMs = Date.now() - SESSION_STALE_MS;
+	const staleMs = windowMs ?? SESSION_STALE_MS;
+	const cutoffMs = Date.now() - staleMs;
 
 	// Pre-flight: "DB missing" (silent) vs "DB unreadable" (genuine failure).
 	try {
@@ -205,11 +251,11 @@ export async function scanDevinSessionsAt(dbPath: string, projectDir: string): P
 			// last_activity_at is epoch SECONDS → compare against cutoff in seconds.
 			const cutoffSec = Math.floor(cutoffMs / 1000);
 
-			// The directory match runs in JS (not SQL) via `sessionDirBelongsToRepo`,
-			// which does prefix/containment matching with separator/case folding plus
-			// the nested-repo exclusion. The old exact `working_directory = :projectDir`
-			// both missed subdirectory sessions and mishandled trailing-slash / backslash
-			// paths.
+			// The directories are CARRIED, not matched — `devinSessionsForRepo` does that
+			// via `sessionDirBelongsToRepo`, which does prefix/containment matching with
+			// separator/case folding plus the nested-repo exclusion. The old exact
+			// `working_directory = :projectDir` both missed subdirectory sessions and
+			// mishandled trailing-slash / backslash paths.
 			const rows = db
 				.prepare(
 					// No ORDER BY: every row passing the SQL filters and the JS directory match is
@@ -227,27 +273,27 @@ export async function scanDevinSessionsAt(dbPath: string, projectDir: string): P
 				workspace_dirs: string | null;
 			}>;
 
-			return rows.flatMap((row): SessionInfo[] => {
-				if (!sessionMatchesDir(row.working_directory, row.workspace_dirs, projectDir)) {
-					return [];
-				}
+			return rows.flatMap((row): DiskSession[] => {
 				if (!Number.isFinite(row.last_activity_at)) {
 					log.warn("Skipping Devin session %s: non-finite last_activity_at", row.id);
 					return [];
 				}
 				return [
 					{
-						sessionId: String(row.id),
-						transcriptPath: `${dbPath}#${row.id}`,
-						updatedAt: new Date(row.last_activity_at * 1000).toISOString(),
-						source: "devin",
-						title: typeof row.title === "string" && row.title.trim().length > 0 ? row.title : undefined,
+						session: {
+							sessionId: String(row.id),
+							transcriptPath: `${dbPath}#${row.id}`,
+							updatedAt: new Date(row.last_activity_at * 1000).toISOString(),
+							source: "devin",
+							title: typeof row.title === "string" && row.title.trim().length > 0 ? row.title : undefined,
+						},
+						dirs: sessionDirs(row.working_directory, row.workspace_dirs),
 					},
 				];
 			});
 		});
 
-		log.debug("Discovered %d Devin session(s) for %s", sessions.length, projectDir);
+		log.debug("Devin disk scan: %d session(s) inside the window", sessions.length);
 		return { sessions };
 	} catch (error: unknown) {
 		const scanError = classifyScanError(error);
@@ -262,8 +308,40 @@ export async function scanDevinSessionsAt(dbPath: string, projectDir: string): P
 	}
 }
 
-/** Backwards-compatible wrapper returning only the session array. */
-export async function discoverDevinSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>> {
-	const { sessions } = await scanDevinSessions(projectDir);
+/**
+ * Narrows a machine-wide Devin scan to one repo.
+ *
+ * A session belongs to `projectDir` when its primary `working_directory` OR any of
+ * its attached `workspace_dirs` is inside the worktree — the same disjunction that
+ * ran inside the scan, now expressed as "any recorded directory matches" because
+ * {@link sessionDirs} collected both into one list.
+ *
+ * Matching is prefix/containment via {@link sessionDirBelongsToRepo}, shared with the
+ * other hookless directory-scoped sources (OpenCode, Copilot): a session started from
+ * a *subdirectory* of the repo — common in a monorepo, e.g. `cd packages/foo && devin
+ * …` — IS attributed to the repo (JOLLI-2015). Sessions living in a nested git repo /
+ * submodule inside the worktree are excluded so they aren't double-captured by both
+ * repos; the helper's docstring has the full rationale.
+ */
+export function devinSessionsForRepo(
+	scanned: ReadonlyArray<DiskSession>,
+	projectDir: string,
+): ReadonlyArray<SessionInfo> {
+	const mine = sessionsForRepo(scanned, (dir) => sessionDirBelongsToRepo(dir, projectDir));
+	log.debug("Discovered %d Devin session(s) for %s", mine.length, projectDir);
+	return mine;
+}
+
+/**
+ * Backwards-compatible wrapper returning only the session array.
+ *
+ * @param windowMs Optional staleness window in milliseconds, forwarded verbatim; see
+ * {@link scanDevinSessions} for the default and for who may widen it.
+ */
+export async function discoverDevinSessions(
+	projectDir: string,
+	windowMs?: number,
+): Promise<ReadonlyArray<SessionInfo>> {
+	const { sessions } = await scanDevinSessions(projectDir, windowMs);
 	return sessions;
 }

--- a/cli/src/core/DiskSessionScan.test.ts
+++ b/cli/src/core/DiskSessionScan.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { SessionInfo } from "../Types.js";
+import { type DiskSession, sessionsForRepo } from "./DiskSessionScan.js";
+
+const entry = (id: string, dirs: string[]): DiskSession => ({
+	session: { sessionId: id, transcriptPath: `/t/${id}`, updatedAt: "2026-07-30T08:00:00.000Z", source: "kimi" },
+	dirs,
+});
+
+const ids = (sessions: ReadonlyArray<SessionInfo>) => sessions.map((s) => s.sessionId);
+
+describe("sessionsForRepo", () => {
+	it("keeps a session when any of its recorded directories matches", () => {
+		// Multi-directory sessions are the reason `dirs` is a list: Claude follows the
+		// user across `cd`, and Devin carries attached workspaces alongside its primary
+		// one. Matching only the first would drop every session started from an
+		// attached worktree.
+		const scanned = [entry("a", ["/other", "/repo"]), entry("b", ["/other"])];
+		expect(ids(sessionsForRepo(scanned, (d) => d === "/repo"))).toEqual(["a"]);
+	});
+
+	it("drops a session that recorded no directory at all", () => {
+		// The tempting reading of an empty list — no directories, therefore no
+		// objection, therefore keep it — would attach the session to every repo on the
+		// machine. `some` on an empty array is false, which is the behaviour wanted.
+		expect(sessionsForRepo([entry("a", [])], () => true)).toEqual([]);
+	});
+
+	it("filters rather than partitions: two repos may both claim one session", () => {
+		// Two clones or two worktrees of one project legitimately share a session.
+		// Assigning it to exactly one would silently drop it from the other.
+		const scanned = [entry("shared", ["/repo"])];
+		expect(ids(sessionsForRepo(scanned, (d) => d === "/repo"))).toEqual(["shared"]);
+		expect(ids(sessionsForRepo(scanned, (d) => d.startsWith("/re")))).toEqual(["shared"]);
+	});
+
+	it("returns the session verbatim, without rebuilding it", () => {
+		// Ids, synthetic transcript paths and native titles are per-source rules that
+		// live next to the store that produced them. Narrowing must not re-derive them.
+		const one = entry("a", ["/repo"]);
+		expect(sessionsForRepo([one], () => true)[0]).toBe(one.session);
+	});
+
+	it("stops testing a session's directories at the first match", () => {
+		// Not an optimisation detail: a predicate that hits the filesystem (the
+		// nested-repo `.git` walk does) would otherwise pay for directories that cannot
+		// change the answer.
+		const seen: string[] = [];
+		sessionsForRepo([entry("a", ["/repo", "/other"])], (d) => {
+			seen.push(d);
+			return d === "/repo";
+		});
+		expect(seen).toEqual(["/repo"]);
+	});
+
+	it("propagates a throwing predicate instead of dropping the session", () => {
+		// Every real attribution rule here is a pure path comparison, so a throw means
+		// the closure captured something it should not have. Swallowing it would turn a
+		// programming error into silently missing sessions.
+		expect(() =>
+			sessionsForRepo([entry("a", ["/repo"])], () => {
+				throw new Error("predicate blew up");
+			}),
+		).toThrow("predicate blew up");
+	});
+});

--- a/cli/src/core/DiskSessionScan.ts
+++ b/cli/src/core/DiskSessionScan.ts
@@ -1,0 +1,127 @@
+/**
+ * The shared shape of a machine-wide session scan, and the one step every source's
+ * per-repo narrowing has in common.
+ *
+ * ## Why every hookless source has a scan/narrow pair
+ *
+ * None of these stores is keyed by repo. Kimi hashes the working directory into a
+ * bucket name it does not document, Codex partitions by DATE, OpenCode / Copilot CLI
+ * / Devin keep one global SQLite for every project, Cline keeps one
+ * `taskHistory.json` per editor flavour, and the VS Code-family sources key on a
+ * workspace hash that can only be resolved by reading every `workspace.json`. So
+ * "which sessions belong to this repo" is never answerable from a path — only by
+ * opening the records and reading the directory each one recorded.
+ *
+ * A repo-scoped scan therefore re-reads the SAME records once per registered repo.
+ * That was measured on a machine with three repos where only two of these sources
+ * were installed (Claude 36 ms + 464 ms per repo; Codex 68 ms per repo, 201 ms across
+ * three) — and the measurement understated the problem, because the other nine
+ * sources were absent from that machine and each returned on its first `readdir`. A
+ * developer who actually runs Cursor, Copilot and Cline pays a full SQLite open, a
+ * full-table scan and a JSON parse of every task history once per repo, on every
+ * dashboard pass. "Absent on the profiling machine" is not evidence about the
+ * machines this ships to.
+ *
+ * The fix is the same in every case: scan the store ONCE for the whole run, carrying
+ * each session's directory evidence, then narrow per repo in memory.
+ *
+ * ## What this module deliberately does NOT own
+ *
+ * It does not own attribution. Each source keeps its own rule, spelled as a predicate
+ * in its own file and passed to {@link sessionsForRepo} as a closure. That is the
+ * whole design: the rules are genuinely different, and turning them into shared DATA
+ * — a flag, a mode enum, a "match style" string — is the exact move this module's
+ * history warns about. Three live examples of how little they have in common:
+ *
+ *  - Codex / Kimi / OpenCode / Copilot CLI / Devin match by prefix containment, so a
+ *    session started in a SUBDIRECTORY counts (JOLLI-2015) and a nested git repo's
+ *    own sessions are excluded.
+ *  - Cursor CLI / Cline / Cline CLI match by exact path equality, so a subdirectory
+ *    session does NOT count. That is the known, intentional limit of sources whose
+ *    records carry a workspace root rather than a cwd.
+ *  - Devin matches a primary `working_directory` OR any entry of an attached
+ *    `workspace_dirs` array; Antigravity matches one recorded workspace against EVERY
+ *    worktree root of the repo, which needs a `git worktree list` the scan cannot do.
+ *
+ * Keeping each predicate in its source's file means this change moved WHEN a rule
+ * runs, never WHAT it says.
+ *
+ * ## Filtering, not partitioning
+ *
+ * {@link sessionsForRepo} filters. A session may legitimately be claimed by two
+ * registered repos — two clones of one project, or two worktrees of it — and
+ * assigning each session to exactly one would silently drop it from the other. Not
+ * hypothetical: measured on real Claude transcripts, 27 of 64 carried more than one
+ * working directory.
+ */
+
+import type { SessionInfo, TranscriptSource } from "../Types.js";
+
+/**
+ * "The database already holds this session at or past this instant" — asked by a
+ * scanner BEFORE it pays for an expensive read, and by the collector before it pays
+ * for a transcript parse.
+ *
+ * Declared here rather than in the dashboard because the scanners live in `core/`
+ * and must not import from `dashboard/`. Only the ANSWER is dashboard-shaped; the
+ * question is just "have I already got this?".
+ *
+ * A scanner that consults this must still return the session, with whatever facts it
+ * could gather cheaply. Dropping it instead would make the run's own count of
+ * discovered conversations shrink on every converged pass, so a repeat run would
+ * report "0 conversations found" — which is the confusion the reported count exists
+ * to prevent.
+ */
+export type AlreadyCurrent = (source: TranscriptSource, sessionId: string, updatedAtMs: number) => boolean;
+
+/**
+ * One session found by a machine-wide scan, plus the directory evidence that decides
+ * which repo owns it.
+ *
+ * The session is carried FULLY BUILT rather than as loose fields. Every source has
+ * its own rules for the id, the synthetic transcript path and the native title, and
+ * those belong next to the store they read — re-deriving them at narrow time would be
+ * a second place to get them wrong. What a machine-wide scan genuinely cannot decide
+ * is repo ownership, and that is exactly what {@link dirs} carries.
+ */
+export interface DiskSession {
+	readonly session: SessionInfo;
+	/**
+	 * Every directory this session recorded, in the source's own order.
+	 *
+	 * Plural because a session is not always one directory: Claude follows the user
+	 * across `cd`, and Devin carries a primary `working_directory` plus an array of
+	 * attached `workspace_dirs` — matching only the first silently drops every session
+	 * started from an attached worktree.
+	 *
+	 * A source that records exactly one directory still uses a one-element array, so
+	 * every narrowing reads the same shape.
+	 *
+	 * Empty means "this session recorded no usable directory". Such a session matches
+	 * nothing, which is correct: it cannot be attributed, and the alternative — no
+	 * directories therefore no objection therefore claimed by everyone — would attach
+	 * it to every repo on the machine.
+	 */
+	readonly dirs: ReadonlyArray<string>;
+}
+
+/**
+ * Narrows a machine-wide scan to the sessions whose directory evidence satisfies
+ * `matches`.
+ *
+ * `matches` is the CALLER's attribution rule, passed as a closure so it stays in the
+ * source's own file — see this module's header for why that is the point rather than
+ * an omission. It is called per recorded directory and the session is kept on the
+ * first one that answers true, which is what makes a multi-directory session (Claude
+ * after a `cd`, Devin with attached workspaces) attach to the repo it touched.
+ *
+ * A predicate that throws is a programming error and propagates: every real rule here
+ * is a pure path comparison, so a throw means the closure captured something it
+ * should not have, and swallowing it would silently drop sessions.
+ */
+export function sessionsForRepo(
+	scanned: ReadonlyArray<DiskSession>,
+	matches: (dir: string) => boolean,
+): ReadonlyArray<SessionInfo> {
+	return scanned.filter((entry) => entry.dirs.some(matches)).map((entry) => entry.session);
+}

--- a/cli/src/core/KimiSessionDiscoverer.test.ts
+++ b/cli/src/core/KimiSessionDiscoverer.test.ts
@@ -144,6 +144,23 @@ describe("discoverKimiSessions", () => {
 		await rm(repo, { recursive: true, force: true });
 	});
 
+	it("admits that session when an explicit wider window is passed", async () => {
+		// The staleness gate sits in a per-session helper, so this also pins that the
+		// parameter reaches it rather than stopping at the exported function.
+		const repo = await mkdtemp(join(realTmpdir(), "kimi-repo-"));
+		await writeKimiSession({ workDir: repo, ageMs: 49 * 60 * 60 * 1000 });
+		const sessions = await discoverKimiSessions(repo, 7 * 24 * 60 * 60 * 1000);
+		expect(sessions).toHaveLength(1);
+		await rm(repo, { recursive: true, force: true });
+	});
+
+	it("still rejects a session older than the widened window", async () => {
+		const repo = await mkdtemp(join(realTmpdir(), "kimi-repo-"));
+		await writeKimiSession({ workDir: repo, ageMs: 8 * 24 * 60 * 60 * 1000 });
+		expect(await discoverKimiSessions(repo, 7 * 24 * 60 * 60 * 1000)).toEqual([]);
+		await rm(repo, { recursive: true, force: true });
+	});
+
 	it("ignores a non-directory entry in the sessions tree", async () => {
 		const repo = await mkdtemp(join(realTmpdir(), "kimi-repo-"));
 		await writeKimiSession({ workDir: repo });
@@ -157,6 +174,16 @@ describe("discoverKimiSessions", () => {
 	it("skips a session with malformed state.json (no recoverable cwd)", async () => {
 		const repo = await mkdtemp(join(realTmpdir(), "kimi-repo-"));
 		await writeKimiSession({ rawState: "{ not json" });
+		expect(await discoverKimiSessions(repo)).toEqual([]);
+		await rm(repo, { recursive: true, force: true });
+	});
+
+	it("skips a state.json that is valid JSON but not an OBJECT", async () => {
+		// A different failure from the one above, and it does not throw: `JSON.parse`
+		// succeeds and hands back `null`, so the parse-error path never runs. Without the
+		// shape test the reader would go on to index a non-object for `workDir`.
+		const repo = await mkdtemp(join(realTmpdir(), "kimi-repo-"));
+		await writeKimiSession({ rawState: "null" });
 		expect(await discoverKimiSessions(repo)).toEqual([]);
 		await rm(repo, { recursive: true, force: true });
 	});

--- a/cli/src/core/KimiSessionDiscoverer.ts
+++ b/cli/src/core/KimiSessionDiscoverer.ts
@@ -34,6 +34,8 @@ import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { createLogger } from "../Logger.js";
 import type { SessionInfo } from "../Types.js";
+import { mapWithConcurrency, withIoBudget } from "../util/Concurrency.js";
+import { type DiskSession, sessionsForRepo } from "./DiskSessionScan.js";
 import { sessionDirBelongsToRepo } from "./SessionDirMatch.js";
 
 const log = createLogger("KimiDiscoverer");
@@ -67,21 +69,48 @@ const CWD_STATE_FIELDS = ["workDir", "cwd", "workingDirectory", "workspaceRoot",
  * staleness window (48 hours).
  *
  * @param projectDir - The git repository root to match sessions against
+ * @param windowMs - Staleness window; defaults to {@link SESSION_STALE_MS}. The
+ *   dashboard's history back-fill passes a wider one (7 days); every caller that
+ *   must keep the 48 h horizon omits it — the sidebar's Active Conversations,
+ *   `jolli status`, and `QueueWorker`'s post-commit summary, which decides which
+ *   conversations belong to the commit being summarised. Widening that last one
+ *   would write week-old unrelated conversations into a commit's stored memory,
+ *   persistently and silently, which is why the constant stays a default.
  * @returns Array of matching sessions with source="kimi"
  */
-export async function discoverKimiSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>> {
+export async function discoverKimiSessions(projectDir: string, windowMs?: number): Promise<ReadonlyArray<SessionInfo>> {
+	return kimiSessionsForRepo(await scanKimiSessionsOnDisk(windowMs), projectDir);
+}
+
+/**
+ * Scans every Kimi session tree on this machine and returns those inside the window,
+ * each carrying the working directory its `state.json` recorded.
+ *
+ * MACHINE-WIDE and repo-agnostic on purpose. `~/.kimi-code/sessions/` is one global
+ * tree whose `<workDirKey>` buckets are `wd_<slug>_<hash>` names Kimi does not
+ * document, so they cannot be derived from a repo path and every bucket has to be
+ * opened. A repo-scoped scan therefore re-reads every `state.json` on the machine
+ * once per registered repo. Callers scan once and narrow with
+ * {@link kimiSessionsForRepo}.
+ */
+export async function scanKimiSessionsOnDisk(windowMs?: number): Promise<ReadonlyArray<DiskSession>> {
 	const sessionsDir = join(kimiCodeHome(), "sessions");
-	const resolvedProject = resolve(projectDir);
-	const sessions: SessionInfo[] = [];
+	const staleMs = windowMs ?? SESSION_STALE_MS;
+	const scanned: DiskSession[] = [];
 
 	let workDirKeys: string[];
 	try {
 		workDirKeys = await readdir(sessionsDir);
 	} catch {
 		log.debug("Kimi sessions directory not found: %s", sessionsDir);
-		return sessions;
+		return scanned;
 	}
 
+	// Every session directory on the machine, flattened first so the fan-out below is
+	// over sessions rather than over buckets. Bucket counts are lopsided — one project
+	// the user lives in can hold most of their sessions — so fanning out per bucket
+	// would leave the widest one running alone.
+	const sessionDirs: Array<{ readonly sessionId: string; readonly sessionDir: string }> = [];
 	for (const workDirKey of workDirKeys) {
 		const workDirPath = join(sessionsDir, workDirKey);
 		let sessionIds: string[];
@@ -90,18 +119,40 @@ export async function discoverKimiSessions(projectDir: string): Promise<Readonly
 		} catch {
 			continue;
 		}
-
 		for (const sessionId of sessionIds) {
-			const sessionDir = join(workDirPath, sessionId);
-			const session = await tryParseSession(sessionDir, sessionId, resolvedProject);
-			if (session) {
-				sessions.push(session);
-			}
+			sessionDirs.push({ sessionId, sessionDir: join(workDirPath, sessionId) });
 		}
 	}
 
-	log.debug("Discovered %d Kimi session(s)", sessions.length);
-	return sessions;
+	// One `stat` plus one small `state.json` read per session, each independent — and
+	// each taking a slot from the shared budget inside `tryParseSession`, so this
+	// running alongside the other scans cannot push the process past its total.
+	const parsed = await mapWithConcurrency(sessionDirs, ({ sessionId, sessionDir }) =>
+		tryParseSession(sessionDir, sessionId, staleMs),
+	);
+	scanned.push(...parsed.filter((session): session is DiskSession => session !== null));
+
+	log.debug("Kimi disk scan: %d session(s) inside the window", scanned.length);
+	return scanned;
+}
+
+/**
+ * Narrows a machine-wide Kimi scan to one repo.
+ *
+ * Attribution is prefix/containment, unchanged from when it ran inside the scan: a
+ * session started in a SUBDIRECTORY of the repo still counts, while one living in a
+ * nested git repo does not.
+ */
+export function kimiSessionsForRepo(
+	scanned: ReadonlyArray<DiskSession>,
+	projectDir: string,
+): ReadonlyArray<SessionInfo> {
+	// The predicate is verbatim what ran inside the scan, `resolve` on both sides
+	// included — this change moved when it runs, not what it says.
+	const resolvedProject = resolve(projectDir);
+	const mine = sessionsForRepo(scanned, (dir) => sessionDirBelongsToRepo(resolve(dir), resolvedProject));
+	log.debug("Discovered %d Kimi session(s) for %s", mine.length, projectDir);
+	return mine;
 }
 
 /**
@@ -119,46 +170,50 @@ export async function isKimiInstalled(): Promise<boolean> {
 }
 
 /**
- * Builds a SessionInfo for one `<workDirKey>/<sessionId>/` tree, or null when it
- * has no readable transcript, is stale, or cannot be attributed to the project.
+ * Builds a scanned session for one `<workDirKey>/<sessionId>/` tree, or null when it
+ * has no readable transcript, is stale, or records no working directory at all.
+ *
+ * Repo attribution is deliberately NOT done here: it belongs to
+ * {@link kimiSessionsForRepo}, so one scan of this global tree can serve every
+ * registered repo instead of being re-run per repo. A session with no working
+ * directory is still dropped here — with no directory it can never be attributed, so
+ * carrying it forward would only make every filter re-decide the same thing.
  */
-async function tryParseSession(
-	sessionDir: string,
-	sessionId: string,
-	resolvedProject: string,
-): Promise<SessionInfo | null> {
+async function tryParseSession(sessionDir: string, sessionId: string, staleMs: number): Promise<DiskSession | null> {
 	const transcriptPath = join(sessionDir, "agents", "main", "wire.jsonl");
 
 	// Staleness gate BEFORE reading state.json — an absent/old transcript is
-	// skipped with a single stat.
+	// skipped with a single stat. Zero bytes claimed from the budget: a `stat` and a
+	// small `state.json` need a slot, not part of the byte allowance a whole
+	// transcript would take.
 	let mtimeIso: string;
 	try {
-		const fileStat = await stat(transcriptPath);
+		const fileStat = await withIoBudget(0, () => stat(transcriptPath));
 		mtimeIso = fileStat.mtime.toISOString();
 	} catch {
 		return null;
 	}
-	if (Date.now() - new Date(mtimeIso).getTime() > SESSION_STALE_MS) {
+	if (Date.now() - new Date(mtimeIso).getTime() > staleMs) {
 		return null;
 	}
 
-	const state = await readState(sessionDir);
+	const state = await withIoBudget(0, () => readState(sessionDir));
 	const cwd = cwdFromState(state);
 	if (!cwd) {
 		log.debug("No working directory in state.json for Kimi session %s", sessionId);
 		return null;
 	}
-	if (!sessionDirBelongsToRepo(resolve(cwd), resolvedProject)) {
-		return null;
-	}
 
 	const title = titleFromState(state);
 	return {
-		sessionId,
-		transcriptPath,
-		updatedAt: mtimeIso,
-		source: "kimi",
-		...(title ? { title } : {}),
+		session: {
+			sessionId,
+			transcriptPath,
+			updatedAt: mtimeIso,
+			source: "kimi",
+			...(title ? { title } : {}),
+		},
+		dirs: [cwd],
 	};
 }
 

--- a/cli/src/core/OpenCodeSessionDiscoverer.test.ts
+++ b/cli/src/core/OpenCodeSessionDiscoverer.test.ts
@@ -322,6 +322,20 @@ describe("OpenCodeSessionDiscoverer", () => {
 			expect(sessions[0].sessionId).toBe("fresh");
 		});
 
+		// The dashboard's history back-fill passes a wider window than the 48h default.
+		// Same fixture, two calls: the default rejects the row, the explicit window admits
+		// it — which is the whole point of the parameter being opt-in.
+		it("admits a session outside the 48h window when an explicit wider window is passed", async () => {
+			const old = Date.now() - 72 * 60 * 60 * 1000;
+			const dbDir = join(fakeHome, ".local", "share", "opencode");
+			await createOpenCodeDb(dbDir, [{ id: "old", directory: projectDir, time_created: old, time_updated: old }]);
+
+			expect(await discoverOpenCodeSessions(projectDir)).toHaveLength(0);
+
+			const widened = await discoverOpenCodeSessions(projectDir, 7 * 24 * 60 * 60 * 1000);
+			expect(widened.map((s) => s.sessionId)).toEqual(["old"]);
+		});
+
 		it("includes child sessions from auto-compaction (non-null parent_id)", async () => {
 			const now = Date.now();
 			const dbDir = join(fakeHome, ".local", "share", "opencode");

--- a/cli/src/core/OpenCodeSessionDiscoverer.ts
+++ b/cli/src/core/OpenCodeSessionDiscoverer.ts
@@ -22,6 +22,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { createLogger } from "../Logger.js";
 import type { SessionInfo } from "../Types.js";
+import { type DiskSession, sessionsForRepo } from "./DiskSessionScan.js";
 import { sessionDirBelongsToRepo } from "./SessionDirMatch.js";
 import {
 	classifyScanError as classifySqliteScanError,
@@ -130,14 +131,48 @@ export interface OpenCodeScanResult {
  * sessions (within 48h) matching the given project directory.
  *
  * @param projectDir - The git repository root to filter sessions by
+ * @param windowMs - Optional staleness window in milliseconds. Defaults to
+ *   {@link SESSION_STALE_MS} (48 h). The dashboard's history back-fill passes a wider
+ *   window (7 d) to recover conversations the database never recorded. Callers that
+ *   must NOT widen it omit the argument entirely: the "Active Conversations" sidebar,
+ *   `jolli status`, and — the one that matters — the post-commit summary in
+ *   `QueueWorker`, which uses this window to decide which conversations belong to the
+ *   commit being summarised. That summary is written to the git orphan branch and
+ *   kept, so a wider window there quietly attaches week-old unrelated conversations
+ *   to a commit's stored memory with no error anywhere.
  * @returns { sessions, error? } — sessions is always an array; if `error` is
  *   present and its kind is not "missing", callers should surface it to the user
  *   rather than silently reporting "0 sessions" (which is indistinguishable
  *   from a genuinely-empty scan).
  */
-export async function scanOpenCodeSessions(projectDir: string): Promise<OpenCodeScanResult> {
+export async function scanOpenCodeSessions(projectDir: string, windowMs?: number): Promise<OpenCodeScanResult> {
+	const { sessions, error } = await scanOpenCodeSessionsOnDisk(windowMs);
+	const mine = openCodeSessionsForRepo(sessions, projectDir);
+	return error ? { sessions: mine, error } : { sessions: mine };
+}
+
+/** A machine-wide OpenCode scan: every in-window session, plus a genuine failure. */
+export interface OpenCodeDiskScanResult {
+	readonly sessions: ReadonlyArray<DiskSession>;
+	readonly error?: OpenCodeScanError;
+}
+
+/**
+ * Scans OpenCode's global database once and returns every session inside the window,
+ * each carrying the `directory` its row recorded.
+ *
+ * MACHINE-WIDE and repo-agnostic on purpose. `~/.local/share/opencode/opencode.db` is
+ * ONE database holding every project's sessions, so a repo-scoped scan opens the same
+ * file, runs the same query and re-parses the same rows once per registered repo.
+ * Callers scan once and narrow with {@link openCodeSessionsForRepo}.
+ *
+ * The time cutoff stays in SQL — it is the filter that keeps the row set small, and
+ * it is repo-independent, so hoisting the scan does not weaken it.
+ */
+export async function scanOpenCodeSessionsOnDisk(windowMs?: number): Promise<OpenCodeDiskScanResult> {
 	const dbPath = getOpenCodeDbPath();
-	const cutoffMs = Date.now() - SESSION_STALE_MS;
+	const staleMs = windowMs ?? SESSION_STALE_MS;
+	const cutoffMs = Date.now() - staleMs;
 
 	// Pre-flight: distinguish "DB missing" (silent) from "DB exists but unreadable"
 	// (genuine failure) before calling DatabaseSync, which surfaces both as the same
@@ -167,13 +202,14 @@ export async function scanOpenCodeSessions(projectDir: string): Promise<OpenCode
 			// Auto-compact creates child sessions (parent_id != NULL) that carry on the conversation,
 			// so filtering to parent_id IS NULL would miss active sessions after compaction.
 			//
-			// The directory match runs in JS via `sessionDirBelongsToRepo` (shared with
-			// Devin/Copilot): prefix/containment with separator + case folding (handling
-			// the "E:\\proj" vs "e:\\proj" Windows drive-letter drift and case-sensitive
-			// Linux) plus the nested-repo exclusion. It replaced the SQL `directory =
-			// :projectDir` (and the win32/darwin LOWER() variant), which silently dropped
-			// every session run from a subdirectory of the repo (JOLLI-2015). Rows are
-			// still narrowed by the time cutoff in SQL; the directory filter is JS-side.
+			// The directory is CARRIED, not matched. `openCodeSessionsForRepo` does the
+			// matching through `sessionDirBelongsToRepo` (shared with Devin/Copilot):
+			// prefix/containment with separator + case folding (handling the "E:\\proj" vs
+			// "e:\\proj" Windows drive-letter drift and case-sensitive Linux) plus the
+			// nested-repo exclusion. That replaced the SQL `directory = :projectDir` (and
+			// the win32/darwin LOWER() variant), which silently dropped every session run
+			// from a subdirectory of the repo (JOLLI-2015). Rows are still narrowed by the
+			// time cutoff in SQL, which is repo-independent and so stays here.
 			const rows = db
 				.prepare(
 					// No ORDER BY: every row passing the SQL cutoff and the JS directory filter is
@@ -190,10 +226,7 @@ export async function scanOpenCodeSessions(projectDir: string): Promise<OpenCode
 				directory: string;
 			}>;
 
-			return rows.flatMap((row): SessionInfo[] => {
-				if (!sessionDirBelongsToRepo(row.directory, projectDir)) {
-					return [];
-				}
+			return rows.flatMap((row): DiskSession[] => {
 				// Guard against schema drift: SQL's `time_updated > :cutoff` already
 				// filters NULL, but a non-numeric value would make new Date().toISOString()
 				// throw RangeError and bubble up as a spurious "unknown" scan error.
@@ -203,18 +236,21 @@ export async function scanOpenCodeSessions(projectDir: string): Promise<OpenCode
 				}
 				return [
 					{
-						sessionId: String(row.id),
-						// Synthetic path: DB path + session discriminator for unique cursor keying
-						transcriptPath: `${dbPath}#${row.id}`,
-						updatedAt: new Date(row.time_updated).toISOString(),
-						source: "opencode",
-						title: typeof row.title === "string" && row.title.trim().length > 0 ? row.title : undefined,
+						session: {
+							sessionId: String(row.id),
+							// Synthetic path: DB path + session discriminator for unique cursor keying
+							transcriptPath: `${dbPath}#${row.id}`,
+							updatedAt: new Date(row.time_updated).toISOString(),
+							source: "opencode",
+							title: typeof row.title === "string" && row.title.trim().length > 0 ? row.title : undefined,
+						},
+						dirs: [row.directory],
 					},
 				];
 			});
 		});
 
-		log.debug("Discovered %d OpenCode session(s) for %s", sessions.length, projectDir);
+		log.debug("OpenCode disk scan: %d session(s) inside the window", sessions.length);
 		return { sessions };
 	} catch (error: unknown) {
 		const scanError = classifyScanError(error);
@@ -234,11 +270,35 @@ export async function scanOpenCodeSessions(projectDir: string): Promise<OpenCode
 }
 
 /**
+ * Narrows a machine-wide OpenCode scan to one repo.
+ *
+ * Attribution is `sessionDirBelongsToRepo`, verbatim from when it ran inside the
+ * scan's `flatMap`: prefix/containment with separator and case folding plus the
+ * nested-repo exclusion, so a session run from a SUBDIRECTORY still counts
+ * (JOLLI-2015). The helper's own null guard is what keeps a row whose `directory`
+ * column is NULL from throwing here — such a session simply matches no repo.
+ */
+export function openCodeSessionsForRepo(
+	scanned: ReadonlyArray<DiskSession>,
+	projectDir: string,
+): ReadonlyArray<SessionInfo> {
+	const mine = sessionsForRepo(scanned, (dir) => sessionDirBelongsToRepo(dir, projectDir));
+	log.debug("Discovered %d OpenCode session(s) for %s", mine.length, projectDir);
+	return mine;
+}
+
+/**
  * Backwards-compatible wrapper around `scanOpenCodeSessions` that only returns
  * the session array. Callers that need to surface scan failures to the user
  * should call `scanOpenCodeSessions` directly.
+ *
+ * @param windowMs - Forwarded to {@link scanOpenCodeSessions}; see that function for why
+ *   the post-commit caller leaves it unset.
  */
-export async function discoverOpenCodeSessions(projectDir: string): Promise<ReadonlyArray<SessionInfo>> {
-	const { sessions } = await scanOpenCodeSessions(projectDir);
+export async function discoverOpenCodeSessions(
+	projectDir: string,
+	windowMs?: number,
+): Promise<ReadonlyArray<SessionInfo>> {
+	const { sessions } = await scanOpenCodeSessions(projectDir, windowMs);
 	return sessions;
 }

--- a/cli/src/core/SessionTitleResolver.test.ts
+++ b/cli/src/core/SessionTitleResolver.test.ts
@@ -148,6 +148,37 @@ describe("resolveSessionTitle", () => {
 		expect(result).toBe("the first human turn");
 		expect(readFirstUserMessageTitle).not.toHaveBeenCalled();
 	});
+
+	describe("a supplied aiTitle", () => {
+		const claude = { sessionId: "s", transcriptPath: "/t/s.jsonl", updatedAt: "x", source: "claude" as const };
+
+		it("is used without streaming the transcript", async () => {
+			expect(await resolveSessionTitle(claude, undefined, "handed over")).toBe("handed over");
+			expect(readClaudeAiTitle).not.toHaveBeenCalled();
+		});
+
+		it("null means 'looked, found none' and still skips the stream", async () => {
+			// The state the three-way parameter exists for: a short conversation with no
+			// ai-title row is common, and treating its absence as "unknown" would leave
+			// the up-to-4 MB stream on for most sessions.
+			vi.mocked(readFirstUserMessageTitle).mockResolvedValue("from the entries");
+
+			const result = await resolveSessionTitle(claude, [{ role: "human", content: "from the entries" }], null);
+
+			expect(result).toBe("from the entries");
+			expect(readClaudeAiTitle).not.toHaveBeenCalled();
+		});
+
+		it("undefined means 'did not look', so the stream still runs", async () => {
+			vi.mocked(readClaudeAiTitle).mockResolvedValue("streamed");
+			expect(await resolveSessionTitle(claude, undefined, undefined)).toBe("streamed");
+			expect(readClaudeAiTitle).toHaveBeenCalledTimes(1);
+		});
+
+		it("loses to a native SessionInfo.title, which is still checked first", async () => {
+			expect(await resolveSessionTitle({ ...claude, title: "native" }, undefined, "handed over")).toBe("native");
+		});
+	});
 });
 
 // Every source has an entry in PARSE_LINE, but the ones whose discoverer always

--- a/cli/src/core/SessionTitleResolver.ts
+++ b/cli/src/core/SessionTitleResolver.ts
@@ -46,10 +46,26 @@ const PARSE_LINE: Record<TranscriptSource, (line: string) => string | undefined>
  * message-count), pass them in and the resolver skips its own redundant
  * `readFirstUserMessageTitle` stream — extracting the first human turn
  * directly from the array. Saves one full transcript scan per session.
+ *
+ * `aiTitle` is the same bargain for step 2, and it needs THREE states rather than
+ * two. `undefined` means "I did not look" and the resolver streams the file itself.
+ * A string is the title it found. **`null` means "I looked and there is none"**, which
+ * is the state that actually matters: without it a caller who had already read the
+ * whole transcript still paid a second streaming pass of up to
+ * `ClaudeAiTitleReader.TAIL_SCAN_BYTES` — 4 MB — to be told the same nothing. A short
+ * conversation with no `ai-title` row is a common case, not an edge one, so treating
+ * absence as "unknown" would have left the expensive path on for most sessions.
+ *
+ * **No production caller passes `aiTitle` today.** The dashboard back-fill did, out of
+ * the Claude disk scan's own parse, until that handoff was reverted for the resident-set
+ * reason in `acceptFacts` (`ClaudeSessionDiscoverer`). The parameter stays because the
+ * three-state contract is the part that was hard to get right, and any caller that
+ * regains the answer cheaply needs it — not because something is currently using it.
  */
 export async function resolveSessionTitle(
 	session: SessionInfo,
 	mergedEntries?: ReadonlyArray<TranscriptEntry>,
+	aiTitle?: string | null,
 ): Promise<string> {
 	// 1. Pre-populated native title (cheap path for opencode/cursor/copilot).
 	if (typeof session.title === "string" && session.title.trim().length > 0) {
@@ -65,7 +81,12 @@ export async function resolveSessionTitle(
 	// whose live transcript is gone): opening a read stream on "" is a real
 	// fs round-trip that always ENOENTs — pure waste, and it made callers'
 	// evidence pipelines timing-sensitive for nothing.
-	if (source === "claude" && session.transcriptPath) {
+	// A caller that already knows the answer short-circuits the stream — including
+	// when the answer is "there is none" (`null`), which is the whole point of the
+	// three-state parameter.
+	if (aiTitle !== undefined) {
+		if (aiTitle) return truncateToCodePoints(aiTitle, TITLE_MAX_CODE_POINTS);
+	} else if (source === "claude" && session.transcriptPath) {
 		try {
 			const ai = await readClaudeAiTitle(session.transcriptPath);
 			if (ai && ai.length > 0) {

--- a/cli/src/core/SessionTracker.test.ts
+++ b/cli/src/core/SessionTracker.test.ts
@@ -241,6 +241,33 @@ describe("SessionTracker", () => {
 			expect(sessions).toEqual([]);
 		});
 
+		it("should widen the read filter when given an explicit window", async () => {
+			// Written straight to the registry rather than through `saveSession`, which
+			// would prune this row before it ever reached disk — which is also why
+			// widening the window recovers so little in practice: the write path deletes
+			// what the read path would otherwise be allowed to see.
+			const dir = await ensureJolliMemoryDir(tempDir);
+			await writeFile(
+				join(dir, "sessions.json"),
+				JSON.stringify({
+					version: 1,
+					sessions: {
+						old: {
+							sessionId: "old",
+							transcriptPath: "/path/old.jsonl",
+							updatedAt: new Date(Date.now() - 72 * 3600_000).toISOString(),
+							source: "claude",
+						},
+					},
+				}),
+				"utf-8",
+			);
+
+			expect(await loadAllSessions(tempDir)).toEqual([]);
+			const wide = await loadAllSessions(tempDir, 7 * 24 * 3600_000);
+			expect(wide.map((s) => s.sessionId)).toEqual(["old"]);
+		});
+
 		it("should handle corrupted sessions.json gracefully", async () => {
 			const dir = await ensureJolliMemoryDir(tempDir);
 			await writeFile(join(dir, "sessions.json"), "not valid json", "utf-8");

--- a/cli/src/core/SessionTracker.ts
+++ b/cli/src/core/SessionTracker.ts
@@ -92,11 +92,23 @@ export async function saveSession(sessionInfo: SessionInfo, cwd?: string): Promi
 /**
  * Loads all active (non-stale) sessions from the registry.
  * Returns an empty array if no sessions exist.
+ *
+ * `windowMs` widens the read-side filter and defaults to {@link SESSION_STALE_MS},
+ * so every existing caller is unaffected. It exists for interface symmetry with the
+ * per-source discoverers, which the dashboard's back-fill calls with a 7-day window.
+ *
+ * **Widening it recovers almost nothing, and for Gemini nothing at all.** The prune
+ * here only filters what it returns, but `saveSession` writes back the pruned
+ * registry — a PHYSICAL delete — and every Claude or Gemini turn triggers one. So
+ * rows past the window are normally gone from the file before any reader could have
+ * asked for them. Claude has a second route (`ClaudeSessionDiscoverer` reads the
+ * transcripts themselves, which survive indefinitely); Gemini has none, so its
+ * history older than 48 h is unrecoverable until a Gemini disk scanner exists.
  */
-export async function loadAllSessions(cwd?: string): Promise<ReadonlyArray<SessionInfo>> {
+export async function loadAllSessions(cwd?: string, windowMs?: number): Promise<ReadonlyArray<SessionInfo>> {
 	const dir = getJolliMemoryDir(cwd);
 	const registry = await loadSessionsRegistry(dir);
-	const { activeSessions } = pruneStale(registry.sessions);
+	const { activeSessions } = pruneStale(registry.sessions, windowMs);
 	const sessions = Object.values(activeSessions);
 	return sessions;
 }
@@ -1253,10 +1265,19 @@ async function loadCursorsRegistry(dir: string, filename: string = CURSORS_FILE)
 }
 
 /**
- * Filters out sessions older than SESSION_STALE_MS.
+ * Filters out sessions older than `staleMs` (default {@link SESSION_STALE_MS}).
  * Returns the active sessions and the transcript paths of pruned sessions.
+ *
+ * The window is a parameter only for the read path ({@link loadAllSessions}). The
+ * WRITE callers — `saveSession` and `pruneStaleSessions` — deliberately keep the
+ * default, because what they do with the result is delete rows from disk: a caller
+ * that widened the window there would not be reading more, it would be changing how
+ * long the registry retains anything.
  */
-function pruneStale(sessions: Readonly<Record<string, SessionInfo>>): {
+function pruneStale(
+	sessions: Readonly<Record<string, SessionInfo>>,
+	staleMs: number = SESSION_STALE_MS,
+): {
 	activeSessions: Record<string, SessionInfo>;
 	stalePaths: string[];
 } {
@@ -1266,7 +1287,7 @@ function pruneStale(sessions: Readonly<Record<string, SessionInfo>>): {
 
 	for (const [id, session] of Object.entries(sessions)) {
 		const age = now - new Date(session.updatedAt).getTime();
-		if (age > SESSION_STALE_MS) {
+		if (age > staleMs) {
 			log.info("Pruning stale session %s (age: %dh)", id, Math.round(age / 3600000));
 			stalePaths.push(session.transcriptPath);
 		} else {

--- a/cli/src/core/SessionWindow.ts
+++ b/cli/src/core/SessionWindow.ts
@@ -1,0 +1,31 @@
+/**
+ * How far back a session scan looks, for the one caller that does not want the
+ * live 48-hour horizon.
+ *
+ * Each per-source discoverer keeps its own `SESSION_STALE_MS = 48 h` as the DEFAULT
+ * of an optional window parameter. That default is what the sidebar's Active
+ * Conversations, `jolli status`, and the post-commit summary generation all get by
+ * simply not passing anything — and the last of those is the reason the defaults
+ * were never turned into knobs. `QueueWorker` uses that window to decide which
+ * conversations belong to the commit it is summarising: widening it there would
+ * write week-old unrelated conversations into that commit's stored memory, on the
+ * git orphan branch, persistently, with no error printed anywhere. A noisy sidebar
+ * is visible; that is not.
+ *
+ * This constant is the other side of that split, and it lives in its own module so
+ * that neither side can be reached by editing the other. It is imported by the
+ * dashboard's history back-fill (which passes it to every source) and by
+ * `ClaudeSessionDiscoverer` (whose only caller is that back-fill, so it is also its
+ * default).
+ */
+
+/**
+ * The history back-fill's discovery window: 7 days.
+ *
+ * Chosen against what the 48-hour horizon was actually costing. Measured on a real
+ * machine, `sessions.json` held 3 Claude sessions while `~/.claude/projects` held 64
+ * transcripts — the other 61 conversations, and every skill and MCP call in them,
+ * were invisible to the dashboard because a hook registry that prunes at 48 h was
+ * the only route to them.
+ */
+export const BACKFILL_SESSION_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;

--- a/cli/src/core/TranscriptMessageCounter.ts
+++ b/cli/src/core/TranscriptMessageCounter.ts
@@ -24,21 +24,11 @@
 
 import { createLogger, errMsg } from "../Logger.js";
 import type { SessionInfo, TranscriptEntry, TranscriptReadResult, TranscriptSource } from "../Types.js";
-import { readAntigravityTranscript } from "./AntigravityTranscriptReader.js";
-import { readClineCliTranscript } from "./ClineCliTranscriptReader.js";
-import { readClineTranscript } from "./ClineTranscriptReader.js";
 import { applyOverlay, loadOverlay } from "./ConversationOverlayStore.js";
-import { readCopilotChatTranscript } from "./CopilotChatTranscriptReader.js";
-import { readCopilotTranscript } from "./CopilotTranscriptReader.js";
-import { readCursorCliTranscript } from "./CursorCliTranscriptReader.js";
-import { readCursorTranscript } from "./CursorTranscriptReader.js";
-import { readDevinTranscript } from "./DevinTranscriptReader.js";
-import { readGeminiTranscript } from "./GeminiTranscriptReader.js";
-import { readOpenCodeTranscript } from "./OpenCodeTranscriptReader.js";
 import { loadCursorForTranscript } from "./SessionTracker.js";
 import { loadTranscript } from "./TranscriptLoader.js";
-import { getParserForSource } from "./TranscriptParser.js";
-import { isMissingTranscriptError, readTranscript } from "./TranscriptReader.js";
+import { isMissingTranscriptError } from "./TranscriptReader.js";
+import { readTranscriptForSource } from "./TranscriptSourceReader.js";
 
 const log = createLogger("TranscriptMessageCounter");
 
@@ -127,35 +117,8 @@ async function readUnreadTranscript(
 	transcriptPath: string,
 	cursor: Awaited<ReturnType<typeof loadCursorForTranscript>>,
 ): Promise<TranscriptReadResult> {
-	switch (source) {
-		case "gemini":
-			return readGeminiTranscript(transcriptPath, cursor);
-		case "opencode":
-			return readOpenCodeTranscript(transcriptPath, cursor);
-		case "cursor":
-			return readCursorTranscript(transcriptPath, cursor);
-		case "copilot":
-			return readCopilotTranscript(transcriptPath, cursor);
-		case "devin":
-			return readDevinTranscript(transcriptPath, cursor);
-		case "cursor-cli":
-			return readCursorCliTranscript(transcriptPath, cursor);
-		case "copilot-chat":
-			return readCopilotChatTranscript(transcriptPath, cursor ?? undefined);
-		case "cline":
-			return readClineTranscript(transcriptPath, cursor);
-		case "cline-cli":
-			return readClineCliTranscript(transcriptPath, cursor);
-		case "antigravity":
-			return readAntigravityTranscript(transcriptPath, cursor ?? undefined);
-		case "codex":
-			return readTranscript(transcriptPath, cursor, getParserForSource("codex"));
-		case "kimi":
-			return readTranscript(transcriptPath, cursor, getParserForSource("kimi"));
-		default:
-			// Claude is the fallback parser; SessionInfo.source defaults to
-			// "claude" for back-compat, so unknown values flow through here
-			// too rather than throwing.
-			return readTranscript(transcriptPath, cursor, getParserForSource("claude"));
-	}
+	// The dispatch itself lives in `TranscriptSourceReader`, shared with the dashboard
+	// back-fill. It used to be inline here, where nothing else could reach it — which
+	// is how the back-fill ended up unable to read anything but Claude.
+	return readTranscriptForSource(source, transcriptPath, cursor);
 }

--- a/cli/src/core/TranscriptParser.test.ts
+++ b/cli/src/core/TranscriptParser.test.ts
@@ -395,6 +395,176 @@ describe("ClaudeTranscriptParser", () => {
 			).toEqual([{ name: "code-review", kind: "skill", calls: 1 }]);
 		});
 
+		it("names a Skill call after what the host launched, not what the model asked for", () => {
+			// `input.skill` is the request; `toolUseResult.commandName` is the resolved id,
+			// and a plugin-provided skill differs by its prefix. `ClaudeSkillScanner` has
+			// always preferred the resolved one, so reporting the request here put ONE
+			// invocation in two `session_tool_use` rows with the calls split between them.
+			const result = parser.parseToolUse([
+				line([{ type: "tool_use", id: "t1", name: "Skill", input: { skill: "brainstorming" } }]),
+				JSON.stringify({
+					type: "user",
+					toolUseResult: { success: true, commandName: "superpowers:brainstorming" },
+					message: { role: "user", content: [{ type: "tool_result", tool_use_id: "t1" }] },
+				}),
+			]);
+			expect(result).toEqual([{ name: "superpowers:brainstorming", kind: "skill", calls: 1 }]);
+		});
+
+		it("counts a held-back skill call once when its response repeats across lines", () => {
+			// Skill blocks are tallied after the stream rather than where they are seen, so
+			// the repeat-dedupe has to survive the detour — it still rides on the block id.
+			const dup = line([{ type: "tool_use", id: "toolu_s", name: "Skill", input: { skill: "code-review" } }]);
+			expect(parser.parseToolUse([dup, dup])).toEqual([{ name: "code-review", kind: "skill", calls: 1 }]);
+		});
+
+		it("ignores a resolved name that belongs to a different call", () => {
+			// The pairing is by `tool_use_id`. A result whose id matches nothing must not
+			// rename an unrelated skill.
+			const result = parser.parseToolUse([
+				line([{ type: "tool_use", id: "t1", name: "Skill", input: { skill: "code-review" } }]),
+				JSON.stringify({
+					toolUseResult: { commandName: "other:skill" },
+					message: { role: "user", content: [{ type: "tool_result", tool_use_id: "t2" }] },
+				}),
+			]);
+			expect(result).toEqual([{ name: "code-review", kind: "skill", calls: 1 }]);
+		});
+
+		it("stamps a tool call with the instant of the LINE that recorded it", () => {
+			// Read per line rather than per file: one session's calls span hours, and the
+			// dashboard windows recall activity by this field — a session-level clock would
+			// date a three-week-old call as today's.
+			const at = "2026-08-01T10:00:00.000Z";
+			const result = parser.parseToolUse([
+				JSON.stringify({
+					type: "assistant",
+					timestamp: at,
+					message: { role: "assistant", content: [{ type: "tool_use", id: "t1", name: "Bash" }] },
+				}),
+			]);
+			expect(result).toEqual([{ name: "Bash", kind: "builtin", calls: 1, lastCallAtMs: Date.parse(at) }]);
+		});
+
+		it("stamps a HELD-BACK skill call from its own line too", () => {
+			// Skills are tallied after the whole stream, so their instant has to survive
+			// that detour — it is captured with the request, not when the fold runs.
+			const at = "2026-08-01T11:00:00.000Z";
+			const result = parser.parseToolUse([
+				JSON.stringify({
+					type: "assistant",
+					timestamp: at,
+					message: {
+						role: "assistant",
+						content: [{ type: "tool_use", id: "s1", name: "Skill", input: { skill: "code-review" } }],
+					},
+				}),
+			]);
+			expect(result).toEqual([{ name: "code-review", kind: "skill", calls: 1, lastCallAtMs: Date.parse(at) }]);
+		});
+
+		it("still counts a tool_use block that carries no id", () => {
+			// The repeat-dedupe keys on the block id; without one there is nothing to
+			// dedupe against, so the call is counted rather than dropped.
+			expect(parser.parseToolUse([line([{ type: "tool_use", name: "Bash" }])])).toEqual([
+				{ name: "Bash", kind: "builtin", calls: 1 },
+			]);
+		});
+
+		it("skips a line that is not JSON, and one whose content is not an array", () => {
+			// Both are routine in a live transcript: a partially-written last line, and
+			// the many record shapes whose `content` is a plain string.
+			expect(parser.parseToolUse(["{not json", JSON.stringify({ message: { content: "plain text" } })])).toEqual(
+				[],
+			);
+		});
+
+		it("resolves nothing from a tool_result block with no tool_use_id", () => {
+			// The name is paired to a call BY id, so a result that identifies no call
+			// cannot rename anything — the skill keeps what the model requested.
+			const result = parser.parseToolUse([
+				line([{ type: "tool_use", id: "t1", name: "Skill", input: { skill: "code-review" } }]),
+				JSON.stringify({
+					toolUseResult: { commandName: "superpowers:brainstorming" },
+					message: { role: "user", content: [{ type: "tool_result" }] },
+				}),
+			]);
+			expect(result).toEqual([{ name: "code-review", kind: "skill", calls: 1 }]);
+		});
+
+		it("keeps a Skill call that carries no id, without consulting the resolved names", () => {
+			// No id means nothing to pair a result against, so the fold must not try — and
+			// the call still has to be counted, under the name the model asked for.
+			const result = parser.parseToolUse([
+				line([{ type: "tool_use", name: "Skill", input: { skill: "code-review" } }]),
+				JSON.stringify({
+					toolUseResult: { commandName: "superpowers:brainstorming" },
+					message: { role: "user", content: [{ type: "tool_result", tool_use_id: "t-other" }] },
+				}),
+			]);
+			expect(result).toEqual([{ name: "code-review", kind: "skill", calls: 1 }]);
+		});
+
+		it("ignores a block that is neither a tool_use nor a tool_result", () => {
+			// Assistant content is mostly text; only the tool-shaped blocks are tallied.
+			expect(parser.parseToolUse([line([{ type: "text", text: "thinking" }])])).toEqual([]);
+		});
+
+		it("ignores a tool_use whose name is not a string", () => {
+			expect(parser.parseToolUse([line([{ type: "tool_use", id: "t1", name: 42 }])])).toEqual([]);
+		});
+
+		it("ignores a Skill block whose requested skill is not a string", () => {
+			// It falls through to the builtin path rather than being held back, so it is
+			// counted as one call of the `Skill` tool itself — the honest answer when the
+			// skill it ran cannot be read.
+			expect(
+				parser.parseToolUse([line([{ type: "tool_use", id: "t1", name: "Skill", input: { skill: 7 } }])]),
+			).toEqual([{ name: "Skill", kind: "builtin", calls: 1 }]);
+		});
+
+		it("resolves nothing when one record carries SEVERAL tool results", () => {
+			// `toolUseResult` is one object, so a record with two results leaves no way to
+			// tell which one its name describes. Attributing it to both would rename the
+			// other skill after the first. Both fall back to what the model requested,
+			// which is what a missing result record already does.
+			const result = parser.parseToolUse([
+				line([
+					{ type: "tool_use", id: "t1", name: "Skill", input: { skill: "code-review" } },
+					{ type: "tool_use", id: "t2", name: "Skill", input: { skill: "brainstorming" } },
+				]),
+				JSON.stringify({
+					toolUseResult: { commandName: "superpowers:brainstorming" },
+					message: {
+						role: "user",
+						content: [
+							{ type: "tool_result", tool_use_id: "t1" },
+							{ type: "tool_result", tool_use_id: "t2" },
+						],
+					},
+				}),
+			]);
+			expect(result).toEqual([
+				{ name: "code-review", kind: "skill", calls: 1 },
+				{ name: "brainstorming", kind: "skill", calls: 1 },
+			]);
+		});
+
+		it("keeps the requested name when the result resolves to an EMPTY one", () => {
+			// An empty `commandName` is not an answer. Taken as one it would win the
+			// fallback and file the invocation under a nameless skill — a row nobody can
+			// recognise, and one `mergeToolCalls` cannot fold with the skill scanner's,
+			// since that fold is on the name.
+			const result = parser.parseToolUse([
+				line([{ type: "tool_use", id: "t1", name: "Skill", input: { skill: "code-review" } }]),
+				JSON.stringify({
+					toolUseResult: { commandName: "" },
+					message: { role: "user", content: [{ type: "tool_result", tool_use_id: "t1" }] },
+				}),
+			]);
+			expect(result).toEqual([{ name: "code-review", kind: "skill", calls: 1 }]);
+		});
+
 		it("falls back to the builtin name when a Skill call carries no skill id", () => {
 			expect(parser.parseToolUse([line([{ type: "tool_use", id: "t1", name: "Skill", input: {} }])])).toEqual([
 				{ name: "Skill", kind: "builtin", calls: 1 },

--- a/cli/src/core/TranscriptParser.ts
+++ b/cli/src/core/TranscriptParser.ts
@@ -45,6 +45,21 @@ function latestOf(...times: ReadonlyArray<number | undefined>): { lastCallAtMs?:
 	return known.length > 0 ? { lastCallAtMs: Math.max(...known) } : {};
 }
 
+/**
+ * How many `tool_result` blocks one record's content carries.
+ *
+ * Only the count matters, and only to decide whether the record's single
+ * `toolUseResult.commandName` can be attributed to a specific block — see
+ * `ClaudeTranscriptParser.parseToolUse`.
+ */
+function countToolResults(content: ReadonlyArray<unknown>): number {
+	let n = 0;
+	// Plain member access, matching how the tally loop reads the same blocks: a `?.`
+	// here would add a null branch no transcript can produce and no test can reach.
+	for (const block of content) if ((block as { type?: unknown }).type === "tool_result") n++;
+	return n;
+}
+
 // Re-exported for the callers that already imported it from here; the shared
 // classifiers now live in ToolNameClassify.ts alongside the other dialects.
 export { classifyToolName } from "./ToolNameClassify.js";
@@ -167,12 +182,34 @@ export class ClaudeTranscriptParser implements TranscriptParser {
 	 * would otherwise count each call several times. The block id is unique per
 	 * call and stable across those repeats — exactly the identity needed.
 	 *
-	 * A `Skill` call is re-attributed to the skill it ran (`input.skill`), since
-	 * "which skills does this person use" is the question being asked; counting
-	 * every skill invocation as one builtin named `Skill` would answer nothing.
+	 * A `Skill` call is re-attributed to the skill it ran, since "which skills does
+	 * this person use" is the question being asked; counting every skill invocation
+	 * as one builtin named `Skill` would answer nothing.
+	 *
+	 * ## The skill's name comes from the RESULT record, not from the request
+	 *
+	 * `input.skill` is what the model asked for; `toolUseResult.commandName`, on the
+	 * following `tool_result` record, is what the host actually launched — and for a
+	 * plugin-provided skill the two differ by the plugin prefix (`brainstorming`
+	 * against `superpowers:brainstorming`). `ClaudeSkillScanner` has always preferred
+	 * the resolved name, so reporting the requested one here made the two halves of
+	 * one skill's usage disagree: `mergeToolCalls` folds on `(kind, name)`, so a
+	 * single invocation surfaced as TWO `session_tool_use` rows — one of them under a
+	 * name the user never typed, with the call count split between them.
+	 *
+	 * That is why skill blocks are held back rather than tallied where they are seen:
+	 * the result record arrives after the request, so the resolved name is not known
+	 * yet. Everything else is tallied inline, and the held-back skills are folded in
+	 * at the end (which is why they sort last). A call whose result never arrived —
+	 * an incremental slice that split the pair, a session still mid-turn — falls back
+	 * to the requested name, exactly as before.
 	 */
 	parseToolUse(lines: ReadonlyArray<string>): ToolCallCount[] {
 		const tally = new ToolUseTally();
+		/** Skill requests, awaiting whatever name their result record resolves to. */
+		const pendingSkills: Array<{ readonly id?: string; readonly requested: string; readonly atMs?: number }> = [];
+		/** `tool_use_id` → the skill id the host reported launching for it. */
+		const resolved = new Map<string, string>();
 		for (const line of lines) {
 			let parsed: unknown;
 			try {
@@ -180,22 +217,73 @@ export class ClaudeTranscriptParser implements TranscriptParser {
 			} catch {
 				continue;
 			}
-			const content = (parsed as { message?: { content?: unknown } })?.message?.content;
+			const record = parsed as { message?: { content?: unknown }; toolUseResult?: { commandName?: unknown } };
+			const content = record?.message?.content;
 			if (!Array.isArray(content)) continue;
+			// Read once per line: the resolved name lives on the RECORD, beside the
+			// content, while the id it belongs to lives in the `tool_result` block below.
+			//
+			// An EMPTY string is treated as no answer rather than as the name. It would
+			// otherwise win the `??` fallback below and file the invocation under a
+			// nameless skill — a row the user cannot recognise and cannot merge with the
+			// scanner's own, since `mergeToolCalls` folds on the name.
+			//
+			const rawCommandName = record.toolUseResult?.commandName;
+			const commandName =
+				typeof rawCommandName === "string" && rawCommandName.length > 0 ? rawCommandName : undefined;
+			// `toolUseResult` is ONE object, so it can only describe one result — and
+			// Claude Code writes each tool result as its own record, which is why every
+			// real record here carries exactly one `tool_result` block. A record with
+			// several would leave no way to tell which one the name belongs to, and
+			// handing it to all of them would rename an unrelated skill: two parallel
+			// skill calls answered in one record would both take the first one's name.
+			//
+			// So a multi-result record resolves NOTHING and every skill in it falls back
+			// to what the model requested. That is the same outcome as a result record
+			// that never arrived, which the fold below already handles. Defensive rather
+			// than observed: no capture shows this shape, and the check costs one pass
+			// over a handful of blocks.
+			const namesOneResult = countToolResults(content) === 1;
 			// The line's own instant, so the bucket can be windowed by when the call
 			// happened rather than by when its session was last touched. Read per
 			// line and not per file: one session's calls span hours.
 			const atMs = parseIsoMs(this.parseTimestamp(line));
 			for (const block of content) {
-				const b = block as { type?: unknown; id?: unknown; name?: unknown; input?: { skill?: unknown } };
+				const b = block as {
+					type?: unknown;
+					id?: unknown;
+					tool_use_id?: unknown;
+					name?: unknown;
+					input?: { skill?: unknown };
+				};
+				if (b.type === "tool_result") {
+					if (commandName !== undefined && namesOneResult && typeof b.tool_use_id === "string")
+						resolved.set(b.tool_use_id, commandName);
+					continue;
+				}
 				if (b.type !== "tool_use" || typeof b.name !== "string") continue;
-				tally.addOnce(typeof b.id === "string" ? b.id : undefined, {
-					...(b.name === "Skill" && typeof b.input?.skill === "string"
-						? skillTool(b.input.skill)
-						: classifyToolName(b.name)),
+				const id = typeof b.id === "string" ? b.id : undefined;
+				if (b.name === "Skill" && typeof b.input?.skill === "string") {
+					pendingSkills.push({
+						...(id !== undefined ? { id } : {}),
+						requested: b.input.skill,
+						...(atMs !== undefined ? { atMs } : {}),
+					});
+					continue;
+				}
+				tally.addOnce(id, {
+					...classifyToolName(b.name),
 					...(atMs !== undefined && { lastCallAtMs: atMs }),
 				});
 			}
+		}
+		for (const pending of pendingSkills) {
+			// De-duplication still rides on the block id, so a response repeated across
+			// lines contributes one call however many times it was held back.
+			tally.addOnce(pending.id, {
+				...skillTool((pending.id !== undefined ? resolved.get(pending.id) : undefined) ?? pending.requested),
+				...(pending.atMs !== undefined && { lastCallAtMs: pending.atMs }),
+			});
 		}
 		return tally.values();
 	}

--- a/cli/src/core/TranscriptReader.ts
+++ b/cli/src/core/TranscriptReader.ts
@@ -152,10 +152,6 @@ export async function readTranscript(
 	parser?: TranscriptParser,
 	beforeTimestamp?: string,
 ): Promise<TranscriptReadResult> {
-	const startLine = cursor?.lineNumber ?? 0;
-	const activeParser = parser ?? new ClaudeTranscriptParser();
-	const parseFn = (line: string, num: number) => activeParser.parseLine(line, num);
-
 	let content: string;
 	try {
 		content = await readFile(transcriptPath, "utf-8");
@@ -171,8 +167,55 @@ export async function readTranscript(
 		// the next reader's trap, not a live bug.
 		throwTranscriptReadError(log, `Cannot read transcript: ${transcriptPath}`, error);
 	}
+	return parseTranscriptContent(transcriptPath, content, cursor, parser, beforeTimestamp);
+}
 
-	const lines = content.split("\n").filter((line) => line.trim().length > 0);
+/**
+ * A JSONL transcript's non-blank lines, as every reader here counts them.
+ *
+ * Exported because line NUMBERS cross module boundaries: a scanner handed these
+ * lines reports a cursor position against them, and the incremental cursors in
+ * `discovery-cursors.json` are monotonic — a mark advanced past a line is never
+ * re-read. So a second filter that disagreed by even one blank line would not
+ * fail loudly; it would silently strand records on one side of the boundary.
+ * One function, one definition of "line N".
+ */
+export function splitTranscriptLines(content: string): string[] {
+	return content.split("\n").filter((line) => line.trim().length > 0);
+}
+
+/**
+ * Everything {@link readTranscript} does once the file is in hand — same result,
+ * same rules, no disk access.
+ *
+ * Split out for a caller that has ALREADY read the file, so one read can serve both
+ * it and this parse — by extraction rather than by a second implementation, which is
+ * what keeps "what counts as a turn, a token, a tool call" in exactly one place.
+ *
+ * **No such caller exists today**, and the reason is worth knowing before adding one.
+ * The Claude disk scan was it: it reads each transcript whole for the working
+ * directories a `cd` scattered through the file, and handing that text over here
+ * removed a second read (measured 464 ms across 64 transcripts, paid twice). It was
+ * reverted because the parse then had to be CARRIED for the whole run, which made a
+ * back-fill's resident set grow with its window — see `acceptFacts` in
+ * `ClaudeSessionDiscoverer`. So the seam is kept, and a future caller may use it, but
+ * only one that consumes the result immediately rather than holding it.
+ *
+ * `transcriptPath` is still required: it is not read, but it is what the returned
+ * cursor names.
+ */
+export function parseTranscriptContent(
+	transcriptPath: string,
+	content: string,
+	cursor?: TranscriptCursor | null,
+	parser?: TranscriptParser,
+	beforeTimestamp?: string,
+): TranscriptReadResult {
+	const startLine = cursor?.lineNumber ?? 0;
+	const activeParser = parser ?? new ClaudeTranscriptParser();
+	const parseFn = (line: string, num: number) => activeParser.parseLine(line, num);
+
+	const lines = splitTranscriptLines(content);
 
 	// Process only new lines since cursor
 	const newLines = lines.slice(startLine);

--- a/cli/src/core/TranscriptSourceReader.test.ts
+++ b/cli/src/core/TranscriptSourceReader.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TranscriptCursor, TranscriptReadResult, TranscriptSource } from "../Types.js";
+
+// PARTIAL, and it has to be: `Logger` imports `appendFile` / `readdir` / `rename` /
+// `stat` / `unlink` from the same module to write `debug.log`, so a factory offering
+// only `readFile` makes the first `log.warn` in a case here fail with a TypeError
+// instead of exercising the branch under test.
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const original = await importOriginal<typeof import("node:fs/promises")>();
+	return { ...original, readFile: vi.fn() };
+});
+
+// Every per-source reader is replaced, because what this module IS is the dispatch:
+// the bug it exists to prevent is a source reaching the wrong one, and handing a
+// SQLite file to a line parser does not fail — it reports an empty conversation.
+vi.mock("./GeminiTranscriptReader.js", () => ({ readGeminiTranscript: vi.fn() }));
+vi.mock("./OpenCodeTranscriptReader.js", () => ({ readOpenCodeTranscript: vi.fn() }));
+vi.mock("./CursorTranscriptReader.js", () => ({ readCursorTranscript: vi.fn() }));
+vi.mock("./CopilotTranscriptReader.js", () => ({ readCopilotTranscript: vi.fn() }));
+vi.mock("./DevinTranscriptReader.js", () => ({ readDevinTranscript: vi.fn() }));
+vi.mock("./CursorCliTranscriptReader.js", () => ({ readCursorCliTranscript: vi.fn() }));
+vi.mock("./CopilotChatTranscriptReader.js", () => ({ readCopilotChatTranscript: vi.fn() }));
+vi.mock("./ClineTranscriptReader.js", () => ({ readClineTranscript: vi.fn() }));
+vi.mock("./ClineCliTranscriptReader.js", () => ({ readClineCliTranscript: vi.fn() }));
+vi.mock("./AntigravityTranscriptReader.js", () => ({ readAntigravityTranscript: vi.fn() }));
+// PARTIAL: only the read is faked. `splitTranscriptLines` is a pure string split this
+// module's line accessor depends on, and a mocked-away `undefined` would surface as a
+// TypeError rather than as a failed expectation.
+vi.mock("./TranscriptReader.js", async (importOriginal) => {
+	const original = await importOriginal<typeof import("./TranscriptReader.js")>();
+	return { ...original, readTranscript: vi.fn() };
+});
+
+import { readFile } from "node:fs/promises";
+import { readAntigravityTranscript } from "./AntigravityTranscriptReader.js";
+import { readClineCliTranscript } from "./ClineCliTranscriptReader.js";
+import { readClineTranscript } from "./ClineTranscriptReader.js";
+import { readCopilotChatTranscript } from "./CopilotChatTranscriptReader.js";
+import { readCopilotTranscript } from "./CopilotTranscriptReader.js";
+import { readCursorCliTranscript } from "./CursorCliTranscriptReader.js";
+import { readCursorTranscript } from "./CursorTranscriptReader.js";
+import { readDevinTranscript } from "./DevinTranscriptReader.js";
+import { readGeminiTranscript } from "./GeminiTranscriptReader.js";
+import { readOpenCodeTranscript } from "./OpenCodeTranscriptReader.js";
+import { getParserForSource } from "./TranscriptParser.js";
+import { readTranscript } from "./TranscriptReader.js";
+import { readTranscriptForSource, readTranscriptLinesForSource } from "./TranscriptSourceReader.js";
+
+const PATH = "/tmp/s1.jsonl";
+const CURSOR: TranscriptCursor = { transcriptPath: PATH, lineNumber: 3, updatedAt: "2026-08-01T00:00:00.000Z" };
+
+function result(tag: string): TranscriptReadResult {
+	return {
+		entries: [],
+		newCursor: { transcriptPath: tag, lineNumber: 0, updatedAt: "2026-08-01T00:00:00.000Z" },
+		totalLinesRead: 0,
+	};
+}
+
+/** Every dedicated reader, paired with the source tag that must reach it. */
+const DEDICATED = [
+	{ source: "gemini", reader: readGeminiTranscript },
+	{ source: "opencode", reader: readOpenCodeTranscript },
+	{ source: "cursor", reader: readCursorTranscript },
+	{ source: "copilot", reader: readCopilotTranscript },
+	{ source: "devin", reader: readDevinTranscript },
+	{ source: "cursor-cli", reader: readCursorCliTranscript },
+	{ source: "copilot-chat", reader: readCopilotChatTranscript },
+	{ source: "cline", reader: readClineTranscript },
+	{ source: "cline-cli", reader: readClineCliTranscript },
+	{ source: "antigravity", reader: readAntigravityTranscript },
+] as const;
+
+/** The two readers whose signature takes `undefined` rather than `null` for no cursor. */
+const UNDEFINED_ON_NULL = new Set<string>(["copilot-chat", "antigravity"]);
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe("readTranscriptForSource", () => {
+	for (const { source, reader } of DEDICATED) {
+		it(`sends ${source} to its own reader and nothing else`, async () => {
+			vi.mocked(reader).mockResolvedValue(result(source));
+
+			await expect(readTranscriptForSource(source as TranscriptSource, PATH, CURSOR)).resolves.toEqual(
+				result(source),
+			);
+
+			expect(reader).toHaveBeenCalledWith(PATH, CURSOR);
+			// The shared JSONL entry point must not see a store-backed source: its
+			// transcriptPath is a synthetic `<dbPath>#<sessionId>` handle, not a file.
+			expect(readTranscript).not.toHaveBeenCalled();
+			for (const other of DEDICATED) {
+				if (other.source !== source) expect(other.reader, other.source).not.toHaveBeenCalled();
+			}
+		});
+	}
+
+	for (const { source, reader } of DEDICATED) {
+		const expected = UNDEFINED_ON_NULL.has(source) ? undefined : null;
+		it(`passes a null cursor to ${source} as ${String(expected)}`, async () => {
+			// Two readers take `TranscriptCursor | undefined` while the rest accept null.
+			// Normalising in the wrong direction would not fail — it would silently read
+			// from the start.
+			vi.mocked(reader).mockResolvedValue(result(source));
+
+			await readTranscriptForSource(source as TranscriptSource, PATH, null);
+
+			expect(reader).toHaveBeenCalledWith(PATH, expected);
+		});
+	}
+
+	it("sends codex through the shared entry point with the codex parser", async () => {
+		vi.mocked(readTranscript).mockResolvedValue(result("codex"));
+
+		await readTranscriptForSource("codex", PATH, CURSOR);
+
+		expect(readTranscript).toHaveBeenCalledWith(PATH, CURSOR, getParserForSource("codex"));
+	});
+
+	it("sends kimi through the shared entry point with the kimi parser", async () => {
+		vi.mocked(readTranscript).mockResolvedValue(result("kimi"));
+
+		await readTranscriptForSource("kimi", PATH, CURSOR);
+
+		expect(readTranscript).toHaveBeenCalledWith(PATH, CURSOR, getParserForSource("kimi"));
+	});
+
+	it("sends claude through the shared entry point with the claude parser", async () => {
+		vi.mocked(readTranscript).mockResolvedValue(result("claude"));
+
+		await readTranscriptForSource("claude", PATH, CURSOR);
+
+		expect(readTranscript).toHaveBeenCalledWith(PATH, CURSOR, getParserForSource("claude"));
+	});
+
+	it("falls back to the claude parser for an UNKNOWN source rather than throwing", async () => {
+		// `SessionInfo.source` defaults to "claude" for back-compat, so unknown values
+		// flow through here too. Claude's pre-filters simply match nothing on a foreign
+		// transcript.
+		vi.mocked(readTranscript).mockResolvedValue(result("fallback"));
+
+		await readTranscriptForSource("something-new" as TranscriptSource, PATH, CURSOR);
+
+		expect(readTranscript).toHaveBeenCalledWith(PATH, CURSOR, getParserForSource("claude"));
+	});
+
+	it("lets a reader's failure propagate — the caller decides what it means", async () => {
+		// The message counter degrades to an empty transcript because a panel must still
+		// render; the back-fill logs and keeps the session row it already has. Swallowing
+		// here would take that choice away from both.
+		vi.mocked(readOpenCodeTranscript).mockRejectedValue(new Error("database is locked"));
+
+		await expect(readTranscriptForSource("opencode", PATH, CURSOR)).rejects.toThrow("database is locked");
+	});
+});
+
+describe("readTranscriptLinesForSource", () => {
+	it("answers undefined for a source with no line-oriented transcript", async () => {
+		// `undefined` rather than `[]`: a line scanner reads `[]` as "the conversation is
+		// empty" and would report a confident "no skills used" about a store it never
+		// opened. The file is not touched at all.
+		expect(await readTranscriptLinesForSource("opencode", PATH)).toBeUndefined();
+		expect(readFile).not.toHaveBeenCalled();
+	});
+
+	for (const source of ["claude", "codex", "kimi"] as const) {
+		it(`splits ${source}'s raw lines`, async () => {
+			vi.mocked(readFile).mockResolvedValue('{"a":1}\n\n{"b":2}\n');
+
+			expect(await readTranscriptLinesForSource(source, PATH)).toEqual(['{"a":1}', '{"b":2}']);
+			expect(readFile).toHaveBeenCalledWith(PATH, "utf-8");
+		});
+	}
+
+	it("drops blank lines the same way every other reader counts them", async () => {
+		// One definition of "line N": a second filter disagreeing by even one blank line
+		// would silently strand records on one side of a monotonic cursor.
+		vi.mocked(readFile).mockResolvedValue("\n   \n{}\n\t\n");
+
+		expect(await readTranscriptLinesForSource("claude", PATH)).toEqual(["{}"]);
+	});
+
+	it("answers undefined for an empty file rather than throwing", async () => {
+		vi.mocked(readFile).mockResolvedValue("");
+		expect(await readTranscriptLinesForSource("claude", PATH)).toEqual([]);
+	});
+
+	it("stays SILENT for a transcript that was rotated away", async () => {
+		// Routine rather than exceptional: a transcript can be deleted between the scan
+		// and this read, so ENOENT takes the quiet path.
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		vi.mocked(readFile).mockRejectedValue(Object.assign(new Error("nope"), { code: "ENOENT" }));
+
+		expect(await readTranscriptLinesForSource("claude", PATH)).toBeUndefined();
+
+		warn.mockRestore();
+	});
+
+	it("answers undefined for a genuine read failure too", async () => {
+		// Still undefined, never `[]` — the distinction that keeps a skill scanner from
+		// reporting about a file it could not see.
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		vi.mocked(readFile).mockRejectedValue(Object.assign(new Error("denied"), { code: "EACCES" }));
+
+		expect(await readTranscriptLinesForSource("claude", PATH)).toBeUndefined();
+
+		warn.mockRestore();
+	});
+});

--- a/cli/src/core/TranscriptSourceReader.ts
+++ b/cli/src/core/TranscriptSourceReader.ts
@@ -1,0 +1,124 @@
+/**
+ * TranscriptSourceReader — read one conversation, whichever agent wrote it.
+ *
+ * The per-source dispatch used to live privately inside `TranscriptMessageCounter`,
+ * where exactly one caller could reach it. That is why the dashboard back-fill,
+ * needing the same thing, instead grew `if (source !== "claude") return base` and
+ * silently gave up on tool calls for the other twelve sources — the capability was
+ * present, addressable only from a module about counting messages.
+ *
+ * Two dispatch styles, and the split is the sources' own:
+ *
+ *   - **JSONL** (claude / codex / kimi) — line-streamed through the matching
+ *     {@link TranscriptParser}. New agents in this family need no entry here, only
+ *     a parser.
+ *   - **Dedicated readers** (gemini's JSON file; the SQLite-backed opencode,
+ *     cursor, copilot, copilot-chat, cline, cline-cli, devin, cursor-cli and
+ *     antigravity stores) — each owns its own format, and several take the cursor
+ *     in a slightly different shape.
+ *
+ * **Every import is dynamic**, which is not a style choice: most of the readers
+ * below reach for `node:sqlite`, and a static import would emit its
+ * ExperimentalWarning in every process that merely loads this module — including
+ * the git hooks, which must stay silent on stdout. The previous home of this
+ * dispatch imported all of them eagerly, so moving it here also removes that.
+ */
+
+import { readFile } from "node:fs/promises";
+import { createLogger, errMsg, isEnoent } from "../Logger.js";
+import type { TranscriptCursor, TranscriptReadResult, TranscriptSource } from "../Types.js";
+import { getParserForSource } from "./TranscriptParser.js";
+import { readTranscript, splitTranscriptLines } from "./TranscriptReader.js";
+
+/**
+ * Sources whose transcript is a JSONL FILE, so raw lines are a thing it has.
+ *
+ * Exactly the sources the dispatch below sends to `readTranscript`; everything
+ * else is answered by a dedicated reader over a JSON file or a SQLite database,
+ * where a `transcriptPath` is a synthetic `<dbPath>#<sessionId>` handle rather
+ * than something that can be opened and split.
+ *
+ * Kept next to that dispatch because the two must agree: a source added to one
+ * and not the other either loses its lines silently, or gets handed the bytes of
+ * a SQLite file to parse as JSONL.
+ */
+const LINE_ORIENTED_SOURCES: ReadonlySet<string> = new Set(["claude", "codex", "kimi"]);
+
+const log = createLogger("TranscriptSourceReader");
+
+/**
+ * The transcript's raw non-blank lines, or `undefined` when this source has none.
+ *
+ * `undefined` rather than `[]` throughout — including for an unreadable file —
+ * because a line scanner reads `[]` as "the conversation is empty" and would
+ * report a confident "no skills used" about a file it never got to see.
+ */
+export async function readTranscriptLinesForSource(
+	source: TranscriptSource,
+	transcriptPath: string,
+): Promise<ReadonlyArray<string> | undefined> {
+	if (!LINE_ORIENTED_SOURCES.has(source)) return undefined;
+	try {
+		return splitTranscriptLines(await readFile(transcriptPath, "utf-8"));
+	} catch (err) {
+		// A transcript can be rotated or deleted between the scan and this read, which
+		// is routine rather than exceptional — ENOENT stays silent, as everywhere else.
+		if (!isEnoent(err))
+			log.warn("cannot read %s transcript lines from %s: %s", source, transcriptPath, errMsg(err));
+		return undefined;
+	}
+}
+
+/**
+ * Reads `transcriptPath` as `source` wrote it, from `cursor` forward.
+ *
+ * Throws whatever the underlying reader throws — a locked database, a malformed
+ * file, a missing one. Callers decide what a failure means: the message counter
+ * degrades to an empty transcript because a panel must still render, while the
+ * back-fill logs and keeps the session row it already has. Swallowing errors here
+ * would take that choice away from both.
+ */
+export async function readTranscriptForSource(
+	source: TranscriptSource,
+	transcriptPath: string,
+	cursor?: TranscriptCursor | null,
+): Promise<TranscriptReadResult> {
+	switch (source) {
+		case "gemini":
+			return (await import("./GeminiTranscriptReader.js")).readGeminiTranscript(transcriptPath, cursor);
+		case "opencode":
+			return (await import("./OpenCodeTranscriptReader.js")).readOpenCodeTranscript(transcriptPath, cursor);
+		case "cursor":
+			return (await import("./CursorTranscriptReader.js")).readCursorTranscript(transcriptPath, cursor);
+		case "copilot":
+			return (await import("./CopilotTranscriptReader.js")).readCopilotTranscript(transcriptPath, cursor);
+		case "devin":
+			return (await import("./DevinTranscriptReader.js")).readDevinTranscript(transcriptPath, cursor);
+		case "cursor-cli":
+			return (await import("./CursorCliTranscriptReader.js")).readCursorCliTranscript(transcriptPath, cursor);
+		case "copilot-chat":
+			return (await import("./CopilotChatTranscriptReader.js")).readCopilotChatTranscript(
+				transcriptPath,
+				cursor ?? undefined,
+			);
+		case "cline":
+			return (await import("./ClineTranscriptReader.js")).readClineTranscript(transcriptPath, cursor);
+		case "cline-cli":
+			return (await import("./ClineCliTranscriptReader.js")).readClineCliTranscript(transcriptPath, cursor);
+		case "antigravity":
+			return (await import("./AntigravityTranscriptReader.js")).readAntigravityTranscript(
+				transcriptPath,
+				cursor ?? undefined,
+			);
+		case "codex":
+			return readTranscript(transcriptPath, cursor, getParserForSource("codex"));
+		case "kimi":
+			return readTranscript(transcriptPath, cursor, getParserForSource("kimi"));
+		default:
+			// Claude is the fallback parser; `SessionInfo.source` defaults to "claude"
+			// for back-compat, so unknown values flow through here too rather than
+			// throwing. A source with no reader of its own gets Claude's, whose
+			// pre-filters simply match nothing on a foreign transcript.
+			return readTranscript(transcriptPath, cursor, getParserForSource("claude"));
+	}
+}

--- a/cli/src/core/VscodeWorkspaceLocator.test.ts
+++ b/cli/src/core/VscodeWorkspaceLocator.test.ts
@@ -219,6 +219,77 @@ describe("findVscodeWorkspaceHash", () => {
 		expect(await findVscodeWorkspaceHash("Code", toNativePath("/Users/test/myproject"))).toBeNull();
 		expect(await findVscodeWorkspaceHash("Cursor", toNativePath("/Users/test/myproject"))).toBe("cursor1");
 	});
+
+	// ─── The forward direction, used by the machine-wide scans ──────────────────
+	describe("listVscodeWorkspaceFolders", () => {
+		it("returns every single-folder workspace with the path it opens", async () => {
+			// The direction a machine-wide scan needs: resolving a hash FROM a repo can
+			// only answer for the repo you already hold, so a scan built on the find
+			// re-reads every workspace.json once per registered repo.
+			makeWorkspaceEntry("Code", "ws-a", { folder: toFileUri("/Users/test/a") });
+			makeWorkspaceEntry("Code", "ws-b", { folder: toFileUri("/Users/test/b") });
+
+			const { listVscodeWorkspaceFolders } = await import("./VscodeWorkspaceLocator.js");
+			const found = await listVscodeWorkspaceFolders("Code");
+
+			expect(found.map((w) => w.hash).sort()).toEqual(["ws-a", "ws-b"]);
+			expect(found.find((w) => w.hash === "ws-a")?.folderPath).toBe(toNativePath("/Users/test/a"));
+		});
+
+		it("keeps BOTH entries when one folder is open under two workspaces", async () => {
+			// Routine — VS Code mints a new workspace per window identity. This is why the
+			// machine-wide scan cannot be `findVscodeWorkspaceHash` in a loop: that stops
+			// at the first match and would lose the second entry's sessions.
+			makeWorkspaceEntry("Code", "ws-1", { folder: toFileUri("/Users/test/same") });
+			makeWorkspaceEntry("Code", "ws-2", { folder: toFileUri("/Users/test/same") });
+
+			const { listVscodeWorkspaceFolders } = await import("./VscodeWorkspaceLocator.js");
+
+			expect((await listVscodeWorkspaceFolders("Code")).map((w) => w.hash).sort()).toEqual(["ws-1", "ws-2"]);
+		});
+
+		it("skips an entry with no workspace.json, a malformed one, and a multi-root one", async () => {
+			// A `workspace` field instead of `folder` is a multi-root `.code-workspace`
+			// file, which has no single folder to attribute sessions to.
+			makeWorkspaceEntry("Code", "ws-none", null);
+			makeWorkspaceEntry("Code", "ws-ok", { folder: toFileUri("/Users/test/ok") });
+			const bad = join(tmpRoot, "Library", "Application Support", "Code", "User", "workspaceStorage", "ws-bad");
+			mkdirSync(bad, { recursive: true });
+			writeFileSync(join(bad, "workspace.json"), "{ not json");
+			makeWorkspaceEntry("Code", "ws-multi", { workspace: "/Users/test/team.code-workspace" });
+
+			const { listVscodeWorkspaceFolders } = await import("./VscodeWorkspaceLocator.js");
+
+			expect((await listVscodeWorkspaceFolders("Code")).map((w) => w.hash)).toEqual(["ws-ok"]);
+		});
+
+		it("skips a folder URI that is not a file:// one", async () => {
+			// Remote workspaces (`vscode-remote://`, `ssh://`) have no local path, so there
+			// is nothing to match a repo against.
+			makeWorkspaceEntry("Code", "ws-remote", { folder: "vscode-remote://ssh-remote+box/home/u/p" });
+			makeWorkspaceEntry("Code", "ws-local", { folder: toFileUri("/Users/test/local") });
+
+			const { listVscodeWorkspaceFolders } = await import("./VscodeWorkspaceLocator.js");
+
+			expect((await listVscodeWorkspaceFolders("Code")).map((w) => w.hash)).toEqual(["ws-local"]);
+		});
+
+		it("returns an empty list when the storage directory is unreadable", async () => {
+			// Same silent degradation as the find, and for the same reason: a machine
+			// without this editor installed is not a failure to report.
+			const { listVscodeWorkspaceFolders } = await import("./VscodeWorkspaceLocator.js");
+			expect(await listVscodeWorkspaceFolders("VSCodium")).toEqual([]);
+		});
+
+		it("isolates flavors the same way the find does", async () => {
+			makeWorkspaceEntry("Cursor", "cursor-only", { folder: toFileUri("/Users/test/p") });
+
+			const { listVscodeWorkspaceFolders } = await import("./VscodeWorkspaceLocator.js");
+
+			expect(await listVscodeWorkspaceFolders("Code")).toEqual([]);
+			expect((await listVscodeWorkspaceFolders("Cursor")).map((w) => w.hash)).toEqual(["cursor-only"]);
+		});
+	});
 });
 
 describe("ALL_VSCODE_FLAVORS", () => {

--- a/cli/src/core/VscodeWorkspaceLocator.ts
+++ b/cli/src/core/VscodeWorkspaceLocator.ts
@@ -9,8 +9,14 @@
  * Public symbols:
  *   - getVscodeUserDataDir(flavor, home?)
  *   - getVscodeWorkspaceStorageDir(flavor, home?)
- *   - findVscodeWorkspaceHash(flavor, projectDir)
+ *   - findVscodeWorkspaceHash(flavor, projectDir)   — one repo → its workspace hash
+ *   - listVscodeWorkspaceFolders(flavor)            — every workspace → its folder
  *   - normalizePathForMatch(p)
+ *
+ * The last two are the two directions of the same lookup, and which one a caller
+ * wants follows from how many repos it serves: a per-repo question takes the find,
+ * a machine-wide scan serving every registered repo takes the list. Calling the
+ * find in a loop re-reads every `workspace.json` on the machine once per repo.
  */
 
 import { readdir, readFile } from "node:fs/promises";
@@ -76,12 +82,92 @@ export function normalizePathForMatch(p: string): string {
 }
 
 /**
+ * Reads one `workspaceStorage/<entry>/workspace.json` and returns the local path its
+ * `folder` URI points at, or undefined when there is none to read.
+ *
+ * Single-folder workspaces only — an entry with a `workspace` field instead of
+ * `folder` (a multi-root `.code-workspace` file) yields undefined and is skipped by
+ * every caller.
+ */
+async function readWorkspaceFolderPath(
+	flavor: VscodeFlavor,
+	wsStorageDir: string,
+	entry: string,
+): Promise<string | undefined> {
+	const wsJsonPath = join(wsStorageDir, entry, "workspace.json");
+	let folderUri: string | undefined;
+	try {
+		const raw = await readFile(wsJsonPath, "utf8");
+		const parsed = JSON.parse(raw) as Record<string, unknown>;
+		folderUri = typeof parsed.folder === "string" ? parsed.folder : undefined;
+	} catch {
+		return undefined;
+	}
+
+	if (!folderUri || !folderUri.startsWith("file://")) {
+		return undefined;
+	}
+
+	try {
+		return fileURLToPath(folderUri);
+	} catch {
+		log.warn("%s workspace %s has unparseable folder URI: %s", flavor, entry, folderUri);
+		return undefined;
+	}
+}
+
+/** One VS Code-family workspace: its storage directory name and the folder it opens. */
+export interface VscodeWorkspaceFolder {
+	/** The `workspaceStorage/<hash>` entry name. */
+	readonly hash: string;
+	/** The local path its `folder` URI resolves to. Raw — not normalised for matching. */
+	readonly folderPath: string;
+}
+
+/**
+ * Every single-folder workspace this flavour has storage for.
+ *
+ * The forward direction of {@link findVscodeWorkspaceHash}, and the one a machine-wide
+ * scan needs. Resolving a hash FROM a repo path can only answer for the repo you
+ * already have, so a scan built on it re-reads every `workspace.json` on the machine
+ * once per registered repo. Listing them once gives every repo its answer from one
+ * pass.
+ *
+ * Returns an empty list when the storage directory is unreadable — the same silent
+ * degradation `findVscodeWorkspaceHash` applies, and for the same reason: a machine
+ * without this editor installed is not a failure to report.
+ */
+export async function listVscodeWorkspaceFolders(flavor: VscodeFlavor): Promise<ReadonlyArray<VscodeWorkspaceFolder>> {
+	const wsStorageDir = getVscodeWorkspaceStorageDir(flavor);
+
+	let entries: string[];
+	try {
+		entries = await readdir(wsStorageDir);
+	} catch {
+		log.debug("%s workspaceStorage not readable at %s", flavor, wsStorageDir);
+		return [];
+	}
+
+	const out: VscodeWorkspaceFolder[] = [];
+	for (const entry of entries) {
+		const folderPath = await readWorkspaceFolderPath(flavor, wsStorageDir, entry);
+		if (folderPath !== undefined) out.push({ hash: entry, folderPath });
+	}
+	return out;
+}
+
+/**
  * Scans the workspaceStorage directory for an entry whose `workspace.json` has
  * a `folder` URI that resolves to projectDir. Returns the entry name (workspace
  * hash) on match, or null when no match is found.
  *
  * Single-folder workspaces only — entries with a `workspace` field instead of
  * `folder` (multi-root .code-workspace files) are skipped silently.
+ *
+ * Deliberately NOT written as a filter over {@link listVscodeWorkspaceFolders}: this
+ * stops at the first match, and its callers ask about one repo at a time. A caller
+ * that needs every workspace should use the list directly rather than calling this in
+ * a loop.
  */
 export async function findVscodeWorkspaceHash(flavor: VscodeFlavor, projectDir: string): Promise<string | null> {
 	const wsStorageDir = getVscodeWorkspaceStorageDir(flavor);
@@ -97,29 +183,8 @@ export async function findVscodeWorkspaceHash(flavor: VscodeFlavor, projectDir: 
 	const target = normalizePathForMatch(projectDir);
 
 	for (const entry of entries) {
-		const wsJsonPath = join(wsStorageDir, entry, "workspace.json");
-		let folderUri: string | undefined;
-		try {
-			const raw = await readFile(wsJsonPath, "utf8");
-			const parsed = JSON.parse(raw) as Record<string, unknown>;
-			folderUri = typeof parsed.folder === "string" ? parsed.folder : undefined;
-		} catch {
-			continue;
-		}
-
-		if (!folderUri || !folderUri.startsWith("file://")) {
-			continue;
-		}
-
-		let folderPath: string;
-		try {
-			folderPath = fileURLToPath(folderUri);
-		} catch {
-			log.warn("%s workspace %s has unparseable folder URI: %s", flavor, entry, folderUri);
-			continue;
-		}
-
-		if (normalizePathForMatch(folderPath) === target) {
+		const folderPath = await readWorkspaceFolderPath(flavor, wsStorageDir, entry);
+		if (folderPath !== undefined && normalizePathForMatch(folderPath) === target) {
 			return entry;
 		}
 	}

--- a/cli/src/core/sessions/SessionSignalExtractor.test.ts
+++ b/cli/src/core/sessions/SessionSignalExtractor.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import type { ToolCallCount } from "../../Types.js";
+import { mergeToolCalls } from "./SessionSignalExtractor.js";
+
+/**
+ * The merge key's separator, written as an ESCAPE.
+ *
+ * Never the byte itself: git decides a file is binary by looking for a NUL in the
+ * first 8000 bytes, so one literal control character would turn this whole test file
+ * into an unreviewable diff — the same trap `KEY_SEP` documents in the module under
+ * test.
+ */
+const NUL = "\u0000";
+
+/** One bucket, with only the fields a case is about spelled out. */
+function bucket(over: Partial<ToolCallCount> & Pick<ToolCallCount, "name">): ToolCallCount {
+	return { kind: "builtin", calls: 1, ...over };
+}
+
+describe("mergeToolCalls", () => {
+	it("returns nothing for no groups at all", () => {
+		expect(mergeToolCalls([])).toEqual([]);
+	});
+
+	it("returns nothing when every group is empty", () => {
+		// Distinct from the case above: the loop runs, the map stays empty. An
+		// extractor that answered `{ tools: [] }` is what produces this.
+		expect(mergeToolCalls([[], []])).toEqual([]);
+	});
+
+	it("passes a single group through, preserving order", () => {
+		const group = [bucket({ name: "Bash" }), bucket({ name: "Read" })];
+		expect(mergeToolCalls([group])).toEqual(group);
+	});
+
+	it("takes the LARGER count for one bucket seen twice, never the sum", () => {
+		// The whole reason this is a merge rather than a tally: the skill scanner and
+		// the tool reader are two VIEWS of one set of records. Summing doubled every
+		// tool-entered skill call.
+		const merged = mergeToolCalls([
+			[bucket({ name: "code-review", kind: "skill", calls: 1 })],
+			[bucket({ name: "code-review", kind: "skill", calls: 3 })],
+		]);
+		expect(merged).toEqual([{ name: "code-review", kind: "skill", calls: 3 }]);
+	});
+
+	it("keeps the larger count when the BIGGER one arrives first", () => {
+		// `Math.max` either way — the result must not depend on which extractor ran
+		// first, since the registry's order is documented as carrying no meaning.
+		const merged = mergeToolCalls([
+			[bucket({ name: "code-review", kind: "skill", calls: 3 })],
+			[bucket({ name: "code-review", kind: "skill", calls: 1 })],
+		]);
+		expect(merged).toEqual([{ name: "code-review", kind: "skill", calls: 3 }]);
+	});
+
+	it("does NOT fold two kinds that share a name", () => {
+		// The key is `(kind, name)`, matching `session_tool_use`'s primary key: a
+		// skill and a builtin called the same thing are two different things.
+		const merged = mergeToolCalls([
+			[bucket({ name: "code-review", kind: "skill", calls: 2 })],
+			[bucket({ name: "code-review", kind: "builtin", calls: 5 })],
+		]);
+		expect(merged).toEqual([
+			{ name: "code-review", kind: "skill", calls: 2 },
+			{ name: "code-review", kind: "builtin", calls: 5 },
+		]);
+	});
+
+	it("keeps a server the FIRST side carried", () => {
+		const merged = mergeToolCalls([
+			[bucket({ name: "linear.list_issues", kind: "mcp", server: "linear", calls: 1 })],
+			[bucket({ name: "linear.list_issues", kind: "mcp", calls: 2 })],
+		]);
+		expect(merged).toEqual([{ name: "linear.list_issues", kind: "mcp", server: "linear", calls: 2 }]);
+	});
+
+	it("adopts a server only the SECOND side carried", () => {
+		// Two buckets with the same (kind, name) name the same server, so it rides
+		// along from whichever side has it.
+		const merged = mergeToolCalls([
+			[bucket({ name: "linear.list_issues", kind: "mcp", calls: 2 })],
+			[bucket({ name: "linear.list_issues", kind: "mcp", server: "linear", calls: 1 })],
+		]);
+		expect(merged).toEqual([{ name: "linear.list_issues", kind: "mcp", server: "linear", calls: 2 }]);
+	});
+
+	it("omits `server` entirely when neither side has one", () => {
+		const merged = mergeToolCalls([[bucket({ name: "Bash" })], [bucket({ name: "Bash", calls: 4 })]]);
+		expect(merged).toEqual([{ name: "Bash", kind: "builtin", calls: 4 }]);
+		expect(merged[0]).not.toHaveProperty("server");
+	});
+
+	it("takes the LATER instant when both sides have one", () => {
+		const merged = mergeToolCalls([
+			[bucket({ name: "Bash", lastCallAtMs: 1_000 })],
+			[bucket({ name: "Bash", lastCallAtMs: 5_000 })],
+		]);
+		expect(merged).toEqual([{ name: "Bash", kind: "builtin", calls: 1, lastCallAtMs: 5_000 }]);
+	});
+
+	it("keeps a present instant when merged with an ABSENT one", () => {
+		// Absence means "this source records no timestamp", so it must not discard a
+		// real one the other side found.
+		const merged = mergeToolCalls([
+			[bucket({ name: "Bash", lastCallAtMs: 7_000 })],
+			[bucket({ name: "Bash", calls: 2 })],
+		]);
+		expect(merged).toEqual([{ name: "Bash", kind: "builtin", calls: 2, lastCallAtMs: 7_000 }]);
+	});
+
+	it("omits the instant when NEITHER side has one, rather than writing 0", () => {
+		// A zero is a real instant in 1970 and would sort as the oldest call ever made.
+		const merged = mergeToolCalls([[bucket({ name: "Bash" })], [bucket({ name: "Bash", calls: 2 })]]);
+		expect(merged[0]).not.toHaveProperty("lastCallAtMs");
+	});
+
+	it("folds three groups of the same bucket down to one", () => {
+		const merged = mergeToolCalls([
+			[bucket({ name: "Bash", calls: 1 })],
+			[bucket({ name: "Bash", calls: 9 })],
+			[bucket({ name: "Bash", calls: 4 })],
+		]);
+		expect(merged).toEqual([{ name: "Bash", kind: "builtin", calls: 9 }]);
+	});
+
+	it("does not let a NUL in a name collide two buckets", () => {
+		// The merge key joins kind and name with a NUL, chosen because no real name
+		// can contain one. This pins the property rather than the separator.
+		const merged = mergeToolCalls([
+			[bucket({ name: `a${NUL}b`, kind: "skill" }), bucket({ name: "a", kind: "skill" })],
+		]);
+		expect(merged).toHaveLength(2);
+	});
+});

--- a/cli/src/core/sessions/SessionSignalExtractor.ts
+++ b/cli/src/core/sessions/SessionSignalExtractor.ts
@@ -1,0 +1,178 @@
+/**
+ * SessionSignalExtractor — what the back-fill mines out of one conversation,
+ * described as a registry rather than as a chain of source names.
+ *
+ * ## The shape of the problem
+ *
+ * "What can be learned from a session" and "which agents can answer it" are two
+ * different questions, and the back-fill used to answer both with one line:
+ * `if (source !== "claude") return base`. Everything except Claude therefore
+ * contributed a bare session row — no tool calls, no MCP calls, no skills — even
+ * though nine sources have a reader that reports tool calls and three have a
+ * skill scanner. None of that was missing; none of it was wired.
+ *
+ * An extractor here answers the first question. The SOURCES it applies to are
+ * the second, and each extractor answers that for itself by consulting the
+ * capability table its own subsystem already maintains. So the back-fill names
+ * no agent at all: it asks every registered extractor whether it supports the
+ * source in hand, and merges what comes back.
+ *
+ * ## Why two extractors and not three, given `builtin` / `mcp` / `skill`
+ *
+ * Those are three CLASSIFICATIONS of one datum, not three data. A tool call is
+ * read once and filed by the shape of its name — `mcp__server__tool` is MCP, a
+ * `Skill` block is re-attributed to the skill it launched, everything else is a
+ * builtin. Splitting that into an "MCP extractor" would read the same file twice
+ * and leave two copies of a classification that must not drift.
+ *
+ * Skills need a second extractor for a different reason, and the distinction is
+ * the whole point of this module: **half of the skill data is not a tool call at
+ * all.** A `/plugin:skill` slash command appears as a `<command-name>` tag plus a
+ * following meta record — no `tool_use` block anywhere — so the tool reader is
+ * structurally unable to see it. Measured on one real machine: 36 Claude sessions
+ * over 7 days contained ZERO `Skill` tool blocks and 15 slash-command
+ * invocations, i.e. the tool-shaped path found none of that user's skill usage.
+ *
+ * The rule that follows: **an extractor exists per RECORD SHAPE that has to be
+ * parsed, not per column that comes out.** If a future signal rides on tool calls
+ * it belongs in the tool extractor; if it has its own record shape it gets its
+ * own.
+ */
+
+import type { ToolCallCount, TranscriptReadResult, TranscriptSource } from "../../Types.js";
+
+/**
+ * One session's content, read at most once however many extractors ask for it.
+ *
+ * Both accessors memoise, which is what lets extractors stay independent: the
+ * tool extractor and the skill extractor both want this transcript, neither
+ * knows the other ran, and the file is opened once regardless. Without that,
+ * adding an extractor would silently add a whole-file read per session.
+ *
+ * Sources whose transcripts are SQLite rows rather than JSONL have no lines to
+ * offer, so {@link lines} answers `undefined` — distinct from `[]`, which would
+ * claim the file was read and found empty and would send a line scanner off to
+ * report "no skills" about a store it never looked at.
+ */
+export interface SessionContent {
+	/** The parsed transcript, per that source's own reader. */
+	read(): Promise<TranscriptReadResult>;
+	/** Raw non-blank lines, or `undefined` for a source with no line-oriented transcript. */
+	lines(): Promise<ReadonlyArray<string> | undefined>;
+}
+
+/** What one extractor is given. */
+export interface SessionSignalInput {
+	readonly source: TranscriptSource;
+	readonly sessionId: string;
+	readonly transcriptPath: string;
+	readonly content: SessionContent;
+}
+
+/**
+ * What one extractor contributes to a session row.
+ *
+ * Deliberately a partial: an extractor reports only what it found, and the
+ * caller merges. Adding a field here (references, plan progress, …) is how a new
+ * KIND of signal joins, and no existing extractor has to change.
+ */
+export interface SessionSignals {
+	/**
+	 * Tool / MCP / skill call buckets.
+	 *
+	 * Merged across extractors on `(kind, name)` — see {@link mergeToolCalls} for
+	 * why that pair is the key and not the name alone.
+	 */
+	readonly tools?: ReadonlyArray<ToolCallCount>;
+}
+
+/** One kind of extraction, across every source that can answer it. */
+export interface SessionSignalExtractor {
+	/** Stable id, for logs. Not user-facing. */
+	readonly id: string;
+	/**
+	 * Whether this extractor can answer for `source`.
+	 *
+	 * MUST be derived from the subsystem's own capability table, never from a
+	 * literal list written here — a second list is a second thing to forget, and
+	 * forgetting it is silent (the source simply reports nothing, which reads
+	 * exactly like an agent that was not used).
+	 */
+	supports(source: TranscriptSource): boolean;
+	extract(input: SessionSignalInput): Promise<SessionSignals>;
+}
+
+/**
+ * Separator inside the merge key, written as an ESCAPE and never as a raw byte.
+ *
+ * NUL is the right separator — no tool name or kind can contain it, so no pair of
+ * distinct buckets can collide on one key. Typing the byte itself into the source
+ * is not: git detects a binary file by looking for a NUL in the first 8000 bytes,
+ * so one literal control character turned this whole module into `Bin 0 -> 6109
+ * bytes` in every diff. A file with no reviewable diff is a file whose changes
+ * nobody reads, which is exactly how the merge bug below survived.
+ */
+const KEY_SEP = "\u0000";
+
+/**
+ * Folds several extractors' buckets into one list.
+ *
+ * Keyed on `(kind, name)`, matching `session_tool_use`'s own primary key: a skill
+ * and a builtin may share a name, and merging them would put two different things
+ * in one row.
+ *
+ * ## `calls` takes the LARGER count, it does not add
+ *
+ * Two extractors reporting the same `(kind, name)` are two VIEWS of one set of
+ * records, never two independent tallies, so adding them reports a call that
+ * never happened. That is not hypothetical — it is the normal case for skills:
+ * `parseToolUse` re-attributes a `Skill` tool block to the skill it launched and
+ * emits it as `kind: "skill"`, while `ClaudeSkillScanner` counts that SAME tool
+ * block again (its `bucket(skill, "tool")` path) on top of the slash-command
+ * invocations only it can see. Summing doubled every tool-entered skill call in
+ * the dashboard.
+ *
+ * Folding on the name only works while the two agree on WHICH name, and they read
+ * it from the same place for that reason: `toolUseResult.commandName`, the id the
+ * host reported launching, falling back to the model's requested `input.skill`
+ * when no result record was in the slice. A version of `parseToolUse` that
+ * reported the requested name unconditionally put one invocation in two rows —
+ * see its own docstring.
+ *
+ * The larger count is the right answer rather than a compromise, because the two
+ * views are nested: the skill scanner sees both entry paths, the tool reader sees
+ * one of them. When they agree the max is that agreed number, so this degrades to
+ * "leave it alone" in every non-overlapping case.
+ *
+ * This is the same rule {@link mergeArchivedSkills} states for the archived-skill
+ * merge ("a transcript-derived count always wins ... archived refs cannot
+ * double-count against it"). Both exist because one skill invocation is
+ * observable from more than one record shape.
+ *
+ * `lastCallAtMs` takes the later of the two, and survives one side not having it —
+ * absence means "this source records no timestamp", so a present value must not be
+ * discarded by a merge with an absent one.
+ */
+export function mergeToolCalls(groups: ReadonlyArray<ReadonlyArray<ToolCallCount>>): ToolCallCount[] {
+	const merged = new Map<string, ToolCallCount>();
+	for (const group of groups) {
+		for (const call of group) {
+			const key = `${call.kind}${KEY_SEP}${call.name}`;
+			const seen = merged.get(key);
+			if (!seen) {
+				merged.set(key, call);
+				continue;
+			}
+			const lastCallAtMs = Math.max(seen.lastCallAtMs ?? 0, call.lastCallAtMs ?? 0);
+			merged.set(key, {
+				...seen,
+				// `server` rides along from whichever side has it: only MCP buckets carry
+				// one, and two buckets with the same (kind, name) name the same server.
+				...((seen.server ?? call.server) ? { server: seen.server ?? call.server } : {}),
+				calls: Math.max(seen.calls, call.calls),
+				...(lastCallAtMs > 0 ? { lastCallAtMs } : {}),
+			});
+		}
+	}
+	return [...merged.values()];
+}

--- a/cli/src/core/sessions/SessionSignals.test.ts
+++ b/cli/src/core/sessions/SessionSignals.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ToolCallCount, TranscriptSource } from "../../Types.js";
+
+// The registry is a module-level constant built from these two, so replacing the
+// modules is what lets a case decide who answers, who declines and who throws.
+vi.mock("./ToolCallExtractor.js", () => ({
+	toolCallExtractor: { id: "tool-calls", supports: vi.fn(), extract: vi.fn() },
+}));
+vi.mock("./SkillExtractor.js", () => ({
+	skillExtractor: { id: "skills", supports: vi.fn(), extract: vi.fn() },
+}));
+
+import type { SessionSignalInput } from "./SessionSignalExtractor.js";
+import { extractSessionSignals } from "./SessionSignals.js";
+import { skillExtractor } from "./SkillExtractor.js";
+import { toolCallExtractor } from "./ToolCallExtractor.js";
+
+const INPUT: SessionSignalInput = {
+	source: "claude",
+	sessionId: "s1",
+	transcriptPath: "/tmp/s1.jsonl",
+	content: {
+		read: async () => ({
+			entries: [],
+			newCursor: { transcriptPath: "/tmp/s1.jsonl", lineNumber: 0, updatedAt: "2026-08-01T00:00:00.000Z" },
+			totalLinesRead: 0,
+		}),
+		lines: async () => undefined,
+	},
+};
+
+/** Both extractors as vi mocks, since the module mock erases their real identity. */
+const tools = vi.mocked(toolCallExtractor);
+const skills = vi.mocked(skillExtractor);
+
+function bucket(name: string, calls: number): ToolCallCount {
+	return { name, kind: "builtin", calls };
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	tools.supports.mockReturnValue(false);
+	skills.supports.mockReturnValue(false);
+});
+
+describe("extractSessionSignals", () => {
+	it("reports ABSENCE when no extractor supports the source", async () => {
+		// `{}` rather than `{ tools: [] }`: in the database an empty list reads as "this
+		// agent called no tools" and absence reads as "this agent cannot report them".
+		const signals = await extractSessionSignals(INPUT);
+		expect(signals).toEqual({});
+		expect(tools.extract).not.toHaveBeenCalled();
+		expect(skills.extract).not.toHaveBeenCalled();
+	});
+
+	it("does not call an extractor that declined the source", async () => {
+		tools.supports.mockReturnValue(true);
+		tools.extract.mockResolvedValue({ tools: [bucket("Bash", 1)] });
+
+		await extractSessionSignals(INPUT);
+
+		expect(tools.extract).toHaveBeenCalledTimes(1);
+		expect(skills.extract).not.toHaveBeenCalled();
+	});
+
+	it("reports ABSENCE when every supporting extractor declined to answer", async () => {
+		// Supported but silent is still "cannot say" — an extractor that returns `{}`
+		// must not be upgraded to an empty list.
+		tools.supports.mockReturnValue(true);
+		skills.supports.mockReturnValue(true);
+		tools.extract.mockResolvedValue({});
+		skills.extract.mockResolvedValue({});
+
+		expect(await extractSessionSignals(INPUT)).toEqual({});
+	});
+
+	it("keeps an EMPTY list one extractor did produce", async () => {
+		// The positive claim "called no tools", which is worth storing.
+		tools.supports.mockReturnValue(true);
+		tools.extract.mockResolvedValue({ tools: [] });
+
+		expect(await extractSessionSignals(INPUT)).toEqual({ tools: [] });
+	});
+
+	it("merges both extractors' buckets", async () => {
+		tools.supports.mockReturnValue(true);
+		skills.supports.mockReturnValue(true);
+		tools.extract.mockResolvedValue({ tools: [bucket("Bash", 2)] });
+		skills.extract.mockResolvedValue({ tools: [bucket("Read", 1)] });
+
+		const signals = await extractSessionSignals(INPUT);
+
+		expect(signals.tools).toEqual([bucket("Bash", 2), bucket("Read", 1)]);
+	});
+
+	it("folds one bucket both extractors reported, taking the larger count", async () => {
+		// Two views of one set of records, never two tallies — see `mergeToolCalls`.
+		tools.supports.mockReturnValue(true);
+		skills.supports.mockReturnValue(true);
+		tools.extract.mockResolvedValue({ tools: [{ name: "code-review", kind: "skill", calls: 1 }] });
+		skills.extract.mockResolvedValue({ tools: [{ name: "code-review", kind: "skill", calls: 4 }] });
+
+		const signals = await extractSessionSignals(INPUT);
+
+		expect(signals.tools).toEqual([{ name: "code-review", kind: "skill", calls: 4 }]);
+	});
+
+	it("keeps the other extractor's findings when one THROWS", async () => {
+		// These read real files belonging to other applications, which can be locked,
+		// half-written or removed between the scan and this call.
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		tools.supports.mockReturnValue(true);
+		skills.supports.mockReturnValue(true);
+		tools.extract.mockRejectedValue(new Error("locked"));
+		skills.extract.mockResolvedValue({ tools: [bucket("Read", 1)] });
+
+		const signals = await extractSessionSignals(INPUT);
+
+		expect(signals.tools).toEqual([bucket("Read", 1)]);
+		warn.mockRestore();
+	});
+
+	it("reports ABSENCE when every extractor throws", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		tools.supports.mockReturnValue(true);
+		skills.supports.mockReturnValue(true);
+		tools.extract.mockRejectedValue(new Error("locked"));
+		skills.extract.mockRejectedValue(new Error("gone"));
+
+		expect(await extractSessionSignals(INPUT)).toEqual({});
+		warn.mockRestore();
+	});
+
+	it("asks every extractor about the source it was given", async () => {
+		tools.supports.mockReturnValue(false);
+		skills.supports.mockReturnValue(false);
+
+		await extractSessionSignals({ ...INPUT, source: "kimi" as TranscriptSource });
+
+		expect(tools.supports).toHaveBeenCalledWith("kimi");
+		expect(skills.supports).toHaveBeenCalledWith("kimi");
+	});
+
+	it("hands each extractor the SAME content object, so the read is shared", async () => {
+		// Sequential rather than concurrent for exactly this reason: the memo only
+		// collapses the two reads if both extractors see one object.
+		tools.supports.mockReturnValue(true);
+		skills.supports.mockReturnValue(true);
+		tools.extract.mockResolvedValue({});
+		skills.extract.mockResolvedValue({});
+
+		await extractSessionSignals(INPUT);
+
+		expect(tools.extract.mock.calls[0][0].content).toBe(INPUT.content);
+		expect(skills.extract.mock.calls[0][0].content).toBe(INPUT.content);
+	});
+});

--- a/cli/src/core/sessions/SessionSignals.ts
+++ b/cli/src/core/sessions/SessionSignals.ts
@@ -1,0 +1,73 @@
+/**
+ * SessionSignals — the registry of things the back-fill mines out of a
+ * conversation, and the one function that runs them.
+ *
+ * Adding a signal is adding an entry here. Nothing in `DashboardCollector` or
+ * `DbBackfill` names an extractor or an agent; they call {@link extractSessionSignals}
+ * and merge what comes back. See {@link SessionSignalExtractor} for why the list
+ * is split the way it is (per record shape, not per output column).
+ */
+
+import { createLogger, errMsg } from "../../Logger.js";
+import type { ToolCallCount } from "../../Types.js";
+import { mergeToolCalls, type SessionSignalExtractor, type SessionSignalInput } from "./SessionSignalExtractor.js";
+import { skillExtractor } from "./SkillExtractor.js";
+import { toolCallExtractor } from "./ToolCallExtractor.js";
+
+const log = createLogger("SessionSignals");
+
+/**
+ * Every extractor, in the order their results are merged.
+ *
+ * Order does not affect the merge: {@link mergeToolCalls} folds on `(kind, name)`
+ * and takes the LARGER `calls` count rather than adding them — two extractors
+ * reporting one bucket are two views of one set of records, and summing them would
+ * double every tool-entered skill call. So this is only the order the reads are
+ * ISSUED in — and they share one memoised {@link SessionContent}, so the second
+ * extractor's read is free.
+ */
+export const SESSION_SIGNAL_EXTRACTORS: ReadonlyArray<SessionSignalExtractor> = [toolCallExtractor, skillExtractor];
+
+/** What one session's extractors found, already merged. */
+export interface ExtractedSignals {
+	/** Absent when no extractor could answer for this source — never `[]`. */
+	readonly tools?: ReadonlyArray<ToolCallCount>;
+}
+
+/**
+ * Runs every extractor that supports this session's source and merges the result.
+ *
+ * **One failing extractor must not cost the others their findings**, so each is
+ * caught independently. That is not defensive padding: these read real files
+ * belonging to other applications, which can be locked, half-written or removed
+ * between the scan and this call. A source whose skill scan throws should still
+ * contribute its tool calls.
+ *
+ * Absence is preserved through the merge. When no extractor supported the source,
+ * or every one of them declined to answer, `tools` is omitted rather than set to
+ * `[]` — the caller writes that distinction into the database, where `[]` reads as
+ * "this agent called no tools" and absence reads as "this agent cannot report
+ * them".
+ *
+ * Sequential rather than concurrent, deliberately: the extractors share one
+ * memoised content object, so running them in parallel would race two reads of
+ * the same transcript rather than reusing one. The outer fan-out over SESSIONS is
+ * where the concurrency belongs, and it is already there.
+ */
+export async function extractSessionSignals(input: SessionSignalInput): Promise<ExtractedSignals> {
+	const groups: ToolCallCount[][] = [];
+	let answered = false;
+	for (const extractor of SESSION_SIGNAL_EXTRACTORS) {
+		if (!extractor.supports(input.source)) continue;
+		try {
+			const signals = await extractor.extract(input);
+			if (signals.tools) {
+				answered = true;
+				groups.push([...signals.tools]);
+			}
+		} catch (err) {
+			log.warn("%s extractor failed: %s", extractor.id, errMsg(err));
+		}
+	}
+	return answered ? { tools: mergeToolCalls(groups) } : {};
+}

--- a/cli/src/core/sessions/SessionSourceDefinition.test.ts
+++ b/cli/src/core/sessions/SessionSourceDefinition.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SessionInfo } from "../../Types.js";
+import { defineSessionSource } from "./SessionSourceDefinition.js";
+
+/** A scan payload shape no other source uses, so the erasure is visibly round-tripped. */
+interface FakeScanned {
+	readonly id: string;
+}
+
+const SESSION: SessionInfo = {
+	sessionId: "s1",
+	transcriptPath: "/tmp/s1.jsonl",
+	updatedAt: "2026-08-01T00:00:00.000Z",
+	source: "claude",
+};
+
+describe("defineSessionSource", () => {
+	it("defaults `usesAlreadyRecorded` to false when the spec omits it", () => {
+		// Declared rather than inferred, so the registry can report which sources
+		// participate in scan-level skipping. Most do not.
+		const def = defineSessionSource<FakeScanned>({
+			source: "codex",
+			scan: async () => [],
+			forRepo: () => [],
+		});
+		expect(def.usesAlreadyRecorded).toBe(false);
+	});
+
+	it("keeps `usesAlreadyRecorded` when the spec declares it", () => {
+		const def = defineSessionSource<FakeScanned>({
+			source: "claude",
+			usesAlreadyRecorded: true,
+			scan: async () => [],
+			forRepo: () => [],
+		});
+		expect(def.usesAlreadyRecorded).toBe(true);
+	});
+
+	it("hands `scan`'s own payload straight back to `forRepo`", () => {
+		// The erasure is only sound because the pair is called through one definition:
+		// whatever `scan` produced is what `forRepo` receives, untouched.
+		const scanned: FakeScanned[] = [{ id: "a" }];
+		const forRepo = vi.fn(() => [SESSION]);
+		const def = defineSessionSource<FakeScanned>({
+			source: "codex",
+			scan: async () => scanned,
+			forRepo,
+		});
+
+		expect(def.forRepo(scanned, "/repo", 1_000)).toEqual([SESSION]);
+		expect(forRepo).toHaveBeenCalledWith(scanned, "/repo", 1_000);
+	});
+
+	it("forwards an absent window as undefined rather than inventing one", () => {
+		// Most sources ignore the argument; the ones that read it (Cursor) must be able
+		// to tell "no window given" from a number.
+		const forRepo = vi.fn(() => []);
+		const def = defineSessionSource<FakeScanned>({ source: "codex", scan: async () => [], forRepo });
+
+		def.forRepo([], "/repo");
+
+		expect(forRepo).toHaveBeenCalledWith([], "/repo", undefined);
+	});
+
+	it("carries `scanForRepo` through when the spec has one", async () => {
+		const scanForRepo = vi.fn(async () => [SESSION]);
+		const def = defineSessionSource<FakeScanned>({
+			source: "codex",
+			scan: async () => [],
+			forRepo: () => [],
+			scanForRepo,
+		});
+
+		expect(def.scanForRepo).toBeDefined();
+		await expect(def.scanForRepo?.("/repo", 500)).resolves.toEqual([SESSION]);
+		expect(scanForRepo).toHaveBeenCalledWith("/repo", 500);
+	});
+
+	it("OMITS `scanForRepo` when the spec has none — Claude's case", () => {
+		// Absent, not a no-op stub: `loadAllSessions` reads its presence to decide
+		// whether a source has a per-repo fallback at all, and Claude's per-repo route
+		// is the hook registry rather than its own store.
+		const def = defineSessionSource<FakeScanned>({
+			source: "claude",
+			scan: async () => [],
+			forRepo: () => [],
+		});
+		expect(def.scanForRepo).toBeUndefined();
+		expect("scanForRepo" in def).toBe(false);
+	});
+
+	it("passes the scan options through verbatim, including the skip predicate", async () => {
+		const scan = vi.fn(async () => []);
+		const alreadyRecorded = vi.fn(() => false);
+		const def = defineSessionSource<FakeScanned>({ source: "claude", scan, forRepo: () => [] });
+
+		await def.scan({ windowMs: 42, alreadyRecorded });
+
+		expect(scan).toHaveBeenCalledWith({ windowMs: 42, alreadyRecorded });
+	});
+
+	it("supports an ASYNC `forRepo`, which two sources genuinely need", async () => {
+		// Antigravity enumerates the repo's worktrees, Cursor resolves a workspace
+		// hash — both are per-repo questions no machine-wide scan could answer ahead.
+		const def = defineSessionSource<FakeScanned>({
+			source: "antigravity",
+			scan: async () => [],
+			forRepo: async () => [SESSION],
+		});
+		await expect(def.forRepo([], "/repo")).resolves.toEqual([SESSION]);
+	});
+});

--- a/cli/src/core/sessions/SessionSourceDefinition.ts
+++ b/cli/src/core/sessions/SessionSourceDefinition.ts
@@ -1,0 +1,155 @@
+/**
+ * SessionSourceDefinition — one agent's machine-global session store, described
+ * as data rather than as four hand-kept lists.
+ *
+ * ## What this replaces, and why the lists were dangerous
+ *
+ * Discovering "which conversations exist on this disk" used to be spelled out in
+ * FOUR places, each enumerating the same set of agents:
+ *
+ *   - the `PreScannedSessions` interface (one optional field per agent),
+ *   - `scanAllStores` (one `tryScan` per agent),
+ *   - `preScannedForRepo` (one `if (pre.x)` per agent),
+ *   - `loadAllSessions` (one lazy loader per agent).
+ *
+ * Adding an agent meant editing all four, and the compiler could not enforce it
+ * because every list keys off a different thing. Worse, the two failure modes
+ * differ: miss the scan list and the agent is simply never read; miss the narrow
+ * list and its sessions ARE read but can never be attributed to a repo, so they
+ * vanish with no error anywhere. A definition here is the single edit, and a
+ * source that is registered is registered for every phase at once.
+ *
+ * ## Why each definition closes over its own types
+ *
+ * The scanners genuinely do not agree, and normalising them would mean rewriting
+ * twelve modules to fit a shape none of them chose:
+ *
+ *   - **Arguments.** Some take the window alone, some take `(root, window)`,
+ *     Cursor's composer scan takes nothing, and two accept the already-recorded
+ *     predicate because their per-session read is expensive enough to be worth
+ *     skipping (Claude parses whole transcripts, Antigravity opens a SQLite each).
+ *   - **Results.** Most yield `DiskSession`, Claude yields a richer record that
+ *     also carries whatever its whole-file read produced, and Cursor yields
+ *     composers rather than sessions.
+ *   - **Narrowing.** Most are synchronous filters over carried directories; two
+ *     are async because the question is genuinely per-repo — Antigravity has to
+ *     enumerate the repo's worktrees, Cursor has to resolve its workspace hash.
+ *
+ * {@link defineSessionSource} keeps all of that type-checked AT THE DEFINITION,
+ * then erases the payload type so the registry can hold twelve unrelated shapes
+ * in one array. The erasure is why `scan` and `forRepo` may only ever be called
+ * as a PAIR, through the same definition — see {@link SessionSourceDefinition}.
+ *
+ * ## Two rules a new definition must honour
+ *
+ * **Import the discoverer lazily, inside `scan`.** Several reach for
+ * `node:sqlite`, and a static import would emit its ExperimentalWarning in every
+ * process that merely loads this registry — including ones that never scan a
+ * session. Every existing definition does this; a static import here is a
+ * review blocker, not a style preference.
+ *
+ * **A failed scan is ABSENCE, never an empty array.** They are different claims:
+ * absence means "this store could not be read", an empty array means "this store
+ * holds no sessions in the window". The collector's per-source reporting reads
+ * the second as a positive fact about the agent, so degrading one into the other
+ * turns an I/O failure into a confident, wrong statement about the user's usage.
+ */
+
+import type { SessionInfo, TranscriptSource } from "../../Types.js";
+import type { AlreadyCurrent } from "../DiskSessionScan.js";
+
+/** What every machine-wide scan is given. */
+export interface SessionScanOptions {
+	/** How far back to look. The back-fill's 7-day horizon, not the live 48 h one. */
+	readonly windowMs: number;
+	/**
+	 * Lets an expensive scanner skip a session the database already holds at or
+	 * past its last turn. Forwarded to the two definitions that declare
+	 * {@link SessionSourceSpec.usesAlreadyRecorded}; ignored by the rest, whose
+	 * per-session cost is smaller than the check would save.
+	 */
+	readonly alreadyRecorded?: AlreadyCurrent;
+}
+
+/** A source definition with its payload type still visible. See {@link defineSessionSource}. */
+export interface SessionSourceSpec<T> {
+	/** The `TranscriptSource` tag every downstream row is stamped with. */
+	readonly source: TranscriptSource;
+	/**
+	 * True when {@link SessionScanOptions.alreadyRecorded} actually reaches the
+	 * scanner. Declared rather than inferred so the registry can report which
+	 * sources participate in scan-level skipping — a fact worth reading off the
+	 * table, since it is the difference between a converged re-run costing a tail
+	 * read per file and costing a full parse of every one.
+	 */
+	readonly usesAlreadyRecorded?: boolean;
+	/** Read this agent's machine-global store. MUST import its discoverer lazily. */
+	readonly scan: (opts: SessionScanOptions) => Promise<ReadonlyArray<T>>;
+	/**
+	 * Narrow one scan's result to the sessions belonging to `cwd`.
+	 *
+	 * Async is allowed because two sources genuinely need I/O here — see the
+	 * header. A synchronous filter may simply return its array.
+	 */
+	readonly forRepo: (
+		scanned: ReadonlyArray<T>,
+		cwd: string,
+		windowMs?: number,
+	) => ReadonlyArray<SessionInfo> | Promise<ReadonlyArray<SessionInfo>>;
+	/**
+	 * The per-repo fallback: discover this source's sessions for ONE repo,
+	 * without a machine-wide scan behind it.
+	 *
+	 * This is a DIFFERENT function from {@link scan}, not a wrapper over it —
+	 * every discoverer ships both, and the per-repo one re-reads the store each
+	 * time it is called. It runs only when {@link scan} produced nothing for this
+	 * source (it failed, or the caller supplied no pre-scan), which is what keeps
+	 * a failed machine-wide read from costing the source its sessions entirely.
+	 *
+	 * Optional, and Claude is the one entry without it: its per-repo route is the
+	 * hook registry (`sessions.json`), which is not this source's own store and is
+	 * loaded unconditionally by the collector for Gemini's sake anyway.
+	 */
+	readonly scanForRepo?: (cwd: string, windowMs?: number) => Promise<ReadonlyArray<SessionInfo>>;
+}
+
+/**
+ * A registered source, payload type erased.
+ *
+ * `scan` returns `unknown` and `forRepo` accepts `unknown` by construction, so
+ * the two are only sound when called through the SAME definition — the registry
+ * never holds a scan result apart from the definition that produced it, and
+ * {@link defineSessionSource} is what guarantees the pair type-checked together.
+ */
+export interface SessionSourceDefinition {
+	readonly source: TranscriptSource;
+	readonly usesAlreadyRecorded: boolean;
+	readonly scan: (opts: SessionScanOptions) => Promise<unknown>;
+	readonly forRepo: (
+		scanned: unknown,
+		cwd: string,
+		windowMs?: number,
+	) => ReadonlyArray<SessionInfo> | Promise<ReadonlyArray<SessionInfo>>;
+	readonly scanForRepo?: (cwd: string, windowMs?: number) => Promise<ReadonlyArray<SessionInfo>>;
+}
+
+/**
+ * Registers one source, checking `scan` and `forRepo` against each other and
+ * then erasing the payload type.
+ *
+ * The cast below is the erasure and is safe for one reason: nothing outside this
+ * function ever produces a value for `forRepo` except the matching `scan`, and
+ * callers are structurally unable to cross the two (a scan result is passed
+ * straight back to the definition it came from). That is the same trade the
+ * context-kind registry makes — a narrow, contained cast bought with a type-safe
+ * definition site.
+ */
+export function defineSessionSource<T>(spec: SessionSourceSpec<T>): SessionSourceDefinition {
+	return {
+		source: spec.source,
+		usesAlreadyRecorded: spec.usesAlreadyRecorded ?? false,
+		scan: spec.scan,
+		forRepo: (scanned, cwd, windowMs) => spec.forRepo(scanned as ReadonlyArray<T>, cwd, windowMs),
+		...(spec.scanForRepo ? { scanForRepo: spec.scanForRepo } : {}),
+	};
+}

--- a/cli/src/core/sessions/SessionSources.test.ts
+++ b/cli/src/core/sessions/SessionSources.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { orFail, SESSION_SOURCES } from "./SessionSources.js";
+
+describe("orFail", () => {
+	it("passes a clean scan straight through", () => {
+		const sessions = [{ id: "a" }];
+		expect(orFail("opencode", sessions, undefined)).toBe(sessions);
+	});
+
+	it("passes an empty CLEAN scan through — the store was read and holds nothing", () => {
+		// The one case where empty is a positive fact rather than a failure, and the
+		// reason `orFail` cannot simply test for emptiness.
+		expect(orFail("opencode", [], undefined)).toEqual([]);
+	});
+
+	it("THROWS for a scan that found nothing AND reported an error", () => {
+		// The only way `scanAllStores` can record the source as ABSENT, which is what
+		// keeps its per-repo fallback reachable. Reading `.sessions` alone would spell
+		// this as `[]` — "read and holds nothing" — and skip the fallback for the whole
+		// run while reporting that nothing as a fact about the agent.
+		expect(() => orFail("opencode", [], { kind: "locked", message: "database is locked" })).toThrow(
+			/opencode scan failed \(locked\): database is locked/,
+		);
+	});
+
+	it("KEEPS a partial scan's sessions instead of discarding them", () => {
+		// Cline scans each editor flavour independently and Copilot Chat each workspace,
+		// so an error beside sessions means "some of it was unreadable", not "this
+		// failed". Dropping them would lose data the old per-repo path kept.
+		const sessions = [{ id: "a" }];
+		expect(orFail("cline", sessions, { kind: "permission", message: "one store unreadable" })).toBe(sessions);
+	});
+});
+
+describe("SESSION_SOURCES", () => {
+	it("registers each source tag exactly once", () => {
+		// The registry is keyed by tag downstream (`PreScannedSessions`, the per-source
+		// counts, the collector's dedupe), so a duplicate would make one entry
+		// unreachable with nothing to say so.
+		const tags = SESSION_SOURCES.map((def) => def.source);
+		expect(new Set(tags).size).toBe(tags.length);
+	});
+
+	it("gives every source a scan and a narrowing half", () => {
+		// Miss the scan and the agent is never read; miss the narrowing and its sessions
+		// ARE read but can never be attributed to a repo, so they vanish with no error.
+		for (const def of SESSION_SOURCES) {
+			expect(typeof def.scan, def.source).toBe("function");
+			expect(typeof def.forRepo, def.source).toBe("function");
+		}
+	});
+
+	it("gives every source a per-repo fallback EXCEPT claude", () => {
+		// Claude's per-repo route is the hook registry (`sessions.json`), which the
+		// collector loads unconditionally for Gemini's sake anyway — so it is the one
+		// definition that needs no `scanForRepo`.
+		const without = SESSION_SOURCES.filter((def) => def.scanForRepo === undefined).map((def) => def.source);
+		expect(without).toEqual(["claude"]);
+	});
+
+	it("declares scan-level skipping for exactly the two expensive scanners", () => {
+		// Claude parses each whole transcript, Antigravity opens one SQLite per
+		// conversation. Everything else reads a few hundred bytes per session or answers
+		// the whole store in one query, where the check would cost about what it saves.
+		const skipping = SESSION_SOURCES.filter((def) => def.usesAlreadyRecorded).map((def) => def.source);
+		expect(skipping).toEqual(["claude", "antigravity"]);
+	});
+
+	it("defaults `usesAlreadyRecorded` to a real boolean on every entry", () => {
+		// Read off the table by the back-fill; an undefined would be falsy by accident
+		// rather than by declaration.
+		for (const def of SESSION_SOURCES) expect(typeof def.usesAlreadyRecorded, def.source).toBe("boolean");
+	});
+});

--- a/cli/src/core/sessions/SessionSources.ts
+++ b/cli/src/core/sessions/SessionSources.ts
@@ -1,0 +1,259 @@
+/**
+ * SessionSources — the registry of agents whose conversations the back-fill can
+ * discover.
+ *
+ * One entry per agent. Adding an agent is adding an entry here; nothing in
+ * `DbBackfill` or `DashboardCollector` names a source, so neither has to change.
+ * See {@link SessionSourceDefinition} for what an entry promises and for the two
+ * rules (lazy import, absence-not-empty) a new one must honour.
+ *
+ * ## Why every import in this file is lazy, including the narrowing halves
+ *
+ * The scan halves must be lazy — several discoverers reach for `node:sqlite`, and
+ * eager loading emits its ExperimentalWarning in processes that never scan a
+ * session. The narrowing halves (`…SessionsForRepo`) live in those same modules,
+ * so importing them statically would drag the whole set in anyway and quietly
+ * undo it. Keeping both sides lazy leaves this module free of side effects: a
+ * process may load the registry to ask what exists without opening anything.
+ *
+ * The cost is one `await import` per source per repo, which after the first is a
+ * cache lookup — set against a scan that reads megabytes.
+ *
+ * ## Two entries are asymmetric on purpose
+ *
+ * `claude` and `antigravity` declare `usesAlreadyRecorded`, because their
+ * per-session read is the expensive kind: Claude parses each whole transcript to
+ * collect the directories a `cd` scattered through it, and Antigravity opens one
+ * SQLite per conversation. Everything else reads a few hundred bytes per session
+ * or answers the whole store in one query, where the check would cost about what
+ * it saves.
+ *
+ * Neither of them hands its parsed content over to the collector, and that is a
+ * deliberate reversal: `claude` used to, which made the collector's read free and
+ * the whole run's memory unbounded. See `acceptFacts` for the measurement and for
+ * why a carried payload may not come back without a byte cap.
+ */
+
+import type { ClaudeDiskSession } from "../ClaudeSessionDiscoverer.js";
+import type { CodexDiskSession } from "../CodexSessionDiscoverer.js";
+import type { CursorDiskComposer } from "../CursorSessionDiscoverer.js";
+import type { DiskSession } from "../DiskSessionScan.js";
+import { defineSessionSource, type SessionSourceDefinition } from "./SessionSourceDefinition.js";
+
+/**
+ * The shape every one of these scans reports a failure in: `{ kind, message }`, on a
+ * channel beside the sessions rather than as a throw.
+ */
+export interface ScanError {
+	readonly kind: string;
+	readonly message: string;
+}
+
+/**
+ * Turns a scan that reported a TOTAL failure on its error channel back into a throw,
+ * which is the only way `scanAllStores` can record it as ABSENCE.
+ *
+ * Most of these discoverers never throw: they answer `{ sessions, error? }` and let the
+ * caller decide. Reading `.sessions` alone therefore spells a failed scan as `[]` — the
+ * one thing the registry's absence-not-empty rule exists to prevent (see
+ * {@link SessionSourceDefinition}'s header). The consequences are both silent: the
+ * per-repo `scanForRepo` fallback is skipped for the whole run, because a present-but-
+ * empty entry means "the store was read and holds nothing", and the collector's
+ * per-source counts report that same nothing as a positive fact about the agent.
+ *
+ * A PARTIAL result is kept and not thrown, which is why the sessions are consulted and
+ * not just the error. Cline scans each editor flavour independently and Copilot Chat
+ * each workspace, so one unreadable directory beside several readable ones has
+ * genuinely found the sessions it returned — dropping them would lose data the old
+ * per-repo path kept, and its callers read `.sessions` and ignored `.error` for exactly
+ * that reason.
+ *
+ * Exported for its own tests: which of the three outcomes it picks is the difference
+ * between a source falling back to per-repo scans and a source silently reporting
+ * "this agent was not used", and nine definitions depend on getting it right. Reaching
+ * it through those definitions would mean mocking nine discoverers to assert one rule.
+ */
+export function orFail<T>(source: string, sessions: ReadonlyArray<T>, error: ScanError | undefined): ReadonlyArray<T> {
+	if (error === undefined || sessions.length > 0) return sessions;
+	throw new Error(`${source} scan failed (${error.kind}): ${error.message}`);
+}
+
+const claudeSource = defineSessionSource<ClaudeDiskSession>({
+	source: "claude",
+	usesAlreadyRecorded: true,
+	scan: async ({ windowMs, alreadyRecorded }) => {
+		const mod = await import("../ClaudeSessionDiscoverer.js");
+		return mod.scanClaudeSessionsOnDisk({ windowMs, ...(alreadyRecorded ? { alreadyRecorded } : {}) });
+	},
+	forRepo: async (scanned, cwd) =>
+		(await import("../ClaudeSessionDiscoverer.js")).claudeSessionsForRepo(scanned, cwd),
+});
+
+const codexSource = defineSessionSource<CodexDiskSession>({
+	source: "codex",
+	scan: async ({ windowMs }) => (await import("../CodexSessionDiscoverer.js")).scanCodexSessionsOnDisk(windowMs),
+	forRepo: async (scanned, cwd) => (await import("../CodexSessionDiscoverer.js")).codexSessionsForRepo(scanned, cwd),
+	scanForRepo: async (cwd, windowMs) =>
+		(await import("../CodexSessionDiscoverer.js")).discoverCodexSessions(cwd, windowMs),
+});
+
+const cursorSource = defineSessionSource<CursorDiskComposer>({
+	source: "cursor",
+	// No window at scan time, and passing one here would be wrong rather than
+	// merely redundant: anchored composers bypass the window, so a scan that
+	// applied it would drop them before the narrowing step could rescue them.
+	scan: async () =>
+		(await import("../CursorSessionDiscoverer.js"))
+			.scanCursorComposersOnDisk()
+			.then((r) => orFail("cursor", r.composers, r.error)),
+	forRepo: async (scanned, cwd, windowMs) =>
+		(await import("../CursorSessionDiscoverer.js")).cursorSessionsForRepo(scanned, cwd, windowMs),
+	scanForRepo: async (cwd, windowMs) =>
+		(await import("../CursorSessionDiscoverer.js")).scanCursorSessions(cwd, windowMs).then((r) => r.sessions),
+});
+
+const kimiSource = defineSessionSource<DiskSession>({
+	source: "kimi",
+	scan: async ({ windowMs }) => (await import("../KimiSessionDiscoverer.js")).scanKimiSessionsOnDisk(windowMs),
+	forRepo: async (scanned, cwd) => (await import("../KimiSessionDiscoverer.js")).kimiSessionsForRepo(scanned, cwd),
+	scanForRepo: async (cwd, windowMs) =>
+		(await import("../KimiSessionDiscoverer.js")).discoverKimiSessions(cwd, windowMs),
+});
+
+const openCodeSource = defineSessionSource<DiskSession>({
+	source: "opencode",
+	scan: async ({ windowMs }) =>
+		(await import("../OpenCodeSessionDiscoverer.js"))
+			.scanOpenCodeSessionsOnDisk(windowMs)
+			.then((r) => orFail("opencode", r.sessions, r.error)),
+	forRepo: async (scanned, cwd) =>
+		(await import("../OpenCodeSessionDiscoverer.js")).openCodeSessionsForRepo(scanned, cwd),
+	scanForRepo: async (cwd, windowMs) =>
+		(await import("../OpenCodeSessionDiscoverer.js")).scanOpenCodeSessions(cwd, windowMs).then((r) => r.sessions),
+});
+
+const copilotSource = defineSessionSource<DiskSession>({
+	source: "copilot",
+	scan: async ({ windowMs }) =>
+		(await import("../CopilotSessionDiscoverer.js"))
+			.scanCopilotSessionsOnDisk(windowMs)
+			.then((r) => orFail("copilot", r.sessions, r.error)),
+	forRepo: async (scanned, cwd) =>
+		(await import("../CopilotSessionDiscoverer.js")).copilotSessionsForRepo(scanned, cwd),
+	scanForRepo: async (cwd, windowMs) =>
+		(await import("../CopilotSessionDiscoverer.js")).scanCopilotSessions(cwd, windowMs).then((r) => r.sessions),
+});
+
+const copilotChatSource = defineSessionSource<DiskSession>({
+	source: "copilot-chat",
+	scan: async ({ windowMs }) =>
+		(await import("../CopilotChatSessionDiscoverer.js"))
+			.scanCopilotChatSessionsOnDisk(windowMs)
+			.then((r) => orFail("copilot-chat", r.sessions, r.error)),
+	forRepo: async (scanned, cwd) =>
+		(await import("../CopilotChatSessionDiscoverer.js")).copilotChatSessionsForRepo(scanned, cwd),
+	scanForRepo: async (cwd, windowMs) =>
+		(await import("../CopilotChatSessionDiscoverer.js"))
+			.scanCopilotChatSessions(cwd, windowMs)
+			.then((r) => r.sessions),
+});
+
+// The four below take the window in a LATER position, behind their own
+// directory-override seams — passing `undefined` there keeps each default.
+const clineSource = defineSessionSource<DiskSession>({
+	source: "cline",
+	scan: async ({ windowMs }) =>
+		(await import("../ClineSessionDiscoverer.js"))
+			.scanClineSessionsOnDisk(undefined, windowMs)
+			.then((r) => r.sessions),
+	forRepo: async (scanned, cwd) => (await import("../ClineSessionDiscoverer.js")).clineSessionsForRepo(scanned, cwd),
+	scanForRepo: async (cwd, windowMs) =>
+		(await import("../ClineSessionDiscoverer.js"))
+			.scanClineSessions(cwd, undefined, windowMs)
+			.then((r) => r.sessions),
+});
+
+const clineCliSource = defineSessionSource<DiskSession>({
+	source: "cline-cli",
+	scan: async ({ windowMs }) =>
+		(await import("../ClineCliSessionDiscoverer.js"))
+			.scanClineCliSessionsOnDisk(undefined, windowMs)
+			.then((r) => orFail("cline-cli", r.sessions, r.error)),
+	forRepo: async (scanned, cwd) =>
+		(await import("../ClineCliSessionDiscoverer.js")).clineCliSessionsForRepo(scanned, cwd),
+	scanForRepo: async (cwd, windowMs) =>
+		(await import("../ClineCliSessionDiscoverer.js"))
+			.scanClineCliSessions(cwd, undefined, windowMs)
+			.then((r) => r.sessions),
+});
+
+const devinSource = defineSessionSource<DiskSession>({
+	source: "devin",
+	scan: async ({ windowMs }) =>
+		(await import("../DevinSessionDiscoverer.js"))
+			.scanDevinSessionsOnDisk(windowMs)
+			.then((r) => orFail("devin", r.sessions, r.error)),
+	forRepo: async (scanned, cwd) => (await import("../DevinSessionDiscoverer.js")).devinSessionsForRepo(scanned, cwd),
+	scanForRepo: async (cwd, windowMs) =>
+		(await import("../DevinSessionDiscoverer.js")).scanDevinSessions(cwd, windowMs).then((r) => r.sessions),
+});
+
+const cursorCliSource = defineSessionSource<DiskSession>({
+	source: "cursor-cli",
+	scan: async ({ windowMs }) =>
+		(await import("../CursorCliSessionDiscoverer.js"))
+			.scanCursorCliSessionsOnDisk(undefined, undefined, windowMs)
+			.then((r) => orFail("cursor-cli", r.sessions, r.error)),
+	forRepo: async (scanned, cwd) =>
+		(await import("../CursorCliSessionDiscoverer.js")).cursorCliSessionsForRepo(scanned, cwd),
+	scanForRepo: async (cwd, windowMs) =>
+		(await import("../CursorCliSessionDiscoverer.js"))
+			.scanCursorCliSessions(cwd, undefined, undefined, windowMs)
+			.then((r) => r.sessions),
+});
+
+const antigravitySource = defineSessionSource<DiskSession>({
+	source: "antigravity",
+	usesAlreadyRecorded: true,
+	scan: async ({ windowMs, alreadyRecorded }) => {
+		const mod = await import("../AntigravitySessionDiscoverer.js");
+		const result = alreadyRecorded
+			? await mod.scanAntigravitySessionsOnDisk(undefined, windowMs, { alreadyRecorded })
+			: await mod.scanAntigravitySessionsOnDisk(undefined, windowMs);
+		return orFail("antigravity", result.sessions, result.error);
+	},
+	forRepo: async (scanned, cwd) =>
+		(await import("../AntigravitySessionDiscoverer.js")).antigravitySessionsForRepo(scanned, cwd),
+	scanForRepo: async (cwd, windowMs) =>
+		(await import("../AntigravitySessionDiscoverer.js"))
+			.scanAntigravitySessions(cwd, undefined, windowMs)
+			.then((r) => r.sessions),
+});
+
+/**
+ * Every agent whose sessions the back-fill can discover.
+ *
+ * Order is the fan-out order and carries no meaning — the scans run concurrently
+ * and the collector dedupes on `(source, sessionId)` afterwards. Kept
+ * alphabetical-ish by family so a reader can find an entry, not because anything
+ * depends on it.
+ */
+export const SESSION_SOURCES: ReadonlyArray<SessionSourceDefinition> = [
+	claudeSource,
+	codexSource,
+	cursorSource,
+	kimiSource,
+	openCodeSource,
+	copilotSource,
+	copilotChatSource,
+	clineSource,
+	clineCliSource,
+	devinSource,
+	cursorCliSource,
+	antigravitySource,
+];
+
+// A run's scan results are `PreScannedSessions` in `DashboardCollector`, keyed by
+// source tag with the same absent-versus-empty rule this file's `orFail` enforces.
+// A second type for the same value used to live here and had no callers — the shape
+// belongs next to the collector that narrows it, not next to the registry.

--- a/cli/src/core/sessions/SkillExtractor.test.ts
+++ b/cli/src/core/sessions/SkillExtractor.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The capability table is the seam: `supports` asks it rather than restating a list
+// of agents, so driving it here is what pins that delegation.
+vi.mock("../skills/SkillTranscriptScanner.js", () => ({ getSkillScanner: vi.fn() }));
+
+import type { SkillInvocation, SkillUse, TranscriptSource } from "../../Types.js";
+import { getSkillScanner } from "../skills/SkillTranscriptScanner.js";
+import type { SessionSignalInput } from "./SessionSignalExtractor.js";
+import { skillExtractor } from "./SkillExtractor.js";
+
+function use(skill: string, invocations: ReadonlyArray<SkillInvocation>): SkillUse {
+	return { source: "claude", skill, entryPaths: [], invocations };
+}
+
+/** A scanner stub that returns `uses` for any lines it is handed. */
+function scannerFor(uses: ReadonlyArray<SkillUse>) {
+	return { source: "claude" as const, scan: vi.fn(() => ({ uses, lastLine: 0 })) };
+}
+
+function input(
+	lines: () => Promise<ReadonlyArray<string> | undefined>,
+	source: TranscriptSource = "claude",
+): SessionSignalInput {
+	return {
+		source,
+		sessionId: "s1",
+		transcriptPath: "/tmp/s1.jsonl",
+		content: {
+			read: async () => ({
+				entries: [],
+				newCursor: { transcriptPath: "/tmp/s1.jsonl", lineNumber: 0, updatedAt: "2026-08-01T00:00:00.000Z" },
+				totalLinesRead: 0,
+			}),
+			lines,
+		},
+	};
+}
+
+beforeEach(() => {
+	vi.mocked(getSkillScanner).mockReset();
+});
+
+describe("skillExtractor.supports", () => {
+	it("says yes for a source the scanner table has", () => {
+		vi.mocked(getSkillScanner).mockReturnValue(scannerFor([]));
+		expect(skillExtractor.supports("claude")).toBe(true);
+	});
+
+	it("says no for a source the table has no scanner for", () => {
+		// Asking the table rather than restating it is what makes a new scanner reach
+		// the back-fill for free.
+		vi.mocked(getSkillScanner).mockReturnValue(undefined);
+		expect(skillExtractor.supports("opencode")).toBe(false);
+	});
+});
+
+describe("skillExtractor.extract", () => {
+	it("reports nothing when the source has no scanner", async () => {
+		// The defensive half of `supports`: reached only if a caller extracts without
+		// asking first.
+		vi.mocked(getSkillScanner).mockReturnValue(undefined);
+		expect(await skillExtractor.extract(input(async () => ["{}"]))).toEqual({});
+	});
+
+	it("reports nothing — NOT an empty list — for a source with no line-oriented transcript", async () => {
+		// `{}` leaves the tool extractor's answer untouched; `{ tools: [] }` would be a
+		// claim about a store this never opened.
+		vi.mocked(getSkillScanner).mockReturnValue(scannerFor([use("code-review", [])]));
+		const signals = await skillExtractor.extract(input(async () => undefined));
+		expect(signals).toEqual({});
+		expect(signals.tools).toBeUndefined();
+	});
+
+	it("reports nothing when the scan found no skills", async () => {
+		vi.mocked(getSkillScanner).mockReturnValue(scannerFor([]));
+		expect(await skillExtractor.extract(input(async () => ["{}"]))).toEqual({});
+	});
+
+	it("scans from line 0 — a whole-conversation read, not an incremental one", async () => {
+		// The back-fill has no cursor here and must not touch the live discovery marks:
+		// those are monotonic, so advancing one would strand the lines in between for
+		// the StopHook that was going to read them.
+		const scanner = scannerFor([]);
+		vi.mocked(getSkillScanner).mockReturnValue(scanner);
+
+		await skillExtractor.extract(input(async () => ["a", "b"]));
+
+		expect(scanner.scan).toHaveBeenCalledWith(["a", "b"], 0);
+	});
+
+	it("turns one skill into a bucket named after the skill", async () => {
+		// The skill's own name, matching what the `Skill` tool path reports, so the two
+		// halves of one skill's usage fold together instead of appearing as two rows.
+		vi.mocked(getSkillScanner).mockReturnValue(
+			scannerFor([use("code-review", [{ at: "2026-08-01T10:00:00.000Z", ok: true }])]),
+		);
+
+		const signals = await skillExtractor.extract(input(async () => ["{}"]));
+
+		expect(signals.tools).toEqual([
+			{ name: "code-review", kind: "skill", calls: 1, lastCallAtMs: Date.parse("2026-08-01T10:00:00.000Z") },
+		]);
+	});
+
+	it("counts calls as the number of invocations", async () => {
+		vi.mocked(getSkillScanner).mockReturnValue(
+			scannerFor([
+				use("code-review", [
+					{ at: "2026-08-01T10:00:00.000Z", ok: true },
+					{ at: "2026-08-01T09:00:00.000Z", ok: true },
+				]),
+			]),
+		);
+
+		const signals = await skillExtractor.extract(input(async () => ["{}"]));
+
+		expect(signals.tools?.[0].calls).toBe(2);
+	});
+
+	it("takes the MAXIMUM instant, not the first entry", async () => {
+		// Claude, Kimi and OpenCode all sort newest-first, so for them the two are the
+		// same number — this stops the value depending on an ordering convention that
+		// lives in three separate scanners and is enforced nowhere.
+		vi.mocked(getSkillScanner).mockReturnValue(
+			scannerFor([
+				use("code-review", [
+					{ at: "2026-08-01T09:00:00.000Z", ok: true },
+					{ at: "2026-08-01T11:00:00.000Z", ok: true },
+				]),
+			]),
+		);
+
+		const signals = await skillExtractor.extract(input(async () => ["{}"]));
+
+		expect(signals.tools?.[0].lastCallAtMs).toBe(Date.parse("2026-08-01T11:00:00.000Z"));
+	});
+
+	it("omits the instant when every invocation is undateable, rather than writing 0", async () => {
+		// A zero is a real instant in 1970 and would sort as the oldest call ever made;
+		// absence is what readers fall back on.
+		vi.mocked(getSkillScanner).mockReturnValue(scannerFor([use("code-review", [{ at: "not a date", ok: true }])]));
+
+		const signals = await skillExtractor.extract(input(async () => ["{}"]));
+
+		expect(signals.tools?.[0]).not.toHaveProperty("lastCallAtMs");
+	});
+
+	it("keeps a dateable instant beside an undateable one", async () => {
+		vi.mocked(getSkillScanner).mockReturnValue(
+			scannerFor([
+				use("code-review", [
+					{ at: "nope", ok: true },
+					{ at: "2026-08-01T08:00:00.000Z", ok: true },
+				]),
+			]),
+		);
+
+		const signals = await skillExtractor.extract(input(async () => ["{}"]));
+
+		expect(signals.tools?.[0].lastCallAtMs).toBe(Date.parse("2026-08-01T08:00:00.000Z"));
+	});
+
+	it("omits the instant for a skill with no invocations at all", async () => {
+		vi.mocked(getSkillScanner).mockReturnValue(scannerFor([use("code-review", [])]));
+
+		const signals = await skillExtractor.extract(input(async () => ["{}"]));
+
+		expect(signals.tools).toEqual([{ name: "code-review", kind: "skill", calls: 0 }]);
+	});
+
+	it("reports one bucket per skill", async () => {
+		vi.mocked(getSkillScanner).mockReturnValue(
+			scannerFor([use("code-review", [{ at: "2026-08-01T10:00:00.000Z", ok: true }]), use("brainstorming", [])]),
+		);
+
+		const signals = await skillExtractor.extract(input(async () => ["{}"]));
+
+		expect(signals.tools?.map((t) => t.name)).toEqual(["code-review", "brainstorming"]);
+	});
+
+	it("rethrows a scanner failure with the session named", async () => {
+		const scanner = {
+			source: "claude" as const,
+			scan: vi.fn(() => {
+				throw new Error("bad line");
+			}),
+		};
+		vi.mocked(getSkillScanner).mockReturnValue(scanner);
+
+		await expect(skillExtractor.extract(input(async () => ["{}"], "kimi"))).rejects.toThrow(
+			/skill extraction failed for kimi\/s1: bad line/,
+		);
+	});
+});

--- a/cli/src/core/sessions/SkillExtractor.ts
+++ b/cli/src/core/sessions/SkillExtractor.ts
@@ -1,0 +1,113 @@
+/**
+ * SkillExtractor — skill invocations the tool reader structurally cannot see.
+ *
+ * ## Why this is a separate extractor and not a column of the tool one
+ *
+ * A skill is entered two ways, and only one of them is a tool call:
+ *
+ *   - **Skill tool** — a `tool_use` block named `Skill`. The tool extractor
+ *     already reports these, re-attributed to the skill they launched.
+ *   - **Slash command** — a user-typed `/plugin:skill`. There is no
+ *     `SlashCommand` tool anywhere in the corpus; it appears as a
+ *     `<command-name>` tag plus a following meta record. **No tool-call reader
+ *     can see it, at any source.**
+ *
+ * That second path is not an edge case. Measured on one real machine: across 36
+ * Claude sessions in a 7-day window there were ZERO `Skill` tool blocks and 15
+ * slash-command invocations — so the tool-shaped route found none of that user's
+ * skill usage, and the dashboard's Skills card was fed entirely by rows merged
+ * back from already-archived commits.
+ *
+ * ## Overlap with the tool extractor is expected and harmless
+ *
+ * Both report the tool-path invocations, and `mergeToolCalls` folds them on
+ * `(kind, name)`. The counts are the same measurement of the same records, so
+ * folding is a merge rather than a sum of two independent tallies — see the note
+ * on `calls` below, which is why this extractor reports the scanner's own
+ * invocation count and not a second one derived some other way.
+ *
+ * ## Which agents this answers for
+ *
+ * Whatever `getSkillScanner` has a scanner for — claude, codex (heuristic, from
+ * shell commands that read a `SKILL.md`) and kimi today. Asking the table rather
+ * than restating it is what makes a new scanner reach the back-fill for free.
+ *
+ * OpenCode is deliberately absent even though it HAS skill discovery: its
+ * implementation reads SQLite rows and persists them itself, so it is a
+ * scan-and-write pipeline rather than a line scanner, and there is nothing here
+ * to hand lines to. Wiring it in means giving it a pure-extraction entry point,
+ * which is its own change.
+ */
+
+import { errMsg } from "../../Logger.js";
+import type { SkillUse, ToolCallCount, TranscriptSource } from "../../Types.js";
+import { getSkillScanner } from "../skills/SkillTranscriptScanner.js";
+import type { SessionSignalExtractor, SessionSignalInput, SessionSignals } from "./SessionSignalExtractor.js";
+
+/**
+ * Folds one scanned skill into a tool bucket.
+ *
+ * `calls` is the invocation count the scanner measured, and `lastCallAtMs` comes
+ * from the invocation list — NOT from the session's own clock. A session's
+ * `updatedAt` moves every time the conversation is touched afterwards, so using it
+ * would date a skill run from three weeks ago as today's and quietly shift it into
+ * whatever window the dashboard is showing.
+ *
+ * Taken as the MAXIMUM over the list rather than as `invocations[0]`. Claude, Kimi
+ * and OpenCode all sort newest-first, so for them the two are the same number —
+ * this only stops the value depending on an ordering convention that lives in three
+ * separate scanners and is not enforced anywhere.
+ *
+ * **The heuristic Codex path is a documented floor, not a last-call instant.**
+ * `scanCodexSkillLines` records one invocation per skill at the FIRST `SKILL.md`
+ * read it saw, deliberately: 49% of real (session, skill) pairs are several paged
+ * reads of one use, so counting each read would claim a skill was entered ten times
+ * when it was entered once. That leaves no last-use instant in the data to recover,
+ * so a Codex bucket dates from when the skill entered the picture. Reporting the
+ * first read is a lower bound on a real use; the alternative — no timestamp — would
+ * drop the skill out of every windowed view instead of placing it early in one.
+ *
+ * Invocations with an unparseable instant contribute no timestamp rather than a
+ * zero: absence means "no timestamp recorded", which readers fall back on, while
+ * a zero is a real instant in 1970 and would sort as the oldest call ever made.
+ */
+function toToolCall(use: SkillUse): ToolCallCount {
+	let lastCallAtMs = Number.NaN;
+	for (const invocation of use.invocations) {
+		const at = Date.parse(invocation.at);
+		if (Number.isFinite(at) && (!Number.isFinite(lastCallAtMs) || at > lastCallAtMs)) lastCallAtMs = at;
+	}
+	return {
+		// The skill's own name, matching what the `Skill` tool path reports, so the two
+		// halves of one skill's usage fold together instead of appearing as two rows.
+		name: use.skill,
+		kind: "skill",
+		calls: use.invocations.length,
+		...(Number.isFinite(lastCallAtMs) ? { lastCallAtMs } : {}),
+	};
+}
+
+export const skillExtractor: SessionSignalExtractor = {
+	id: "skills",
+	supports: (source: TranscriptSource) => getSkillScanner(source) !== undefined,
+	extract: async (input: SessionSignalInput): Promise<SessionSignals> => {
+		const scanner = getSkillScanner(input.source);
+		if (!scanner) return {};
+		const lines = await input.content.lines();
+		// A source with a scanner but no line-oriented transcript reports nothing at
+		// all — not an empty list. `{}` leaves the tool extractor's answer untouched;
+		// `{ tools: [] }` would be a claim about a store this never opened.
+		if (!lines) return {};
+		try {
+			// From line 0: this is a whole-conversation read, not an incremental one. The
+			// back-fill has no cursor of its own here and must not touch the live
+			// `discovery-cursors.json` marks — those are monotonic and owned by the hooks,
+			// so advancing one from here would permanently strand the lines between the
+			// old mark and the new one for the StopHook that was going to read them.
+			const result = scanner.scan(lines, 0);
+			return result.uses.length > 0 ? { tools: result.uses.map(toToolCall) } : {};
+		} catch (err) {
+			throw new Error(`skill extraction failed for ${input.source}/${input.sessionId}: ${errMsg(err)}`);
+		}
+	},
+};

--- a/cli/src/core/sessions/ToolCallExtractor.test.ts
+++ b/cli/src/core/sessions/ToolCallExtractor.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ToolCallCount, TranscriptReadResult, TranscriptSource } from "../../Types.js";
+import type { SessionSignalInput } from "./SessionSignalExtractor.js";
+import { toolCallExtractor } from "./ToolCallExtractor.js";
+
+function readResult(over: Partial<TranscriptReadResult> = {}): TranscriptReadResult {
+	return {
+		entries: [],
+		newCursor: { transcriptPath: "/tmp/s1.jsonl", lineNumber: 0, updatedAt: "2026-08-01T00:00:00.000Z" },
+		totalLinesRead: 0,
+		...over,
+	};
+}
+
+/** An input whose `read()` behaves however the case needs; `lines()` is unused here. */
+function input(read: () => Promise<TranscriptReadResult>, source: TranscriptSource = "claude"): SessionSignalInput {
+	return {
+		source,
+		sessionId: "s1",
+		transcriptPath: "/tmp/s1.jsonl",
+		content: { read, lines: async () => undefined },
+	};
+}
+
+describe("toolCallExtractor.supports", () => {
+	it("answers from TOOL_RECORDING_SOURCES rather than a list of its own", () => {
+		// The set is half probed and half hand-maintained against real captures, and it
+		// already carries the rule that matters — a source joins only once its reader
+		// has been written against a real transcript.
+		expect(toolCallExtractor.supports("claude")).toBe(true);
+		expect(toolCallExtractor.supports("codex")).toBe(true);
+	});
+
+	it("declines a source the set does not carry", () => {
+		// A source wrongly included would report `toolUse: []`, which every consumer
+		// reads as the positive claim "this agent called no tools".
+		expect(toolCallExtractor.supports("cursor" as TranscriptSource)).toBe(false);
+	});
+});
+
+describe("toolCallExtractor.extract", () => {
+	it("forwards the reader's buckets", async () => {
+		const tools: ToolCallCount[] = [{ name: "Bash", kind: "builtin", calls: 2 }];
+		const signals = await toolCallExtractor.extract(input(async () => readResult({ toolUse: tools })));
+		expect(signals).toEqual({ tools });
+	});
+
+	it("forwards an EMPTY bucket list, which is a real answer", async () => {
+		// "Called no tools" is worth storing. It must not be turned into absence.
+		const signals = await toolCallExtractor.extract(input(async () => readResult({ toolUse: [] })));
+		expect(signals).toEqual({ tools: [] });
+		expect(signals.tools).toHaveLength(0);
+	});
+
+	it("reports ABSENCE when the reader produced no `toolUse` at all", async () => {
+		// Absence means this slice could not say; the two must not collapse.
+		const signals = await toolCallExtractor.extract(input(async () => readResult()));
+		expect(signals).toEqual({});
+		expect(signals.tools).toBeUndefined();
+	});
+
+	it("rethrows a failed read with the session named, rather than swallowing it", async () => {
+		// An unreadable transcript and a transcript with no tool calls are different
+		// facts. Returning `{}` here would spell them the same way — the caller is what
+		// decides the consequence.
+		const boom = async (): Promise<TranscriptReadResult> => {
+			throw new Error("database is locked");
+		};
+		await expect(toolCallExtractor.extract(input(boom, "codex"))).rejects.toThrow(
+			/tool-call extraction failed for codex\/s1: database is locked/,
+		);
+	});
+
+	it("reads the transcript exactly once per extraction", async () => {
+		const read = vi.fn(async () => readResult({ toolUse: [] }));
+		await toolCallExtractor.extract(input(read));
+		expect(read).toHaveBeenCalledTimes(1);
+	});
+});

--- a/cli/src/core/sessions/ToolCallExtractor.ts
+++ b/cli/src/core/sessions/ToolCallExtractor.ts
@@ -1,0 +1,53 @@
+/**
+ * ToolCallExtractor — every tool call one conversation made, however its agent
+ * spells a tool name.
+ *
+ * Covers builtin calls, MCP calls and the tool-shaped half of skill invocations
+ * in ONE pass, because those are three classifications of a single record rather
+ * than three kinds of record — see {@link SessionSignalExtractor}'s header. The
+ * classification itself belongs to `ToolNameClassify` and each source's parser or
+ * reader; nothing about it is repeated here.
+ *
+ * ## What decides which agents this answers for
+ *
+ * {@link TOOL_RECORDING_SOURCES}, and deliberately nothing else. That set is half
+ * probed (a parser either implements `parseToolUse` or does not) and half
+ * hand-maintained against real captures, and it already carries the rule that
+ * matters: a source joins it only once its reader has been written against a real
+ * transcript from that host. Restating the list here would be a second copy of a
+ * decision that is deliberately conservative — and the failure would be silent,
+ * because a source wrongly included reports `toolUse: []`, which every consumer
+ * reads as the positive claim "this agent called no tools".
+ *
+ * That is also why absence is preserved: a source outside the set contributes no
+ * `tools` field at all, never an empty one. "Cannot express tool calls" and
+ * "expressed none" are different facts and the dashboard renders them
+ * differently.
+ */
+
+import { errMsg } from "../../Logger.js";
+import type { TranscriptSource } from "../../Types.js";
+import { TOOL_RECORDING_SOURCES } from "../TranscriptParser.js";
+import type { SessionSignalExtractor, SessionSignalInput, SessionSignals } from "./SessionSignalExtractor.js";
+
+export const toolCallExtractor: SessionSignalExtractor = {
+	id: "tool-calls",
+	supports: (source: TranscriptSource) => TOOL_RECORDING_SOURCES.has(source),
+	extract: async (input: SessionSignalInput): Promise<SessionSignals> => {
+		try {
+			const read = await input.content.read();
+			// Forwarded only when the reader actually produced it. An empty array means
+			// "called no tools" and is worth storing; absence means this slice could not
+			// say, and the two must not collapse.
+			return read.toolUse ? { tools: read.toolUse } : {};
+		} catch (err) {
+			// Rethrown with the session named, NOT swallowed: an unreadable transcript
+			// and a transcript with no tool calls are different facts, and returning `{}`
+			// here would spell them the same way. The caller is what decides the
+			// consequence — it logs this and keeps the session row built from what the
+			// discoverer already knew, so a conversation that cannot be parsed still
+			// counts as a conversation.
+			throw new Error(`tool-call extraction failed for ${input.source}/${input.sessionId}: ${errMsg(err)}`);
+		}
+	},
+};

--- a/cli/src/core/skills/CodexSkillScanner.test.ts
+++ b/cli/src/core/skills/CodexSkillScanner.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
 	CODEX_CAT_SKILL,
 	CODEX_COMPOUND_SKILL,
+	CODEX_EXEC_TOOL_COMPOUND_SKILL,
+	CODEX_EXEC_TOOL_SKILL,
 	CODEX_GLOB_LOOP_OVER_SKILLS,
 	CODEX_RG_SEARCH_FOR_SKILLS,
 	CODEX_SED_SKILL,
@@ -162,11 +164,45 @@ describe("scanCodexSkillLines", () => {
 		expect(uses[0].invocations[0].at).toBe(T1);
 	});
 
-	it("accepts the custom_tool_call shape as well as function_call", () => {
-		// Codex emits both for shell work. Matching only `function_call` would silently
-		// halve the signal for whichever sessions used the other form.
-		const inner = CODEX_CAT_SKILL.replace('"type":"function_call"', '"type":"custom_tool_call"');
-		expect(scanCodexSkillLines([codexRecord(inner, T1)], 0).uses).toHaveLength(1);
+	it("reads a real custom_tool_call, whose command lives in `input` and not `arguments`", () => {
+		// The majority form — 619 of 729 shell calls across 41 real session files — and
+		// the one this scanner could not see for a year. The predecessor of this test
+		// built its record by string-replacing the TYPE of a `function_call` fixture and
+		// left `arguments` in place, so it passed while every real `custom_tool_call`
+		// was dropped at the field read: 2 of 17 (session, skill) pairs survived on one
+		// machine's 7-day window. The fixture is a capture now, which is what makes the
+		// assertion mean anything.
+		const { uses } = scanCodexSkillLines([codexRecord(CODEX_EXEC_TOOL_SKILL, T1)], 0);
+		expect(uses).toHaveLength(1);
+		expect(uses[0].skill).toBe("comprehensive-review-full-review");
+		expect(uses[0].detection).toBe("heuristic");
+	});
+
+	it("reads the custom_tool_call form when the command chains other work after the read", () => {
+		// How it usually arrives: the capture chained the read with printf, pwd and git
+		// status in one `cmd`. The path is no longer at the end of the string, so this
+		// exercises the regex against trailing shell text rather than a clean terminator.
+		const { uses } = scanCodexSkillLines([codexRecord(CODEX_EXEC_TOOL_COMPOUND_SKILL, T1)], 0);
+		expect(uses.map((u) => u.skill)).toEqual(["comprehensive-review-full-review"]);
+	});
+
+	it("folds both record shapes into one entry for the same skill", () => {
+		// A session mixes the two forms freely. Keying on the skill name rather than on
+		// the record shape is what stops one skill being reported as two.
+		const { uses } = scanCodexSkillLines(
+			[codexRecord(CODEX_SED_SKILL, T2), codexRecord(CODEX_EXEC_TOOL_SKILL, T1)],
+			0,
+		);
+		expect(uses).toHaveLength(1);
+		expect(uses[0].invocations[0].at).toBe(T1);
+	});
+
+	it("ignores a custom_tool_call whose `input` is not a string", () => {
+		// Same rule as the `arguments` case below: the path only counts when it is in the
+		// text the model ran. A structured object still carries the needle into the raw
+		// line, so the pre-filter admits it and the type check is what rejects it.
+		const inner = '{"type":"custom_tool_call","name":"exec","input":{"cmd":"cat /x/skills/git-commit/SKILL.md"}}';
+		expect(scanCodexSkillLines([codexRecord(inner, T1)], 0).uses).toEqual([]);
 	});
 
 	it("ignores a non-call record even when it quotes a skill path", () => {

--- a/cli/src/core/skills/CodexSkillScanner.ts
+++ b/cli/src/core/skills/CodexSkillScanner.ts
@@ -1,9 +1,28 @@
 /**
  * CodexSkillScanner — infers skill usage from Codex shell calls.
  *
- * Codex has NO skill tool. Its only signal is an `exec_command` whose shell string
+ * Codex has NO skill tool. Its only signal is a shell call whose command string
  * happens to read a `SKILL.md`, so unlike the Claude and OpenCode scanners this one
  * is heuristic and every entry it produces says so via `detection: "heuristic"`.
+ *
+ * ## Codex spells a shell call two ways, and they disagree on the field name
+ *
+ * `function_call` (`name: "exec_command"`) carries its parameters as a JSON string
+ * in `arguments`. `custom_tool_call` (`name: "exec"`) carries a JavaScript snippet
+ * in `input` instead — `const r = await tools.exec_command({ cmd: "…" })`. Both are
+ * a shell command the model ran, so both are the same signal here.
+ *
+ * The second form is now the overwhelming majority: re-measured across 41 real
+ * session files, 619 `custom_tool_call` against 110 `function_call`. Reading only
+ * `arguments` therefore dropped 85% of the shell calls this scanner exists to see —
+ * on one machine's 7-day window, 2 of 17 (session, skill) pairs survived, and one
+ * skill was never recorded at all. `TranscriptParser` had already measured the same
+ * split (804 vs 415) without that reaching this file.
+ *
+ * That gap outlived a test named for covering it, because the test built its
+ * `custom_tool_call` by string-replacing the TYPE of a `function_call` fixture and
+ * left the `arguments` field in place — a shape Codex never emits. Both forms are
+ * verbatim captures now, which is the only version of this test that can fail.
  *
  * Measured over 1,503 real session files before any of this was written: 976 calls
  * touch a `SKILL.md`, across 594 distinct (session, skill) pairs. Three properties
@@ -91,7 +110,7 @@ export function scanCodexSkillLines(lines: ReadonlyArray<string>, fromLine: numb
 		const payload = isRecord(record.payload) ? record.payload : record;
 		if (payload.type !== "function_call" && payload.type !== "custom_tool_call") continue;
 
-		const args = typeof payload.arguments === "string" ? payload.arguments : "";
+		const args = commandStringOf(payload);
 		if (!args.includes(NEEDLE)) continue;
 
 		const at = timestampOf(record, payload);
@@ -129,6 +148,25 @@ export function scanCodexSkillLines(lines: ReadonlyArray<string>, fromLine: numb
 	}
 	if (uses.length > 0) log.debug("Inferred %d Codex skill(s) from shell reads", uses.length);
 	return { uses, lastLine };
+}
+
+/**
+ * The command string a shell call carries, whichever of its two field names holds it.
+ *
+ * `arguments` is preferred only because it is the older, JSON-shaped form; the two
+ * never appear together on one record, so the order is not a precedence rule. A value
+ * that is present but not a string yields `""` — the path only counts when it is in
+ * the text the model actually ran, and a structured object still puts "SKILL.md" in
+ * the raw line, so the needle pre-filter lets it through and this is what rejects it.
+ *
+ * Nothing here parses the JavaScript wrapper `custom_tool_call` uses. The path regex
+ * runs over the whole string either way, and a real parse would buy nothing: the
+ * signal is a substring, and a snippet this scanner cannot parse is a snippet whose
+ * skill read it would rather still find.
+ */
+function commandStringOf(payload: Record<string, unknown>): string {
+	if (typeof payload.arguments === "string") return payload.arguments;
+	return typeof payload.input === "string" ? payload.input : "";
 }
 
 /** Codex timestamps live on the envelope, not the payload. */

--- a/cli/src/core/skills/__fixtures__/codexExecCalls.ts
+++ b/cli/src/core/skills/__fixtures__/codexExecCalls.ts
@@ -1,12 +1,25 @@
 /**
- * Real Codex `function_call` envelopes that touch a `SKILL.md`, copied verbatim
- * out of `~/.codex/sessions/**`.
+ * Real Codex shell-call envelopes that touch a `SKILL.md`, copied verbatim out of
+ * `~/.codex/sessions/**` (only the home directory and repo path are rewritten).
  *
  * Codex has NO skill tool. Its only signal is a shell command that happens to read
  * a skill file, which is why capture from this source is heuristic and says so.
  * Measured over 1,503 real session files: 976 such calls across 594 distinct
  * (session, skill) pairs, median 1 read per pair but 49% read more than once —
  * paged reads of one file, not repeat entries.
+ *
+ * ## Both record shapes are captures, and that is the point
+ *
+ * Codex spells a shell call as either a `function_call` (`name: "exec_command"`,
+ * parameters as a JSON string in `arguments`) or a `custom_tool_call` (`name:
+ * "exec"`, a JavaScript snippet in `input`). Re-measured across 41 session files,
+ * the second outnumbers the first 619 to 110.
+ *
+ * The custom-tool form had no fixture for a year: the test covering it built one by
+ * string-replacing `"type":"function_call"` in a fixture above and kept the
+ * `arguments` field — a record Codex never writes. It passed against a scanner that
+ * could not read a single real one. A fixture that is edited rather than captured
+ * proves only that the edit is self-consistent.
  */
 
 /** The plainest form. */
@@ -41,6 +54,29 @@ export const CODEX_GLOB_LOOP_OVER_SKILLS =
 /** A shell call with nothing skill-related, for the pre-filter. */
 export const CODEX_UNRELATED_EXEC =
 	'{"type":"function_call","name":"exec_command","arguments":"{\\"cmd\\":\\"git status --short\\"}","call_id":"call_plain"}';
+
+/**
+ * The `custom_tool_call` form, and the majority one: 619 of 729 shell calls across
+ * 41 real session files.
+ *
+ * Three differences from every fixture above, all of them load-bearing. The tool is
+ * named `exec` rather than `exec_command`; the parameters live in `input` rather
+ * than `arguments`; and `input` is a JavaScript snippet, not a JSON string — the
+ * command sits inside a `tools.exec_command({ cmd: … })` call. The scanner reads the
+ * path straight out of the text, so the wrapper never has to be parsed.
+ */
+export const CODEX_EXEC_TOOL_SKILL =
+	'{"type":"custom_tool_call","id":"rs_00a1b2c3","status":"completed","call_id":"call_5NfQwMxT2rKpVbZ8","name":"exec","input":"const r = await tools.exec_command({\\n  cmd: \\"sed -n \'1,240p\' /Users/flyer/.agents/skills/comprehensive-review-full-review/SKILL.md\\",\\n  workdir: \\"/Users/flyer/jolli/code/jolli\\",\\n  yield_time_ms: 10000,\\n  max_output_tokens: 30000\\n});\\ntext(r.output);"}';
+
+/**
+ * The same form carrying a compound command, which is how it usually arrives: the
+ * captured original chained the skill read with `printf`, `pwd`, `git status` and
+ * `git branch` in one `cmd`. Kept because the path is no longer at the end of the
+ * string, so it exercises the regex against trailing shell text rather than against
+ * a clean terminator.
+ */
+export const CODEX_EXEC_TOOL_COMPOUND_SKILL =
+	'{"type":"custom_tool_call","id":"rs_00d4e5f6","status":"completed","call_id":"call_7HjKlMnP4qRsTuVw","name":"exec","input":"const r = await tools.exec_command({\\n  cmd: \\"sed -n \'1,240p\' /Users/flyer/.agents/skills/comprehensive-review-full-review/SKILL.md && printf \'\\\\n---REPO---\\\\n\' && pwd && git status --short --branch\\",\\n  workdir: \\"/Users/flyer/jolli/code/jolli\\"\\n});\\ntext(r.output);"}';
 
 /** Codex wraps records in a `payload` envelope with its own timestamp. */
 export function codexRecord(inner: string, timestamp: string): string {

--- a/cli/src/dashboard/DashboardCollector.test.ts
+++ b/cli/src/dashboard/DashboardCollector.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
-import type { GitCommandResult, SessionInfo, TranscriptReadResult } from "../Types.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GitCommandResult, SessionInfo, TranscriptReadResult, TranscriptSource } from "../Types.js";
 
 vi.mock("../core/GitOps.js", () => ({
 	execGit: vi.fn(),
@@ -10,12 +10,16 @@ vi.mock("../core/SummaryStore.js", () => ({
 	getSummary: vi.fn(),
 	readTranscriptsForCommits: vi.fn(),
 }));
-// Only the read is faked — `isMissingTranscriptError` classifies the rejection
-// the collector catches, so the real predicate has to stay in place.
-vi.mock("../core/TranscriptReader.js", async (importOriginal) => ({
-	...(await importOriginal<typeof import("../core/TranscriptReader.js")>()),
-	readTranscript: vi.fn(),
-}));
+// Only the read is faked; everything else in the module stays REAL, for two
+// separate reasons. `isMissingTranscriptError` classifies the rejection the
+// collector catches, so the real predicate has to stay in place. And
+// `splitTranscriptLines` is a pure string split that the line-oriented
+// extractors depend on — a mocked-away `undefined` would surface as a TypeError
+// deep inside a lazily-imported reader rather than as a failed expectation.
+vi.mock("../core/TranscriptReader.js", async (importOriginal) => {
+	const original = await importOriginal<typeof import("../core/TranscriptReader.js")>();
+	return { ...original, readTranscript: vi.fn() };
+});
 // The default session loader fans out to every discoverer; mock the registry
 // loader so `loadAllSessions` has one deterministic success and the rest of
 // the discoverers run for real against a directory that has none of their stores.
@@ -23,7 +27,18 @@ vi.mock("../core/SessionTracker.js", async (importOriginal) => {
 	const original = await importOriginal<typeof import("../core/SessionTracker.js")>();
 	return { ...original, loadAllSessions: vi.fn() };
 });
+// PARTIAL: only the per-repo scan is replaced, so `codexSessionsForRepo` keeps doing
+// real attribution. The spy is how the "a pre-scanned source is not scanned again"
+// guarantee is asserted — without it that double read would be invisible.
+vi.mock("../core/CodexSessionDiscoverer.js", async (importOriginal) => {
+	const original = await importOriginal<typeof import("../core/CodexSessionDiscoverer.js")>();
+	return { ...original, discoverCodexSessions: vi.fn(async () => []) };
+});
 
+import type { ClaudeDiskSession } from "../core/ClaudeSessionDiscoverer.js";
+import type { CodexDiskSession } from "../core/CodexSessionDiscoverer.js";
+import { discoverCodexSessions } from "../core/CodexSessionDiscoverer.js";
+import type { DiskSession } from "../core/DiskSessionScan.js";
 import { execGit, getCurrentBranch } from "../core/GitOps.js";
 import { loadAllSessions as loadRegistrySessions } from "../core/SessionTracker.js";
 import { getIndex, getSummary, readTranscriptsForCommits } from "../core/SummaryStore.js";
@@ -36,8 +51,18 @@ import {
 	collectWorktreeEvent,
 	loadAllSessions,
 	parseNumstatLog,
+	sessionPassKey,
+	sourceOfSessionPassKey,
 	summaryEventFromCommitSummary,
 } from "./DashboardCollector.js";
+
+beforeEach(() => {
+	// The partial SessionTracker mock keeps the real module except for this read.
+	// Give the seam its valid default explicitly: a bare `vi.fn()` resolves to
+	// undefined, which violates the loader contract and makes the fan-out fail while
+	// spreading a fulfilled result that is not an array.
+	vi.mocked(loadRegistrySessions).mockResolvedValue([]);
+});
 
 const git = (stdout: string): GitCommandResult => ({ stdout, stderr: "", exitCode: 0 });
 const gitFail = (stderr: string): GitCommandResult => ({ stdout: "", stderr, exitCode: 128 });
@@ -48,6 +73,39 @@ const claudeSession = (over: Partial<SessionInfo> = {}): SessionInfo => ({
 	updatedAt: "2026-07-30T08:00:00.000Z",
 	source: "claude",
 	...over,
+});
+
+/** A repo root the disk-scan fixtures below attribute themselves to. */
+const WORKTREE = "/w/repo";
+
+const diskSession = (over: Partial<ClaudeDiskSession> = {}): ClaudeDiskSession => ({
+	sessionId: "d1",
+	transcriptPath: "/t/d1.jsonl",
+	updatedAt: "2026-07-30T08:00:00.000Z",
+	dirs: [WORKTREE],
+	// The whole-file read every non-skipped transcript gets; the scan only reports
+	// `false` when the database already held the session.
+	complete: true,
+	...over,
+});
+
+const codexDiskSession = (over: Partial<CodexDiskSession> = {}): CodexDiskSession => ({
+	sessionId: "x1",
+	transcriptPath: "/t/x1.jsonl",
+	updatedAt: "2026-07-30T08:00:00.000Z",
+	dirs: [WORKTREE],
+	...over,
+});
+
+/** A machine-wide scan entry for any of the sources that use the shared shape. */
+const diskEntry = (source: TranscriptSource, id: string, dirs: string[] = [WORKTREE]): DiskSession => ({
+	session: {
+		sessionId: id,
+		transcriptPath: `/t/${id}.jsonl`,
+		updatedAt: "2026-07-30T08:00:00.000Z",
+		source,
+	},
+	dirs,
 });
 
 const transcript = (over: Partial<TranscriptReadResult> = {}): TranscriptReadResult => ({
@@ -97,6 +155,47 @@ describe("collectSessionEvents", () => {
 		expect(events[0].models).toBeUndefined();
 	});
 
+	it("omits the duration for a conversation with a single turn", async () => {
+		// First and last entry are the same record, so there is no elapsed time to
+		// report. Writing 0 would claim a measurement; absence says there is none —
+		// and the guard is `>`, not `>=`, for exactly this case.
+		vi.mocked(readTranscript).mockResolvedValue(
+			transcript({
+				entries: [{ role: "human", content: "one turn", timestamp: "2026-07-30T07:00:00.000Z" }],
+				usageByModel: [],
+			}),
+		);
+
+		const events = await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: "/w",
+			loadSessions: async () => [claudeSession()],
+		});
+
+		expect(events[0].messageCount).toBe(1);
+		expect(events[0].durationMs).toBeUndefined();
+	});
+
+	it("keeps the NEWER of two views of one session, whichever order they arrive in", async () => {
+		// Two discoverers can surface the same conversation — the hook registry and a
+		// rescan of the same store — and the dedupe has to be an explicit comparison
+		// rather than last-write-wins, or which timestamp survives depends on the order
+		// the loaders happened to finish in.
+		vi.mocked(readTranscript).mockResolvedValue(transcript({ usageByModel: [] }));
+
+		const events = await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: "/w",
+			loadSessions: async () => [
+				claudeSession({ updatedAt: "2026-07-30T09:00:00.000Z" }),
+				claudeSession({ updatedAt: "2026-07-30T08:00:00.000Z" }),
+			],
+		});
+
+		expect(events).toHaveLength(1);
+		expect(events[0].updatedAtMs).toBe(Date.parse("2026-07-30T09:00:00.000Z"));
+	});
+
 	it("keeps a session whose transcript is unreadable, with what the discoverer knew", async () => {
 		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 		vi.mocked(readTranscript).mockRejectedValue(new Error("moved"));
@@ -129,12 +228,19 @@ describe("collectSessionEvents", () => {
 		warn.mockRestore();
 	});
 
-	it("does not read transcripts for non-Claude sources — no per-turn usage exists there", async () => {
+	it("never sends a non-Claude transcript to Claude's reader", async () => {
+		// Non-Claude sources DO get read now — that is what gave the other twelve agents
+		// their tool and MCP calls. What must not happen is them being read by the
+		// Claude-shaped `readTranscript`: a Cursor `transcriptPath` is a synthetic
+		// `<dbPath>#<sessionId>` handle, and a JSONL reader handed one does not fail
+		// loudly, it parses zero lines and reports an empty conversation.
 		const events = await collectSessionEvents({
 			repoIdentity: "r",
 			cwd: "/w",
 			loadSessions: async () => [claudeSession({ source: "cursor", sessionId: "c1" })],
 		});
+		// The row survives whatever its own reader did — an unreadable transcript still
+		// counts as a session, recorded from what the discoverer knew.
 		expect(events).toEqual([
 			expect.objectContaining({
 				source: "cursor",
@@ -194,6 +300,310 @@ describe("collectSessionEvents", () => {
 			},
 		});
 		expect(events[0].source).toBe("claude");
+	});
+
+	it("adds pre-scanned Claude transcripts whose working directory matches the repo", async () => {
+		vi.mocked(readTranscript).mockResolvedValue(transcript({ usageByModel: [] }));
+		const events = await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: WORKTREE,
+			loadSessions: async () => [],
+			preScanned: { claude: [diskSession()] },
+		});
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({ source: "claude", sessionId: "d1" });
+	});
+
+	it("reads a pre-scanned transcript itself rather than taking the scan's word", async () => {
+		// The scan parsed this file to collect its working directories and deliberately
+		// kept none of it — carrying the parse made a run's resident set grow with the
+		// window (see `acceptFacts`). So the read is paid here, per session, and it is a
+		// re-read rather than a first read.
+		vi.mocked(readTranscript).mockResolvedValue(
+			transcript({ entries: [{ role: "human", content: "only turn" }], usageByModel: [] }),
+		);
+
+		const events = await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: WORKTREE,
+			loadSessions: async () => [],
+			preScanned: { claude: [diskSession()] },
+		});
+
+		expect(readTranscript).toHaveBeenCalledTimes(1);
+		expect(events[0].messageCount).toBe(1);
+	});
+
+	it("reads a cheap-path scan the same way — `complete` no longer changes anything here", async () => {
+		// `complete: false` says the scan only read a tail, so its `dirs` may be short.
+		// That is an attribution caveat and not a content one: neither path carries
+		// content, so both cost exactly one read here.
+		vi.mocked(readTranscript).mockResolvedValue(transcript({ usageByModel: [] }));
+
+		await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: WORKTREE,
+			loadSessions: async () => [],
+			preScanned: { claude: [diskSession({ complete: false })] },
+		});
+
+		expect(readTranscript).toHaveBeenCalledTimes(1);
+	});
+
+	it("drops a pre-scanned transcript belonging to another repo", async () => {
+		const events = await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: WORKTREE,
+			loadSessions: async () => [],
+			preScanned: { claude: [diskSession({ dirs: ["/somewhere/else"] })] },
+		});
+		expect(events).toEqual([]);
+		expect(readTranscript).not.toHaveBeenCalled();
+	});
+
+	it("merges the disk scan with the registry instead of replacing it", async () => {
+		vi.mocked(readTranscript).mockResolvedValue(transcript({ usageByModel: [] }));
+		const events = await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: WORKTREE,
+			// Only reachable through `sessions.json` — e.g. Gemini, which has no disk scanner.
+			loadSessions: async () => [claudeSession({ source: "gemini", sessionId: "g1" })],
+			preScanned: { claude: [diskSession()] },
+		});
+		expect(events.map((e) => e.sessionId).sort()).toEqual(["d1", "g1"]);
+	});
+
+	it("keeps the registry copy when both routes surface one session (its instant is later)", async () => {
+		vi.mocked(readTranscript).mockResolvedValue(transcript({ usageByModel: [] }));
+		const events = await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: WORKTREE,
+			// The Stop hook stamps the hook's own instant, a few seconds after the last turn.
+			loadSessions: async () => [claudeSession({ sessionId: "d1", updatedAt: "2026-07-30T08:00:03.000Z" })],
+			preScanned: { claude: [diskSession({ updatedAt: "2026-07-30T08:00:00.000Z" })] },
+		});
+		expect(events).toHaveLength(1);
+		expect(events[0].updatedAtMs).toBe(Date.parse("2026-07-30T08:00:03.000Z"));
+	});
+
+	it("skips a session the database already holds at or past its instant, without reading it", async () => {
+		const events = await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: "/w",
+			loadSessions: async () => [claudeSession()],
+			isAlreadyCurrent: () => true,
+		});
+		expect(events).toEqual([]);
+		// The whole point of the skip: the expensive transcript parse never happens.
+		expect(readTranscript).not.toHaveBeenCalled();
+	});
+
+	it("passes source, id and instant to the skip predicate", async () => {
+		vi.mocked(readTranscript).mockResolvedValue(transcript({ usageByModel: [] }));
+		const seen: Array<[string, string, number]> = [];
+		await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: "/w",
+			loadSessions: async () => [claudeSession(), claudeSession({ source: "cursor", sessionId: "c1" })],
+			isAlreadyCurrent: (source, sessionId, updatedAtMs) => {
+				seen.push([source, sessionId, updatedAtMs]);
+				return source === "cursor";
+			},
+		});
+		expect(seen).toContainEqual(["claude", "s1", Date.parse("2026-07-30T08:00:00.000Z")]);
+		expect(seen).toContainEqual(["cursor", "c1", Date.parse("2026-07-30T08:00:00.000Z")]);
+	});
+
+	it("re-reads a session whose stored instant is older than the disk one", async () => {
+		vi.mocked(readTranscript).mockResolvedValue(transcript({ usageByModel: [] }));
+		const stored = Date.parse("2026-07-27T00:00:00.000Z");
+		const events = await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: "/w",
+			// A three-day-old conversation the user has just resumed. A repo-wide
+			// high-water mark would skip this; a per-session compare must not.
+			loadSessions: async () => [claudeSession({ updatedAt: "2026-07-30T00:00:00.000Z" })],
+			isAlreadyCurrent: (_source, _sessionId, updatedAtMs) => stored >= updatedAtMs,
+		});
+		expect(events).toHaveLength(1);
+	});
+
+	it("adds pre-scanned Codex rollouts whose working directory matches the repo", async () => {
+		const events = await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: WORKTREE,
+			loadSessions: async () => [],
+			preScanned: { codex: [codexDiskSession()] },
+		});
+		expect(events).toEqual([expect.objectContaining({ source: "codex", sessionId: "x1" })]);
+		// Codex writes JSONL, so it shares the one reader Claude uses — with its own
+		// parser, which is the part that must be right. The tier used to open Claude's
+		// transcript alone and hand every other agent a bare session row.
+		const [path, , parser] = vi.mocked(readTranscript).mock.calls[0];
+		expect(path).toBe("/t/x1.jsonl");
+		expect(parser?.constructor.name).toBe("CodexTranscriptParser");
+	});
+
+	it("drops a pre-scanned Codex rollout belonging to another repo", async () => {
+		const events = await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: WORKTREE,
+			loadSessions: async () => [],
+			preScanned: { codex: [codexDiskSession({ dirs: ["/somewhere/else"] })] },
+		});
+		expect(events).toEqual([]);
+	});
+
+	it("does not scan Codex again when a pre-scan was supplied", async () => {
+		// The whole point of hoisting it: a per-repo scan on top of the run-wide one
+		// would read `~/.codex/sessions/` twice per repo instead of once per run.
+		await loadAllSessions("/w", undefined, { codex: [codexDiskSession()] });
+
+		expect(discoverCodexSessions).not.toHaveBeenCalled();
+	});
+
+	it("treats an EMPTY pre-scan as already scanned, not as no scan", async () => {
+		// The distinction the whole `PreScannedSessions` shape rests on: `[]` is the
+		// positive claim "the scan ran and found nothing", so the per-repo loader must
+		// still be skipped. Reading `[]` as "nothing supplied" would re-scan the store
+		// for every repo — silently, since both spellings produce zero sessions.
+		await loadAllSessions("/w", undefined, { codex: [] });
+
+		expect(discoverCodexSessions).not.toHaveBeenCalled();
+	});
+
+	it("does scan Codex when no pre-scan was supplied", async () => {
+		// Every caller outside the back-fill relies on this — the sidebar, `jolli status`
+		// and the post-commit summary all pass nothing and must still get the source.
+		await loadAllSessions("/w");
+
+		expect(discoverCodexSessions).toHaveBeenCalledWith("/w", undefined);
+	});
+
+	// Every hookless source reads a machine-global store, so every one of them can be
+	// pre-scanned once for a whole multi-repo run and narrowed here. The two halves are
+	// asserted together on purpose: a source that narrows correctly but is not skipped
+	// by the fan-out reads its store twice per repo, and a source that is skipped but
+	// does not narrow disappears from the run — both are silent, and both produce a
+	// plausible-looking result.
+	// `PreScannedSessions` is keyed by `TranscriptSource` itself, so the key IS the
+	// source — spelled once here rather than as a parallel camelCase column, which is
+	// what let three of these sit unmatched: an unknown key narrows to nothing, and
+	// the "belongs to another repo" half of each pair expects nothing anyway, so only
+	// one of the two assertions could ever notice.
+	//
+	// `lineOriented` marks the sources whose transcript is a JSONL file. Those share
+	// the one `readTranscript` entry point (with their own parser) — see
+	// LINE_ORIENTED_SOURCES in TranscriptSourceReader; the rest own a reader over a
+	// JSON file or a SQLite store and never reach it.
+	const HOISTED = [
+		{ source: "kimi", lineOriented: true },
+		{ source: "opencode", lineOriented: false },
+		{ source: "copilot", lineOriented: false },
+		{ source: "copilot-chat", lineOriented: false },
+		{ source: "cline", lineOriented: false },
+		{ source: "cline-cli", lineOriented: false },
+		{ source: "devin", lineOriented: false },
+		{ source: "cursor-cli", lineOriented: false },
+		{ source: "antigravity", lineOriented: false },
+	] as const;
+
+	for (const { source, lineOriented } of HOISTED) {
+		const key = source;
+		it(`adds pre-scanned ${source} sessions whose directory matches the repo`, async () => {
+			const events = await collectSessionEvents({
+				repoIdentity: "r",
+				cwd: WORKTREE,
+				loadSessions: async () => [],
+				preScanned: { [key]: [diskEntry(source, `${source}-1`)] },
+			});
+			expect(events).toEqual([expect.objectContaining({ source, sessionId: `${source}-1` })]);
+			// A JSONL source is read through the shared entry point; a store-backed one
+			// is read by its own module and must never reach it — handing a SQLite file
+			// to a line parser does not fail, it reports an empty conversation.
+			if (lineOriented) expect(readTranscript).toHaveBeenCalled();
+			else expect(readTranscript).not.toHaveBeenCalled();
+		});
+
+		it(`drops a pre-scanned ${source} session belonging to another repo`, async () => {
+			const events = await collectSessionEvents({
+				repoIdentity: "r",
+				cwd: WORKTREE,
+				loadSessions: async () => [],
+				preScanned: { [key]: [diskEntry(source, `${source}-1`, ["/somewhere/else"])] },
+			});
+			expect(events).toEqual([]);
+		});
+	}
+
+	it("drops a pre-scanned session that recorded no directory at all", async () => {
+		// An empty `dirs` must match NOTHING. The tempting reading — no directories,
+		// therefore no objection, therefore keep it — would attach the session to every
+		// repo on the machine.
+		const events = await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: WORKTREE,
+			loadSessions: async () => [],
+			preScanned: { kimi: [diskEntry("kimi", "k1", [])] },
+		});
+		expect(events).toEqual([]);
+	});
+
+	it("does not skip a session whose instant cannot be parsed", async () => {
+		const predicate = vi.fn(() => true);
+		await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: "/w",
+			loadSessions: async () => [claudeSession({ updatedAt: "not-a-date" })],
+			isAlreadyCurrent: predicate,
+		});
+		// Being unable to date a session is a reason to look at it, not to assume
+		// it is current — so the predicate is never consulted for it.
+		expect(predicate).not.toHaveBeenCalled();
+	});
+
+	it("keeps the other sources' sessions when one source's NARROWING throws", async () => {
+		// Narrowing is real I/O for two sources (Antigravity enumerates the repo's
+		// worktrees, Cursor resolves a workspace hash), so a failure here is a live
+		// mode rather than a defensive catch — and it must cost that source alone.
+		// A payload of the wrong shape is the cheapest way to make one throw: every
+		// narrowing starts by iterating the scan it was handed.
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		vi.mocked(readTranscript).mockResolvedValue(transcript({ usageByModel: [] }));
+
+		const events = await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: WORKTREE,
+			loadSessions: async () => [],
+			preScanned: {
+				kimi: "not an array" as unknown as ReadonlyArray<unknown>,
+				opencode: [diskEntry("opencode", "oc1")],
+			},
+		});
+
+		expect(events.map((e) => e.sessionId)).toEqual(["oc1"]);
+		warn.mockRestore();
+	});
+});
+
+describe("sessionPassKey", () => {
+	it("joins the source and the session id", () => {
+		expect(sessionPassKey("claude", "s1")).toBe("claude:s1");
+	});
+
+	it("reads the source back off a key", () => {
+		expect(sourceOfSessionPassKey("copilot-chat:abc")).toBe("copilot-chat");
+	});
+
+	it("keeps only the FIRST segment, so an id containing a colon cannot shift the source", () => {
+		expect(sourceOfSessionPassKey("cursor:a:b:c")).toBe("cursor");
+	});
+
+	it("answers the whole string for a key with no separator at all", () => {
+		// Nothing produces such a key today — every one comes from `sessionPassKey`. The
+		// fallback exists so a malformed key degrades to a wrong-looking agent NAME in a
+		// report rather than to an empty label that reads as a missing agent.
+		expect(sourceOfSessionPassKey("nocolon")).toBe("nocolon");
 	});
 });
 

--- a/cli/src/dashboard/DashboardCollector.ts
+++ b/cli/src/dashboard/DashboardCollector.ts
@@ -23,7 +23,11 @@ import { loadConfig } from "../core/SessionTracker.js";
 import type { StorageProvider } from "../core/StorageProvider.js";
 import { getIndex, getSummary, readTranscriptsForCommits } from "../core/SummaryStore.js";
 import { collectDisplayTopics, getTranscriptIds } from "../core/SummaryTree.js";
+import type { SessionContent } from "../core/sessions/SessionSignalExtractor.js";
+import { extractSessionSignals } from "../core/sessions/SessionSignals.js";
+import { SESSION_SOURCES } from "../core/sessions/SessionSources.js";
 import { isMissingTranscriptError, readTranscript } from "../core/TranscriptReader.js";
+import { readTranscriptForSource, readTranscriptLinesForSource } from "../core/TranscriptSourceReader.js";
 import { readGraph } from "../graph/GraphArtifactStore.js";
 import type { KnowledgeGraph } from "../graph/GraphSchema.js";
 import { createLogger, errMsg } from "../Logger.js";
@@ -33,8 +37,10 @@ import type {
 	SessionInfo,
 	SkillCommitRef,
 	ToolCallCount,
+	TranscriptReadResult,
 	TranscriptSource,
 } from "../Types.js";
+import { mapWithConcurrency, withIoBudget } from "../util/Concurrency.js";
 import type {
 	CommitCreatedEvent,
 	CommitFileChange,
@@ -90,37 +96,114 @@ function toStatsModelUsage(models: ReadonlyArray<ModelTokenUsage>): StatsModelUs
  * discoverers themselves are shape-neutral, it is only the aggregator above
  * them that applies sidebar policy.
  */
-export type SessionLoader = (cwd: string) => Promise<ReadonlyArray<SessionInfo>>;
+/**
+ * Machine-wide scans a caller has already run, keyed by source.
+ *
+ * A key's PRESENCE means "already scanned": {@link loadAllSessions} skips that
+ * source's per-repo loader, and {@link collectSessionEvents} narrows these records to
+ * the repo instead. Absent means "load it here", which is what every caller outside
+ * the back-fill wants.
+ *
+ * ## Why presence, and not a separate "did I scan this" flag
+ *
+ * The two facts — *was it pre-scanned* and *what did the scan find* — must never
+ * disagree, and this shape is what makes disagreeing impossible. They used to be two
+ * fields (`codexDisk` plus a `{ codex: boolean }`), kept in step by hand at the call
+ * site; getting that wrong in either direction is silent. Say the source is scanned
+ * twice and every one of its sessions is discovered twice, or say it is skipped by the
+ * fan-out with nothing supplied in its place and the source vanishes from the run
+ * entirely — with no error either way, because "this source found nothing" and "this
+ * source was never asked" produce the identical empty result.
+ *
+ * The distinction that DOES survive is empty-versus-absent. An empty array is the
+ * positive claim "the scan ran and found nothing", so the fan-out still skips that
+ * source. `undefined` means no scan happened and the per-repo loader runs. A caller
+ * whose scan FAILED must therefore pass `undefined`, never `[]` — see the failure
+ * handling in `dbBackfillRepos`.
+ *
+ * ## Claude is the one source that is added to, not substituted for
+ *
+ * Every other key replaces its loader. Claude's does not, because the `sessions.json`
+ * half of the fan-out carries Claude too (as this scan's fallback) and Gemini (which
+ * has no other route at all). So the registry loader always runs and the pre-scanned
+ * Claude sessions are concatenated onto it; the dedupe below merges the two views of
+ * one session.
+ *
+ * ## Keyed by source TAG, and payload-typed as `unknown`
+ *
+ * This used to be twelve named fields, which cost two things worth naming. It was
+ * a thirteenth list to keep in step with {@link SESSION_SOURCES} — and the one no
+ * compiler could check, since a missing field simply meant that source was never
+ * pre-scanned. And its field names were camel-cased (`copilotChat`, `cursorCli`)
+ * while the tags they stood for are hyphenated (`copilot-chat`, `cursor-cli`), so
+ * every producer and consumer hand-mapped between the two spellings.
+ *
+ * The payload is `unknown` because each source's scan yields its own private
+ * record shape, and only the definition that produced a value ever consumes it —
+ * see {@link defineSessionSource} for why that pairing is what makes the erasure
+ * sound.
+ */
+export type PreScannedSessions = Readonly<Partial<Record<TranscriptSource, ReadonlyArray<unknown>>>>;
 
-/** Default loader: every per-source discoverer, failures logged and skipped. */
-export async function loadAllSessions(cwd: string): Promise<ReadonlyArray<SessionInfo>> {
-	// Lazy imports, same rationale as ActiveSessionAggregator: several
-	// discoverers reach for node:sqlite, and loading them eagerly would emit
-	// the ExperimentalWarning in processes that never scan sessions.
-	const loaders: ReadonlyArray<() => Promise<ReadonlyArray<SessionInfo>>> = [
-		async () => (await import("../core/SessionTracker.js")).loadAllSessions(cwd),
-		async () =>
-			(await import("../core/CursorSessionDiscoverer.js")).scanCursorSessions(cwd).then((r) => r.sessions),
-		async () => (await import("../core/CodexSessionDiscoverer.js")).discoverCodexSessions(cwd),
-		async () =>
-			(await import("../core/OpenCodeSessionDiscoverer.js")).scanOpenCodeSessions(cwd).then((r) => r.sessions),
-		async () =>
-			(await import("../core/CopilotSessionDiscoverer.js")).scanCopilotSessions(cwd).then((r) => r.sessions),
-		async () =>
-			(await import("../core/CopilotChatSessionDiscoverer.js"))
-				.scanCopilotChatSessions(cwd)
-				.then((r) => r.sessions),
-		async () => (await import("../core/ClineSessionDiscoverer.js")).scanClineSessions(cwd).then((r) => r.sessions),
-		async () =>
-			(await import("../core/ClineCliSessionDiscoverer.js")).scanClineCliSessions(cwd).then((r) => r.sessions),
-		async () => (await import("../core/DevinSessionDiscoverer.js")).scanDevinSessions(cwd).then((r) => r.sessions),
-		async () =>
-			(await import("../core/CursorCliSessionDiscoverer.js")).scanCursorCliSessions(cwd).then((r) => r.sessions),
-		async () =>
-			(await import("../core/AntigravitySessionDiscoverer.js"))
-				.scanAntigravitySessions(cwd)
-				.then((r) => r.sessions),
+export type SessionLoader = (
+	cwd: string,
+	windowMs?: number,
+	preScanned?: PreScannedSessions,
+) => Promise<ReadonlyArray<SessionInfo>>;
+
+/**
+ * Default loader: every per-source discoverer, failures logged and skipped.
+ *
+ * `windowMs` is forwarded to all of them and omitted by default, so every source
+ * keeps its own 48 h `SESSION_STALE_MS` unless a caller asks for more. The
+ * history back-fill is the only caller that does — see
+ * {@link BACKFILL_SESSION_WINDOW_MS} for why widening the constants instead would
+ * have reached the post-commit summary and corrupted what it stores.
+ */
+export async function loadAllSessions(
+	cwd: string,
+	windowMs?: number,
+	preScanned: PreScannedSessions = {},
+): Promise<ReadonlyArray<SessionInfo>> {
+	// Lazy imports throughout, same rationale as ActiveSessionAggregator: several
+	// discoverers reach for node:sqlite, and loading them eagerly would emit the
+	// ExperimentalWarning in processes that never scan sessions. The registry keeps
+	// that property — see the header of `SessionSources`.
+	const loaders: Array<() => Promise<ReadonlyArray<SessionInfo>>> = [
+		// The hook registry (`sessions.json`), which holds Claude and Gemini.
+		//
+		// The one source that is NOT machine-global: it is a per-project file, so reading
+		// it once per repo is reading a different file each time — there is nothing to
+		// hoist. It also stays unconditional even when Claude was pre-scanned, for two
+		// reasons: it is the only route Claude has when that scan fails, and it is the
+		// only route Gemini has at all (there is no Gemini disk discoverer — only
+		// `GeminiSessionDetector`, which answers "is it installed" — and no Gemini
+		// producer hook). Keeping both costs nothing, because the dedupe below merges
+		// the two views of one session.
+		//
+		// It is deliberately NOT a `SESSION_SOURCES` entry: the registry describes
+		// machine-global stores, and this is the one route that is per-project. That is
+		// also why `claude` is the single definition without a `scanForRepo` — this line
+		// IS its per-repo route.
+		//
+		// KNOWN CONSEQUENCE for Gemini: history older than 48 h is permanently
+		// unrecoverable. `pruneStale` deletes those rows from the file on every
+		// `saveSession`, so widening a window cannot bring them back — only a Gemini
+		// disk scanner could, and that is deliberately its own change.
+		async () => (await import("../core/SessionTracker.js")).loadAllSessions(cwd, windowMs),
 	];
+	// EVERY registered source is skippable, because every one of them reads a store
+	// keyed by something other than the repo — so a caller that already scanned it
+	// machine-wide must not have it read a second time, once per repo.
+	//
+	// The check is `!== undefined`, never truthiness: `[]` is the positive claim "the
+	// scan ran and found nothing", and re-running the per-repo loader on that would
+	// undo the hoist for exactly the sources that are cheapest to get wrong about.
+	for (const def of SESSION_SOURCES) {
+		const perRepo = def.scanForRepo;
+		if (!perRepo || preScanned[def.source] !== undefined) continue;
+		loaders.push(() => perRepo(cwd, windowMs));
+	}
 	const settled = await Promise.allSettled(loaders.map((load) => load()));
 	const sessions: SessionInfo[] = [];
 	for (const result of settled) {
@@ -128,6 +211,60 @@ export async function loadAllSessions(cwd: string): Promise<ReadonlyArray<Sessio
 		else log.warn("session discoverer failed during dashboard collection: %s", errMsg(result.reason));
 	}
 	return sessions;
+}
+
+/**
+ * One agent's share of a session pass.
+ *
+ * Kept separate from the processed count, which only the caller can know: this module
+ * reports what it SAW and what it declined to re-read, while "processed" is how many
+ * of the reads survived {@link sessionEventFromInfo} — a source can be discovered,
+ * not skipped, and still produce no event.
+ */
+export interface SessionSourceCounts {
+	/** Sessions this agent contributed to the deduped set. */
+	readonly discovered: number;
+	/** Of those, the ones the database already held at or past their instant. */
+	readonly skipped: number;
+}
+
+/**
+ * The dedupe key one session was counted under: `<source>:<sessionId>`.
+ *
+ * Spelled by {@link sessionPassKey} and stable across repos, which is the whole
+ * reason the keys are reported alongside the counts. One conversation can be
+ * claimed by SEVERAL repos — Cursor's attribution is coarse by construction (with
+ * no workspace pointer in its global store, every in-window composer belongs to
+ * every repo Cursor has a workspace for), and two clones of one project claim the
+ * same set outright. A caller that adds up N repos' counts therefore reports one
+ * conversation N times, and no count can undo that afterwards. A key can.
+ */
+export type SessionPassKey = string;
+
+/** The dedupe key a session pass counts a session under. */
+export function sessionPassKey(source: TranscriptSource | string, sessionId: string): SessionPassKey {
+	return `${source}:${sessionId}`;
+}
+
+/** The source half of a {@link SessionPassKey}. */
+export function sourceOfSessionPassKey(key: SessionPassKey): string {
+	const sep = key.indexOf(":");
+	return sep === -1 ? key : key.slice(0, sep);
+}
+
+/** {@link CollectSessionsOptions.onCounts}'s payload: run totals plus the per-agent split. */
+export interface SessionPassCounts {
+	readonly discovered: number;
+	readonly skipped: number;
+	readonly bySource: Readonly<Record<string, SessionSourceCounts>>;
+	/**
+	 * Every session the pass discovered, by {@link SessionPassKey}. Same population as
+	 * `discovered`, identified rather than tallied — see {@link SessionPassKey} for why
+	 * a cross-repo reader needs the identity and not the number.
+	 */
+	readonly discoveredKeys: ReadonlyArray<SessionPassKey>;
+	/** The subset of {@link discoveredKeys} the skip removed. */
+	readonly skippedKeys: ReadonlyArray<SessionPassKey>;
 }
 
 export interface CollectSessionsOptions {
@@ -140,6 +277,92 @@ export interface CollectSessionsOptions {
 	 * Claude JSONL via `readTranscript`.
 	 */
 	readonly readUsage?: typeof readTranscript;
+	/**
+	 * Machine-wide scans the caller already ran, narrowed here to this repo.
+	 *
+	 * Passed in rather than scanned per call so a multi-repo run reads each global
+	 * store ONCE for the whole run instead of once per registered repo. Every hookless
+	 * source is eligible, because not one of them keys its store by repo: Claude
+	 * encodes a path lossily, Codex partitions by date, OpenCode / Copilot CLI / Devin
+	 * / Cursor keep one database for every project, Cline keeps one task history per
+	 * editor flavour, and the VS Code-family sources key on a workspace hash. In every
+	 * case "which sessions are this repo's" is only answerable after opening the
+	 * records — so a repo-scoped scan re-opens the same records N times.
+	 *
+	 * Measured on a three-repo machine: Claude one walk is 36 ms of head/tail reads
+	 * with a 464 ms full parse behind it, and Codex is 68 ms per repo / 201 ms across
+	 * three. Those were the only two sources installed there, which is exactly why the
+	 * profile is not the argument: on that machine the other nine returned on their
+	 * first `readdir` and cost under a millisecond between them, so the numbers say
+	 * nothing about a developer who actually runs Cursor, Copilot and Cline and pays a
+	 * SQLite open, a full-table scan and a whole-history JSON parse per repo per pass.
+	 * All of them are hoisted on that reasoning rather than on a profile of a machine
+	 * that did not have them installed.
+	 *
+	 * What did NOT move is any attribution rule: each source's `…SessionsForRepo`
+	 * still owns its own, in its own file. This changed when a rule runs, never what
+	 * it says — restating those rules as shared data is where this module's bugs have
+	 * historically come from.
+	 *
+	 * Absent (for a given source) means "no scan was supplied", which is not the same
+	 * as "the scan found nothing" — see {@link PreScannedSessions}.
+	 */
+	readonly preScanned?: PreScannedSessions;
+	/**
+	 * Discovery window forwarded to every source, in ms. Omitted leaves each source
+	 * on its own 48 h default; the back-fill passes
+	 * {@link BACKFILL_SESSION_WINDOW_MS}.
+	 */
+	readonly windowMs?: number;
+	/**
+	 * True when the database already holds this session at or past `updatedAtMs` —
+	 * i.e. when re-reading its transcript would write back the row that is already
+	 * there.
+	 *
+	 * This is NOT the high-water cursor this module's header rules out, and the
+	 * difference is the whole reason it is safe. That rule is about ONE number
+	 * standing in for a whole repo, which an out-of-order update slips past: resume a
+	 * three-day-old conversation and its timestamp still sits below the repo's
+	 * high-water mark, so it is skipped forever. This compares each session against
+	 * its OWN stored instant, so that conversation's stored time is older than the
+	 * turn just added and it is re-read.
+	 */
+	readonly isAlreadyCurrent?: (source: TranscriptSource, sessionId: string, updatedAtMs: number) => boolean;
+	/**
+	 * What the pass saw, for the caller's one-line report: how many distinct sessions
+	 * the window turned up, how many of those {@link isAlreadyCurrent} removed, and the
+	 * same split per agent.
+	 *
+	 * Both totals are reported rather than one derived from the other, because the
+	 * difference is not the skip count. A session can also drop out with an unparseable
+	 * instant, so `discovered - events.length` overstates what was skipped — and
+	 * "skipped" is the number a reader would act on.
+	 *
+	 * `bySource` is built HERE rather than by the caller counting the returned events,
+	 * because the events are what survived: a skipped session produces none, so an
+	 * event-side count can only ever report the processed third of the picture. Every
+	 * source that reached the dedupe gets an entry, including one whose sessions were
+	 * all skipped — "codex 51 found, 0 read" and "codex absent" are different facts and
+	 * an omitted key spells them the same way.
+	 *
+	 * Reported through a callback rather than on the return value because the caller
+	 * needs these only to print, and widening the return type would rewrite every
+	 * existing call site for numbers none of them read. Fires once, after the loop.
+	 */
+	readonly onCounts?: (counts: SessionPassCounts) => void;
+	/**
+	 * How many sessions may be read at once; defaults to
+	 * {@link mapWithConcurrency}'s own width.
+	 *
+	 * A knob rather than a constant because the right width depends on what the
+	 * caller is doing while this runs, and only the caller knows: the back-fill owns
+	 * the whole process and wants the default, while a surface reading sessions
+	 * alongside other work may want it narrower. Lowering it to 1 also restores the
+	 * strictly sequential read order, which is occasionally what a test wants to
+	 * assert — though it is not needed for determinism, since the fan-out preserves
+	 * input order at any width.
+	 */
+	readonly concurrency?: number;
 }
 
 /**
@@ -184,6 +407,50 @@ async function resolveTitle(s: SessionInfo): Promise<string | undefined> {
  *
  * Returns null when the discoverer's timestamp is unparseable — an event
  * without a valid `updatedAtMs` cannot be bucketed anywhere.
+ *
+ * ## Every source now costs a transcript read here, deliberately
+ *
+ * This function used to `return base` for anything that was not Claude, so for the
+ * other twelve agents it was pure CPU: no file opened, no database queried. It is not
+ * any more — `sessionContent.read()` plus the extractors run for every source — and
+ * that is the whole point of the change (see the note beside `extractSessionSignals`
+ * below), not an oversight to be walked back. Two consequences are worth having in
+ * mind before "optimising" this, because both look like regressions in isolation:
+ *
+ *  - **The VS Code 60 s tick pays it too**, through `recordSessionsFromTick`. That
+ *    path is bounded rather than free-running (it only builds events for sessions whose
+ *    `updatedAt` moved since its last write), and the read is not new to the tick —
+ *    `ActiveSessionAggregator` already loads every listed conversation to count its
+ *    messages. What IS new is that the same file is parsed a SECOND time in the same
+ *    tick, because the aggregator's parsed form cannot be handed over. It is the reason
+ *    a first tick after a window reload is the expensive one (the tick watermark is per
+ *    process, so it starts at 0).
+ *
+ *    **KNOWN, DEFERRED — do not re-report this as a review finding.** The follow-up is
+ *    understood and scoped. The aggregator reads each file to count unread turns and,
+ *    when there are any, reads it whole again to resolve a title; at that moment it is
+ *    holding exactly what this function then goes and re-reads. It throws the raw text
+ *    away because the two want different things from it: the aggregator wants the
+ *    INCREMENTAL slice with the user's overlay edits applied, while this wants the
+ *    WHOLE file unedited, plus token usage, tool calls and raw lines the aggregator
+ *    never looks at. The bridge between them (`ActiveConversationItem`) is deliberately
+ *    five fields wide because it is `postMessage`d into the webview, so widening it to
+ *    carry a transcript is not an option — the follow-up needs a separate
+ *    host-process-only channel, and it has to draw the overlay boundary explicitly:
+ *    whoever gets the pre-overlay text must be the dashboard side, or a user's manual
+ *    edits start showing up in token totals with nothing to signal it.
+ *  - **The back-fill pays it as a RE-read.** The Claude disk scan has already read every
+ *    in-window transcript in full, to collect the directories a `cd` scattered through
+ *    it. It used to hand that parse over so this function opened nothing; it no longer
+ *    keeps it, because keeping it made a whole run's memory grow with the window and with
+ *    nothing to cap it (see `acceptFacts`). So a Claude session costs the scan's read,
+ *    this read, the `lines()` read behind the skill extractor and one tail read for the
+ *    `ai-title` row — four passes over the same file, traded for a bounded resident set.
+ *    Two of those four are collapsible on their own; see `sessionContentFor`.
+ *  - **A source with no per-turn usage still opens its store.** `sessions-only` is now
+ *    reached by "this reader reports no usage", not by "this is not Claude", so the read
+ *    happens even when the token columns end up empty. It is what yields the message
+ *    count, the duration and the tool/skill signals, none of which the discoverer knows.
  */
 export async function sessionEventFromInfo(
 	repoIdentity: string,
@@ -202,14 +469,29 @@ export async function sessionEventFromInfo(
 		...(title ? { title } : {}),
 		updatedAtMs,
 	};
-	if (source !== "claude") return base;
+	// One memoised view of this conversation, shared by the token/duration read below
+	// and by every extractor. Without the memo, each extractor that wanted the
+	// transcript would open it again — so adding one would silently add a whole-file
+	// read per session.
+	const sessionContent = sessionContentFor(source, s.transcriptPath, readUsage);
 	try {
-		const read = await readUsage(s.transcriptPath);
+		const read = await sessionContent.read();
 		const models: StatsModelUsage[] = toStatsModelUsage(read.usageByModel ?? []);
 		const first = read.entries[0]?.timestamp;
 		const last = read.entries[read.entries.length - 1]?.timestamp;
 		const startedAtMs = first ? Date.parse(first) : Number.NaN;
 		const endedAtMs = last ? Date.parse(last) : Number.NaN;
+		// Every source that can answer, asked by capability rather than by name. This
+		// replaces `if (source !== "claude") return base`, which gave twelve agents a
+		// bare session row — no tool calls, no MCP calls, no skills — while nine of them
+		// had a reader that reports tool calls and three had a skill scanner. None of it
+		// was missing; it was unreachable.
+		const signals = await extractSessionSignals({
+			source,
+			sessionId: s.sessionId,
+			transcriptPath: s.transcriptPath,
+			content: sessionContent,
+		});
 		return {
 			...base,
 			messageCount: read.entries.length,
@@ -217,13 +499,16 @@ export async function sessionEventFromInfo(
 			...(Number.isFinite(startedAtMs) && Number.isFinite(endedAtMs) && endedAtMs > startedAtMs
 				? { durationMs: endedAtMs - startedAtMs }
 				: {}),
+			// `sessions-only` is now reached by a source having no per-turn usage to
+			// report rather than by it not being Claude. Same outcome for the sources
+			// that carry none, and an honest `full` for any that does.
 			...(models.length > 0
 				? { models, tokenCoverage: "full" as const, pricesAsOf: PRICES_AS_OF }
 				: { tokenCoverage: "sessions-only" as const }),
-			// Forwarded only when the reader actually produced it. An empty array
-			// means "called no tools" and is worth storing; absence means "this
-			// source records none", and the two must not collapse.
-			...(read.toolUse ? { tools: read.toolUse } : {}),
+			// Forwarded only when an extractor actually answered. An empty array means
+			// "called no tools" and is worth storing; absence means "this source cannot
+			// report them", and the two must not collapse.
+			...(signals.tools ? { tools: signals.tools } : {}),
 		};
 	} catch (err) {
 		// A moved or deleted transcript still counts as a session — record it
@@ -237,26 +522,238 @@ export async function sessionEventFromInfo(
 	}
 }
 
+/**
+ * One session's content, read at most once no matter how many callers ask.
+ *
+ * `readUsage` is consulted for Claude only, because that is what its signature
+ * describes: a JSONL reader taking a path. Every other source needs its own reader
+ * (a JSON file, a SQLite database, a synthetic `<dbPath>#<sessionId>` handle), and
+ * handing one of those to a Claude-shaped reader would not fail cleanly — it would
+ * parse zero lines and report an empty conversation.
+ *
+ * ## Both reads claim a slot in the shared I/O budget
+ *
+ * These are the largest reads in a session pass, and they used to be the only leaf
+ * reads that took no slot at all — so the fan-out's width was the only thing bounding
+ * them, and a scanner fanning out at the same time could push the process past its
+ * descriptor limit, where reads fail with `EMFILE` and take the whole batch down with
+ * them (see {@link withIoBudget}).
+ *
+ * They claim a slot and ZERO bytes, which is honest rather than ideal: the byte
+ * dimension needs the size up front, and neither reader knows it (one streams a file,
+ * the others query a database). So the budget bounds how MANY of these run at once and
+ * not how much they materialise — closing that needs a `stat` before the read, which is
+ * its own change. Claiming a guessed byte figure would be worse than claiming none,
+ * because an over-claim holds allowance a genuinely large read needs.
+ *
+ * The claim wraps the read and nothing above it, which is what keeps it un-nested: no
+ * caller of `sessionEventFromInfo` holds a budget slot, and none of these readers takes
+ * one internally. Both halves matter — see {@link IoBudget.run} on nesting.
+ *
+ * ## KNOWN, DEFERRED: the two reads below open a line-oriented file TWICE
+ *
+ * Not a defect to report again — it is measured, understood, and scheduled. For the
+ * three JSONL sources (claude / codex / kimi) `read()` opens the file and parses it,
+ * and then `lines()` opens the SAME file again to split its raw text. The memos stop
+ * each accessor repeating itself; they do not make the two share one read, because
+ * `read()`'s result carries no raw text and `lines()`' text carries no parse.
+ *
+ * That makes one Claude session in a session pass cost FOUR passes over its file: the
+ * disk scan's own read (for the working directories a `cd` scattered through it), the
+ * `read()` here, the `lines()` here, and `resolveSessionTitle`'s tail stream for the
+ * `ai-title` row. An earlier docstring in this module said three — it did not count
+ * `lines()`, which only exists since the skill extractor was wired in.
+ *
+ * The fix is mechanical and the pieces already exist: read the text once, then feed
+ * `parseTranscriptContent` and `splitTranscriptLines` from that one string.
+ * `readTranscript(path)` is by definition `readFile` followed by
+ * `parseTranscriptContent`, so the RESULT is identical — this is purely one fewer
+ * open.
+ *
+ * It is NOT in this change because of where the test seam sits. `readUsage` is an
+ * injected whole-file reader, and `DashboardCollector.test.ts` mocks exactly
+ * `readTranscript` while deliberately keeping `parseTranscriptContent` and
+ * `splitTranscriptLines` real. Feeding a parse from text therefore stops the injected
+ * reader being called at all, so ~20 cases that hand this module a ready-made
+ * `TranscriptReadResult` would have to hand it a real JSONL string instead. That is a
+ * seam change (the injection point moves from "read the file" to "here is the text"),
+ * not an optimisation, and it belongs with the tick work below — both are the same
+ * question of who owns reading versus parsing.
+ */
+function sessionContentFor(
+	source: TranscriptSource,
+	transcriptPath: string,
+	readUsage: typeof readTranscript,
+): SessionContent {
+	let readOnce: Promise<TranscriptReadResult> | undefined;
+	let linesOnce: Promise<ReadonlyArray<string> | undefined> | undefined;
+	return {
+		read: () => {
+			readOnce ??= withIoBudget(0, () =>
+				source === "claude" ? readUsage(transcriptPath) : readTranscriptForSource(source, transcriptPath),
+			);
+			return readOnce;
+		},
+		lines: () => {
+			linesOnce ??= withIoBudget(0, () => readTranscriptLinesForSource(source, transcriptPath));
+			return linesOnce;
+		},
+	};
+}
+
+/**
+ * Narrows every supplied machine-wide scan to one repo.
+ *
+ * Each source's own `…SessionsForRepo` does its own matching — this only decides
+ * WHICH ones to ask, and asks exactly those the caller supplied. Two are async and
+ * that is inherent, not an inconsistency: Antigravity has to enumerate the repo's
+ * worktrees (`git worktree list`), and Cursor has to resolve the repo's workspace
+ * hash and read that workspace's anchor pointers. Both are per-repo questions no
+ * machine-wide scan could have answered in advance.
+ *
+ * The result is CONCATENATED with the fan-out's, never substituted for it — the
+ * caller's dedupe on `(source, sessionId)` is what reconciles a session that both
+ * halves saw, which is the normal case for Claude.
+ */
+async function preScannedForRepo(
+	pre: PreScannedSessions,
+	cwd: string,
+	windowMs?: number,
+): Promise<ReadonlyArray<SessionInfo>> {
+	const out: SessionInfo[] = [];
+	for (const def of SESSION_SOURCES) {
+		const scanned = pre[def.source];
+		// `!== undefined` rather than truthiness: `[]` means the scan ran and found
+		// nothing, which must still be narrowed (to nothing) rather than treated as
+		// "no scan happened".
+		if (scanned === undefined) continue;
+		try {
+			// The window is forwarded to every definition and used by one: Cursor needs
+			// it HERE rather than at scan time, because anchored composers bypass it and
+			// a scan that applied it would have dropped them before this step could keep
+			// them. The rest ignore the argument.
+			out.push(...(await def.forRepo(scanned, cwd, windowMs)));
+		} catch (err) {
+			// One source's narrowing failure must not lose the other eleven's sessions.
+			// Narrowing is I/O for two of them (worktree enumeration, workspace-hash
+			// resolution), so this is a real failure mode rather than a defensive catch.
+			log.warn("narrowing %s sessions to %s failed: %s", def.source, cwd, errMsg(err));
+		}
+	}
+	return out;
+}
+
 /** Collects one `session.upserted` per discoverable session (see {@link sessionEventFromInfo}). */
 export async function collectSessionEvents(opts: CollectSessionsOptions): Promise<ReadonlyArray<SessionUpsertedEvent>> {
 	const load = opts.loadSessions ?? loadAllSessions;
 	const readUsage = opts.readUsage ?? readTranscript;
-	const sessions = await load(opts.cwd);
+	const preScanned = opts.preScanned ?? {};
+	// A source supplied as a pre-scan is NOT loaded again by the fan-out — otherwise
+	// its store would be read twice per repo, which is the opposite of the point. One
+	// object drives both halves, so the two cannot disagree.
+	const discovered = await load(opts.cwd, opts.windowMs, preScanned);
+	const sessions = [...discovered, ...(await preScannedForRepo(preScanned, opts.cwd, opts.windowMs))];
 
 	// Dedupe on (source, id), newest wins — two discoverers can surface the same
 	// session (e.g. a registry entry and a rescan of the same store).
-	const bySourceAndId = new Map<string, SessionInfo>();
+	//
+	// A Claude session present in BOTH `sessions.json` and the disk scan resolves to
+	// the registry copy, because the Stop hook's instant is the last turn plus the
+	// few seconds the hook took to fire. Nothing is lost by that: such a session is
+	// exactly the one `isAlreadyCurrent` is about to skip, so which of the two
+	// timestamps won never reaches a row.
+	const bySourceAndId = new Map<SessionPassKey, SessionInfo>();
 	for (const s of sessions) {
-		const key = `${s.source ?? "claude"}:${s.sessionId}`;
+		const key = sessionPassKey(s.source ?? "claude", s.sessionId);
 		const existing = bySourceAndId.get(key);
 		if (!existing || Date.parse(s.updatedAt) > Date.parse(existing.updatedAt)) bySourceAndId.set(key, s);
 	}
 
-	const events: SessionUpsertedEvent[] = [];
-	for (const s of bySourceAndId.values()) {
-		const event = await sessionEventFromInfo(opts.repoIdentity, s, readUsage);
-		if (event) events.push(event);
+	// The skip runs as its own pass, BEFORE the fan-out below, for two reasons. It
+	// has to come before `sessionEventFromInfo`, which is where the cost is: for
+	// Claude that call reads the whole transcript and resolves the title (measured
+	// 464 ms across 64 files), so skipping after it would save nothing. What the
+	// skip cannot reclaim is the scan itself — the instant being compared had to be
+	// read to exist — so the saving is the parse, not the open. And because the
+	// decision is one synchronous map lookup, settling it here means the whole
+	// concurrency budget below goes to sessions that genuinely need a read.
+	//
+	// A session whose reported instant is unparseable is NOT skipped: being unable
+	// to date a session is a reason to look at it, never a reason to assume it is
+	// current.
+	const toRead: SessionInfo[] = [];
+	let skipped = 0;
+	// Mutable accumulators, frozen into the readonly payload at the end. Every source
+	// that reached the dedupe is registered on sight, before the skip decision, so a
+	// source whose sessions were ALL skipped still reports `discovered: n, skipped: n`
+	// rather than vanishing from the split — absence has to keep meaning "this agent
+	// contributed nothing to the window".
+	const perSource = new Map<string, { discovered: number; skipped: number }>();
+	const skippedKeys: SessionPassKey[] = [];
+	for (const [key, s] of bySourceAndId) {
+		const source = s.source ?? "claude";
+		const counts = perSource.get(source) ?? { discovered: 0, skipped: 0 };
+		counts.discovered++;
+		perSource.set(source, counts);
+		const updatedAtMs = Date.parse(s.updatedAt);
+		if (
+			opts.isAlreadyCurrent &&
+			Number.isFinite(updatedAtMs) &&
+			opts.isAlreadyCurrent(source, s.sessionId, updatedAtMs)
+		) {
+			skipped++;
+			counts.skipped++;
+			skippedKeys.push(key);
+			continue;
+		}
+		toRead.push(s);
 	}
+
+	// Bounded fan-out rather than a sequential loop: this is the expensive half of
+	// the whole back-fill and every unit of it is independent I/O. Each Claude
+	// session costs a full transcript read plus parse plus a tail read for the
+	// `ai-title` stream, and running them one at a time leaves the disk idle
+	// between parses — on a machine with a week of history that is tens of
+	// sequential 464 ms-class reads.
+	//
+	// Safe to overlap because nothing here is shared: every source's reader builds its
+	// own parser and opens its own handle per call, `resolveSessionTitle` only reads
+	// files, and none of them touches the dashboard database — that write is
+	// `applyBatches`, after this returns.
+	//
+	// EVERY source now costs a read here, not just Claude. The `if (source !== "claude")
+	// return base` that used to make this comment's "for a non-Claude source nothing is
+	// opened at all" true is gone: a SQLite-backed source opens its store, which is why
+	// the fan-out is bounded rather than the width being a Claude-only concern. Callers
+	// on a hot path are the ones that must keep the read set small — the tick producer
+	// does it with its own watermark, the back-fill with `isAlreadyCurrent` above.
+	//
+	// BOUNDED, not `Promise.all`: each unit holds one whole transcript in memory
+	// while it parses, which is the same exposure the disk scan's phase 2 already
+	// accepts at the same width — and an unbounded fan-out over a machine-global
+	// store is the `EMFILE` shape {@link mapWithConcurrency} exists to prevent.
+	//
+	// Order is preserved by `mapWithConcurrency`, so the event array is identical
+	// to what the sequential loop produced. That is load-bearing for the caller:
+	// `applyBatches` slices this array into fixed-size batches, and a
+	// completion-ordered result would reshuffle which sessions share a batch from
+	// run to run.
+	const read = await mapWithConcurrency(
+		toRead,
+		(s) => sessionEventFromInfo(opts.repoIdentity, s, readUsage),
+		opts.concurrency,
+	);
+	const events = read.filter((event): event is SessionUpsertedEvent => event !== null);
+	// Logged because "nothing was imported" and "nothing needed importing" look
+	// identical from the outside, and this is the only place that can tell them apart.
+	if (skipped > 0) log.debug("skipped %d session(s) already current in the database", skipped);
+	opts.onCounts?.({
+		discovered: bySourceAndId.size,
+		skipped,
+		bySource: Object.fromEntries(perSource),
+		discoveredKeys: [...bySourceAndId.keys()],
+		skippedKeys,
+	});
 	return events;
 }
 

--- a/cli/src/dashboard/DbBackfill.test.ts
+++ b/cli/src/dashboard/DbBackfill.test.ts
@@ -13,6 +13,12 @@ vi.mock("./DashboardCollector.js", () => ({
 	collectSessionEvents: vi.fn(),
 	collectSummaryEvents: vi.fn(),
 	collectWorktreeEvent: vi.fn(),
+	// A pure key builder, not a seam: the backfill maps every session event through
+	// it to report which sessions a pass processed. A `vi.fn()` here returns
+	// undefined and the map throws, which this whole-module factory turns into
+	// `mode: "skipped"` on every repo rather than into a readable failure. Its real
+	// behaviour is pinned by DashboardCollector.test.ts.
+	sessionPassKey: (source: string, sessionId: string) => `${source}:${sessionId}`,
 }));
 vi.mock("../core/GitOps.js", () => ({
 	getHeadHash: vi.fn(),
@@ -33,6 +39,52 @@ vi.mock("../core/SummaryStore.js", () => ({
 	// the identity default doubles as the assertion target for the seam below.
 	resolveReadStorage: vi.fn(),
 }));
+// `dbBackfillRepos` scans `~/.claude/projects` and `~/.codex/sessions` once per run.
+// Both are mocked because the real scans read the DEVELOPER's home directory:
+// unmocked, every case in this file would walk whatever transcripts happen to be on
+// the machine — slow, and its results would vary per machine. Their own behaviour is
+// covered by each discoverer's suite against a temp tree.
+// EVERY machine-global scan is mocked, not just the two that are asserted on. These
+// read the developer's real home directory (~/.claude, ~/.cursor, ~/.codex, the
+// OpenCode and Devin databases, …), so an unmocked one makes this suite depend on
+// which AI tools the machine running it happens to have installed — the exact kind of
+// environment coupling that made the original per-repo profile misleading.
+vi.mock("../core/ClaudeSessionDiscoverer.js", () => ({
+	scanClaudeSessionsOnDisk: vi.fn(),
+}));
+vi.mock("../core/CodexSessionDiscoverer.js", () => ({
+	scanCodexSessionsOnDisk: vi.fn(),
+}));
+vi.mock("../core/CursorSessionDiscoverer.js", () => ({
+	scanCursorComposersOnDisk: vi.fn(async () => ({ composers: [] })),
+}));
+vi.mock("../core/KimiSessionDiscoverer.js", () => ({
+	scanKimiSessionsOnDisk: vi.fn(async () => []),
+}));
+vi.mock("../core/OpenCodeSessionDiscoverer.js", () => ({
+	scanOpenCodeSessionsOnDisk: vi.fn(async () => ({ sessions: [] })),
+}));
+vi.mock("../core/CopilotSessionDiscoverer.js", () => ({
+	scanCopilotSessionsOnDisk: vi.fn(async () => ({ sessions: [] })),
+}));
+vi.mock("../core/CopilotChatSessionDiscoverer.js", () => ({
+	scanCopilotChatSessionsOnDisk: vi.fn(async () => ({ sessions: [] })),
+}));
+vi.mock("../core/ClineSessionDiscoverer.js", () => ({
+	scanClineSessionsOnDisk: vi.fn(async () => ({ sessions: [] })),
+}));
+vi.mock("../core/ClineCliSessionDiscoverer.js", () => ({
+	scanClineCliSessionsOnDisk: vi.fn(async () => ({ sessions: [] })),
+}));
+vi.mock("../core/DevinSessionDiscoverer.js", () => ({
+	scanDevinSessionsOnDisk: vi.fn(async () => ({ sessions: [] })),
+}));
+vi.mock("../core/CursorCliSessionDiscoverer.js", () => ({
+	scanCursorCliSessionsOnDisk: vi.fn(async () => ({ sessions: [] })),
+}));
+vi.mock("../core/AntigravitySessionDiscoverer.js", () => ({
+	scanAntigravitySessionsOnDisk: vi.fn(async () => ({ sessions: [] })),
+}));
 vi.mock("../core/RepoProfile.js", () => ({
 	readCutoverFence: vi.fn(),
 }));
@@ -48,8 +100,21 @@ vi.mock("./SotImport.js", async (importOriginal) => ({
 	importRepoMemory: vi.fn(),
 }));
 
+import { scanAntigravitySessionsOnDisk } from "../core/AntigravitySessionDiscoverer.js";
+import { scanClaudeSessionsOnDisk } from "../core/ClaudeSessionDiscoverer.js";
+import { scanClineCliSessionsOnDisk } from "../core/ClineCliSessionDiscoverer.js";
+import { scanClineSessionsOnDisk } from "../core/ClineSessionDiscoverer.js";
+import { scanCodexSessionsOnDisk } from "../core/CodexSessionDiscoverer.js";
+import { scanCopilotChatSessionsOnDisk } from "../core/CopilotChatSessionDiscoverer.js";
+import { scanCopilotSessionsOnDisk } from "../core/CopilotSessionDiscoverer.js";
+import { scanCursorCliSessionsOnDisk } from "../core/CursorCliSessionDiscoverer.js";
+import { scanCursorComposersOnDisk } from "../core/CursorSessionDiscoverer.js";
+import { scanDevinSessionsOnDisk } from "../core/DevinSessionDiscoverer.js";
 import { execGit, getHeadHash, listFilesInBranch } from "../core/GitOps.js";
+import { scanKimiSessionsOnDisk } from "../core/KimiSessionDiscoverer.js";
+import { scanOpenCodeSessionsOnDisk } from "../core/OpenCodeSessionDiscoverer.js";
 import { readCutoverFence } from "../core/RepoProfile.js";
+import { BACKFILL_SESSION_WINDOW_MS } from "../core/SessionWindow.js";
 import { getIndex, resolveReadStorage } from "../core/SummaryStore.js";
 import {
 	collectCommitEvents,
@@ -90,6 +155,11 @@ const sessionEvent: SessionUpsertedEvent = {
 	repoIdentity: repo.repoIdentity,
 	source: "claude",
 	sessionId: "s1",
+	// Carried because it is what makes the stored row a READ receipt: `started_at_ms`
+	// comes from the transcript's first entry, so only a full read can produce it, and
+	// `readKnownSessions` counts a row as evidence on exactly that basis. An event
+	// without it projects a row indistinguishable from one a commit summary seeded.
+	startedAtMs: 1_700_000_000_000,
 	updatedAtMs: 1_700_000_050_000,
 };
 
@@ -120,6 +190,11 @@ beforeEach(() => {
 	// memories nothing is "absent from the tip", so the mode stays `seed` unless a
 	// test says otherwise.
 	vi.mocked(listFilesInBranch).mockResolvedValue([]);
+	// An empty disk scan by default. It must RESOLVE rather than return undefined:
+	// `dbBackfillRepos` attaches a `.catch` to the call, so a bare `vi.fn()` with no
+	// return value throws a TypeError before any repo is swept.
+	vi.mocked(scanClaudeSessionsOnDisk).mockResolvedValue([]);
+	vi.mocked(scanCodexSessionsOnDisk).mockResolvedValue([]);
 	vi.mocked(collectCommitEvents).mockResolvedValue([commitEvent("aaa"), commitEvent("bbb")]);
 	vi.mocked(collectSessionEvents).mockResolvedValue([sessionEvent]);
 	vi.mocked(collectSummaryEvents).mockResolvedValue({ events: [], complete: true });
@@ -198,6 +273,11 @@ describe("dbBackfillRepo — bootstrap", () => {
 			// the fixture), asserted below rather than inlined into the pattern.
 			{ source: "git-commits", cursor: expect.stringMatching(/@head-1\+[0-9a-f]{64}$/) },
 			{ source: "sessions", cursor: String(sessionEvent.updatedAtMs) },
+			// NOT a high-water mark like the others — a receipt. It records which build's
+			// full transcript read produced the stored session rows, and it is the only
+			// thing that makes the per-session skip safe to trust. See
+			// `SESSION_READ_GENERATION`.
+			{ source: "sessions-read-generation", cursor: "3" },
 			// The memory import's own signal: the orphan tip (a hash of everything it
 			// reads) plus the mode, since seed and catch-up do not write the same rows.
 			{ source: "sot-import", cursor: `${"ab".repeat(20)}#seed` },
@@ -499,7 +579,11 @@ describe("dbBackfillRepo — recovery", () => {
 		// cursor is unaffected — it is anchored on the orphan tip, which resolves
 		// whether or not HEAD does.
 		const cursors = await query<{ source: string }>("SELECT source FROM ingest_cursors ORDER BY source");
-		expect(cursors).toEqual([{ source: "sessions" }, { source: "sot-import" }]);
+		expect(cursors).toEqual([
+			{ source: "sessions" },
+			{ source: "sessions-read-generation" },
+			{ source: "sot-import" },
+		]);
 	});
 
 	it("skips the worktree event when the collector returns null", async () => {
@@ -585,6 +669,32 @@ describe("dbBackfillRepos", () => {
 		expect(vi.mocked(collectSessionEvents).mock.calls.every((c) => c[0].repoIdentity !== "local:gone")).toBe(true);
 	});
 
+	it("does not scan machine-global stores when no repo has a live checkout", async () => {
+		const gone: RegisteredRepo = {
+			...repo,
+			repoIdentity: "local:only-gone",
+			worktreeRoot: join(dir, "deleted"),
+		};
+
+		await dbBackfillRepos([gone], { dbPath });
+
+		expect(scanClaudeSessionsOnDisk).not.toHaveBeenCalled();
+		expect(scanCodexSessionsOnDisk).not.toHaveBeenCalled();
+		expect(scanCursorComposersOnDisk).not.toHaveBeenCalled();
+	});
+
+	it("keeps a custom session loader isolated from real machine-global stores", async () => {
+		const loadSessions = vi.fn(async () => []);
+
+		await dbBackfillRepos([repo], { dbPath, loadSessions });
+
+		expect(scanClaudeSessionsOnDisk).not.toHaveBeenCalled();
+		expect(scanCodexSessionsOnDisk).not.toHaveBeenCalled();
+		expect(scanCursorComposersOnDisk).not.toHaveBeenCalled();
+		expect(vi.mocked(collectSessionEvents).mock.calls[0][0].loadSessions).toBe(loadSessions);
+		expect(vi.mocked(collectSessionEvents).mock.calls[0][0].preScanned).toEqual({});
+	});
+
 	it("counts only the surviving repos when stamping each one's place in the run", async () => {
 		// `repoTotal` follows the list that is actually swept, so a dead entry does
 		// not make the progress line count to a total it will never reach.
@@ -593,6 +703,368 @@ describe("dbBackfillRepos", () => {
 		await dbBackfillRepos([gone, repo], { dbPath, onProgress: (p) => seen.push(p.repoTotal) });
 		expect(seen.length).toBeGreaterThan(0);
 		expect(seen.every((total) => total === 1)).toBe(true);
+	});
+
+	it("scans the Claude transcript tree ONCE for the whole run, not once per repo", async () => {
+		// The point of hoisting it out of the loop: that tree is machine-global, so a
+		// per-repo scan re-reads every transcript once per registered repo.
+		const second: RegisteredRepo = { ...repo, repoIdentity: "local:second", repoName: "second" };
+		const third: RegisteredRepo = { ...repo, repoIdentity: "local:third", repoName: "third" };
+
+		await dbBackfillRepos([repo, second, third], { dbPath });
+
+		expect(scanClaudeSessionsOnDisk).toHaveBeenCalledTimes(1);
+		// …and every repo still received it.
+		const seen = vi.mocked(collectSessionEvents).mock.calls.map((c) => c[0].preScanned?.claude);
+		expect(seen).toHaveLength(3);
+		expect(seen.every((d) => d !== undefined)).toBe(true);
+	});
+
+	it("uses a caller-supplied scan instead of running its own", async () => {
+		const supplied = [
+			{
+				sessionId: "d1",
+				transcriptPath: "/t/d1.jsonl",
+				updatedAt: "2026-07-30T08:00:00.000Z",
+				dirs: ["/w"],
+				complete: true,
+			},
+		];
+
+		await dbBackfillRepos([repo], { dbPath, preScanned: { claude: supplied } });
+
+		expect(scanClaudeSessionsOnDisk).not.toHaveBeenCalled();
+		expect(vi.mocked(collectSessionEvents).mock.calls[0][0].preScanned?.claude).toEqual(supplied);
+	});
+
+	it("does not let the scans skip anything on a first pass", async () => {
+		// No repo has completed a session pass yet, so nothing in the database can be
+		// trusted as a receipt — see `readRecordedSessions`. The scan must read
+		// everything properly exactly once.
+		await dbBackfillRepos([repo], { dbPath });
+
+		expect(vi.mocked(scanClaudeSessionsOnDisk).mock.calls[0][0]?.alreadyRecorded).toBeUndefined();
+	});
+
+	it("lets the scans skip once every repo has completed a session pass", async () => {
+		await dbBackfillRepos([repo], { dbPath });
+		vi.mocked(scanClaudeSessionsOnDisk).mockClear();
+
+		await dbBackfillRepos([repo], { dbPath });
+
+		expect(vi.mocked(scanClaudeSessionsOnDisk).mock.calls[0][0]?.alreadyRecorded).toBeDefined();
+	});
+
+	it("turns skipping off for the whole run when one repo is newly registered", async () => {
+		// The reason the gate is over EVERY repo rather than per repo: a fresh repo has
+		// no rows, and skipping on another repo's evidence would leave it permanently
+		// without them.
+		await dbBackfillRepos([repo], { dbPath });
+		const fresh: RegisteredRepo = { ...repo, repoIdentity: "local:fresh", repoName: "fresh" };
+		vi.mocked(scanClaudeSessionsOnDisk).mockClear();
+
+		await dbBackfillRepos([repo, fresh], { dbPath });
+
+		expect(vi.mocked(scanClaudeSessionsOnDisk).mock.calls[0][0]?.alreadyRecorded).toBeUndefined();
+	});
+
+	it("keeps sweeping when the disk scan fails", async () => {
+		// Not fatal by design: every other source scans its own store, and the
+		// `sessions.json` half of the collector still carries Claude — so a failed scan
+		// costs Claude its pre-48 h reach, never the run.
+		vi.mocked(scanClaudeSessionsOnDisk).mockRejectedValue(new Error("home directory unreadable"));
+
+		const results = await dbBackfillRepos([repo], { dbPath });
+
+		expect(results[0].mode).toBe("bootstrapped");
+		expect(vi.mocked(collectSessionEvents).mock.calls[0][0].preScanned?.claude).toBeUndefined();
+	});
+
+	it("scans the Codex rollout tree ONCE for the whole run too", async () => {
+		// `~/.codex/sessions/` is keyed by DATE, so it has the same per-repo repetition
+		// as the Claude tree — measured 68 ms per repo, 201 ms across three.
+		const second: RegisteredRepo = { ...repo, repoIdentity: "local:second", repoName: "second" };
+
+		await dbBackfillRepos([repo, second], { dbPath });
+
+		expect(scanCodexSessionsOnDisk).toHaveBeenCalledTimes(1);
+		expect(scanCodexSessionsOnDisk).toHaveBeenCalledWith(BACKFILL_SESSION_WINDOW_MS);
+		expect(vi.mocked(collectSessionEvents).mock.calls.every((c) => c[0].preScanned?.codex !== undefined)).toBe(
+			true,
+		);
+	});
+
+	it("falls back to per-repo Codex scans — not to an empty set — when its scan fails", async () => {
+		// `undefined`, not `[]`. An empty array is the positive claim "the scan ran and
+		// found nothing", which makes the collector skip its own codex loader and lose the
+		// source outright. Absence sends it back to scanning per repo.
+		vi.mocked(scanCodexSessionsOnDisk).mockRejectedValue(new Error("codex home unreadable"));
+
+		const results = await dbBackfillRepos([repo], { dbPath });
+
+		expect(results[0].mode).toBe("bootstrapped");
+		expect(vi.mocked(collectSessionEvents).mock.calls[0][0].preScanned?.codex).toBeUndefined();
+	});
+
+	// Every other machine-global store, held to the same two guarantees: scanned once
+	// per RUN, and handed to every repo. Table-driven because the failure they guard
+	// against is per-source and silent — a source left out of the hoist just goes back
+	// to costing a full store read per repo, with an identical result set.
+	const HOISTED_SCANS = [
+		{ key: "cursor", spy: () => scanCursorComposersOnDisk },
+		{ key: "kimi", spy: () => scanKimiSessionsOnDisk },
+		{ key: "opencode", spy: () => scanOpenCodeSessionsOnDisk },
+		{ key: "copilot", spy: () => scanCopilotSessionsOnDisk },
+		// Keyed by the source TAG now, not by a camel-cased field name — the two
+		// spellings used to be hand-mapped, and the map is gone.
+		{ key: "copilot-chat", spy: () => scanCopilotChatSessionsOnDisk },
+		{ key: "cline", spy: () => scanClineSessionsOnDisk },
+		{ key: "cline-cli", spy: () => scanClineCliSessionsOnDisk },
+		{ key: "devin", spy: () => scanDevinSessionsOnDisk },
+		{ key: "cursor-cli", spy: () => scanCursorCliSessionsOnDisk },
+		{ key: "antigravity", spy: () => scanAntigravitySessionsOnDisk },
+	] as const;
+
+	for (const { key, spy } of HOISTED_SCANS) {
+		it(`scans the ${key} store ONCE for the whole run and gives it to every repo`, async () => {
+			const second: RegisteredRepo = { ...repo, repoIdentity: "local:second", repoName: "second" };
+			const third: RegisteredRepo = { ...repo, repoIdentity: "local:third", repoName: "third" };
+
+			await dbBackfillRepos([repo, second, third], { dbPath });
+
+			expect(spy()).toHaveBeenCalledTimes(1);
+			const seen = vi.mocked(collectSessionEvents).mock.calls.map((c) => c[0].preScanned?.[key]);
+			expect(seen).toHaveLength(3);
+			expect(seen.every((d) => d !== undefined)).toBe(true);
+		});
+
+		it(`falls back to per-repo ${key} scans when its scan fails`, async () => {
+			// Same rule as Codex: absence, never `[]`. Per source, so one broken store
+			// costs that source its run-wide scan and nothing else.
+			vi.mocked(spy()).mockRejectedValue(new Error(`${key} store unreadable`));
+
+			const results = await dbBackfillRepos([repo], { dbPath });
+
+			expect(results[0].mode).toBe("bootstrapped");
+			expect(vi.mocked(collectSessionEvents).mock.calls[0][0].preScanned?.[key]).toBeUndefined();
+		});
+	}
+
+	it("treats a scan that reported failure on its ERROR CHANNEL as absence too", async () => {
+		// Most of these discoverers never throw — they answer `{ sessions, error }` and let
+		// the caller decide. Reading `.sessions` alone spelled a failed scan as `[]`, which
+		// is the positive claim "the store was read and holds nothing": the per-repo
+		// fallback was skipped for the whole run, and the pass reported that nothing as a
+		// fact about the agent.
+		vi.mocked(scanOpenCodeSessionsOnDisk).mockResolvedValue({
+			sessions: [],
+			error: { kind: "locked", message: "database is locked" },
+		});
+
+		const results = await dbBackfillRepos([repo], { dbPath });
+
+		expect(results[0].mode).toBe("bootstrapped");
+		expect(vi.mocked(collectSessionEvents).mock.calls[0][0].preScanned?.opencode).toBeUndefined();
+	});
+
+	it("keeps a PARTIAL scan's sessions instead of discarding them", async () => {
+		// Cline scans each editor flavour independently and Copilot Chat each workspace, so
+		// an error beside sessions means "some of it was unreadable", not "this failed".
+		// Only empty-AND-errored is a total failure.
+		vi.mocked(scanOpenCodeSessionsOnDisk).mockResolvedValue({
+			sessions: [
+				{
+					session: {
+						sessionId: "oc1",
+						transcriptPath: "/tmp/oc.db#oc1",
+						updatedAt: "2026-08-01T00:00:00.000Z",
+						source: "opencode",
+					},
+					dirs: [repo.worktreeRoot],
+				},
+			],
+			error: { kind: "permission", message: "one store unreadable" },
+		});
+
+		await dbBackfillRepos([repo], { dbPath });
+
+		expect(vi.mocked(collectSessionEvents).mock.calls[0][0].preScanned?.opencode).toHaveLength(1);
+	});
+
+	it("gives every source the back-fill's wider window, not each source's 48 h default", async () => {
+		// The reason the back-fill has its own scan path at all. A source left on the
+		// default silently contributes only two days of history to a seven-day import.
+		await dbBackfillRepos([repo], { dbPath });
+
+		expect(scanCodexSessionsOnDisk).toHaveBeenCalledWith(BACKFILL_SESSION_WINDOW_MS);
+		expect(scanKimiSessionsOnDisk).toHaveBeenCalledWith(BACKFILL_SESSION_WINDOW_MS);
+		expect(scanOpenCodeSessionsOnDisk).toHaveBeenCalledWith(BACKFILL_SESSION_WINDOW_MS);
+		expect(scanCopilotSessionsOnDisk).toHaveBeenCalledWith(BACKFILL_SESSION_WINDOW_MS);
+		expect(scanCopilotChatSessionsOnDisk).toHaveBeenCalledWith(BACKFILL_SESSION_WINDOW_MS);
+		expect(scanDevinSessionsOnDisk).toHaveBeenCalledWith(BACKFILL_SESSION_WINDOW_MS);
+		// These three take the window behind their own directory-override seams.
+		expect(scanClineSessionsOnDisk).toHaveBeenCalledWith(undefined, BACKFILL_SESSION_WINDOW_MS);
+		expect(scanClineCliSessionsOnDisk).toHaveBeenCalledWith(undefined, BACKFILL_SESSION_WINDOW_MS);
+		expect(scanCursorCliSessionsOnDisk).toHaveBeenCalledWith(undefined, undefined, BACKFILL_SESSION_WINDOW_MS);
+		expect(scanAntigravitySessionsOnDisk).toHaveBeenCalledWith(undefined, BACKFILL_SESSION_WINDOW_MS);
+		// Cursor Composer is the exception and must NOT take one: its anchors bypass the
+		// window, so filtering at scan time would drop anchored composers. The window is
+		// applied per repo instead, in `cursorSessionsForRepo`.
+		expect(scanCursorComposersOnDisk).toHaveBeenCalledWith();
+	});
+});
+
+describe("dbBackfillRepo — per-session skip", () => {
+	/** Runs one sweep and returns the predicate the collector was handed. */
+	async function capturePredicate(): Promise<
+		(source: "claude" | "codex" | "cursor", sessionId: string, updatedAtMs: number) => boolean
+	> {
+		await dbBackfillRepo({ repo, dbPath });
+		const opts = vi.mocked(collectSessionEvents).mock.calls.at(-1)?.[0];
+		const predicate = opts?.isAlreadyCurrent;
+		if (!predicate) throw new Error("collector received no isAlreadyCurrent predicate");
+		return predicate;
+	}
+
+	it("skips a session the database already holds at its instant", async () => {
+		// First sweep stores `sessionEvent` (source claude, id s1, at 1_700_000_050_000).
+		await dbBackfillRepo({ repo, dbPath });
+		const predicate = await capturePredicate();
+
+		expect(predicate("claude", "s1", 1_700_000_050_000)).toBe(true);
+	});
+
+	it("skips a session the database holds at a LATER instant", async () => {
+		await dbBackfillRepo({ repo, dbPath });
+		const predicate = await capturePredicate();
+
+		expect(predicate("claude", "s1", 1_700_000_040_000)).toBe(true);
+	});
+
+	it("does NOT skip a session that has moved on since it was stored", async () => {
+		// The case a repo-wide high-water mark gets wrong: resuming an old conversation.
+		await dbBackfillRepo({ repo, dbPath });
+		const predicate = await capturePredicate();
+
+		expect(predicate("claude", "s1", 1_700_000_060_000)).toBe(false);
+	});
+
+	it("does NOT skip a session the database has never seen", async () => {
+		await dbBackfillRepo({ repo, dbPath });
+		const predicate = await capturePredicate();
+
+		expect(predicate("claude", "never-stored", 1)).toBe(false);
+	});
+
+	it("keys the skip on source as well as id", async () => {
+		await dbBackfillRepo({ repo, dbPath });
+		const predicate = await capturePredicate();
+
+		// Same session id, different agent — a different conversation entirely.
+		expect(predicate("codex", "s1", 1_700_000_050_000)).toBe(false);
+	});
+
+	it("does NOT skip a session whose only row was seeded by a commit summary", async () => {
+		// The permanent-skip trap. A summary's session links seed a row stamped with the
+		// COMMIT's time, which is necessarily later than the conversation's last turn — so
+		// taken as a receipt it skips that transcript on every pass forever, and the seed's
+		// ON CONFLICT never rewrites the instant that would walk it back. A seed can arrive
+		// at any moment (the QueueWorker writes one from post-commit), which is why the
+		// generation gate cannot cover it and the row itself has to be disqualified.
+		await dbBackfillRepo({ repo, dbPath });
+		await withDashboardDb(
+			(db) => {
+				db.prepare(
+					`INSERT INTO sessions (event_id, repo_id, source, session_id, updated_at_ms, message_count)
+					 VALUES ('session:seeded', (SELECT id FROM repos WHERE repo_identity = ?), 'codex', 'seeded-1', ?, 4)`,
+				).run(repo.repoIdentity, 1_700_000_900_000);
+			},
+			{ dbPath },
+		);
+
+		const predicate = await capturePredicate();
+
+		expect(predicate("codex", "seeded-1", 1_700_000_050_000)).toBe(false);
+	});
+
+	it("does NOT skip a session whose row carries only a title", async () => {
+		// The other way a row looks like a receipt without being one. `sessionEventFromInfo`
+		// resolves the title BEFORE it opens the transcript and keeps it when that read
+		// throws, and every source with a native title column (opencode, cursor, devin,
+		// cline, copilot, antigravity) answers from the discoverer without reading anything.
+		// So a store that was momentarily locked writes a title and nothing else — and
+		// counting that as a receipt strands the session there: no message count, no
+		// duration, no tokens, no tools, no skills, never re-read until it gains a turn.
+		await dbBackfillRepo({ repo, dbPath });
+		await withDashboardDb(
+			(db) => {
+				db.prepare(
+					`INSERT INTO sessions (event_id, repo_id, source, session_id, title, updated_at_ms)
+					 VALUES ('session:titled', (SELECT id FROM repos WHERE repo_identity = ?), 'cursor', 'locked-1', 'Fix the parser', ?)`,
+				).run(repo.repoIdentity, 1_700_000_050_000);
+			},
+			{ dbPath },
+		);
+
+		const predicate = await capturePredicate();
+
+		expect(predicate("cursor", "locked-1", 1_700_000_050_000)).toBe(false);
+	});
+
+	it("hands the collector NO predicate on the first sweep of a repo", async () => {
+		// The receipt gate. A `sessions` row proves when a session last spoke, never that
+		// this build read its transcript — and the summaries tier, which runs first, seeds
+		// rows stamped with the COMMIT's time, necessarily later than the last turn. So a
+		// repo with no recorded read-generation gets one pass with no skipping at all,
+		// which is what stops a first back-fill from skipping the very sessions it exists
+		// to read.
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(vi.mocked(collectSessionEvents).mock.calls.at(-1)?.[0].isAlreadyCurrent).toBeUndefined();
+	});
+
+	it("records the read generation, so the next sweep may skip", async () => {
+		await dbBackfillRepo({ repo, dbPath });
+
+		const cursors = await query<{ source: string; cursor: string }>(
+			"SELECT source, cursor FROM ingest_cursors WHERE source = 'sessions-read-generation'",
+		);
+		expect(cursors).toEqual([{ source: "sessions-read-generation", cursor: "3" }]);
+		// And the second sweep is the one that gets a predicate.
+		await dbBackfillRepo({ repo, dbPath });
+		expect(vi.mocked(collectSessionEvents).mock.calls.at(-1)?.[0].isAlreadyCurrent).toBeDefined();
+	});
+
+	it("re-opens every transcript when the recorded generation is stale", async () => {
+		// What a parser improvement relies on: a session that has not spoken since keeps
+		// whatever the old read stored, because its instant has not moved. Bumping the
+		// generation is the only thing that reaches it.
+		await dbBackfillRepo({ repo, dbPath });
+		await withDashboardDb(
+			(db) => {
+				db.prepare(
+					"UPDATE ingest_cursors SET cursor = 'stale' WHERE source = 'sessions-read-generation'",
+				).run();
+			},
+			{ dbPath },
+		);
+
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(vi.mocked(collectSessionEvents).mock.calls.at(-1)?.[0].isAlreadyCurrent).toBeUndefined();
+	});
+
+	it("records the generation even after a sweep that discovered nothing", async () => {
+		// A partial pass cannot mislead the next one: a session that was never discovered
+		// has no row, so the skip has nothing to match it against.
+		vi.mocked(collectSessionEvents).mockResolvedValue([]);
+
+		await dbBackfillRepo({ repo, dbPath });
+
+		const cursors = await query<{ cursor: string }>(
+			"SELECT cursor FROM ingest_cursors WHERE source = 'sessions-read-generation'",
+		);
+		expect(cursors).toEqual([{ cursor: "3" }]);
 	});
 });
 

--- a/cli/src/dashboard/DbBackfill.ts
+++ b/cli/src/dashboard/DbBackfill.ts
@@ -30,20 +30,28 @@
  */
 
 import { createHash } from "node:crypto";
+import type { AlreadyCurrent } from "../core/DiskSessionScan.js";
 import { execGit, getHeadHash } from "../core/GitOps.js";
 import { GitRefStorage, resolveCommittish } from "../core/GitRefStorage.js";
 import { isJolliInternalRef } from "../core/JolliRefs.js";
+import { BACKFILL_SESSION_WINDOW_MS } from "../core/SessionWindow.js";
 import type { StorageProvider } from "../core/StorageProvider.js";
 import { getIndex, resolveReadStorage } from "../core/SummaryStore.js";
+import { SESSION_SOURCES } from "../core/sessions/SessionSources.js";
 import { createLogger, errMsg, ORPHAN_BRANCH } from "../Logger.js";
-import type { ToolCallCount } from "../Types.js";
+import type { ToolCallCount, TranscriptSource } from "../Types.js";
 import {
 	collectCommitEvents,
 	// collectRepoGraph,  // parked with `repo_graphs` — see SotSchema
 	collectSessionEvents,
 	collectSummaryEvents,
 	collectWorktreeEvent,
+	type PreScannedSessions,
 	type SessionLoader,
+	type SessionPassCounts,
+	type SessionPassKey,
+	type SessionSourceCounts,
+	sessionPassKey,
 } from "./DashboardCollector.js";
 import type { DashboardDbHandle } from "./DashboardDb.js";
 import { inTransaction, withDashboardDb } from "./DashboardDb.js";
@@ -79,8 +87,57 @@ const BATCH_SIZE = 200;
 /** `ingest_cursors.source` keys. */
 const CURSOR_GIT = "git-commits";
 const CURSOR_SESSIONS = "sessions";
+const CURSOR_SESSIONS_GENERATION = "sessions-read-generation";
 const CURSOR_SUMMARIES = "summaries";
 const CURSOR_SOT = "sot-import";
+
+/**
+ * What a full transcript read currently produces, as an opaque generation tag.
+ *
+ * This is HALF the receipt the per-session skip needs, and it is the half about builds:
+ * a row's instant proves when a session last spoke, never that THIS build's reader
+ * produced what the row holds. When transcript parsing learns something new — a tool
+ * shape, a skill call, a token field — every session that has not spoken since keeps
+ * whatever the old parser stored, forever, because its instant has not moved.
+ *
+ * So the skip is gated on this tag: a repo whose recorded tag differs from this value
+ * gets ONE pass with no skipping at all, which re-reads every in-window transcript and
+ * overwrites what the older reader stored (`projectSessionUpserted` assigns
+ * `updated_at_ms` unconditionally, while the summary seed never updates it — so once a
+ * real read lands it cannot be walked back). From the next pass on, the skip is
+ * comparing values a full read produced, which is the only thing it was ever safe to
+ * compare.
+ *
+ * The OTHER half is per row and is not this tag's job, because a per-repo tag cannot
+ * express it: a commit summary seeds a session row stamped with the COMMIT's time,
+ * which is necessarily later than the conversation's last turn, and a seed can land at
+ * any moment — the summaries tier runs before the sessions tier in the same pass, and
+ * the QueueWorker seeds straight from post-commit, long before any back-fill sees the
+ * session. Such a row would read as "already current" forever. That case is answered
+ * where it belongs, by {@link readKnownSessions} refusing to treat a commit-seeded row
+ * as a receipt at all.
+ *
+ * BUMP THIS whenever a change alters what a full read yields. It costs one un-skipped
+ * pass per repo and is the only way an existing database picks the improvement up.
+ * Kept in `ingest_cursors`, which takes a free-form `source` key, precisely so this
+ * needs no column and therefore no schema version bump — see DashboardDb's header for
+ * why that matters across the three surfaces sharing this file.
+ *
+ * `2` — a full read now runs every registered extractor rather than only Claude's
+ * tool tally (see `SessionSignals`). Two things it yields that `1` did not: skill
+ * invocations entered by slash command, which no tool-call reader can see at any
+ * source, and tool/MCP calls from the eight non-Claude sources that were returning
+ * before their transcript was ever opened. Every session already in a database was
+ * stored by the narrower read, and none of their instants will move on their own.
+ *
+ * `3` — Claude's tool reader now names a skill the way the skill scanner already did
+ * (`toolUseResult.commandName`, the id the host launched) instead of the model's
+ * requested `input.skill`. Under `2` a plugin-provided skill therefore landed as TWO
+ * `session_tool_use` rows with the calls split between them, one of them named
+ * something the user never typed. Re-reading is what removes the stale row: the
+ * upsert deletes a session's tool rows before rewriting them, so nothing else can.
+ */
+const SESSION_READ_GENERATION = "3";
 
 /**
  * Content fingerprint of the summary index — the summaries cursor value.
@@ -156,6 +213,16 @@ export interface DbBackfillOptions {
 	readonly now?: () => number;
 	/** Test seams, forwarded to the collector. */
 	readonly loadSessions?: SessionLoader;
+	/**
+	 * The RUN-wide machine-global scans, forwarded to the collector.
+	 *
+	 * Threaded down rather than scanned here because every one of these stores is
+	 * machine-global: scanning them per repo re-reads the same records once per
+	 * registered repo, which is the shape {@link dbBackfillRepos} exists to collapse.
+	 * A source being absent here is a valid state — the collector then falls back to
+	 * scanning that one per repo, exactly as before.
+	 */
+	readonly preScanned?: PreScannedSessions;
 	/** Test seam: read source for the SOT import; defaults to the orphan branch. */
 	readonly storage?: StorageProvider;
 	/**
@@ -189,6 +256,16 @@ export interface RepoProgress {
 	 */
 	readonly detail?: string;
 	/**
+	 * Set on the `sessions` phase-END marker, and only there: what each agent
+	 * contributed to THIS repo.
+	 *
+	 * A phase-end marker exists for this tier alone because it is the only one whose
+	 * interesting output is a breakdown rather than a count. Consumers that only render
+	 * counts ignore the field; the one that renders it keys off its presence rather
+	 * than off `done`, since a repo can legitimately end the tier having processed 0.
+	 */
+	readonly sessionBreakdown?: Readonly<Record<string, SessionSourceTotals>>;
+	/**
 	 * Set on a `commits` phase-start marker when this repo has never completed a
 	 * bootstrap — i.e. when the sweep really will read the whole history.
 	 *
@@ -207,6 +284,64 @@ export interface DbBackfillProgress extends RepoProgress {
 	readonly repoTotal: number;
 }
 
+/**
+ * One repo's session-tier outcome.
+ *
+ * `processed` and `skipped` do not have to add up to `discovered`, and the report
+ * must not assume they do: a session with an unparseable instant is neither — it is
+ * never skipped (being undateable is a reason to look at it) but it also produces no
+ * event. So all three are carried rather than two plus arithmetic.
+ */
+export interface SessionTierSummary {
+	/** Sessions the window turned up, after dedupe and before any skipping. */
+	readonly discovered: number;
+	/** Sessions actually read and projected this pass. */
+	readonly processed: number;
+	/** Sessions the database already held at or past their instant. */
+	readonly skipped: number;
+	/**
+	 * All three totals split by agent, so the report can say which tool each number
+	 * came from rather than only naming the tools that happened to be read.
+	 *
+	 * It carries the same three fields as the totals, and for the same reason they are
+	 * carried rather than derived: an agent's `processed + skipped` need not equal its
+	 * `discovered`. The split is keyed by every source the window turned up, including
+	 * one whose sessions were all skipped — reporting "codex 51 found, 0 read" is the
+	 * point of the breakdown, and dropping the key would spell it as "codex absent".
+	 */
+	readonly bySource: Readonly<Record<string, SessionSourceTotals>>;
+	/**
+	 * The same three populations IDENTIFIED rather than tallied, so a reader merging
+	 * several repos can count conversations instead of counting claims.
+	 *
+	 * The counts above are per-repo facts and stay correct as such: this repo really
+	 * did discover, read and skip that many. They are simply NOT ADDABLE across repos.
+	 * One conversation is routinely claimed by more than one — Cursor's attribution is
+	 * coarse by construction (its global store records no workspace for a composer, so
+	 * every in-window composer belongs to every repo Cursor has a workspace for), and
+	 * two clones of one project claim an identical set — so summing N repos' counts
+	 * reports one conversation N times, and the inflation grows with how many repos are
+	 * registered. Only the machine's owner sees it, which is what kept it invisible.
+	 *
+	 * Keys are {@link SessionPassKey}s, stable across repos, so a cross-repo reader
+	 * unions them into a set first — see `printSessionSummary`.
+	 */
+	readonly keys: SessionTierKeys;
+}
+
+/** {@link SessionTierSummary}'s three populations, by {@link SessionPassKey}. */
+export interface SessionTierKeys {
+	readonly discovered: ReadonlyArray<SessionPassKey>;
+	readonly processed: ReadonlyArray<SessionPassKey>;
+	readonly skipped: ReadonlyArray<SessionPassKey>;
+}
+
+/** One agent's row in {@link SessionTierSummary.bySource}. */
+export interface SessionSourceTotals extends SessionSourceCounts {
+	/** Of this agent's discovered sessions, the ones read and projected this pass. */
+	readonly processed: number;
+}
+
 export interface DbBackfillResult {
 	/**
 	 * 'bootstrapped' = full import ran; 'recovered' = incremental pass;
@@ -220,6 +355,19 @@ export interface DbBackfillResult {
 	 */
 	readonly mode: "bootstrapped" | "recovered" | "skipped" | "unavailable";
 	readonly eventsApplied: number;
+	/**
+	 * What the session tier saw and did, for the caller's one-line report. Absent on
+	 * a repo that never reached that tier.
+	 *
+	 * It exists because this tier had no user-visible output at all: the progress
+	 * block's reveal rule deliberately excludes `sessions` (that tier used to
+	 * re-project everything on every pass, so its progress lines said nothing), which
+	 * left the whole 7-day back-fill invisible — a run that pulled in 18 previously
+	 * unreachable conversations printed exactly what a run that did nothing printed.
+	 * Reported here rather than through `onProgress` because it is a summary, known
+	 * only once the tier is done.
+	 */
+	readonly sessions?: SessionTierSummary;
 	/** Row counts from the v7 SOT import; absent when the repo was skipped. */
 	readonly sotImport?: SotImportResult;
 	/** Present on every result, so a caller can name the repo in its output. */
@@ -256,6 +404,77 @@ function writeCursor(db: DashboardDbHandle, repoIdentity: string, source: string
 		 VALUES ((SELECT id FROM repos WHERE repo_identity = ?), ?, ?, ?)
 		 ON CONFLICT(repo_id, source) DO UPDATE SET cursor = excluded.cursor, updated_at_ms = excluded.updated_at_ms`,
 	).run(repoIdentity, source, cursor, nowMs);
+}
+
+/**
+ * Every session this repo has a row for **that a transcript read produced**, keyed
+ * `<source>:<sessionId>` and valued with the stored `updated_at_ms`.
+ *
+ * This is the whole mechanism behind the collector's `isAlreadyCurrent`, and it needs
+ * no schema of its own: a `sessions` row written by a full read IS the receipt that
+ * the session was processed, and it already records how far the processing got. The
+ * three tables that look like better answers are not: `events_raw` deliberately has no
+ * unique constraint and no index on `event_id` and is pruned once projected, so an
+ * absent row does not mean "never processed"; `ingest_cursors` holds one high-water
+ * value per repo, which an out-of-order update slips past; and `token_coverage` /
+ * `message_count` are written with overlapping value ranges by both the live read and
+ * the commit-seeded path, so neither can tell them apart. A column of its own would
+ * work — appending a migration is legal and no build is refused over a version it does
+ * not know (see DashboardDb's header) — but it would be a permanent, frozen schema
+ * entry restating something the existing columns already answer exactly.
+ *
+ * ## The seeded-row exclusion, which is load-bearing rather than defensive
+ *
+ * Not every `sessions` row came from reading a transcript. `projectSummary` SEEDS one
+ * from a commit summary's session links (the retention case: the agent's own store has
+ * aged the conversation out and the memory pipeline is the only record left), stamped
+ * with the COMMIT's time — necessarily later than the conversation's last turn. Taken
+ * as a receipt, such a row skips the session's transcript on every pass from then on,
+ * and PERMANENTLY: the seed's `ON CONFLICT` never rewrites `updated_at_ms`, so nothing
+ * walks the claim back and the session keeps a row with no title, no start, no
+ * duration, no tools and no skills while the sweep reports it as up to date.
+ * {@link SESSION_READ_GENERATION} cannot cover this — a seed lands at any moment (the
+ * QueueWorker writes one straight from post-commit, and the summaries tier writes one
+ * earlier in this very pass), so there is no point at which one un-skipped pass makes
+ * the remaining rows trustworthy.
+ *
+ * What separates the two writers is which COLUMNS they can fill. A commit summary
+ * knows a session's identity, an instant and its token totals; `started_at_ms` and
+ * `duration_ms` are derived from the transcript's own first and last entry, and the
+ * seed writes neither on insert or on conflict. So either of them being present is
+ * proof a read happened — which is why {@link projectSummary}'s seed must never start
+ * writing one. The converse is a deliberate false negative: a read that yielded
+ * neither (an empty or unreadable transcript) is re-read every pass, which costs one
+ * open of a file with nothing in it and keeps the safe answer safe.
+ *
+ * ## `title` is NOT on that list, and must not be added to it
+ *
+ * It looks like a third receipt — the seed never writes one either — but it is the one
+ * transcript-shaped column that survives a FAILED read.
+ * `sessionEventFromInfo` resolves the title BEFORE it opens the transcript and, when
+ * the read then throws, still returns that base event; `resolveSessionTitle` answers
+ * from `SessionInfo.title` alone for every source whose discoverer carries a native
+ * one (opencode, cursor, devin, cline, copilot, antigravity). So a store that was
+ * momentarily locked (`SQLITE_BUSY` while the user's agent is running) writes a row
+ * with a title and nothing else — and counting that as a receipt would strand the
+ * session at exactly that half-built state: no message count, no duration, no tokens,
+ * no tools, no skills, never re-read until the conversation gains a new turn.
+ *
+ * One indexed read: `repos.repo_identity` is UNIQUE and `ix_sessions_repo_time` leads
+ * with `repo_id`.
+ */
+function readKnownSessions(db: DashboardDbHandle, repoIdentity: string): Map<string, number> {
+	const rows = db
+		.prepare(
+			`SELECT s.source, s.session_id, s.updated_at_ms FROM sessions s
+			   JOIN repos r ON r.id = s.repo_id
+			  WHERE r.repo_identity = ?
+			    AND (s.started_at_ms IS NOT NULL OR s.duration_ms IS NOT NULL)`,
+		)
+		.all(repoIdentity) as ReadonlyArray<{ source: string; session_id: string; updated_at_ms: number }>;
+	const known = new Map<string, number>();
+	for (const row of rows) known.set(`${row.source}:${row.session_id}`, row.updated_at_ms);
+	return known;
 }
 
 /**
@@ -896,6 +1115,12 @@ export async function dbBackfillRepo(opts: DbBackfillOptions): Promise<DbBackfil
 	// graph.
 	const cwd = worktrees[0];
 
+	// Filled by the session tier inside the callback below and read by the same
+	// callback's `return`. It sits out here so the tier that PRODUCES it and the result
+	// assembly that consumes it do not have to be adjacent — the callback runs a tier
+	// per phase between them, and several of those can return early.
+	let sessionSummary: SessionTierSummary | undefined;
+
 	// Read before opening the DB: `withDashboardDb` closes its handle in a
 	// `finally`, which for an async callback runs before the awaits inside it
 	// resolve — so an async read placed inside the callback would come back to an
@@ -1183,14 +1408,54 @@ export async function dbBackfillRepo(opts: DbBackfillOptions): Promise<DbBackfil
 			}
 
 			// Sessions: always re-COLLECT the currently discoverable set. A global
-			// max-updatedAt cursor would miss an old session updated out of order,
-			// so the cursor only records progress for observability — it is never
-			// used to skip. The projection is narrowed per event instead, exactly as
-			// in the two tiers above; see `unchangedSessionEvent`.
+			// max-updatedAt cursor would miss an old session updated out of order, so
+			// `CURSOR_SESSIONS` below only records progress for observability — it is
+			// never used to skip.
+			//
+			// Skipping happens at two narrower layers instead, neither of them repo-wide.
+			// On the READ side it is per-session and exact: `readKnownSessions` answers
+			// "how far did I get with THIS session", so resuming a three-day-old
+			// conversation still re-reads it (its stored instant is older than the turn
+			// just added) — the failure mode a repo-wide high-water mark has and this
+			// does not. On the PROJECTION side it is per event, exactly as in the two
+			// tiers above; see `unchangedSessionEvent`.
 			opts.onProgress?.({ repoName: repo.repoName, kind: "sessions", done: 0 });
+			// The receipt check, and it has two halves. Only a repo whose recorded
+			// generation matches what a full read produces TODAY may have transcripts
+			// skipped — anything else, including a database predating this gate, gets one
+			// un-skipped pass ({@link SESSION_READ_GENERATION}) — and only rows a real read
+			// wrote count as evidence, which is what stops the summaries tier just above
+			// from seeding a commit-time instant this comparison would trust
+			// ({@link readKnownSessions}).
+			const readGeneration = readCursor(db, repo.repoIdentity, CURSOR_SESSIONS_GENERATION);
+			const maySkip = readGeneration === SESSION_READ_GENERATION;
+			const known = maySkip ? readKnownSessions(db, repo.repoIdentity) : new Map<string, number>();
+			let counts: SessionPassCounts = {
+				discovered: 0,
+				skipped: 0,
+				bySource: {},
+				discoveredKeys: [],
+				skippedKeys: [],
+			};
 			const sessionEvents = await collectSessionEvents({
+				onCounts: (seen) => {
+					counts = seen;
+				},
 				repoIdentity: repo.repoIdentity,
 				cwd,
+				// The one caller that widens the horizon past every source's 48 h default.
+				windowMs: BACKFILL_SESSION_WINDOW_MS,
+				...(opts.preScanned ? { preScanned: opts.preScanned } : {}),
+				...(maySkip
+					? {
+							isAlreadyCurrent: (source: TranscriptSource, sessionId: string, updatedAtMs: number) => {
+								const stored = known.get(`${source}:${sessionId}`);
+								// `>=`, not `>`: an equal instant means a re-read would write back
+								// the row already there, which is not worth the transcript parse.
+								return stored !== undefined && stored >= updatedAtMs;
+							},
+						}
+					: {}),
 				...(opts.loadSessions ? { loadSessions: opts.loadSessions } : {}),
 			});
 			const storedSessions = storedSessionRows(db, repo.repoIdentity);
@@ -1210,6 +1475,53 @@ export async function dbBackfillRepo(opts: DbBackfillOptions): Promise<DbBackfil
 			).applied;
 			const maxUpdated = sessionEvents.reduce((max, e) => Math.max(max, e.updatedAtMs), 0);
 			if (maxUpdated > 0) writeCursor(db, repo.repoIdentity, CURSOR_SESSIONS, String(maxUpdated), now());
+			// Recorded unconditionally, including after a pass where a discoverer failed.
+			// A partial pass cannot mislead the next one: a session that was never
+			// discovered has no row a read wrote, so the skip has nothing to match it
+			// against and it is read in full whenever it does turn up. A commit summary may
+			// have seeded a row for it in the meantime, which is exactly why
+			// `readKnownSessions` does not count one.
+			writeCursor(db, repo.repoIdentity, CURSOR_SESSIONS_GENERATION, SESSION_READ_GENERATION, now());
+			// Merged from two sides, and it has to be: the collector knows what it SAW
+			// (discovered / skipped, including for a source it read nothing from), the
+			// event list knows what SURVIVED. Seeding from the collector's keys rather
+			// than from the events is what keeps a fully-skipped agent in the report.
+			const processedBySource: Record<string, number> = {};
+			for (const event of sessionEvents)
+				processedBySource[event.source] = (processedBySource[event.source] ?? 0) + 1;
+			const bySource: Record<string, SessionSourceTotals> = {};
+			for (const [source, seen] of Object.entries(counts.bySource)) {
+				bySource[source] = { ...seen, processed: processedBySource[source] ?? 0 };
+			}
+			// The processed population is spelled from the EVENTS, matching how
+			// `processed` itself is counted — a discovered session that produced no event
+			// belongs to neither the processed nor the skipped set, and the keys have to
+			// keep that gap open the same way the three numbers do.
+			const processedKeys: SessionPassKey[] = sessionEvents.map((event) =>
+				sessionPassKey(event.source, event.sessionId),
+			);
+			sessionSummary = {
+				discovered: counts.discovered,
+				skipped: counts.skipped,
+				processed: sessionEvents.length,
+				bySource,
+				keys: {
+					discovered: counts.discoveredKeys,
+					processed: processedKeys,
+					skipped: counts.skippedKeys,
+				},
+			};
+			// The per-repo breakdown, emitted as its own phase-END marker. The tier's
+			// phase-START marker above cannot carry it — the numbers do not exist until
+			// the reads are done — and the run-wide summary at the very end cannot
+			// either, because it is merged across repos by design. `done` is the
+			// processed count purely so the event is not mistaken for a start marker.
+			opts.onProgress?.({
+				repoName: repo.repoName,
+				kind: "sessions",
+				done: sessionEvents.length,
+				sessionBreakdown: bySource,
+			});
 
 			// Worktree: transient, recomputed every pass — from the PRIMARY checkout
 			// only. `worktree_status` is keyed `(repo_id, branch_key)`, so two
@@ -1400,10 +1712,144 @@ export async function dbBackfillRepo(opts: DbBackfillOptions): Promise<DbBackfil
 
 			const mode = isBootstrap ? "bootstrapped" : "recovered";
 			log.info("%s %s: %d events applied", mode, repo.repoName, applied);
-			return { mode, eventsApplied: applied, sotImport, repoName: repo.repoName } as DbBackfillResult;
+			return {
+				mode,
+				eventsApplied: applied,
+				sotImport,
+				repoName: repo.repoName,
+				...(sessionSummary ? { sessions: sessionSummary } : {}),
+			} as DbBackfillResult;
 		},
 		{ dbPath: opts.dbPath },
 	);
+}
+
+/**
+ * Reads every machine-global session store once, for the whole run.
+ *
+ * Dynamic imports throughout, matching `loadAllSessions`: several of these reach for
+ * `node:sqlite`, and importing them eagerly would emit the ExperimentalWarning in
+ * every process that loads this module without ever backfilling.
+ *
+ * Each scan is independent and all of them run concurrently — they touch different
+ * stores, and one source failing must not delay or fail another. Every source is
+ * given the back-fill's wider window, which is the whole reason the back-fill has its
+ * own scan path rather than reusing the 48 h defaults.
+ *
+ * A partial result is kept rather than discarded: a scan that returns sessions AND an
+ * error (Cline, whose flavours are scanned independently; Copilot Chat, whose
+ * workspaces are) has genuinely found those sessions. Dropping them because a sibling
+ * directory was unreadable would lose data the old per-repo path also kept — its
+ * callers read `.sessions` and ignored `.error` for exactly this reason.
+ */
+async function scanAllStores(alreadyRecorded?: AlreadyCurrent): Promise<PreScannedSessions> {
+	const scanned = new Map<TranscriptSource, ReadonlyArray<unknown>>();
+	// Concurrent, and the results are collected by source tag rather than positionally:
+	// a positional destructure is a second ordering to keep in step with the registry,
+	// and getting it wrong would file one agent's sessions under another's name.
+	await Promise.all(
+		SESSION_SOURCES.map(async (def) => {
+			// `alreadyRecorded` reaches only the definitions that declare they use it —
+			// the two whose per-session read is expensive enough to be worth skipping.
+			// Passing it to the rest would be harmless but misleading: it would read as a
+			// promise that every scanner honours it.
+			const opts = {
+				windowMs: BACKFILL_SESSION_WINDOW_MS,
+				...(alreadyRecorded && def.usesAlreadyRecorded ? { alreadyRecorded } : {}),
+			};
+			try {
+				const result = await def.scan(opts);
+				// A source is recorded ONLY on success. Absence is what tells the collector
+				// to fall back to that source's per-repo scan; recording `[]` for a failed
+				// scan would claim the store was read and found empty, and the fallback that
+				// exists precisely for this case would never run.
+				scanned.set(def.source, result as ReadonlyArray<unknown>);
+			} catch (err) {
+				log.warn(
+					"%s scan failed -- back-fill falls back to per-repo scans for it: %s",
+					def.source,
+					errMsg(err),
+				);
+			}
+		}),
+	);
+	return Object.fromEntries(scanned) as PreScannedSessions;
+}
+
+/**
+ * One machine-wide answer to "is this session already recorded, everywhere it
+ * matters?", for the SCANNERS to consult before they pay for an expensive read.
+ *
+ * ## Why this exists at all, given the per-repo skip already does
+ *
+ * The per-repo `isAlreadyCurrent` runs after the scan, so it saves the second read
+ * of a transcript and not the first. Claude's scan already reads and parses every
+ * in-window transcript in full (to collect the working directories a `cd` scattered
+ * through the file), and Antigravity's already opens one SQLite per conversation. On
+ * a converged re-run — nothing to update, which is the normal case — all of that was
+ * still paid, so a repeat `jolli dashboard` cost roughly half of a first one for no
+ * result. This moves the decision to where the scanner can act on it.
+ *
+ * ## The rule, and the two ways of getting it wrong
+ *
+ * A session is "already recorded" when EVERY repo holding a row for it is at or past
+ * `updatedAtMs`. Two tempting variants are both wrong:
+ *
+ *  - **"every registered repo has a current row"** — a Claude session belongs to one
+ *    repo, so on a machine with three registered repos the other two never have a
+ *    row and the condition never holds. The optimisation would silently do nothing
+ *    the moment a second repo was registered.
+ *  - **"some repo has a current row"** — right for the steady state, wrong the first
+ *    time a NEW repo is registered: that repo's rows do not exist yet, and skipping
+ *    on another repo's evidence would leave it permanently without them.
+ *
+ * The MINIMUM over the repos that do have a row answers the first, and the
+ * generation gate below answers the second: a repo that has never completed a
+ * session pass turns scan-level skipping OFF for the whole run, so it gets one full
+ * scan and every later run gets the fast path.
+ *
+ * Returns `undefined` when nothing may be skipped — no repo, a repo still on an
+ * older read generation, or a database that could not be read. Absence is the safe
+ * answer: it costs one full scan.
+ */
+async function readRecordedSessions(
+	live: ReadonlyArray<RegisteredRepo>,
+	dbPath?: string,
+): Promise<AlreadyCurrent | undefined> {
+	if (live.length === 0) return undefined;
+	try {
+		return await withDashboardDb(
+			(db) => {
+				// Every live repo must be past the gate. One that is not gets a pass with no
+				// skipping at all — see this function's header for the new-repo case.
+				for (const repo of live) {
+					if (readCursor(db, repo.repoIdentity, CURSOR_SESSIONS_GENERATION) !== SESSION_READ_GENERATION) {
+						return undefined;
+					}
+				}
+				// The minimum stored instant per session, across the repos that hold a row.
+				const floor = new Map<string, number>();
+				for (const repo of live) {
+					for (const [key, instant] of readKnownSessions(db, repo.repoIdentity)) {
+						const seen = floor.get(key);
+						if (seen === undefined || instant < seen) floor.set(key, instant);
+					}
+				}
+				if (floor.size === 0) return undefined;
+				return (source: TranscriptSource, sessionId: string, updatedAtMs: number) => {
+					const stored = floor.get(`${source}:${sessionId}`);
+					return stored !== undefined && stored >= updatedAtMs;
+				};
+			},
+			dbPath ? { dbPath } : {},
+		);
+	} catch (err) {
+		// A database that cannot be read is not a failure worth reporting here: the
+		// per-repo passes will hit the same problem and report it properly. All that is
+		// lost is the fast path.
+		log.debug("cannot pre-read recorded sessions -- scans will not skip: %s", errMsg(err));
+		return undefined;
+	}
 }
 
 /**
@@ -1451,6 +1897,68 @@ export async function dbBackfillRepos(
 		unavailable.push({ mode: "unavailable", eventsApplied: 0, repoName: repo.repoName });
 		return false;
 	});
+	// ONE read of each machine-global store for the whole run, hoisted out of the loop
+	// below. Not one of these stores is keyed by repo — Claude by a lossily encoded
+	// path, Codex by DATE, OpenCode / Copilot CLI / Devin / Cursor by nothing at all
+	// (one database for every project), Cline by editor flavour, Copilot Chat and
+	// Cursor by a VS Code workspace hash — so "which sessions are this repo's" can only
+	// be answered after opening the records. Scanning per repo therefore re-opens the
+	// same records once per registered repo. Measured on a three-repo machine: Claude
+	// 64 transcripts (36 ms of head/tail reads, 464 ms of full parse), Codex 68 ms per
+	// repo against 201 ms across three, all of it repetition.
+	//
+	// The nine below were previously left per-repo on the strength of that same
+	// profile, where they cost under a millisecond between them. That was the wrong
+	// conclusion from a correct measurement: those sources were not INSTALLED on the
+	// profiling machine, so each returned on its first `readdir`. On a machine that
+	// actually runs Cursor, Copilot and Cline, each per-repo pass is a real SQLite open
+	// plus a full-table scan, or a JSON parse of the user's entire task history.
+	//
+	// They all run concurrently because they touch different stores and no one's
+	// failure should delay another's.
+	//
+	// A caller may supply its own scans (tests, and any embedder that already has
+	// them); a supplied value wins and no scan happens here for that source.
+	//
+	// Failure is NOT fatal and must not be: every source scans its own store
+	// independently, so one failed scan costs that source its pre-48 h reach and
+	// nothing else. Claude degrades furthest but not to zero — the `sessions.json` half
+	// of the collector still carries it.
+	//
+	// Read BEFORE the scans and not inside them: the answer is one query per repo
+	// against a database the scanners know nothing about, and asking per transcript
+	// would put a database round trip inside the fan-out it is meant to shorten.
+	// There is no consumer for a run-wide scan when every registered checkout is
+	// unavailable. Apart from wasting startup time, scanning here used to open the
+	// user's real agent stores even though the loop below had no repo to attribute a
+	// single result to.
+	//
+	// A custom loader is an ownership boundary too: callers inject it specifically to
+	// define the session set (tests are one caller, embedders are another). Adding real
+	// home-directory scans on top makes that seam non-deterministic and can project
+	// sessions the injected loader never returned. An explicitly supplied `preScanned`
+	// value still wins, so callers that own both halves can opt into the combination.
+	//
+	// COST: this binding is RESIDENT for the whole multi-repo run — it cannot be freed per
+	// repo, because which repo claims a session is only known after `forRepo` runs and any
+	// of them may claim any of it. What it holds is now bounded per session: identity, an
+	// instant, and the directories the session recorded.
+	//
+	// It used to hold each Claude session's whole parse as well (the entries plus the
+	// transcript's own lines), so a 7-day window kept every transcript in memory at once —
+	// over 100 MB on this repo's own 64-file corpus, growing linearly with the window and
+	// with nothing capping the total. `withIoBudget` does not help: that budget caps bytes
+	// IN FLIGHT, released the moment a read returns, and says nothing about what a caller
+	// then keeps. So the parse is no longer carried, and the collector reads each
+	// transcript itself (see `acceptFacts` for what that costs instead).
+	//
+	// Do not reintroduce a carried parse here without a byte cap on the total.
+	const preScanned =
+		rest.preScanned ??
+		(live.length === 0 || rest.loadSessions
+			? {}
+			: await scanAllStores(await readRecordedSessions(live, rest.dbPath)));
+
 	const results: DbBackfillResult[] = [];
 	for (const [i, repo] of live.entries()) {
 		// The index is injected here rather than passed down, so `dbBackfillRepo`
@@ -1459,7 +1967,14 @@ export async function dbBackfillRepos(
 			? { onProgress: (p: RepoProgress) => forward({ ...p, repoIndex: i + 1, repoTotal: live.length }) }
 			: {};
 		try {
-			results.push(await dbBackfillRepo({ ...rest, ...perRepo, repo }));
+			results.push(
+				await dbBackfillRepo({
+					...rest,
+					...perRepo,
+					preScanned,
+					repo,
+				}),
+			);
 		} catch (err) {
 			log.error("db backfill failed for %s: %s", repo.repoName, errMsg(err));
 			// Carried on the result, not just logged: the caller is the only thing

--- a/cli/src/dashboard/ProducerHooks.ts
+++ b/cli/src/dashboard/ProducerHooks.ts
@@ -430,9 +430,19 @@ async function refreshMemoryRows(cwd: string, hashes: ReadonlyArray<string>, dbP
  *
  * The caller (VS Code's 60 s sidebar tick) hands over whatever the aggregator
  * saw; this function writes only the sessions whose `updatedAt` moved since
- * the last tick write — reading a transcript for token usage is the expensive
- * part, and an idle session's row is already correct. Worktree state is
- * refreshed on every effective write (it is one cheap git call).
+ * the last tick write — reading a transcript is the expensive part, and an idle
+ * session's row is already correct. Worktree state is refreshed on every
+ * effective write (it is one cheap git call).
+ *
+ * That gate is what keeps the tick affordable now that `sessionEventFromInfo` reads a
+ * transcript for EVERY source rather than only Claude (it used to return early for the
+ * other twelve, so this loop was near-free for them). Two things follow, and both are
+ * accepted rather than pending — see that function's header for the full note:
+ * the aggregator has already parsed the same files this tick to count messages, so the
+ * read here is a second parse rather than a first; and `lastTickWrite` lives in this
+ * process, so the first tick after a window reload has a watermark of 0 and pays for
+ * every in-window session once. Do not "fix" either by reintroducing a source check —
+ * the tool and skill signals for the non-Claude agents are exactly what that check hid.
  *
  * The watermark advances only **after** `safeApply` reports the write landed.
  * Moving it while building the batch would make a swallowed failure (the DB

--- a/cli/src/dashboard/StatsWriter.ts
+++ b/cli/src/dashboard/StatsWriter.ts
@@ -834,6 +834,15 @@ function projectCommitSummary(db: DashboardDbHandle, event: CommitSummaryEvent):
 	}
 
 	if (event.sessionLinks) {
+		// This statement's COLUMN LIST is load-bearing, and not only for what it writes.
+		// `title`, `started_at_ms` and `duration_ms` are absent because a commit summary
+		// cannot know them — and the back-fill's per-session skip reads that absence as
+		// "no transcript was ever read for this row" (`readKnownSessions` in DbBackfill).
+		// Its instant is the COMMIT's time, later than the conversation's last turn, so a
+		// row this seed created must never look like a read receipt: adding one of those
+		// three columns here would make the sweep skip that session's transcript on every
+		// pass from then on, permanently and silently. Token columns are safe — the
+		// summary genuinely observed those.
 		const seedSession = db.prepare(
 			`INSERT INTO sessions
 			   (event_id, repo_id, source, session_id, updated_at_ms, message_count,

--- a/cli/src/util/Concurrency.test.ts
+++ b/cli/src/util/Concurrency.test.ts
@@ -1,0 +1,316 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { defaultConcurrency, ioBudget, mapWithConcurrency, withIoBudget } from "./Concurrency.js";
+
+/** A promise plus the handles to settle it, so a test can hold an operation open. */
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve = (): void => {};
+	const promise = new Promise<void>((r) => {
+		resolve = r;
+	});
+	return { promise, resolve };
+}
+
+/** Lets every already-resolved continuation run, so pending state is observable. */
+const settle = async (): Promise<void> => {
+	for (let i = 0; i < 5; i++) await Promise.resolve();
+};
+
+afterEach(() => {
+	ioBudget.reset();
+});
+
+describe("mapWithConcurrency", () => {
+	it("preserves input order regardless of completion order", async () => {
+		// Load-bearing rather than cosmetic: callers pair the result with the input by
+		// index, so a completion-ordered result would mis-pair every entry.
+		const out = await mapWithConcurrency([30, 10, 20], async (ms) => {
+			await new Promise((r) => setTimeout(r, ms));
+			return ms;
+		});
+		expect(out).toEqual([30, 10, 20]);
+	});
+
+	it("never exceeds the requested width", async () => {
+		let inFlight = 0;
+		let peak = 0;
+		await mapWithConcurrency(
+			[1, 2, 3, 4, 5, 6, 7],
+			async () => {
+				inFlight++;
+				peak = Math.max(peak, inFlight);
+				await new Promise((r) => setTimeout(r, 1));
+				inFlight--;
+			},
+			2,
+		);
+		expect(peak).toBe(2);
+	});
+
+	it("defaults its width to the shared budget, so a lone call site is not throttled below the pool", async () => {
+		// The whole point of the default: on a real machine most stores are empty, so a
+		// fan-out narrower than the pool would cap the one site that has work while the
+		// pool sat idle.
+		ioBudget.configure({ slots: 3 });
+		expect(defaultConcurrency()).toBe(3);
+		let peak = 0;
+		let inFlight = 0;
+		await mapWithConcurrency([1, 2, 3, 4, 5, 6], async () => {
+			inFlight++;
+			peak = Math.max(peak, inFlight);
+			await new Promise((r) => setTimeout(r, 1));
+			inFlight--;
+		});
+		expect(peak).toBe(3);
+	});
+
+	it("handles an empty list without spawning a worker", async () => {
+		// `width` is clamped to the item count, and Math.max(1, …) would otherwise
+		// spawn one worker for zero items.
+		expect(await mapWithConcurrency([], async () => 1)).toEqual([]);
+	});
+
+	it("propagates a rejection from fn", async () => {
+		// Documented contract: a throw is treated as a programming error and abandons
+		// the remaining items, which is why scanners catch per item and return a
+		// sentinel instead.
+		await expect(
+			mapWithConcurrency([1], async () => {
+				throw new Error("boom");
+			}),
+		).rejects.toThrow("boom");
+	});
+});
+
+describe("withIoBudget", () => {
+	it("holds operations past the slot count until one releases", async () => {
+		ioBudget.configure({ slots: 2 });
+		const gates = [deferred(), deferred(), deferred()];
+		const started: number[] = [];
+		const runs = gates.map((gate, i) =>
+			withIoBudget(0, async () => {
+				started.push(i);
+				await gate.promise;
+			}),
+		);
+
+		await settle();
+		expect(started).toEqual([0, 1]);
+
+		gates[0].resolve();
+		await settle();
+		expect(started).toEqual([0, 1, 2]);
+
+		gates[1].resolve();
+		gates[2].resolve();
+		await Promise.all(runs);
+	});
+
+	it("counts bytes as a second, independent dimension", async () => {
+		// A slot count treats every read as the same size. Two 6-byte reads fit two
+		// slots but not a 10-byte allowance, so the second waits on bytes alone.
+		ioBudget.configure({ slots: 4, bytesInFlight: 10 });
+		const gates = [deferred(), deferred()];
+		const started: number[] = [];
+		const runs = gates.map((gate, i) =>
+			withIoBudget(6, async () => {
+				started.push(i);
+				await gate.promise;
+			}),
+		);
+
+		await settle();
+		expect(started).toEqual([0]);
+
+		gates[0].resolve();
+		await settle();
+		expect(started).toEqual([0, 1]);
+
+		gates[1].resolve();
+		await Promise.all(runs);
+	});
+
+	it("runs a claim larger than the whole byte cap alone rather than never", async () => {
+		// The clamp is what makes an oversized read runnable at all: unclamped it could
+		// never fit and would wait forever.
+		ioBudget.configure({ slots: 4, bytesInFlight: 10 });
+		const held = deferred();
+		const started: string[] = [];
+		const big = withIoBudget(999, async () => {
+			started.push("big");
+			await held.promise;
+		});
+
+		await settle();
+		expect(started).toEqual(["big"]);
+
+		const small = withIoBudget(1, async () => {
+			started.push("small");
+		});
+		await settle();
+		// The oversized claim took the entire allowance, so nothing overlaps it.
+		expect(started).toEqual(["big"]);
+
+		held.resolve();
+		await Promise.all([big, small]);
+		expect(started).toEqual(["big", "small"]);
+	});
+
+	it("grants in arrival order, so a large claim is not starved by later small ones", async () => {
+		ioBudget.configure({ slots: 1, bytesInFlight: 100 });
+		const held = deferred();
+		const order: string[] = [];
+		const first = withIoBudget(0, async () => {
+			order.push("first");
+			await held.promise;
+		});
+		const large = withIoBudget(100, async () => {
+			order.push("large");
+		});
+		const smallA = withIoBudget(1, async () => {
+			order.push("smallA");
+		});
+		const smallB = withIoBudget(1, async () => {
+			order.push("smallB");
+		});
+
+		await settle();
+		expect(order).toEqual(["first"]);
+
+		held.resolve();
+		await Promise.all([first, large, smallA, smallB]);
+		expect(order).toEqual(["first", "large", "smallA", "smallB"]);
+	});
+
+	it("re-clamps a queued claim when the byte cap shrinks under it", async () => {
+		// The whole-process stall this avoids: a waiter whose claim was fixed against the
+		// old cap can never fit the new one, and it is the FIFO head, so nothing behind it
+		// runs either — no error, no timeout, every scan in the process simply stops.
+		ioBudget.configure({ slots: 1, bytesInFlight: 100 });
+		const held = deferred();
+		const order: string[] = [];
+		const first = withIoBudget(0, async () => {
+			order.push("first");
+			await held.promise;
+		});
+		await settle();
+		const queued = withIoBudget(80, async () => {
+			order.push("queued");
+		});
+
+		ioBudget.configure({ bytesInFlight: 8 });
+		held.resolve();
+		await Promise.all([first, queued]);
+
+		expect(order).toEqual(["first", "queued"]);
+	});
+
+	it("releases exactly what it took when the cap changes mid-operation", async () => {
+		// Recomputing the clamp on release would return a different number than was
+		// booked, so `bytesInUse` would drift and the budget would leak capacity (or
+		// invent it) once per resize.
+		ioBudget.configure({ slots: 4, bytesInFlight: 100 });
+		const held = deferred();
+		const running = withIoBudget(100, async () => {
+			await held.promise;
+		});
+		await settle();
+
+		ioBudget.configure({ bytesInFlight: 10 });
+		held.resolve();
+		await running;
+
+		// Nothing left booked: a 10-byte claim is the whole new cap and must still fit.
+		const after = withIoBudget(10, async () => "done");
+		await expect(after).resolves.toBe("done");
+	});
+
+	it("queues behind an existing waiter even when the claim would fit", async () => {
+		// Jumping the queue is the same starvation the FIFO rule exists to prevent, so
+		// a fitting claim still goes to the back.
+		ioBudget.configure({ slots: 1 });
+		const held = deferred();
+		const order: string[] = [];
+		const first = withIoBudget(0, async () => {
+			order.push("first");
+			await held.promise;
+		});
+		await settle();
+		const second = withIoBudget(0, async () => {
+			order.push("second");
+		});
+		const third = withIoBudget(0, async () => {
+			order.push("third");
+		});
+
+		held.resolve();
+		await Promise.all([first, second, third]);
+		expect(order).toEqual(["first", "second", "third"]);
+	});
+
+	it("releases the slot when fn throws", async () => {
+		ioBudget.configure({ slots: 1 });
+		await expect(
+			withIoBudget(5, async () => {
+				throw new Error("read failed");
+			}),
+		).rejects.toThrow("read failed");
+		// A leaked slot would hang this second call forever.
+		expect(await withIoBudget(5, async () => "ok")).toBe("ok");
+	});
+
+	it("wakes waiters when the limits are raised", async () => {
+		// Raising must pump immediately; otherwise a caller already waiting sits until
+		// some unrelated release happens to come along.
+		ioBudget.configure({ slots: 1 });
+		const held = deferred();
+		const order: string[] = [];
+		const first = withIoBudget(0, async () => {
+			order.push("first");
+			await held.promise;
+		});
+		await settle();
+		const second = withIoBudget(0, async () => {
+			order.push("second");
+		});
+		await settle();
+		expect(order).toEqual(["first"]);
+
+		ioBudget.configure({ slots: 2 });
+		await settle();
+		expect(order).toEqual(["first", "second"]);
+
+		held.resolve();
+		await Promise.all([first, second]);
+	});
+
+	it("clamps a configured slot count to at least one", async () => {
+		ioBudget.configure({ slots: 0 });
+		expect(defaultConcurrency()).toBe(1);
+		expect(await withIoBudget(0, async () => "ran")).toBe("ran");
+	});
+
+	it("treats a zero byte cap as byte limiting switched off", async () => {
+		// Every claim clamps to 0, so only the slot count binds.
+		ioBudget.configure({ slots: 2, bytesInFlight: 0 });
+		const gates = [deferred(), deferred()];
+		const started: number[] = [];
+		const runs = gates.map((gate, i) =>
+			withIoBudget(1024, async () => {
+				started.push(i);
+				await gate.promise;
+			}),
+		);
+		await settle();
+		expect(started).toEqual([0, 1]);
+		gates[0].resolve();
+		gates[1].resolve();
+		await Promise.all(runs);
+	});
+
+	it("reset restores the shipped defaults", () => {
+		ioBudget.configure({ slots: 1 });
+		expect(defaultConcurrency()).toBe(1);
+		ioBudget.reset();
+		expect(defaultConcurrency()).toBe(8);
+	});
+});

--- a/cli/src/util/Concurrency.ts
+++ b/cli/src/util/Concurrency.ts
@@ -1,0 +1,260 @@
+/**
+ * Bounded-concurrency fan-out, and the process-wide I/O budget every fan-out
+ * draws on.
+ *
+ * ## Two separate things, deliberately not merged
+ *
+ * {@link mapWithConcurrency} SHAPES a fan-out: how many of one call site's items
+ * are in flight at once. {@link withIoBudget} GATES the actual I/O: how much is
+ * in flight across the whole process, no matter how many call sites are running.
+ *
+ * They are separate because they answer different questions and because merging
+ * them cannot work. A fan-out does not know how many bytes its `fn` is about to
+ * materialise — only the code doing the read knows that — and a budget cannot
+ * know how to shape someone else's item list. So the discipline is: shape with
+ * the fan-out, and wrap each LEAF read in the budget.
+ *
+ * ## Why a shared budget at all
+ *
+ * Because the alternative is a constant per call site, and those multiply
+ * silently. The session scan already fans out across twelve agent stores; giving
+ * each one its own width of 8 would put 96 reads in flight with nothing able to
+ * report the total. Past the process limit on open descriptors (256 by default
+ * on macOS) reads start failing with `EMFILE`, and they fail as rejected
+ * promises inside a fan-out, so the whole batch rejects rather than degrading.
+ *
+ * The budget also stops the opposite waste, which is the common case in
+ * practice: sessions concentrate in one or two agents, so most stores answer
+ * with an empty `readdir` and consume nothing. A per-site constant leaves the
+ * one store that HAS the work capped at its own small share while eleven idle
+ * shares go unused. One pool means the busy site gets all of it.
+ */
+
+/**
+ * Slots in the shared budget: how many I/O operations may be in flight process-wide.
+ *
+ * Comfortably below every platform's descriptor limit, with room for the file
+ * handles the rest of the process holds. It is the default width of every
+ * fan-out for a reason — see {@link mapWithConcurrency}.
+ */
+const DEFAULT_IO_SLOTS = 8;
+
+/**
+ * Bytes the budget will let call sites materialise at once — the second, independent
+ * dimension, and the one a slot count cannot express.
+ *
+ * A slot count treats every read as the same size, and transcripts are not: eight
+ * concurrent reads is nothing at the measured 0.9 MB median and several hundred
+ * megabytes if a user happens to have eight very long conversations, because a file
+ * being parsed exists two or three times over (the UTF-16 string, the split lines,
+ * the parsed objects). Claiming bytes as well as a slot makes the peak a property of
+ * this constant instead of a property of whatever the user's largest conversation
+ * happens to be: many small reads still fill every slot, one huge read quietly runs
+ * alone.
+ */
+const DEFAULT_BYTES_IN_FLIGHT = 64 * 1024 * 1024;
+
+interface Waiter {
+	/**
+	 * What the caller ASKED for, unclamped — the clamp against the cap is applied at
+	 * grant time, not here.
+	 *
+	 * Storing the clamped value would freeze it against the cap in force when the
+	 * caller queued, and {@link IoBudget.configure} can lower that cap afterwards: the
+	 * head of the queue would then hold a claim larger than the whole budget, never
+	 * fit, and stall every I/O in the process with no error and no timeout. Clamping on
+	 * the way out means a shrink re-clamps whoever is still waiting.
+	 */
+	readonly want: number;
+	/** Resumes the caller, handing back the byte allowance actually taken. */
+	readonly wake: (granted: number) => void;
+}
+
+/**
+ * The shared gate. Grants a slot, and optionally a byte allowance, to one
+ * operation at a time in arrival order.
+ *
+ * Strict FIFO: only the queue HEAD is considered, even when a later, smaller
+ * waiter would fit. Letting small requests overtake would starve a large one
+ * indefinitely on a busy scan — the read this exists to bound is exactly the one
+ * that would never run.
+ */
+class IoBudget {
+	private slots = DEFAULT_IO_SLOTS;
+	private bytesCap = DEFAULT_BYTES_IN_FLIGHT;
+	private slotsInUse = 0;
+	private bytesInUse = 0;
+	private readonly waiting: Waiter[] = [];
+
+	/** Current slot count — the default width of every fan-out. */
+	get width(): number {
+		return this.slots;
+	}
+
+	/**
+	 * Resizes the budget. Intended for a HOST that must be gentler than a one-shot
+	 * command — the CLI's dashboard back-fill owns its whole process and wants the
+	 * default, while a long-lived editor host runs this on a timer alongside
+	 * everything else the user is doing.
+	 *
+	 * No host narrows it today; the VS Code extension and the IntelliJ bridge both
+	 * inherit the default. Stated rather than implied, because "there is a knob"
+	 * and "someone turned it" are different facts.
+	 *
+	 * Raising the limits pumps the queue immediately, so callers already waiting
+	 * benefit rather than sitting until the next release. Lowering them is safe for the
+	 * same reason the other direction is: a waiter's claim is clamped when it is
+	 * granted, never when it is queued — see {@link Waiter.want}.
+	 */
+	configure(opts: { readonly slots?: number; readonly bytesInFlight?: number }): void {
+		if (opts.slots !== undefined) this.slots = Math.max(1, Math.floor(opts.slots));
+		if (opts.bytesInFlight !== undefined) this.bytesCap = Math.max(0, Math.floor(opts.bytesInFlight));
+		this.pump();
+	}
+
+	/** Restores the shipped defaults. Test seam. */
+	reset(): void {
+		this.slots = DEFAULT_IO_SLOTS;
+		this.bytesCap = DEFAULT_BYTES_IN_FLIGHT;
+		this.pump();
+	}
+
+	/**
+	 * Runs `fn` holding one slot and `bytes` of the byte allowance.
+	 *
+	 * `bytes` is CLAMPED to the whole cap, which is what keeps a file larger than
+	 * the entire byte budget runnable: it waits until nothing else is in flight and
+	 * then proceeds alone. Without the clamp such a read could never fit and would
+	 * wait forever.
+	 *
+	 * NEVER NEST. An inner call waits for a slot while the outer one holds it, so
+	 * enough nested callers deadlock the pool with no error and no timeout. Wrap the
+	 * leaf read — the one that opens a handle and materialises bytes — and nothing
+	 * above it.
+	 */
+	async run<T>(bytes: number, fn: () => Promise<T>): Promise<T> {
+		// The amount RELEASED is the amount the gate says it granted, never a
+		// recomputation of it: the clamp reads `bytesCap`, and a `configure` call while
+		// this operation runs would otherwise release a different number than was taken
+		// and leave the accounting permanently off.
+		const granted = await this.acquire(Math.max(0, bytes));
+		try {
+			return await fn();
+		} finally {
+			this.slotsInUse--;
+			this.bytesInUse -= granted;
+			this.pump();
+		}
+	}
+
+	/** The share of the byte allowance a request for `want` bytes actually takes. */
+	private clamp(want: number): number {
+		return Math.min(want, this.bytesCap);
+	}
+
+	/** True when a request for `want` bytes can be granted right now. */
+	private fits(want: number): boolean {
+		return this.slotsInUse < this.slots && this.bytesInUse + this.clamp(want) <= this.bytesCap;
+	}
+
+	/** Resolves with the byte allowance taken, which the caller must release verbatim. */
+	private acquire(want: number): Promise<number> {
+		// Queue even when the claim would fit, if anyone is already waiting: jumping
+		// the queue here is the same starvation the FIFO rule exists to prevent.
+		if (this.waiting.length === 0 && this.fits(want)) return Promise.resolve(this.take(want));
+		return new Promise<number>((wake) => {
+			this.waiting.push({ want, wake });
+		});
+	}
+
+	/** Books one slot and the clamped byte allowance, returning what was booked. */
+	private take(want: number): number {
+		const claim = this.clamp(want);
+		this.slotsInUse++;
+		this.bytesInUse += claim;
+		return claim;
+	}
+
+	/**
+	 * Grants what the freed capacity allows, accounting for each grant BEFORE waking
+	 * its waiter. The accounting cannot be left to the woken caller: it resumes in a
+	 * later microtask, by which point this loop would have granted the same capacity
+	 * to everyone behind it.
+	 */
+	private pump(): void {
+		while (this.waiting.length > 0 && this.fits(this.waiting[0].want)) {
+			const next = this.waiting.shift() as Waiter;
+			next.wake(this.take(next.want));
+		}
+	}
+}
+
+/** The process-wide budget. One per process is the point — see the module header. */
+export const ioBudget = new IoBudget();
+
+/**
+ * Runs `fn` under the shared I/O budget, claiming one slot and `bytes` of the
+ * byte allowance.
+ *
+ * Pass the number of bytes `fn` will actually materialise, not the file's size:
+ * a 64 KB tail read of a 50 MB file claims 64 KB. Over-claiming is not merely
+ * pessimistic, it makes one cheap read hold the allowance a genuinely large read
+ * needs. Pass 0 for an operation that opens something without reading it whole
+ * (a SQLite query, a first-line read) — it still takes a slot, which is what
+ * bounds the descriptor count.
+ *
+ * See {@link IoBudget.run} for the no-nesting rule, which is load-bearing.
+ */
+export function withIoBudget<T>(bytes: number, fn: () => Promise<T>): Promise<T> {
+	return ioBudget.run(bytes, fn);
+}
+
+/**
+ * Default fan-out width: the budget's own slot count.
+ *
+ * Deliberately not a smaller, "polite" number. A fan-out narrower than the pool
+ * caps a call site below what the pool would give it, and on a real machine most
+ * stores are empty — so the one site with work to do would be throttled while the
+ * pool sat idle. The pool is what enforces the total; the fan-out only has to be
+ * wide enough not to leave it unused.
+ */
+export function defaultConcurrency(): number {
+	return ioBudget.width;
+}
+
+/**
+ * Maps `items` through `fn` with at most `limit` calls in flight, preserving
+ * input order in the result.
+ *
+ * Order preservation is load-bearing rather than cosmetic: callers pair the
+ * result with the input array by index, and a completion-ordered result would
+ * silently mis-pair every entry.
+ *
+ * This shapes the fan-out; it does NOT gate I/O. An `fn` that reads files should
+ * wrap that read in {@link withIoBudget}, which is what keeps the process-wide
+ * total bounded when several call sites fan out at once. A fan-out whose `fn`
+ * skips the budget is unbounded in aggregate no matter what `limit` says.
+ *
+ * `fn` is expected to handle its own failures — a rejection propagates and
+ * abandons the remaining items, which is the right behaviour for a genuine
+ * programming error and the wrong one for "this file happened to be unreadable".
+ * Scanners therefore catch per item and return a sentinel.
+ */
+export async function mapWithConcurrency<T, R>(
+	items: ReadonlyArray<T>,
+	fn: (item: T, index: number) => Promise<R>,
+	limit: number = defaultConcurrency(),
+): Promise<R[]> {
+	const out: R[] = new Array(items.length);
+	let next = 0;
+	const width = Math.max(1, Math.min(limit, items.length));
+	const workers = Array.from({ length: width }, async () => {
+		for (;;) {
+			const index = next++;
+			if (index >= items.length) return;
+			out[index] = await fn(items[index], index);
+		}
+	});
+	await Promise.all(workers);
+	return out;
+}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Context (3)

- [bytebase/dbhub](https://context7.com/bytebase/dbhub)
- Search
- Recall

## Quick recap

The developer rebuilt how the dashboard gathers a week of AI conversation history at startup. Claude conversations are now read straight from the files on disk, lifting their reach from two days to seven and recovering conversations that were previously invisible along with the skill and tool-call activity recorded in them — on one real machine, sixty-four conversations where only three had been reachable. Every assistant's storage is now examined once per launch and then filtered per project, and one assistant whose history had been limited to two days now reaches the full week.

Repeat launches became dramatically cheaper. A conversation the dashboard already has at its latest point is now identified from a small read of the file's end, and the full read and parse are skipped entirely; a conversation that has genuinely continued is still read in full. Reading a conversation's contents now happens once per file, producing its working directories, token counts, tool calls, and title from a single pass.

Startup also became legible. The history pass prints one line stating how far back it looked, how many conversations it read, how many it already had, and which assistants they came from, ordered by how busy each one was. A launch where everything is already current now says so with a zero rather than printing nothing, and one assistant's scanner no longer stalls the others while it works.

---

## Topics (6)
<details>
<summary><strong>01 · Shared file-reading budget replaces per-scanner concurrency constants</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Each part of the history scan had its own hard-coded limit on how many files it would read at once, with no way to see the total. On a machine where conversations sit in only one or two assistants, the busiest scanner could not borrow the unused capacity of the idle ones, and adding more assistants would multiply the limits until the operating system refused to open more files.

**💡 Decisions Behind the Code**

- **One shared pool instead of per-scanner constants**: A single permit pool lets whichever assistant actually has conversations use the full allowance while the ten uninstalled ones consume nothing. Separate constants added up invisibly, and nothing in the code could answer how many files were open at any moment — the failure mode when that limit is crossed is an outright batch failure, not a slowdown.
- **Byte ceiling as a second, independent axis**: Limiting only the count of simultaneous reads left memory unbounded, since each in-flight conversation holds its full text plus parsed structures. Tracking bytes separately means many small files still run wide while one very large conversation automatically narrows the pass to a single read, making peak memory predictable rather than dependent on how long a user's longest conversation happens to be.
- **Pool sized conservatively for the editor extension**: The same scanners are called by the editor sidebar's periodic refresh inside a long-lived host process, not only by a one-shot command. Choosing a value that is safe for the host, rather than one tuned for the command line, avoids a background refresh quietly taking file handles away from the editor.

**✅ What Was Implemented**

- Added `cli/src/util/Concurrency.ts` with two separate primitives: `mapWithConcurrency` for per-call-site fan-out width and `withIoBudget` for a process-wide permit pool (8 permits) plus an independent byte ceiling (64 MB).
- Byte claims are made per read rather than per file, so a 64 KB tail read of a 50 MB transcript claims only 64 KB; a single read larger than the ceiling is clamped so it runs alone instead of starving forever. The queue is strict FIFO so small requests cannot jump ahead of a large one.
- Every disk-touching path was routed through the budget: Claude transcript reads, Antigravity SQLite opens, Codex first-line reads, Kimi state reads, Copilot Chat stats, and the per-session content reads in `DashboardCollector`.

**📋 Future Enhancements**

Non-Claude conversations still have their skill and tool-call data ignored during the history pass; the prerequisites for fixing that (skip-ahead and shared budget) are now in place but the change itself was not made, pending a decision on whether the feature should cover all assistants or only Claude.

**📁 FILES**
- `cli/src/util/Concurrency.ts`
- `cli/src/core/ClaudeSessionDiscoverer.ts`
- `cli/src/core/AntigravitySessionDiscoverer.ts`
- `cli/src/dashboard/DashboardCollector.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Repeat dashboard runs now skip already-recorded conversations before reading them</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Opening the dashboard a second time re-read and re-parsed every conversation from the past week even when nothing had changed, because the "already up to date" check ran only after the expensive read had happened. Repeat runs are the everyday case, so the cost was paid constantly for no benefit.

**💡 Decisions Behind the Code**

- **Minimum across holding repos, not "every registered repo has it"**: The originally proposed rule required all registered repos to already hold a conversation, which can never be true on a multi-project machine since a conversation usually belongs to one project. Taking the oldest recorded instant among the repos that actually hold it keeps the optimization effective while never skipping a repo that is genuinely behind.
- **Skipped conversations are still reported, using the cheap read's directories**: Dropping a skipped conversation entirely would make a converged run report zero conversations found, which reads as breakage. Keeping it with only the directories the cheap read saw risks missing a directory the conversation visited earlier, an acceptable loss because the skip only fires when every affected project is already current and nothing would have been written.
- **Antigravity drops skipped conversations rather than guessing**: Its project path is buried inside the database file, with no cheap way to read it, so a skipped conversation cannot be attributed at all. The only visible effect is a slightly lower count of conversations found for that run, since no records would have changed either way.

**✅ What Was Implemented**

- `ClaudeSessionDiscoverer` now consults an `alreadyRecorded` callback between its cheap tail read and its whole-file read: the conversation id comes from the filename and the instant from the tail, so a converged run pays one 64 KB tail read per conversation instead of a full read plus full parse.
- The same gate was added to `AntigravitySessionDiscoverer` ahead of its per-conversation SQLite open and streaming title read, using the id from the database filename and the timestamp from a file stat.
- `DbBackfill` supplies the callback by taking the minimum recorded instant across every repo holding a row for the conversation, guarded by a per-repo "has completed one session pass" check so a newly registered repo is not starved.

**📁 FILES**
- `cli/src/core/ClaudeSessionDiscoverer.ts`
- `cli/src/core/AntigravitySessionDiscoverer.ts`
- `cli/src/dashboard/DbBackfill.ts`
- `cli/src/core/DiskSessionScan.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · All twelve assistant stores are scanned once instead of once per project</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The history pass walked each assistant's storage separately for every registered project, even though most assistants keep all projects' conversations in one shared location. With several projects registered, the same files were opened and parsed repeatedly, and one assistant's data was still stuck at a two-day reach.

**💡 Decisions Behind the Code**

- **Each source keeps its own attribution rule**: A single shared containment check would have silently widened matching for the sources that deliberately require an exact directory match and would have lost the assistant that matches across multiple linked checkouts. Only the timing of the scan was lifted out; the ownership rules stayed in each source's own file.
- **Duplicate-copy resolution moved ahead of the expensive work**: One assistant keeps the same conversation under several installation variants and picked the newest by consulting a running record while filling it — correct only while strictly sequential. Deciding the winner from the complete set of timestamps first makes the answer independent of which read finishes first, which is what made concurrent scanning safe at all.
- **The per-project registry file is deliberately still read per project**: It genuinely lives inside each project, so there is no duplicated work to remove, and it remains the only route for one assistant's conversations as well as a fallback if the direct Claude scan fails.

**✅ What Was Implemented**

- Every discoverer was split into a machine-wide scan plus a pure in-memory narrowing step, wired through a new shared `DiskSessionScan` helper: Codex, Kimi, OpenCode, Copilot CLI, Copilot Chat, Cline, Cline CLI, Devin, Cursor, Cursor CLI, Antigravity, and the new Claude disk scan.
- `VscodeWorkspaceLocator` gained `listVscodeWorkspaceFolders` so the Copilot Chat editor-storage half could be inverted from "resolve one workspace for this project" into "list every workspace and carry its folder".
- `DbBackfill` performs the twelve scans concurrently ahead of the per-project loop and passes the pre-scanned results down; the Codex scan now receives the seven-day window explicitly rather than inheriting a two-day default.

**📁 FILES**
- `cli/src/dashboard/DbBackfill.ts`
- `cli/src/core/DiskSessionScan.ts`
- `cli/src/core/CopilotChatSessionDiscoverer.ts`
- `cli/src/core/CodexSessionDiscoverer.ts`
- `cli/src/core/VscodeWorkspaceLocator.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Claude conversations read directly from disk for a seven-day history reach</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Claude conversations were only visible through a small per-project record that is physically trimmed to the last two days, so anything older vanished from the dashboard even though the full conversation files remain on disk indefinitely. On one real machine that meant three visible conversations against sixty-four on disk, each carrying skill and tool-call data the dashboard could not see.

**💡 Decisions Behind the Code**

- **Timestamps come from the last conversation turn, not from file modification time**: Modification time runs ahead of the real last turn by up to nearly two days because non-conversational lines keep being appended, which files old conversations under today and inflated a two-day window from thirty-three to forty-four conversations. Reading the precise value costs little and is required anyway in order to store it.
- **Cheap gate plus selective full read, not one uniform pass**: The last-turn time is answerable from the end of a file, but the set of directories a conversation touched is not — a directory recorded only in the middle is invisible to a partial read, and a partial read disagreed with a full read on twenty-four of sixty-four real files. Splitting the two makes total cost scale with recent activity instead of with total history.
- **Not wired into the editor's live sidebar**: The sidebar answers "what am I talking to right now", which the existing small per-project record already answers correctly with a two-day horizon. Adding this would make every periodic refresh walk the entire machine for an answer it already has.

**✅ What Was Implemented**

- Added `cli/src/core/ClaudeSessionDiscoverer.ts`, which walks the whole conversation tree, reads a growing tail slice to find the last real conversation turn as a cheap gate, then reads in-window files whole to collect every working directory they recorded.
- Turn detection calls the real transcript parser rather than an approximation; the shared `aiTitleFromRecord` rule was extracted from the title reader and `parseTranscriptContent` from the transcript reader, so a single whole-file parse now yields directories, tokens, tool calls, and title together.
- `SessionTitleResolver` accepts a three-state title hint where an explicit "checked, there is none" value lets it skip its own streaming pass, and `sessionEventFromInfo` takes prepared content as an optional argument so the commit-time hook and the editor's periodic refresh keep their existing path.

**📋 Future Enhancements**

Conversations from one assistant older than two days remain permanently unrecoverable because it has no direct disk scan; a dedicated scanner would be needed to reach them.

**📁 FILES**
- `cli/src/core/ClaudeSessionDiscoverer.ts`
- `cli/src/core/TranscriptReader.ts`
- `cli/src/core/ClaudeAiTitleReader.ts`
- `cli/src/core/SessionTitleResolver.ts`
- `cli/src/dashboard/DashboardCollector.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Dashboard startup prints a conversation summary line for the history pass</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

On a repeat dashboard launch where nothing needed updating, the part of startup that back-fills a week of conversations produced no output at all. A run that pulled in eighteen previously unreachable conversations looked identical to a run that did nothing.

**💡 Decisions Behind the Code**

- **Both counts stated outright rather than as a fraction**: Reporting "eighteen of twenty-four" invites the reader to subtract, and the difference would be wrong, since a conversation with an unreadable timestamp is neither read nor skipped. The two numbers a reader would act on are printed directly.
- **One sentence shape for every outcome, including zero**: A separate "nothing to do" message would read as a different kind of event; the same sentence with a zero in it reads as the same event with nothing in it, which is what makes a converged run legible instead of invisible.
- **Assistants ordered by volume rather than by name**: With a dozen possible sources, alphabetical order buries the one the user actually works in. Ties fall back to name order so two runs over identical data print an identical line.

**✅ What Was Implemented**

- Added `printSessionSummary` in `DashboardCommand.ts`, printing one line with how far back the window reached, how many conversations were read, how many were skipped, and a per-assistant breakdown merged across projects.
- Assistant counts are sorted busiest-first with alphabetical tie-breaking so the line is stable across runs, and the line is suppressed entirely only when no project reached the conversation stage.

**📁 FILES**
- `cli/src/commands/DashboardCommand.ts`
- `cli/src/dashboard/DbBackfill.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Antigravity scanner switched from blocking to non-blocking file access</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

One assistant's scanner used blocking file operations, two of them inside its per-conversation loop. While it ran, every other scan was frozen, including the widest one, so on a machine with a long history for that assistant the whole concurrent discovery stage effectively became sequential.

**💡 Decisions Behind the Code**

This was the only scanner of the twelve using blocking file access, and the effect was not merely its own slowness — it stalled everyone else's progress at the same time, which is indistinguishable from a slow disk from the outside. Making it non-blocking was treated as required regardless of whether it also gained concurrency, and a rule was recorded that no scanner may reintroduce blocking file access.

**✅ What Was Implemented**

- Replaced the directory listing, per-conversation stat, and transcript existence check in `AntigravitySessionDiscoverer.ts` with their non-blocking equivalents, and restructured the scan into a listing-and-stat phase followed by a concurrent expensive phase.
- The "first failure" report is now picked from the order-preserving results rather than assigned inside a callback, since completion order no longer matches input order.

**📁 FILES**
- `cli/src/core/AntigravitySessionDiscoverer.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 13, 2026 at 9:15 PM · via Local agent - Claude Code*
<!-- jollimemory-summary-end -->