### PR TITLE
Exclude commits already on a remote from the pre-push sync list

### DIFF
--- a/cli/src/hooks/PrePushHook.test.ts
+++ b/cli/src/hooks/PrePushHook.test.ts
@@ -450,10 +450,15 @@ describe("prePushEntry", () => {
 		expect(args).toEqual(["rev-list", "--reverse", LOCAL, "--not", "--remotes"]);
 	});
 
-	it("uses the remote..local range for an existing remote branch", async () => {
+	it("excludes commits already on a remote from the remote..local range", async () => {
+		// The range alone is not "what this push introduces": a rebased branch
+		// absorbs commits from its updated base that its own remote tip predates,
+		// and git transfers none of them. Without --not --remotes they are enqueued
+		// and reported as "memory still generating" forever — no memory for another
+		// author's commit is ever generated on this machine.
 		await prePushEntry(CWD, `refs/heads/x ${LOCAL} refs/heads/x ${REMOTE}\n`, REMOTE_NAME);
 		const args = vi.mocked(execFileAsyncHidden).mock.calls[0][1];
-		expect(args).toEqual(["rev-list", "--reverse", `${REMOTE}..${LOCAL}`]);
+		expect(args).toEqual(["rev-list", "--reverse", `${REMOTE}..${LOCAL}`, "--not", "--remotes"]);
 	});
 
 	it("no-ops when rev-list yields no commits", async () => {

--- a/cli/src/hooks/PrePushHook.ts
+++ b/cli/src/hooks/PrePushHook.ts
@@ -107,16 +107,34 @@ function branchFromRef(ref: string): string {
 }
 
 /**
- * Lists the commits this ref update introduces, oldest-first. For a brand-new
- * remote branch (`remote-sha` all-zero) there is no remote tip to diff against,
- * so we take everything reachable from the local tip that isn't already on any
- * remote (`--not --remotes`) — otherwise `rev-list <zero>..<local>` would error.
+ * Lists the commits this ref update introduces, oldest-first.
+ *
+ * BOTH arms end in `--not --remotes`, and that exclusion is load-bearing on the
+ * ranged one too. Git hands this hook the old tip of ONE ref; it does not hand it
+ * the set of objects the push will actually transfer, which git works out
+ * afterwards by negotiating against EVERY ref the remote advertises. The two
+ * answers diverge sharply after a rebase, because a rebased branch absorbs
+ * commits that its own remote tip predates: measured on a real force-push,
+ * `<remote-sha>..<local-sha>` reported 12 commits, 11 of which were already on
+ * `origin/main` and authored by other people. Git transferred none of those 11 —
+ * but each was enqueued into push-pending.json, and since a memory is generated
+ * on the machine that made the commit (the summaries branch is local-only, never
+ * fetched), none of them can ever gain one here. They rendered as "memory still
+ * generating — will sync later" on every subsequent push until they aged out.
+ *
+ * Dropping them cannot lose a memory: a commit reachable from a remote ref was
+ * already carried by whichever push put it there. A stale remote-tracking ref
+ * only makes this over-report, which is the pre-existing behaviour.
+ *
+ * The zero-remote-sha arm (a brand-new remote branch) has no tip to diff against
+ * and leans on the same exclusion for its whole answer — `rev-list <zero>..<local>`
+ * would error.
  */
 async function listCommitsForRef(cwd: string, ref: PushRef): Promise<string[]> {
 	const args =
 		ref.remoteSha === ZERO_SHA
 			? ["rev-list", "--reverse", ref.localSha, "--not", "--remotes"]
-			: ["rev-list", "--reverse", `${ref.remoteSha}..${ref.localSha}`];
+			: ["rev-list", "--reverse", `${ref.remoteSha}..${ref.localSha}`, "--not", "--remotes"];
 	try {
 		const { stdout } = await execFileAsyncHidden("git", args, { cwd });
 		return stdout


### PR DESCRIPTION
## Problem

The pre-push hook asks git for the old tip of the ref being pushed and treats `<remote-sha>..<local-sha>` as "what this push introduces". That is not the question git answers when it works out the object set to transfer — git does that afterwards, negotiating against **every** ref the remote advertises.

The two diverge after a rebase, because a rebased branch absorbs commits from its updated base that its own remote tip predates.

Measured on a real force-push of a **one-commit** branch:

```
jollimemory: push to Jolli Space
  … dbd1659d Update specs for the 542c8804..f184549f delta   memory still generating — will sync later
  … e94d5cbc Update specs for the f184549f..3d45b46b delta   memory still generating — will sync later
  … 730c2731 Add Knowledge and Graph dashboard views…        memory still generating — will sync later
  …                        (8 more)
  … 7c63b4da Global CLI daemon…                              syncing in the background
```

12 commits reported; 11 already on `origin/main` and authored by other people. Git transferred none of those 11.

Two consequences, both user-visible:

- Every one was enqueued into `push-pending.json` and retried on each later push.
- A memory is only ever generated on the machine that made the commit — the summaries branch is local-only and never fetched — so those 11 can never gain one here. They were reported as **"memory still generating — will sync later"**, a promise nothing could keep, until they aged out after seven days.

## Fix

Append `--not --remotes` to the ranged arm of `listCommitsForRef`. The zero-remote-sha arm (brand-new remote branch) already carried it; this brings the two into line and matches how git itself scopes the push.

Dropping a commit reachable from a remote ref cannot lose a memory: whichever push put it there already carried it. A stale remote-tracking ref only makes this over-report, which is the pre-existing behaviour.

## Verification

Reproduced against real git in a throwaway repo — branch pushed, `main` advanced by 3 commits, branch rebased, force-pushed:

| Scenario | Before | After |
|---|---|---|
| Force-push after rebase | 4 reported (3 other authors' + 1 mine) | **1** (mine only) |
| Plain fast-forward push of 2 new commits | 2 | 2 (unchanged) |
| Brand-new branch (zero remote sha) | 3 | 3 (unchanged) |

`lint`, `typecheck` and `build` pass; the built `dist/PrePushHook.js` carries the flags on both arms. The one test asserting the old argv was updated.

No Kotlin mirror exists for this logic — IntelliJ installs the hook but dispatches to this same CLI code, so this is a single-site fix.

## Out of scope

The wording bug this exposed is left for a separate change: `PushExecutor` has a single "no summary found" bucket and labels it `generating` regardless of cause, so a commit this machine will never generate a memory for is still described as "still generating — will sync later". This PR stops those commits from entering the list in the rebase case; it does not fix the label.