### PR TITLE
Slim standup to committed work and drop step progress chip

### DIFF
--- a/cli/src/dashboard/DashboardModel.ts
+++ b/cli/src/dashboard/DashboardModel.ts
@@ -1182,14 +1182,28 @@ export interface StandupModel {
 	/** Local `YYYY-MM-DD` the board was built for. */
 	readonly today: string;
 	readonly yesterday: string;
+	/**
+	 * NOT RENDERED, and absence from the page is not an oversight. Both day columns
+	 * are commits only: Today states what was COMPLETED today (JOLLI-2201), and the
+	 * columns are required to list the same rows the stats page's Memory Activity
+	 * card lists for the same day — which is commits and nothing else. A session is
+	 * not a commit, and a live session or an uncommitted worktree is work in flight
+	 * besides.
+	 *
+	 * All three are still queried: they are the only local record of "in progress",
+	 * and the column that wants them has not been designed yet. But a renderer
+	 * putting any of them back into a day column re-opens the ticket.
+	 */
 	readonly yesterdaySessions: ReadonlyArray<RecentSession>;
 	readonly yesterdayCommits: ReadonlyArray<StandupCommit>;
+	/** Not rendered — see {@link StandupModel.yesterdaySessions}. */
 	readonly todaySessions: ReadonlyArray<RecentSession>;
 	readonly todayCommits: ReadonlyArray<StandupCommit>;
+	/** Uncommitted work. Not rendered — see {@link StandupModel.yesterdaySessions}. */
 	readonly workspaces: ReadonlyArray<StandupWorkspace>;
 	/**
-	 * The git identity the commit columns and Risks were filtered to (an email,
-	 * or a name when only that is configured). ABSENT means the filter did not
+	 * The git identity the commit columns were filtered to (an email, or a name
+	 * when only that is configured). ABSENT means the filter did not
 	 * run and the board is showing every author's work — the page states which
 	 * of the two it is, because an unfiltered standup is a draft the user would
 	 * otherwise post as their own. See `authorFilter` in `DashboardQuery.ts`.
@@ -1197,8 +1211,14 @@ export interface StandupModel {
 	readonly authoredBy?: string;
 	/**
 	 * Risks/blockers/questions/TODOs mined from the window's commit memories.
-	 * Present (possibly empty) from the memory tier onwards; absent renders the
-	 * locked card.
+	 * Present (possibly empty) from the memory tier onwards.
+	 *
+	 * NOT RENDERED either, and now for two reasons at once. `todo` is unrouted for
+	 * the reason above and `decision` belongs to the Decisions card; the other
+	 * three had a column of their own until it was removed, because nothing can
+	 * produce them (see {@link CommitInsightKind}). What the field still does is
+	 * carry the memory tier: its mere PRESENCE is what `renderStandup` reads to
+	 * decide how many fields a commit row may show.
 	 */
 	readonly insights?: ReadonlyArray<StandupInsight>;
 }
@@ -1512,13 +1532,24 @@ export interface GraphVersion {
 }
 
 /**
- * Data honesty flags surfaced in the UI footer. Session-level activity older
- * than the live-log window comes only from stored summaries, so an empty
- * stretch of heatmap can mean "not recorded" rather than "not working" — the
- * page says so instead of letting the reader assume.
+ * Data honesty flags surfaced in the UI footer.
+ *
+ * One kind left, and the one that went is worth knowing about. `sessions-window`
+ * said "older activity is reconstructed from commits and stored summaries;
+ * recent sessions are exact" — a caveat about how the timeline is BUILT, printed
+ * under every stats and standup render whether or not the reader was near the
+ * boundary it describes. It was removed as permanent furniture: a line that is
+ * always there is read once and then not at all, so it bought no honesty while
+ * costing a footer on every page. The reconstruction it warned about has not
+ * changed; if that distinction needs stating again, state it where a reader can
+ * act on it (on the affected buckets) rather than under the whole page.
+ *
+ * `no-data` survives because it is not furniture — it appears only on an empty
+ * database, says what will fill it, and disappears for good after the first
+ * session.
  */
 export interface CoverageNote {
-	readonly kind: "sessions-window" | "no-data";
+	readonly kind: "no-data";
 	readonly message: string;
 }
 

--- a/cli/src/dashboard/DashboardQuery.test.ts
+++ b/cli/src/dashboard/DashboardQuery.test.ts
@@ -737,14 +737,17 @@ describe("buildDashboardModel", () => {
 			],
 			{ producerKind: "cli", dbPath },
 		);
+		// One session is enough to retire the note for good: it is a first-run hint,
+		// not a running caveat. The "older activity is reconstructed" line that used
+		// to take its place here was removed as permanent page furniture.
 		const seeded = await withDashboardDb(
 			(db) => buildDashboardModel(db, { view: "stats", scope: { kind: "all" }, timeZone: "UTC", nowMs }),
 			{ dbPath },
 		);
-		expect(seeded.coverage.map((c) => c.kind)).toEqual(["sessions-window"]);
+		expect(seeded.coverage).toEqual([]);
 	});
 
-	it("keeps the session caveats off views that show no session activity", async () => {
+	it("carries no footer note on any view once there is data", async () => {
 		await seed();
 		const notesFor = async (view: "stats" | "standup" | "memories" | "settings") =>
 			(
@@ -754,14 +757,31 @@ describe("buildDashboardModel", () => {
 				)
 			).coverage.map((c) => c.kind);
 
-		// The activity views carry the caveat about how their timeline is built.
-		expect(await notesFor("stats")).toEqual(["sessions-window"]);
-		expect(await notesFor("standup")).toEqual(["sessions-window"]);
-		// Memories renders stored summaries, not a session timeline, so a note about
-		// how session history is reconstructed qualifies nothing there — and with the
-		// import note gone it now carries no coverage note at all.
+		// `seed()` writes sessions, so the one surviving note (the empty-database
+		// first-run hint) does not apply, and nothing replaces it. Stats and standup
+		// both used to print "older activity is reconstructed from commits and stored
+		// summaries" here — removed from both as permanent page furniture, which is
+		// what this case now pins: the footer is empty unless the DB is.
+		expect(await notesFor("stats")).toEqual([]);
+		expect(await notesFor("standup")).toEqual([]);
 		expect(await notesFor("memories")).toEqual([]);
 		expect(await notesFor("settings")).toEqual([]);
+	});
+
+	it("keeps the empty-database hint on stats alone", async () => {
+		// Nothing seeded: the one state the footer still speaks in. It is scoped to
+		// stats because that view's cards are all session-derived — the standup
+		// board is commits-only and says "Nothing recorded." inside each column.
+		const notesFor = async (view: "stats" | "standup") =>
+			(
+				await withDashboardDb(
+					(db) => buildDashboardModel(db, { view, scope: { kind: "all" }, timeZone: "UTC", nowMs }),
+					{ dbPath },
+				)
+			).coverage.map((c) => c.kind);
+
+		expect(await notesFor("stats")).toEqual(["no-data"]);
+		expect(await notesFor("standup")).toEqual([]);
 	});
 
 	describe("custom range", () => {

--- a/cli/src/dashboard/DashboardQuery.ts
+++ b/cli/src/dashboard/DashboardQuery.ts
@@ -2056,11 +2056,23 @@ export function buildDashboardModel(db: DashboardDbHandle, opts: QueryOptions): 
 		...(r.disabled_at != null ? { disabled: true as const } : {}),
 	}));
 
-	// Coverage notes are per VIEW, not global. A caveat is only honest next to
-	// the data it qualifies: "older activity is reconstructed from commits and
-	// stored summaries" describes the session/commit activity timeline, and on the
-	// graph page — which renders a distilled artifact and no activity at all —
-	// it is a statement about something the reader is not looking at.
+	// The footer carries ONE note now, and only when the database is empty.
+	//
+	// The caveat that used to sit under every stats and standup render — "older
+	// activity is reconstructed from commits and stored summaries; recent sessions
+	// are exact" — is gone from both. It was true, and it was permanent: printed
+	// on every load regardless of whether the reader was anywhere near the window
+	// boundary it describes, which is the shape a reader stops seeing. Nothing
+	// about the reconstruction changed; only the decision to state it as page
+	// furniture did. See `CoverageNote` before re-adding one.
+	//
+	// `no-data` is kept for the opposite reason: it appears only on a database
+	// with no sessions at all, says what will fill it, and never comes back once
+	// one lands. It is scoped to STATS because that is the view whose cards are
+	// all session-derived and therefore all empty in that state. The standup board
+	// is commits-only (JOLLI-2200 / 2201), so it is fully populated with zero
+	// sessions, and the empty state each of its columns can really be in is
+	// already stated inside the column ("Nothing recorded.").
 	//
 	// There is deliberately NO in-progress import note. It used to be the one note
 	// that spanned every view, sitting at the foot of all four pages for the whole
@@ -2069,19 +2081,15 @@ export function buildDashboardModel(db: DashboardDbHandle, opts: QueryOptions): 
 	// numbers filling in as the import runs is the behaviour, and it needs no
 	// footnote on every page to be understood.
 	const coverage: CoverageNote[] = [];
-	const showsActivity = options.view === "stats" || options.view === "standup";
-	if (showsActivity) {
+	if (options.view === "stats") {
 		const sessionCount =
 			(db.prepare("SELECT COUNT(*) AS n FROM sessions").get() as { n: number } | undefined)?.n ?? 0;
-		coverage.push(
-			sessionCount === 0
-				? { kind: "no-data", message: "No sessions recorded yet — data appears after your next AI session." }
-				: {
-						kind: "sessions-window",
-						message:
-							"Older activity is reconstructed from commits and stored summaries; recent sessions are exact.",
-					},
-		);
+		if (sessionCount === 0) {
+			coverage.push({
+				kind: "no-data",
+				message: "No sessions recorded yet — data appears after your next AI session.",
+			});
+		}
 	}
 
 	const tier = detectTier(db);

--- a/cli/src/dashboard/StandupAsset.test.ts
+++ b/cli/src/dashboard/StandupAsset.test.ts
@@ -5,11 +5,15 @@
  * served verbatim, so tsc never sees it and a model field read under the wrong
  * name renders "undefined" in the browser with no compile-time signal.
  *
- * What it pins here is the author-filter disclosure. The board's columns feed a
- * Copy-as-standup draft the user posts as their own work, so "filtered to you"
- * and "could not tell who you are, showing everyone" must be distinguishable ON
- * THE PAGE — a silent unfiltered board is how a teammate's commit ends up in
- * someone else's standup.
+ * What it pins here is the author-filter disclosure, plus the three shape rules
+ * the columns were trimmed to (JOLLI-2198 / 2200 / 2201).
+ *
+ * The disclosure is the load-bearing one: the board is what a user reads their
+ * standup off, so "filtered to you" and "could not tell who you are, showing
+ * everyone" must be distinguishable ON THE PAGE — a silent unfiltered board is
+ * how a teammate's commit ends up in someone else's standup. That mattered when
+ * the page still drafted markdown for the clipboard, and it did not stop
+ * mattering when the draft sheet was removed; the reading is now the paste.
  */
 
 import { readFileSync } from "node:fs";
@@ -17,7 +21,6 @@ import { describe, expect, it } from "vitest";
 
 interface JDNamespace {
 	renderStandup: (model: unknown) => void;
-	standupMarkdown: (model: unknown) => string;
 }
 
 interface FakeElement {
@@ -122,22 +125,176 @@ describe("standup author disclosure", () => {
 		expect(element("app").innerHTML).toContain("every author");
 		expect(element("app").innerHTML).not.toContain("yours only");
 	});
+});
 
-	it("warns in the draft sheet before an unfiltered standup is copied", () => {
-		const { JD, element } = loadJD();
-		JD.renderStandup(model());
-		element("copyStandup").onclick?.();
-		// The warning outranks the tier note: what you are about to paste matters
-		// more than which layer the lines came from.
-		expect(element("sheetSub").textContent).toContain("Every author's commits");
-		expect(element("mdOut").value).toContain("feat: my work");
-	});
-
-	it("keeps the memory-tier note once the board IS filtered", () => {
+describe("standup column shape", () => {
+	// JOLLI-2198. The button was the draft sheet's only trigger, so its removal
+	// is also the sheet's: a page that still built the markdown behind an element
+	// nothing can click is dead weight the next reader has to disprove.
+	it("offers no copy-as-standup affordance", () => {
 		const { JD, element } = loadJD();
 		JD.renderStandup(model({ authoredBy: "me@example.com" }));
-		element("copyStandup").onclick?.();
-		expect(element("sheetSub").textContent).toContain("From your commit memories");
+		const html = element("app").innerHTML;
+		expect(html).not.toContain("copyStandup");
+		expect(html).not.toContain("share-note");
+		expect(html).not.toContain("Copy as standup");
+	});
+
+	// JOLLI-2201. A TODO is work that has NOT happened; the column states what
+	// landed today, so an unfinished item in it is a claim the board cannot make.
+	it("keeps TODOs out of Today and counts today's commits instead", () => {
+		const { JD, element } = loadJD();
+		JD.renderStandup(
+			model({
+				todayCommits: [
+					{
+						hash: "0f0f0f0abc",
+						message: "fix: today's landing",
+						committedAtMs: nowMs - 3_600_000,
+						repoName: "jolliai",
+						branch: "main",
+					},
+				],
+				insights: [
+					{
+						kind: "todo",
+						text: "wire the retry path",
+						commitHash: "abc1234def",
+						repoName: "jolliai",
+						committedAtMs: nowMs - 26 * 3_600_000,
+					},
+				],
+			}),
+		);
+		const html = element("app").innerHTML;
+		expect(html).toContain("fix: today&#39;s landing");
+		expect(html).not.toContain("wire the retry path");
+		expect(html).not.toContain("TODO");
+	});
+
+	// Yesterday is commits-only too, at BOTH tiers. Below the memory tier it used
+	// to carry the raw session trail; Memory Activity never lists a session, and
+	// the two are required to agree.
+	it("keeps session rows out of Yesterday at the raw tier", () => {
+		const { JD, element } = loadJD();
+		JD.renderStandup(
+			model({
+				insights: undefined,
+				yesterdaySessions: [
+					{
+						title: "an agent run",
+						source: "claude",
+						messageCount: 40,
+						updatedAtMs: nowMs - 26 * 3_600_000,
+						repoName: "jolliai",
+						isLive: false,
+					},
+				],
+			}),
+		);
+		const html = element("app").innerHTML;
+		expect(html).toContain("feat: my work");
+		expect(html).not.toContain("an agent run");
+		expect(html).toContain("· 1 commit");
+	});
+
+	// Memory Activity's grouping IS the day; here the day is already the column, so
+	// a second axis inside one makes two identical lists read as different ones.
+	it("renders both day columns flat, with no group headers", () => {
+		const { JD, element } = loadJD();
+		JD.renderStandup(model({ authoredBy: "me@example.com" }));
+		expect(element("app").innerHTML).not.toContain("ghead");
+	});
+
+	// The heading and its count already say what the column holds. An EMPTY `.sub`
+	// is not the same as none — it carries a bottom margin, so it would hold the
+	// caption's gap open.
+	it("gives the day columns no caption, and no empty caption element", () => {
+		const { JD, element } = loadJD();
+		JD.renderStandup(model({ authoredBy: "me@example.com" }));
+		const html = element("app").innerHTML;
+		expect(html).not.toContain("Memory Activity lists");
+		expect(html).not.toContain('<div class="sub"></div>');
+	});
+
+	// The four fields Memory Activity's row carries, in its order.
+	it("carries Memory Activity's field set on a memory-tier row", () => {
+		const { JD, element } = loadJD();
+		JD.renderStandup(
+			model({
+				yesterdayCommits: [
+					{
+						hash: "abc1234def",
+						message: "feat: my work",
+						committedAtMs: nowMs - 26 * 3_600_000,
+						repoName: "jolliai",
+						branch: "main",
+						turns: 12,
+						workCategory: "bugfix",
+						estCostUsd: 2.29,
+						insertions: 58,
+						deletions: 11,
+					},
+				],
+			}),
+		);
+		const html = element("app").innerHTML;
+		expect(html).toContain("mem-activity-category");
+		expect(html).toContain("bugfix");
+		expect(html).toContain("12 turns");
+		expect(html).toContain("main");
+		expect(html).toContain("jolliai");
+		// Dropped in favour of Memory Activity's set — the card shows neither. Both
+		// negations name a value, not a unit: a bare "est" or "+" is a substring of
+		// too much surrounding markup to mean anything.
+		expect(html).not.toContain("2.29");
+		expect(html).not.toContain("+58");
+	});
+
+	// Same rule for the two other non-completed sources the column used to carry.
+	it("keeps live sessions and uncommitted work out of Today", () => {
+		const { JD, element } = loadJD();
+		JD.renderStandup(
+			model({
+				todaySessions: [
+					{
+						title: "still going",
+						source: "claude",
+						messageCount: 12,
+						updatedAtMs: nowMs - 60_000,
+						repoName: "jolliai",
+						isLive: true,
+					},
+				],
+				workspaces: [{ repoName: "jolliai", branch: "main", filesChanged: 3, insertions: 40, deletions: 2 }],
+			}),
+		);
+		const html = element("app").innerHTML;
+		expect(html).not.toContain("still going");
+		expect(html).not.toContain("Uncommitted on");
+		expect(html).toContain("Nothing yet.");
+	});
+
+	// JOLLI-2200. Titles only — the decision text belongs to the Decisions card.
+	it("renders Yesterday outcomes without their decision detail", () => {
+		const { JD, element } = loadJD();
+		JD.renderStandup(
+			model({
+				insights: [
+					{
+						kind: "decision",
+						text: "chose the lock-free path",
+						commitHash: "abc1234def",
+						repoName: "jolliai",
+						committedAtMs: nowMs - 26 * 3_600_000,
+					},
+				],
+			}),
+		);
+		const html = element("app").innerHTML;
+		expect(html).toContain("feat: my work");
+		expect(html).not.toContain("chose the lock-free path");
+		expect(html).not.toContain("<b>Decision:</b>");
 	});
 });
 
@@ -150,6 +307,10 @@ describe("standup author disclosure", () => {
  * These cases feed the renderer insights of every kind anyway, including the
  * three it can never really receive: if a filter for them is ever re-added, the
  * column reappears here rather than in a user's browser.
+ *
+ * The same payload also pins the OTHER reason no kind is routed any more: not
+ * one of the five reaches the page, `todo` included (JOLLI-2201). The cases
+ * above state that per column; this block states it against every kind at once.
  */
 describe("standup columns", () => {
 	const everyKind = [
@@ -188,7 +349,7 @@ describe("standup columns", () => {
 		expect(html).not.toContain("Blockers");
 	});
 
-	it("renders no risk rows even when the payload carries those kinds", () => {
+	it("renders no insight row of any kind, risk or otherwise", () => {
 		const { JD, element } = loadJD();
 		JD.renderStandup(model({ insights: everyKind }));
 		const html = element("app").innerHTML;
@@ -197,23 +358,15 @@ describe("standup columns", () => {
 		expect(html).not.toContain("status is lossy");
 		expect(html).not.toContain("kind-blocker");
 		expect(html).not.toContain("tag age");
-		// TODOs stay — they are Today's work, not a risk.
-		expect(html).toContain("TODO: drop the shim");
+		// The two producible kinds are just as unrouted: a TODO is not work that
+		// landed (JOLLI-2201), and a decision belongs to the Decisions card.
+		expect(html).not.toContain("drop the shim");
+		expect(html).not.toContain("chose the lock");
 	});
 
 	it("shows the locked upsell for neither column below the memory tier", () => {
 		const { JD, element } = loadJD();
 		JD.renderStandup(model({ insights: undefined }));
 		expect(element("app").innerHTML).not.toContain("locked-panel");
-	});
-
-	it("drafts no risks section in the copied markdown", () => {
-		const { JD } = loadJD();
-		const md = JD.standupMarkdown(model({ insights: everyKind }));
-		expect(md).toContain("**Yesterday**");
-		expect(md).toContain("**Today**");
-		expect(md).toContain("- TODO: drop the shim");
-		expect(md).not.toContain("Risks");
-		expect(md).not.toContain("waiting on infra");
 	});
 });

--- a/cli/src/dashboard/assets/index.html
+++ b/cli/src/dashboard/assets/index.html
@@ -76,32 +76,19 @@
 	</div>
 
 	<!--
-	  Two page-level layers, both `position: fixed`: a tooltip (positioned by
-	  JD.showTip) and the standup draft sheet. They sit OUTSIDE `.main` so a hover or
-	  a dialog near the edge of a scrolled card is not clipped by that card, but
+	  Page-level layers, all `position: fixed`: the tooltip (positioned by
+	  JD.showTip) and the overlays below. They sit OUTSIDE `.main` so a hover or a
+	  dialog near the edge of a scrolled card is not clipped by that card, but
 	  INSIDE `.jd` — that is the element carrying the colour tokens, and a layer
 	  outside it renders with every `var(--surface)` / `var(--border)` unresolved,
 	  i.e. as unstyled text on a transparent background.
 
-	  The sheet's textarea is EDITABLE on purpose and is this page's actual product:
-	  the mockup's whole claim for the standup view is "everyone edits before it
-	  posts", so the draft has to be visible and correctable, not just written to the
-	  clipboard behind a click.
+	  A third layer used to live here: the standup draft sheet (`#ovStandup`), an
+	  editable textarea holding markdown assembled by `JD.standupMarkdown`. It went
+	  with the Copy-as-standup button that was its only trigger (JOLLI-2198) — the
+	  standup board is read off the page now, not pasted from it.
 	-->
 	<div class="tip" id="tip"></div>
-	<div class="overlay" id="ovStandup" role="dialog" aria-modal="true" aria-labelledby="sheetTitle">
-		<div class="sheet">
-			<h3 id="sheetTitle">Your standup, drafted</h3>
-			<div class="sub" id="sheetSub"></div>
-			<textarea id="mdOut" spellcheck="false" aria-label="Standup markdown"></textarea>
-			<div class="row">
-				<button class="cta" type="button" id="copyMd">Copy markdown</button>
-				<span class="toast" id="mdToast" role="status">Copied ✓</span>
-				<div class="spacer"></div>
-				<button class="cta ghost" type="button" id="closeOv">Close</button>
-			</div>
-		</div>
-	</div>
 	<!--
 	  The Memories page's Context viewer. Same layer rules as the sheet above.
 	  Its body is a read-only <pre>, filled with textContent — the document is

--- a/cli/src/dashboard/assets/js/shell.js
+++ b/cli/src/dashboard/assets/js/shell.js
@@ -719,9 +719,11 @@ window.JD = window.JD || {};
 		   containing & < > " as the literal &amp; / &lt; / &quot;. */
 		var coverageNote = document.getElementById("coverageNote");
 		coverageNote.textContent = (model.coverage || []).map((note) => note.message).join(" · ");
-		/* Hidden when there is nothing to say. `.footer-note` carries `margin: 18px
-		   auto 0` plus padding, so an empty div still pushed dead space under the
-		   grid — visible on Repositories and Memories, which now carry no note. */
+		/* Hidden when there is nothing to say, which is now the NORMAL case on every
+		   page: the only surviving note is the empty-database hint on stats. That
+		   makes the branch load-bearing rather than defensive — `.footer-note`
+		   carries `margin: 18px auto 0` plus padding, so an empty div would push
+		   dead space under the grid on essentially every render. */
 		coverageNote.hidden = coverageNote.textContent.length === 0;
 	};
 
@@ -795,21 +797,20 @@ window.JD = window.JD || {};
 	};
 
 	/* Leading glyph per row kind. Shared rather than per-page: the standup board
-	   and Memories' detail pane both render commit/session/insight rows, and one
-	   kind reading as two different marks depending on the page is the drift
-	   worth preventing. The first three keys have no insight equivalent — they
-	   are standup-only row types.
+	   and Memories' detail pane both render commit rows, and one kind reading as
+	   two different marks depending on the page is the drift worth preventing.
 
-	   `blocker`/`question`/`gotcha` used to have entries here, for the standup's
-	   Risks column. They went with it: those three insight kinds are never
-	   produced (see the note at the top of standup.js), so the marks could not be
-	   reached from anywhere. */
+	   Down to one key, by one rule applied twice. `blocker`/`question`/`gotcha`
+	   went with the standup's Risks column — those insight kinds are never
+	   produced (see the note at the top of standup.js). `session`/`workspace`/
+	   `todo`/`decision` went with the rows that drew them: both day columns are
+	   commits only now (JOLLI-2200 / 2201), and nothing else ever asked for a
+	   mark. Sessions, workspaces and TODOs are all still QUERIED — see
+	   `StandupModel.yesterdaySessions` — so re-add a key here when the column
+	   that wants them is designed, rather than treating this list as the record
+	   of what the model carries. */
 	JD.glyph = {
 		commit: '<span class="glyph commit">◆</span>',
-		session: '<span class="glyph done">✓</span>',
-		workspace: '<span class="glyph next">▸</span>',
-		todo: '<span class="glyph todo">□</span>',
-		decision: '<span class="glyph done">★</span>',
 	};
 
 	/* Session row shared by both pages. */
@@ -849,6 +850,24 @@ window.JD = window.JD || {};
 	JD.sourceIndex = (source) => {
 		var index = SOURCE_ORDER.indexOf(String(source).split("-")[0]);
 		return index >= 0 ? index : SOURCE_ORDER.length;
+	};
+
+	/* Category → colour, shared because TWO pages paint the same category chip:
+	   the stats page's Memory Activity rows and the standup board's columns, which
+	   are required to show the same commits with the same labels. It lives here
+	   rather than in either page for the reason `SOURCE_ORDER` does — a second copy
+	   of the order is a second answer to "what colour is `bugfix`", and the pages
+	   would drift the first time someone appended a category to one of them.
+
+	   A fixed order rather than a hash: the colour for a category must not move
+	   when the SET of categories changes. `s1`..`s4` follow the mockup's own
+	   pairing (feature→s1, bugfix→s2, refactor→s3, docs→s5); the rest are
+	   categories the summarizer actually emits. Anything unlisted lands on the
+	   last slot. */
+	var CATEGORY_ORDER = ["feature", "bugfix", "refactor", "tech-debt", "docs", "ux", "performance", "devops"];
+	JD.categoryColor = (category) => {
+		var index = CATEGORY_ORDER.indexOf(category);
+		return JD.seriesColor(index >= 0 ? index : CATEGORY_ORDER.length);
 	};
 
 	/* The `/api/model` URL for the params the page was rendered with. */

--- a/cli/src/dashboard/assets/js/standup.js
+++ b/cli/src/dashboard/assets/js/standup.js
@@ -5,161 +5,95 @@ window.JD = window.JD || {};
 	   corpus; see JD.glyph in shell.js. */
 	var GLYPH = JD.glyph;
 
-	/* A TODO is what you are going to do next, so it belongs in Today.
-	   The board used to carry a third column — Risks · Blockers · Questions —
-	   filtering for the `blocker`/`question`/`gotcha` kinds. It was removed
-	   because those kinds can never exist: `TOPIC_INSIGHTS_CTE` in
-	   DashboardQuery.ts derives insights from each memory topic's own
-	   `decisions`/`todo` text, so `decision` and `todo` are the only kinds the
-	   payload can ever hold (DashboardCollector.ts says so outright, and calls it
-	   deliberate — a blocker is not guessed from prose). The column therefore
-	   always rendered "Nothing flagged in this window." at the memory tier and an
-	   upsell for a feature that would not fill it below.
+	/* No insight kind is routed into this page any more, for two independent
+	   reasons that landed together.
 
-	   Reinstating it means teaching the SUMMARIZER to record those kinds first;
-	   a filter on its own has nothing to select. */
-	var TODAY_KINDS = ["todo"];
+	   `todo` is unrouted because Today states what LANDED today, and a TODO is by
+	   definition work that has not happened — putting one there made the column
+	   assert something the board cannot know (JOLLI-2201). `decision` is unrouted
+	   because the Decisions card owns it.
 
-	/* ---- rows -------------------------------------------------------------- */
+	   The third column — Risks · Blockers · Questions — is gone because its kinds
+	   can never exist: `TOPIC_INSIGHTS_CTE` in DashboardQuery.ts derives insights
+	   from each memory topic's own `decisions`/`todo` text, so `decision` and
+	   `todo` are the only kinds the payload can ever hold (DashboardCollector.ts
+	   says so outright, and calls it deliberate — a blocker is not guessed from
+	   prose). The column therefore always rendered "Nothing flagged in this
+	   window." at the memory tier and an upsell for a feature that would not fill
+	   it below. Reinstating it means teaching the SUMMARIZER to record those kinds
+	   first; a filter on its own has nothing to select.
 
-	function itemRow(glyph, title, metas, when, note, mono) {
+	   `standup.insights` survives only as the memory-tier flag — see `memory` in
+	   renderStandup. */
+
+	/* ---- rows ---------------------------------------------------------------
+
+	   ONE row shape for both day columns, and it is the stats page's Memory Activity
+	   row restated in this page's markup. The two surfaces answer the same question
+	   for the same day out of the same commits, so a reader comparing them must not
+	   have to work out whether a difference in wording is a difference in data.
+
+	   They are NOT the same query, and the gap is worth knowing: Memory Activity
+	   lists `memories` rows for the window with no author filter, while these
+	   columns list author-filtered `commits`. On a normal machine the two coincide,
+	   because a memory only exists for a commit this machine summarized — measured
+	   18 = 18, fully overlapping, over a two-day window with seven distinct commit
+	   authors in the table. They come apart in two directions: a commit of yours
+	   that never got a memory shows HERE only, and a teammate's commit that somehow
+	   did shows THERE only. Keeping the author filter is deliberate — the board is
+	   read out as your own work — so treat the alignment as "same fields, same
+	   labels", not as an invariant that the two lists are equal. */
+
+	function commitRow(commit, model, memory) {
 		var esc = JD.esc;
-		var html =
-			'<div class="item"><div class="r1">' +
-			glyph +
-			'<span class="t' +
-			(mono ? " mono" : "") +
-			'">' +
-			esc(title) +
-			"</span>" +
-			(when ? '<span class="when">' + esc(when) + "</span>" : "") +
-			"</div>";
-		if (note) html += '<div class="note">' + note + "</div>";
-		if (metas && metas.length > 0) {
-			html += '<div class="meta">';
-			metas.forEach((meta) => {
-				html += '<span class="tag">' + esc(meta) + "</span>";
-			});
-			html += "</div>";
+		var metas = "";
+		/* Same four fields Memory Activity's row carries, in its order: category,
+		   turns, branch, repo. The category chip takes its colour from the shared
+		   JD.categoryColor, so `bugfix` cannot be one colour here and another there. */
+		if (commit.workCategory) {
+			metas +=
+				'<span class="mem-activity-category" style="color:' +
+				JD.categoryColor(commit.workCategory) +
+				'">' +
+				esc(commit.workCategory) +
+				"</span>";
 		}
-		return html + "</div>";
-	}
-
-	function commitItem(commit, model) {
-		var stats =
-			commit.insertions != null || commit.deletions != null
-				? "+" + (commit.insertions || 0) + " −" + (commit.deletions || 0)
-				: null;
-		var metas = [commit.hash.slice(0, 7)];
-		if (stats) metas.push(stats);
-		return itemRow(
-			GLYPH.commit,
-			commit.message,
-			metas,
-			JD.timeOfDay(commit.committedAtMs, model.timeZone),
-			null,
-			true,
+		if (commit.turns != null) {
+			metas += '<span class="tag metric num">' + esc(commit.turns) + " turns</span>";
+		}
+		/* Below the memory tier neither category nor turns exists, so an aligned row
+		   would be a bare title. The hash and the diff size are what git alone can
+		   say, and they keep the raw column readable without claiming enrichment it
+		   does not have. */
+		if (!memory) {
+			metas += '<span class="tag mono">' + esc(commit.hash.slice(0, 7)) + "</span>";
+			if (commit.insertions != null || commit.deletions != null) {
+				metas +=
+					'<span class="tag">+' + (commit.insertions || 0) + " −" + (commit.deletions || 0) + "</span>";
+			}
+		}
+		if (commit.branch) metas += '<span class="tag mono">' + esc(commit.branch) + "</span>";
+		/* Suppressed on a single-repo page for the same reason Memory Activity
+		   suppresses it: every row would carry the identical chip, and the topbar
+		   picker already states it. `!== 1` and not `scope.kind !== "repo"` — the
+		   scope now holds an ARRAY of identities, so a two-repo selection is still
+		   `kind === "repo"` while its rows do need telling apart. */
+		if (JD.scopeIdentities(model).length !== 1) metas += '<span class="tag">' + esc(commit.repoName) + "</span>";
+		return (
+			'<div class="item"><div class="r1">' +
+			GLYPH.commit +
+			'<span class="t">' +
+			esc(commit.message) +
+			'</span><span class="when">' +
+			esc(JD.timeOfDay(commit.committedAtMs, model.timeZone)) +
+			"</span></div>" +
+			(metas ? '<div class="meta">' + metas + "</div>" : "") +
+			"</div>"
 		);
 	}
 
-	function sessionItem(session, model) {
-		var metas = [session.source, session.messageCount + " messages"];
-		if (session.isLive) metas.unshift("live");
-		return itemRow(GLYPH.session, session.title, metas, JD.relTime(session.updatedAtMs, model.generatedAtMs));
-	}
-
-	function workspaceItem(workspace) {
-		return itemRow(GLYPH.workspace, "Uncommitted on " + (workspace.branch || "detached HEAD"), [
-			"+" + workspace.insertions + " −" + workspace.deletions,
-			workspace.filesChanged + " files",
-			workspace.repoName,
-		]);
-	}
-
-	/* ---- grouping ---------------------------------------------------------- */
-
-	/* The mockup groups Yesterday: by `repo · branch` when it only has git and
-	   session logs, and by `TICKET · topic` once memories give it a ticket. Same
-	   function, different key — the point of the group header is "these lines are
-	   one piece of work", and which field says so depends on what is known. */
-	function groupKey(commit, byTicket) {
-		if (byTicket && commit.ticketId) {
-			return commit.ticketId + (commit.workCategory ? " · " + commit.workCategory : "");
-		}
-		return commit.repoName + (commit.branch ? " · " + commit.branch : "");
-	}
-
-	function grouped(rows) {
-		var order = [];
-		/* Prototype-less: the key is `repo · branch`, so a branch called
-		   `constructor` or `__proto__` would otherwise read back an inherited
-		   value and throw on `.push`, blanking the whole page. */
-		var byKey = Object.create(null);
-		rows.forEach((row) => {
-			if (!byKey[row.key]) {
-				byKey[row.key] = [];
-				order.push(row.key);
-			}
-			byKey[row.key].push(row.html);
-		});
-		var html = "";
-		order.forEach((key) => {
-			html += '<div class="ghead"><span class="mono">' + JD.esc(key) + "</span></div>" + byKey[key].join("");
-		});
-		return html;
-	}
-
-	/* ---- yesterday --------------------------------------------------------- */
-
-	/* Below the memory tier there are no outcomes to state, so the column is the
-	   raw trail: what ran, and what it committed, grouped per branch. */
-	function yesterdayRaw(standup, model) {
-		var rows = [];
-		standup.yesterdayCommits.forEach((commit) => {
-			rows.push({ key: groupKey(commit, false), html: commitItem(commit, model) });
-		});
-		/* Sessions get their own group rather than joining a branch group: nothing
-		   records which branch a session was on, and filing it under one would be a
-		   guess printed as a header. */
-		standup.yesterdaySessions.forEach((session) => {
-			rows.push({ key: session.repoName + " · sessions", html: sessionItem(session, model) });
-		});
-		return grouped(rows);
-	}
-
-	/* At the memory tier the column becomes OUTCOMES: one line per commit saying
-	   what landed, carrying the decision the memory recorded and what it cost.
-	   Session rows drop out here on purpose — the raw session trail is what the
-	   stats page's own list is for, and repeating it made this page a duplicate of
-	   that one. */
-	function yesterdayOutcomes(standup, model) {
-		var decisionsByHash = Object.create(null);
-		(standup.insights || []).forEach((insight) => {
-			if (insight.kind !== "decision") return;
-			(decisionsByHash[insight.commitHash] = decisionsByHash[insight.commitHash] || []).push(insight.text);
-		});
-		var rows = standup.yesterdayCommits.map((commit) => {
-			var metas = [];
-			if (commit.estCostUsd != null) metas.push(JD.fmtUsd(commit.estCostUsd) + " est");
-			if (commit.turns != null) metas.push(commit.turns + (commit.turns === 1 ? " turn" : " turns"));
-			if (commit.insertions != null || commit.deletions != null) {
-				metas.push("+" + (commit.insertions || 0) + " −" + (commit.deletions || 0));
-			}
-			if (commit.branch) metas.push(commit.branch);
-			var decisions = decisionsByHash[commit.hash] || [];
-			var note = decisions.length > 0 ? "<b>Decision:</b> " + JD.mdInline(JD.esc(decisions.join(" · "))) : null;
-			return {
-				key: groupKey(commit, true),
-				html: itemRow(
-					GLYPH.session,
-					commit.message,
-					metas,
-					JD.timeOfDay(commit.committedAtMs, model.timeZone),
-					note,
-				),
-			};
-		});
-		return grouped(rows);
+	function dayColumn(commits, model, memory) {
+		return commits.map((commit) => commitRow(commit, model, memory)).join("");
 	}
 
 	/* ---- sprint context ---------------------------------------------------- */
@@ -167,8 +101,8 @@ window.JD = window.JD || {};
 	/* The mockup's ctx-strip chips. Its own version reads `Sprint 14 · day 7 of 10`
 	   and `JOL-142 · 4/7 steps · ● on track`; sprint numbering and plan-step
 	   progress do not exist locally (plan enumeration is a known gap), so the chips
-	   carry the part that does — the tickets the window's commits actually name —
-	   and the last chip states what is missing instead of inventing a status. */
+	   carry only the part that does — the tickets the window's commits actually
+	   name — rather than inventing a status. */
 	function sprintChips(standup, model) {
 		if (!standup.insights) {
 			return (
@@ -188,7 +122,7 @@ window.JD = window.JD || {};
 				"chips appear when a commit names one</span>"
 			);
 		}
-		var html = tickets
+		return tickets
 			.slice(0, 3)
 			.map(
 				(ticket) =>
@@ -200,7 +134,6 @@ window.JD = window.JD || {};
 					"</span>",
 			)
 			.join("");
-		return html + '<span class="schip" style="border-style:dashed">step progress needs plan enumeration</span>';
 	}
 
 	/* Whose commits the board is showing. Stated either way, and never silently:
@@ -217,89 +150,12 @@ window.JD = window.JD || {};
 		);
 	}
 
-	/* ---- the drafted standup ----------------------------------------------- */
-
-	/* The markdown the sheet shows and the clipboard gets. Same two sections as the
-	   board, in the same order, with TODOs under Today — a draft that disagreed
-	   with the columns above it would be the worse of the two bugs. */
-	JD.standupMarkdown = (model) => {
-		var standup = model.standup;
-		var insights = standup.insights || [];
-		var todos = insights.filter((insight) => TODAY_KINDS.indexOf(insight.kind) >= 0);
-		var decisionsByHash = Object.create(null);
-		insights.forEach((insight) => {
-			if (insight.kind !== "decision") return;
-			(decisionsByHash[insight.commitHash] = decisionsByHash[insight.commitHash] || []).push(insight.text);
-		});
-
-		var lines = ["## Standup — " + standup.today, "", "**Yesterday**"];
-		/* Built into its own array first, so the "nothing recorded" test asks what
-		   this section will ACTUALLY emit. Counting the raw inputs instead was one
-		   filter out of date: at the memory tier the session loop below is skipped,
-		   so a day with agent sessions but no commits counted as non-empty and then
-		   printed nothing — `**Yesterday**` immediately followed by `**Today**`,
-		   while the board column correctly said "Nothing recorded." */
-		var yesterday = [];
-		standup.yesterdayCommits.forEach((commit) => {
-			var prefix = commit.ticketId ? commit.ticketId + ": " : "";
-			var decisions = decisionsByHash[commit.hash] || [];
-			yesterday.push(
-				"- " +
-					prefix +
-					commit.message +
-					" (`" +
-					commit.hash.slice(0, 7) +
-					"`" +
-					(commit.branch ? ", " + commit.branch : "") +
-					")" +
-					(decisions.length > 0 ? " — decision: " + decisions.join("; ") : ""),
-			);
-		});
-		/* Session lines only below the memory tier, mirroring the board: once there
-		   are outcomes, the session trail is noise in a standup. */
-		if (!standup.insights) {
-			standup.yesterdaySessions.forEach((session) => {
-				yesterday.push("- [" + session.source + "] " + session.title);
-			});
-		}
-		lines.push(yesterday.length > 0 ? yesterday.join("\n") : "- (nothing recorded)");
-
-		lines.push("", "**Today**");
-		/* Same construction as Yesterday, and for the same reason: the session loop
-		   drops non-live rows at the memory tier, so the raw counts overstate it. */
-		var today = [];
-		standup.todayCommits.forEach((commit) => {
-			today.push("- " + commit.message + " (`" + commit.hash.slice(0, 7) + "`)");
-		});
-		standup.todaySessions.forEach((session) => {
-			if (standup.insights && !session.isLive) return;
-			today.push("- [" + session.source + "] " + session.title + (session.isLive ? " (in progress)" : ""));
-		});
-		todos.forEach((todo) => {
-			today.push("- TODO: " + todo.text + " (`" + todo.commitHash.slice(0, 7) + "`)");
-		});
-		standup.workspaces.forEach((workspace) => {
-			today.push(
-				"- Uncommitted on " +
-					(workspace.branch || "detached HEAD") +
-					" · +" +
-					workspace.insertions +
-					" −" +
-					workspace.deletions +
-					" across " +
-					workspace.filesChanged +
-					" files (" +
-					workspace.repoName +
-					")",
-			);
-		});
-		lines.push(today.length > 0 ? today.join("\n") : "- (nothing yet)");
-
-		return lines.join("\n");
-	};
-
 	/* ---- columns ----------------------------------------------------------- */
 
+	/* `sub` is optional. The two day columns pass none — their heading and count
+	   already say what they hold, and the sentence under them was restating it. An
+	   empty string must not render an empty `.sub`: it carries a bottom margin, so
+	   the blank div would leave the gap the caption used to occupy. */
 	function column(title, count, sub, bodyHtml) {
 		return (
 			'<section class="card col" aria-label="' +
@@ -309,9 +165,8 @@ window.JD = window.JD || {};
 			'<span class="cnt">' +
 			JD.esc(count) +
 			"</span></h2>" +
-			'<div class="sub">' +
-			JD.esc(sub) +
-			'</div><div class="col-list">' +
+			(sub ? '<div class="sub">' + JD.esc(sub) + "</div>" : "") +
+			'<div class="col-list">' +
 			bodyHtml +
 			"</div></section>"
 		);
@@ -323,123 +178,51 @@ window.JD = window.JD || {};
 		var esc = JD.esc;
 		var standup = model.standup;
 		var memory = !!standup.insights;
-		var insights = standup.insights || [];
-		var todos = insights.filter((insight) => TODAY_KINDS.indexOf(insight.kind) >= 0);
 
-		/* Context strip: date, sprint chips, where this goes, and the draft action. */
+		/* Context strip: date and sprint chips. The Copy-as-standup button and its
+		   "posts nowhere" caption used to close this row (JOLLI-2198); the board is
+		   now read directly, so there is nothing to right-align against and the
+		   spacer went with them. */
 		var html =
 			'<div class="ctx"><span class="date">' +
 			esc(JD.weekdayDate(model.generatedAtMs, model.timeZone)) +
 			'</span><span class="sprint-chips">' +
 			authorChip(standup) +
 			sprintChips(standup, model) +
-			'</span><div class="spacer"></div>' +
-			'<span class="share-note">posts nowhere — copy it where you like</span>' +
-			'<button class="copybtn" type="button" id="copyStandup">⧉ Copy as standup</button></div>';
+			"</span></div>";
 
-		/* Yesterday. */
-		var yBody = memory ? yesterdayOutcomes(standup, model) : yesterdayRaw(standup, model);
+		/* The two day columns. Both are COMMITS ONLY, flat, and identical in shape:
+		   what was completed that day, which is what Memory Activity lists for the
+		   same day on the stats page.
+
+		   Three things used to make them disagree with that card, all removed. Today
+		   carried open TODOs, live sessions and uncommitted worktree rows — work in
+		   flight under a heading everyone reads as "done" (JOLLI-2201). Yesterday
+		   carried session rows below the memory tier, which are not commits at all.
+		   And Yesterday grouped its rows under `TICKET · category` / `repo · branch`
+		   headers, which Memory Activity has no counterpart for: its grouping IS the
+		   day, and here the day is already the column. A group header inside one is a
+		   second axis the other page does not have, so two identical lists read as
+		   different ones.
+
+		   Neither column splits by tier any more. A commit is a commit without
+		   memory; only how many FIELDS a row can show varies, and that is the row's
+		   own business (see commitRow). */
+		var yBody = dayColumn(standup.yesterdayCommits, model, memory);
 		if (!yBody) yBody = '<div class="empty-note">Nothing recorded.</div>';
-		var yCount = memory
-			? "· " + plural(standup.yesterdayCommits.length, "outcome")
-			: "· " +
-				plural(standup.yesterdaySessions.length, "session") +
-				" · " +
-				plural(standup.yesterdayCommits.length, "commit");
-		var ySub = memory
-			? "From your commit memories — each line carries the commit it came from"
-			: "Stitched from session logs + git log — raw but real";
+		var yCount = "· " + plural(standup.yesterdayCommits.length, "commit");
 
-		/* Today. Live sessions stay visible at the memory tier (they are the closest
-		   local answer to the mockup's "next plan step, in a session now"); the rest
-		   of today's session trail drops out, same reasoning as Yesterday. */
-		var tBody = "";
-		standup.todayCommits.forEach((commit) => {
-			tBody += commitItem(commit, model);
-		});
-		standup.todaySessions.forEach((session) => {
-			if (memory && !session.isLive) return;
-			tBody += sessionItem(session, model);
-		});
-		todos.forEach((todo) => {
-			tBody += itemRow(GLYPH.todo, "TODO: " + todo.text, [
-				todo.commitHash.slice(0, 7),
-				todo.repoName,
-			]);
-		});
-		standup.workspaces.forEach((workspace) => {
-			tBody += workspaceItem(workspace);
-		});
+		var tBody = dayColumn(standup.todayCommits, model, memory);
 		if (!tBody) tBody = '<div class="empty-note">Nothing yet.</div>';
-		var live = standup.todaySessions.filter((session) => session.isLive).length;
-		var tCount = memory
-			? "· " + plural(todos.length, "TODO") + (live > 0 ? " · " + live + " live" : "")
-			: live > 0
-				? "· " + live + " live"
-				: "· " + plural(standup.todaySessions.length, "session");
-		var tSub = memory
-			? "Open TODOs, live sessions and working-tree state — edit before sharing"
-			: "Live sessions and working-tree state";
+		var tCount = "· " + plural(standup.todayCommits.length, "commit");
 
 		/* Two columns. The third — Risks · Blockers · Questions — is gone; see the
-		   note on TODAY_KINDS at the top of this file for why it could never fill. */
+		   note at the top of this file for why it could never fill. */
 		html += '<div class="cols">';
-		html += column("Yesterday", yCount, ySub, yBody);
-		html += column("Today", tCount, tSub, tBody);
+		html += column("Yesterday", yCount, "", yBody);
+		html += column("Today", tCount, "", tBody);
 		html += "</div>";
 
 		document.getElementById("app").innerHTML = html;
-
-		/* ---- draft sheet --------------------------------------------------- */
-
-		var overlay = document.getElementById("ovStandup");
-		var output = document.getElementById("mdOut");
-		var toast = document.getElementById("mdToast");
-		var copyButton = document.getElementById("copyStandup");
-
-		var flash = () => {
-			toast.classList.add("show");
-			setTimeout(() => toast.classList.remove("show"), 1600);
-		};
-		var close = () => {
-			overlay.classList.remove("open");
-			copyButton.focus();
-		};
-
-		copyButton.onclick = () => {
-			output.value = JD.standupMarkdown(model);
-			/* The unfiltered warning goes FIRST and outranks the tier note: what you
-			   are about to paste containing a teammate's commit matters more than
-			   where the lines came from. */
-			document.getElementById("sheetSub").textContent = !standup.authoredBy
-				? "Every author's commits — no git identity configured, so check the lines are yours before posting."
-				: memory
-					? "From your commit memories. Edit anything before you post it."
-					: "From raw sessions + git log. Enable Jolli Memory for decisions and TODOs.";
-			overlay.classList.add("open");
-			output.focus();
-			/* Copied on open as well as on the button: the one-click path stays as fast
-			   as it was, and the sheet is what makes the draft correctable. */
-			if (navigator.clipboard) navigator.clipboard.writeText(output.value).then(flash, () => {});
-		};
-		document.getElementById("copyMd").onclick = () => {
-			output.select();
-			if (!navigator.clipboard) return;
-			navigator.clipboard.writeText(output.value).then(flash, () => {
-				toast.textContent = "Copy failed";
-				flash();
-			});
-		};
-		document.getElementById("closeOv").onclick = close;
-		overlay.onclick = (event) => {
-			if (event.target === overlay) close();
-		};
-		/* Bound on the document, not the sheet: Escape has to work wherever focus
-		   sits inside the dialog, textarea included. An assignment rather than
-		   addEventListener, so the 30-second re-render replaces this handler instead
-		   of stacking another copy of it. */
-		document.onkeydown = (event) => {
-			if (event.key === "Escape" && overlay.classList.contains("open")) close();
-		};
 	};
 })(window.JD);

--- a/cli/src/dashboard/assets/js/stats.js
+++ b/cli/src/dashboard/assets/js/stats.js
@@ -669,8 +669,8 @@ window.JD = window.JD || {};
 	function skillsCard(model) {
 		var usage = model.stats.toolUsage;
 		/* Puzzle piece — a skill is a part that slots into a run. Was a star,
-		   which is this page's "decision" mark (see JD.glyph) and read as a
-		   rating here. Lucide `puzzle`, like every other icon in this band. */
+		   which was this page's "decision" mark at the time and read as a rating
+		   here. Lucide `puzzle`, like every other icon in this band. */
 		var icon = widgetIcon(
 			"--s2",
 			'<path d="M15.39 4.39a1 1 0 0 0 1.68-.474 2.5 2.5 0 1 1 3.014 3.015 1 1 0 0 0-.474 1.68l1.683 1.682a2.414 ' +
@@ -861,10 +861,10 @@ window.JD = window.JD || {};
 		   list, and "the recall count is MCP-tool calls only".
 
 		   Never held the page-wide clause either ("older activity is reconstructed
-		   from commits and stored summaries") — that describes the activity
+		   from commits and stored summaries") — that described the activity
 		   timeline, while these rows are captured tool calls and nothing here is
-		   reconstructed from a commit; it is also already printed once per page
-		   (buildDashboardModel → #coverageNote). */
+		   reconstructed from a commit. That clause has since been dropped from the
+		   footer as well; see `CoverageNote` in DashboardModel.ts. */
 		return (
 			html +
 			'<div class="w-foot"><span class="w-measure mcp-card-note">ⓘ from <b>' +
@@ -1152,17 +1152,10 @@ window.JD = window.JD || {};
 		);
 	}
 
-	/* Feed-card category colours. The first five and their palette slots are the
-	   mockup's (`CAT_VAR`: bugfix→s2, feature→s1, refactor→s3, tech-debt→s4,
-	   docs→s5); the rest are categories our summarizer actually emits. A fixed
-	   order rather than a hash — same reasoning as `JD.sourceIndex`: the colour
-	   for a category must not move when the set of categories changes. Anything
-	   unlisted lands on the last slot. */
-	var CATEGORY_ORDER = ["feature", "bugfix", "refactor", "tech-debt", "docs", "ux", "performance", "devops"];
-	function catColor(category) {
-		var index = CATEGORY_ORDER.indexOf(category);
-		return JD.seriesColor(index >= 0 ? index : CATEGORY_ORDER.length);
-	}
+	/* Feed-card category colours. Shared with the standup board — the order and
+	   the rationale live on `JD.categoryColor` in shell.js, because both pages
+	   paint the same category chip for the same commits. */
+	var catColor = JD.categoryColor;
 
 	/* "Jul 27 · 4:54pm" — the mockup's row timestamp. Absolute, not relative: the
 	   feed is scanned for "when did this land", and the range control already

--- a/cli/src/dashboard/assets/styles/main.css
+++ b/cli/src/dashboard/assets/styles/main.css
@@ -690,18 +690,9 @@ body {
   .ctx .date { font-size: 15px; font-weight: 650; }
   .sprint-chips { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
   .schip { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--ink-2); border: 1px solid var(--border); border-radius: 999px; padding: 4px 11px; }
-  .schip .st { font-weight: 650; display: inline-flex; align-items: center; gap: 4px; }
-  .st.ok   { color: var(--good-text); }
-  .st.risk { color: var(--serious); }
-  .st.done { color: var(--good-text); }
-  .copybtn {
-    appearance: none; font: inherit; font-size: 12.5px; font-weight: 600; cursor: pointer;
-    background: var(--accent); color: #fff; border: 0; border-radius: 7px; padding: 7px 14px;
-    display: inline-flex; align-items: center; gap: 7px;
-  }
-  .copybtn:focus-visible { outline: 2px solid var(--ink); outline-offset: 2px; }
-  .share-note { font-size: 11.5px; color: var(--muted); }
-
+  /* No `.st` status rule: the mockup's `● on track` chip needed plan-step
+     progress, which does not exist locally, so `sprintChips` emits tickets only
+     and nothing ever carried the class. */
   .cols { display: grid; grid-template-columns: 1fr; gap: 16px; }
   /* Two columns — Yesterday and Today. The third (Risks · Blockers · Questions)
      was removed because the insight kinds it filtered for are never produced; see
@@ -712,17 +703,17 @@ body {
   .col h2 .cnt { font-size: 11px; color: var(--muted); font-weight: 500; }
   .col-list { display: grid; gap: 8px; margin-top: 12px; }
 
-  .ghead { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .05em; margin: 6px 0 -2px; display: flex; gap: 8px; align-items: center; }
-  .ghead .mono { text-transform: none; letter-spacing: 0; }
-
+  /* No `.ghead` group header: both day columns are flat. Memory Activity's
+     grouping IS the day, and here the day is already the column, so a second
+     axis inside one made two identical lists read as different ones. */
   .item { border: 1px solid var(--grid); border-radius: 8px; padding: 10px 12px; display: grid; gap: 6px; font-size: 12.5px; color: var(--ink-2); }
   .item .r1 { display: flex; gap: 8px; align-items: baseline; }
   .item .glyph { flex: 0 0 auto; width: 16px; text-align: center; }
   .item .t { color: var(--ink); font-weight: 550; }
   .item .when { margin-left: auto; color: var(--muted); font-size: 11px; white-space: nowrap; }
   .item .meta { display: flex; gap: 6px; flex-wrap: wrap; padding-left: 24px; }
-  .item .note { padding-left: 24px; font-size: 12px; }
-  .item .note b { font-weight: 600; }
+  /* No `.note` second line: a row is a title plus its meta chips. The decision
+     text that used to sit here belongs to the Decisions card (JOLLI-2200). */
   .item[role="button"] { cursor: pointer; }
   .item[aria-current="true"] { border-color: var(--accent); background: var(--accent-soft); }
   .item[role="button"]:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
@@ -1159,9 +1150,8 @@ body {
   .dx-commit .when { margin-left: auto; color: var(--muted); font-size: 11px; white-space: nowrap; }
   .dx-items { display: grid; gap: 8px; margin-top: 10px; padding-left: 12px; }
 
-  .glyph.done { color: var(--good-text); }
-  .glyph.next { color: var(--accent); }
-  .glyph.todo { color: var(--muted); }
+  /* One variant, because `JD.glyph` is down to one reachable mark — see the note
+     there. `.done` / `.next` / `.todo` went with the keys that emitted them. */
   .glyph.commit { color: var(--muted); }
 
   .team { margin-top: 16px; display: none; }
@@ -1185,18 +1175,12 @@ body {
   .sheet { background: var(--surface); color: var(--ink); border: 1px solid var(--border); border-radius: 12px; width: min(640px, 100%); padding: 18px; }
   .sheet h3 { margin: 0 0 2px; font-size: 14px; }
   .sheet .sub { font-size: 12px; color: var(--muted); margin: 2px 0 10px; }
-  .sheet textarea {
-    width: 100%; height: 300px; resize: vertical; font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-    font-size: 12px; color: var(--ink-2); background: var(--page); border: 1px solid var(--grid); border-radius: 8px; padding: 12px;
-  }
   .ctx-body {
     max-height: 60vh; overflow: auto; margin: 0; white-space: pre-wrap; word-break: break-word;
     font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 12px; line-height: 1.6;
     color: var(--ink-2); background: var(--page); border: 1px solid var(--grid); border-radius: 8px; padding: 12px;
   }
   .sheet .row { display: flex; gap: 10px; margin-top: 10px; align-items: center; }
-  .toast { font-size: 12px; color: var(--good-text); font-weight: 600; visibility: hidden; }
-  .toast.show { visibility: visible; }
 
   /* ---------- popover ---------- */
   .pop {
@@ -1247,7 +1231,7 @@ body {
 
   .footer-note { max-width: 1200px; margin: 18px auto 0; padding: 0 24px; font-size: 11.5px; color: var(--muted); }
   @media (prefers-reduced-motion: no-preference) {
-    .chip, .seg button, .cta, .copybtn { transition: background .12s ease, color .12s ease; }
+    .chip, .seg button, .cta { transition: background .12s ease, color .12s ease; }
     .icard { transition: opacity .18s ease, transform .18s ease; }
   }
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Context (6)
- Recall
- Search
- Skills used — 7 skills · 3822.8k tokens · some inferred

## Quick recap

The daily standup board now shows only committed work, matching the stats page's Memory Activity card row for row: category, turn count, branch, and repository name, with open TODOs, live sessions, and uncommitted work dropped from the board. The standup reads directly off the page, and the copy-to-share button with its editable markdown draft overlay is gone entirely. Yesterday's entries render as compact titles, and the Today column counts only the commits that actually landed that day. The same category now paints the same color on both pages, and where category and turn data do not exist, rows fall back to the commit hash and diff size.

The standup and stats pages no longer print a permanent footer note stating that older activity is reconstructed from commits and stored summaries. The standup page now renders without any footer at all. The only footer text left anywhere is a first-run hint on the stats page for an empty database, telling the user that no sessions are recorded yet and disappearing permanently after the first session.

---

## Topics (5)
<details>
<summary><strong>01 · Remove always-on footer caveat from standup and stats pages</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The daily standup page printed a permanent footer note on every load stating that older activity is reconstructed from commits and stored summaries and that recent sessions are exact. The developer asked to remove it because it appeared regardless of whether the reader was anywhere near the window boundary it described.

**💡 Decisions Behind the Code**

- **Permanent furniture versus scoped hint**: The line was deleted because it was always printed regardless of relevance — a line that is always there gets read once and then ignored, so it cost a footer on every page while buying no real honesty. It survives only as a first-run hint on an empty database, which states what will fill the page and disappears permanently after the first session.
- **Stats keeps the empty-state hint, standup does not**: Stats cards are all session-derived, so an empty database genuinely empties that page. The standup board is built purely from commits, so it stays fully populated with zero sessions, and the empty state each of its columns can really be in is already stated inside the column.

**✅ What Was Implemented**

- Reworked the coverage-note logic in the dashboard query layer: the "sessions-window" note kind was retired entirely, and the only surviving note (the empty-database hint) is now emitted exclusively on the stats page.
- The standup page now produces no footer note at all, consistent with its commits-only board. The note type union was narrowed to a single value, and tests were rewritten to pin that the footer stays empty on every view once the database has data.
- Updated stale comments referencing the removed clause in the shell renderer, the stats card code, and the note's model documentation.

**📁 FILES**
- `cli/src/dashboard/DashboardQuery.ts`
- `cli/src/dashboard/DashboardModel.ts`
- `cli/src/dashboard/assets/js/shell.js`
- `cli/src/dashboard/assets/js/stats.js`

</blockquote>
</details>
<details>
<summary><strong>02 · Align standup day columns with Memory Activity card and drop copy-share sheet</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Several tickets asked to slim the daily standup page: drop the copy-as-standup affordance, list only items completed on a given day, and show yesterday's items as titles only. Users also expected the day columns to show the same commits as the Memory Activity card on the stats page.

**💡 Decisions Behind the Code**

- **One shared row shape**: both surfaces answer the same question from the same commits, so any difference in wording or fields would make users wonder whether the data differed. Aligning to a single row template removes that ambiguity.
- **Shared color table**: duplicating the category-to-color mapping onto each page would create a second answer to what color a category is, and the two pages would drift apart the first time a category was added. It now lives in one place with a fixed, non-hash ordering so a color never shifts when the set of categories changes.
- **Keep the author filter**: the standup filters commits to the user's git identity while Memory Activity does not, and although the two lists coincided on the developer's machine, the alignment was deliberately documented as "same fields, same labels" and not an invariant that the lists are always equal. The filter stays because the board is read as the user's own work.
- **Pull the sheet out entirely, not just its button**: the button was the sheet's only trigger, so keeping the roughly 90-line markdown generator and overlay after removing the button would have left unreachable dead weight that the next reader would have had to disprove.
- **"Completed today" means finished work only**: a TODO is by definition work that has not yet happened, so listing it under a heading everyone reads as "done" asserted something the board cannot know. Commits are the only defensible content, and the count and caption were reworked to match; the per-item detail lines were dropped rather than tucked behind a chevron, keeping the column compact.

**✅ What Was Implemented**

- Removed the "Copy as standup" button, its "posts nowhere" caption, and the whole draft-sheet overlay they opened: the standup markdown generator, the editable textarea, the copy/close and Escape key handlers, and the button's dedicated CSS, with an HTML comment recording where the layer went.
- Both day columns now render a single shared commit row that mirrors the Memory Activity card field-for-field in the same order: category chip, turn count, branch, and repo name. Session rows, live sessions, uncommitted worktree rows, and open TODOs are excluded, the in-column grouping headers (ticket·category / repo·branch) were removed, and each column is a flat list counted as "· N commits". Yesterday entries render as compact titles only, without per-item detail lines.
- The category-to-color mapping was promoted from the stats page into a shared helper on the dashboard shell with a fixed, non-hash ordering; the stats page now delegates to it, so the same category paints the same color on both pages.
- Below the memory tier, where category and turns do not exist, rows fall back to showing the commit hash and diff size. The model now documents that the unrendered session and workspace fields are intentionally not displayed.

**📁 FILES**
- `cli/src/dashboard/assets/js/standup.js`
- `cli/src/dashboard/DashboardModel.ts`
- `cli/src/dashboard/assets/index.html`
- `cli/src/dashboard/assets/js/shell.js`
- `cli/src/dashboard/assets/js/stats.js`

</blockquote>
</details>
<details>
<summary><strong>03 · Delete dead CSS and unused glyph definitions left by the standup slim-down</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The developer flagged leftover dead code after the conflict resolution that slimmed the standup board to commits-only columns — most visibly a group-header style whose only producer had already been deleted.

**💡 Decisions Behind the Code**

- **Producer, not reference count, is the test for dead code**: A selector or glyph is only dead if nothing emits the class or key it styles. Some survivors look like leftovers — the interactive row styling and the commit glyph are still emitted by the memory activity list — while items with zero emitters (the status chip states, the unused glyph keys) were removed.
- **Comments instead of silence**: Each removed rule leaves a short comment stating why there is deliberately no rule, because a silently-missing selector is exactly what a future developer will recreate from the mockup.

**✅ What Was Implemented**

- Removed CSS rules with no remaining producer: the group-header styles, the plan-step status chip states, the row note second-line styles, and the done/next/todo glyph color variants.
- Trimmed the shared glyph map in the shell renderer from five keys down to a single commit mark, deleting the session, workspace, todo, and decision entries whose row types no longer exist.
- Replaced each deleted selector with a one-line comment explaining why no rule exists there, so a future developer does not re-add it by following the mockup.

**📁 FILES**
- `cli/src/dashboard/assets/styles/main.css`
- `cli/src/dashboard/assets/js/shell.js`

</blockquote>
</details>
<details>
<summary><strong>04 · Remove step-progress placeholder chip from standup sprint chips</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The user asked to delete the dashed placeholder chip that announced "step progress needs plan enumeration", since step-progress tracking does not exist locally.

**💡 Decisions Behind the Code**

Removing the placeholder chip entirely was chosen over keeping a chip that announces what's missing. Since step-progress data doesn't exist, the previous chip permanently displayed an unfinished-looking placeholder that never resolved, which was clutter rather than information. Rendering only real ticket data gives the chips an honest, clean appearance and avoids inventing a status for a known gap.

**✅ What Was Implemented**

- In cli/src/dashboard/assets/js/standup.js, removed the unconditional dashed placeholder chip appended at the end of sprintChips(), so the function now returns only the ticket chips rendered from tickets.slice(0, 3).
- Updated the surrounding comment to reflect that chips now render only the tickets commits actually name, without stating a missing status.
- Verified the standup asset test still passes (no test pinned the removed text).

**📋 Future Enhancements**

- The model argument on sprintChips() is unused and could be dropped from its signature and call sites.
- The browser UI spec (line ~142) still describes the "step progress" placeholder chip; it was left untouched to match how earlier spec lines for the removed draft sheet were handled.

**📁 FILES**
- `cli/src/dashboard/assets/js/standup.js`

</blockquote>
</details>
<details>
<summary><strong>05 · Remove caption text under standup Yesterday and Today headings</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The developer asked to delete the small explanatory captions that appeared beneath the "Yesterday" and "Today" headings on the standup page.

**💡 Decisions Behind the Code**

An empty caption had to mean "render no subtitle at all", not "leave a blank subtitle box". The subtitle carries a bottom margin, so a blank placeholder would have looked like an unfinished deletion and held the caption's gap open. The Risks column kept its own caption because that one explains what counts as a risk row, rather than restating the heading.

**✅ What Was Implemented**

The column renderer in standup.js now omits the subtitle element entirely when no caption is supplied, instead of rendering an empty one. The two recently-added captions were removed, and a test pins that no blank subtitle placeholder remains in the page output.

**📋 Future Enhancements**

The Risks column's caption may also be removed later; the user has not decided, and the developer flagged it as available on request.

**📁 FILES**
- `cli/src/dashboard/assets/js/standup.js`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 14, 2026 at 12:00 PM · via Local agent - OpenCode*
<!-- jollimemory-summary-end -->