### PR TITLE
Skip re-projecting unchanged events in the dashboard backfill

### DIFF
--- a/cli/src/dashboard/DbBackfill.test.ts
+++ b/cli/src/dashboard/DbBackfill.test.ts
@@ -932,6 +932,676 @@ describe("dbBackfillRepo — summaries sweep (memory tier)", () => {
 		// Second pass: same index, so the sweep is gated out — and unannounced.
 		expect(await kinds()).not.toContain("summaries");
 	});
+
+	/** Rows the write-ahead log holds for one summary's projection identity. */
+	const loggedSummaries = async (hash: string): Promise<number> => {
+		const rows = await query<{ n: number }>(
+			"SELECT COUNT(*) AS n FROM events_raw WHERE event_id = ?",
+			`commit-summary:${repo.repoIdentity}:${hash}`,
+		);
+		return rows[0]?.n ?? 0;
+	};
+
+	/** Opens the tier's gate by making the index content differ from last pass. */
+	const changeIndex = (n: number): void => {
+		vi.mocked(getIndex).mockResolvedValue({
+			version: 3,
+			entries: Array.from({ length: n }, (_, i) => ({
+				commitHash: `idx${i}`,
+				parentCommitHash: null,
+				commitMessage: "m",
+				commitDate: "2026-07-30T00:00:00Z",
+				branch: "main",
+				generatedAt: "2026-07-30T00:01:00Z",
+			})),
+		});
+	};
+
+	// Carries a branch and a message, so its FIRST projection genuinely writes
+	// something: the bare fixture above adds nothing once `commit.created` has made
+	// the row, and is therefore skipped from pass one — correct, but it cannot show
+	// a re-run.
+	const attributedSummary = { ...summaryEvent, branch: "main", message: "summarized aaa" };
+
+	it("does not re-enqueue a summary whose projection would write nothing", async () => {
+		// The index gate is all-or-nothing: one new memory anywhere re-collects the
+		// WHOLE set, so without a per-event comparison every stored summary is
+		// re-logged and re-projected on each pass. Measured at 219 events per
+		// `jolli dashboard` run, every copy byte-identical (JOLLI-2224).
+		changeIndex(0);
+		vi.mocked(collectSummaryEvents).mockResolvedValue({ events: [attributedSummary], complete: true });
+		await dbBackfillRepo({ repo, dbPath });
+		expect(await loggedSummaries("aaa")).toBe(1);
+
+		changeIndex(1);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSummaries("aaa")).toBe(1);
+	});
+
+	it("still projects a summary whose branch changed", async () => {
+		// The skip must not swallow a real change: this is the late-arriving
+		// attribution the tier above exists to land.
+		changeIndex(0);
+		vi.mocked(collectSummaryEvents).mockResolvedValue({ events: [attributedSummary], complete: true });
+		await dbBackfillRepo({ repo, dbPath });
+
+		changeIndex(1);
+		vi.mocked(collectSummaryEvents).mockResolvedValue({
+			events: [{ ...attributedSummary, branch: "feature/x" }],
+			complete: true,
+		});
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSummaries("aaa")).toBe(2);
+		expect(await branchesOf("aaa")).toEqual(["feature/x"]);
+	});
+
+	it("still projects a summary carrying a session link the database lacks", async () => {
+		// `projectCommitSummary` also SEEDS sessions — a session older than the
+		// agents' own retention exists nowhere else. Comparing only the commits
+		// columns would skip the event and lose that row silently.
+		changeIndex(0);
+		vi.mocked(collectSummaryEvents).mockResolvedValue({ events: [attributedSummary], complete: true });
+		await dbBackfillRepo({ repo, dbPath });
+
+		changeIndex(1);
+		vi.mocked(collectSummaryEvents).mockResolvedValue({
+			events: [
+				{
+					...attributedSummary,
+					sessionLinks: [{ source: "codex" as const, sessionId: "old-1", confidence: "exact" as const }],
+				},
+			],
+			complete: true,
+		});
+		await dbBackfillRepo({ repo, dbPath });
+
+		const seeded = await query<{ session_id: string }>(
+			"SELECT session_id FROM sessions WHERE session_id = 'old-1'",
+		);
+		expect(seeded).toEqual([{ session_id: "old-1" }]);
+	});
+
+	it("still projects a summary whose commit row does not exist yet, when git could not be read", async () => {
+		// The summary can legitimately arrive first — `CommitSummaryEvent` carries
+		// `committedAtMs` precisely so the projection can create the row. With no
+		// reachable set to consult (the collection failed, so nothing was pruned
+		// either) a missing row has to be read that way.
+		vi.mocked(collectCommitEvents).mockRejectedValue(new Error("git log exploded"));
+		changeIndex(0);
+		vi.mocked(collectSummaryEvents).mockResolvedValue({ events: [attributedSummary], complete: true });
+
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSummaries("aaa")).toBe(1);
+		expect(await branchesOf("aaa")).toEqual(["main"]);
+	});
+
+	it("does not re-enqueue a summary whose commit the prune has removed", async () => {
+		// The two tiers used to ping-pong: this tier's `INSERT INTO commits` recreates
+		// a row for a hash git can no longer reach, and the next pass's
+		// `pruneUnreachableCommits` deletes it again — 74 events per run that could
+		// never converge (JOLLI-2224). A COMPLETE commit collection is what makes the
+		// two cases distinguishable: it runs first and would have collected the commit
+		// if git still had it, so a missing row here means the commit is gone.
+		vi.mocked(collectCommitEvents).mockResolvedValue([commitEvent("bbb")]);
+		changeIndex(0);
+		vi.mocked(collectSummaryEvents).mockResolvedValue({ events: [attributedSummary], complete: true });
+
+		await dbBackfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSummaries("aaa")).toBe(0);
+		const rows = await query<{ hash: string }>("SELECT hash FROM commits WHERE hash = 'aaa'");
+		expect(rows).toEqual([]);
+	});
+
+	it("still seeds a pruned commit's sessions, which exist nowhere else", async () => {
+		// The half that must survive the skip above: `projectCommitSummary` seeds
+		// `sessions` from the links independently of the commits row, and a session
+		// older than the agents' own retention has no other record. Only the
+		// commits-row half of the effect is pointless.
+		vi.mocked(collectCommitEvents).mockResolvedValue([commitEvent("bbb")]);
+		changeIndex(0);
+		vi.mocked(collectSummaryEvents).mockResolvedValue({
+			events: [
+				{
+					...attributedSummary,
+					sessionLinks: [{ source: "codex" as const, sessionId: "old-1", confidence: "exact" as const }],
+				},
+			],
+			complete: true,
+		});
+
+		await dbBackfillRepo({ repo, dbPath });
+
+		const seeded = await query<{ session_id: string }>(
+			"SELECT session_id FROM sessions WHERE session_id = 'old-1'",
+		);
+		expect(seeded).toEqual([{ session_id: "old-1" }]);
+	});
+
+	it("still projects a summary after a commit sweep cleared its attribution", async () => {
+		// The case a `commits.branch` comparison alone would miss, and it is the
+		// ordinary one: `commit.created` writes its `branch` COLUMN with COALESCE
+		// (absent keeps the stored value) but replaces `commit_branches` outright, so
+		// an index that does not list the hash clears the ROWS while the column still
+		// reads "main". Skipping there would leave the branch axis empty until an
+		// unrelated ref happened to move.
+		changeIndex(0);
+		vi.mocked(collectSummaryEvents).mockResolvedValue({ events: [attributedSummary], complete: true });
+		await dbBackfillRepo({ repo, dbPath });
+		expect(await branchesOf("aaa")).toEqual(["main"]);
+
+		// The sweep's own message matches what the summary stored, so the comparison
+		// gets past the columns and has only `commit_branches` left to disagree on —
+		// which is the whole point of this case.
+		vi.mocked(getHeadHash).mockResolvedValue("head-2");
+		vi.mocked(collectCommitEvents).mockResolvedValue([
+			{ ...commitEvent("aaa"), message: attributedSummary.message, branches: [] },
+		]);
+		changeIndex(1);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSummaries("aaa")).toBe(2);
+		expect(await branchesOf("aaa")).toEqual(["main"]);
+	});
+
+	it("still projects a summary whose link can upgrade a sessions-only row", async () => {
+		// The seed's own gate: a link with a model split turns a `sessions-only` row
+		// into `full`. That is the one case where the session row EXISTS and the
+		// event still has work to do, so presence alone is not the predicate.
+		const link = { source: "codex" as const, sessionId: "old-1", confidence: "exact" as const };
+		changeIndex(0);
+		vi.mocked(collectSummaryEvents).mockResolvedValue({
+			events: [{ ...attributedSummary, sessionLinks: [link] }],
+			complete: true,
+		});
+		await dbBackfillRepo({ repo, dbPath });
+
+		changeIndex(1);
+		vi.mocked(collectSummaryEvents).mockResolvedValue({
+			events: [
+				{
+					...attributedSummary,
+					sessionLinks: [
+						{
+							...link,
+							models: [{ model: "claude-opus-5", inputTokens: 30, outputTokens: 7, cachedTokens: 0 }],
+						},
+					],
+				},
+			],
+			complete: true,
+		});
+		await dbBackfillRepo({ repo, dbPath });
+
+		const row = await query<{ token_coverage: string; input_tokens: number }>(
+			"SELECT token_coverage, input_tokens FROM sessions WHERE session_id = 'old-1'",
+		);
+		expect(row).toEqual([{ token_coverage: "full", input_tokens: 30 }]);
+	});
+
+	it("still projects a summary whose commit message changed", async () => {
+		// `git commit --amend -m` followed by a regeneration: same hash namespace,
+		// new message. The `commits` row is COALESCE-updated from this event, so a
+		// present message that differs is a real write.
+		changeIndex(0);
+		vi.mocked(collectSummaryEvents).mockResolvedValue({ events: [attributedSummary], complete: true });
+		await dbBackfillRepo({ repo, dbPath });
+
+		changeIndex(1);
+		vi.mocked(collectSummaryEvents).mockResolvedValue({
+			events: [{ ...attributedSummary, message: "reworded aaa" }],
+			complete: true,
+		});
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSummaries("aaa")).toBe(2);
+		const rows = await query<{ message: string }>("SELECT message FROM commits WHERE hash = 'aaa'");
+		expect(rows).toEqual([{ message: "reworded aaa" }]);
+	});
+
+	it("skips a summary that records no session links at all", async () => {
+		// `sessionLinks` is optional on the wire, not merely empty — the loop has to
+		// read an absent list as "nothing to seed" rather than throw.
+		const { sessionLinks: _drop, ...linkless } = attributedSummary;
+		changeIndex(0);
+		vi.mocked(collectSummaryEvents).mockResolvedValue({ events: [linkless], complete: true });
+		await dbBackfillRepo({ repo, dbPath });
+		expect(await loggedSummaries("aaa")).toBe(1);
+
+		changeIndex(1);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSummaries("aaa")).toBe(1);
+	});
+});
+
+describe("dbBackfillRepo — sessions sweep", () => {
+	/** Rows the write-ahead log holds for one session's projection identity. */
+	const loggedSessions = async (sessionId: string): Promise<number> => {
+		const rows = await query<{ n: number }>(
+			"SELECT COUNT(*) AS n FROM events_raw WHERE event_id = ?",
+			`session:${repo.repoIdentity}:claude:${sessionId}`,
+		);
+		return rows[0]?.n ?? 0;
+	};
+
+	it("does not re-enqueue a session whose projection would write nothing", async () => {
+		// This tier has NO cursor at all — spec 350 records the `sessions` cursor as
+		// observability only — so every discoverable session was re-logged on every
+		// pass. Half of them carry no usage at all and are pure repeats (JOLLI-2224).
+		await dbBackfillRepo({ repo, dbPath });
+		expect(await loggedSessions("s1")).toBe(1);
+
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(1);
+	});
+
+	it("still projects a session whose transcript moved on", async () => {
+		await dbBackfillRepo({ repo, dbPath });
+
+		vi.mocked(collectSessionEvents).mockResolvedValue([
+			{ ...sessionEvent, updatedAtMs: sessionEvent.updatedAtMs + 1000, messageCount: 12 },
+		]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		const row = await query<{ message_count: number }>(
+			"SELECT message_count FROM sessions WHERE session_id = 's1'",
+		);
+		expect(row).toEqual([{ message_count: 12 }]);
+	});
+
+	// Every column the comparison reads, so an unchanged re-read has to clear all
+	// of them rather than falling through on absent fields.
+	const richSession: SessionUpsertedEvent = {
+		...sessionEvent,
+		title: "a conversation",
+		startedAtMs: 1_700_000_000_000,
+		messageCount: 9,
+		durationMs: 45_000,
+		inputTokens: 120,
+		outputTokens: 40,
+		cachedTokens: 8,
+		estCostUsd: 0.031,
+		tokenCoverage: "full",
+		pricesAsOf: "2026-07-30",
+	};
+
+	it("does not re-enqueue a fully-populated session that is byte-identical", async () => {
+		vi.mocked(collectSessionEvents).mockResolvedValue([richSession]);
+		await dbBackfillRepo({ repo, dbPath });
+		expect(await loggedSessions("s1")).toBe(1);
+
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(1);
+	});
+
+	it("still projects a session whose token totals moved without its timestamp", async () => {
+		// A better parser re-reading the same transcript slice: `updated_at_ms` is
+		// unchanged, so the tokens are the only thing that can say the row is stale.
+		vi.mocked(collectSessionEvents).mockResolvedValue([richSession]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		vi.mocked(collectSessionEvents).mockResolvedValue([{ ...richSession, inputTokens: 500 }]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		const row = await query<{ input_tokens: number }>("SELECT input_tokens FROM sessions WHERE session_id = 's1'");
+		expect(row).toEqual([{ input_tokens: 500 }]);
+	});
+
+	it("still projects a session whose title arrived later", async () => {
+		// A COALESCE'd column: absent leaves the stored value alone (and is not a
+		// difference), but a present one that disagrees is a real write.
+		const { title: _none, ...untitled } = richSession;
+		vi.mocked(collectSessionEvents).mockResolvedValue([untitled]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		vi.mocked(collectSessionEvents).mockResolvedValue([richSession]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		const row = await query<{ title: string }>("SELECT title FROM sessions WHERE session_id = 's1'");
+		expect(row).toEqual([{ title: "a conversation" }]);
+	});
+
+	it("still projects a session whose model split arrived later", async () => {
+		// The child tables are replace-when-observed, so a session that had no split
+		// and now has one is a real write — the same shape as a COALESCE'd column
+		// filling in, one table further down.
+		await dbBackfillRepo({ repo, dbPath });
+
+		vi.mocked(collectSessionEvents).mockResolvedValue([
+			{
+				...sessionEvent,
+				models: [{ model: "claude-opus-5", inputTokens: 10, outputTokens: 5, cachedTokens: 0 }],
+			},
+		]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		const usage = await query<{ model: string }>("SELECT model FROM session_model_usage");
+		expect(usage).toEqual([{ model: "claude-opus-5" }]);
+	});
+
+	// The child tables are the LAST source of per-run churn: measured on a real
+	// machine, two back-to-back `jolli dashboard` runs each re-projected the same
+	// 17 sessions, byte-identical, purely because they carried a model split
+	// (JOLLI-2224 follow-up). Every one of these events is compared against the
+	// rows it would write rather than against `projectSession`'s merge RULES —
+	// the rules are what a restatement would drift from.
+	const modelSession: SessionUpsertedEvent = {
+		...sessionEvent,
+		tokenCoverage: "full",
+		models: [
+			{ model: "claude-opus-5", inputTokens: 100, outputTokens: 50, cachedTokens: 10, estCostUsd: 0.5 },
+			{ model: "claude-haiku-4-5", inputTokens: 20, outputTokens: 5, cachedTokens: 0 },
+		],
+	};
+
+	const toolSession: SessionUpsertedEvent = {
+		...sessionEvent,
+		tools: [
+			{ name: "Bash", kind: "builtin", calls: 40, lastCallAtMs: 1_700_000_040_000 },
+			{ name: "jollimemory.recall", kind: "mcp", server: "jollimemory", calls: 1 },
+		],
+	};
+
+	it("does not re-enqueue a session whose model split is unchanged", async () => {
+		vi.mocked(collectSessionEvents).mockResolvedValue([modelSession]);
+		await dbBackfillRepo({ repo, dbPath });
+		expect(await loggedSessions("s1")).toBe(1);
+
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(1);
+	});
+
+	it("still projects a session whose model split moved", async () => {
+		vi.mocked(collectSessionEvents).mockResolvedValue([modelSession]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		const [opus, haiku] = modelSession.models ?? [];
+		vi.mocked(collectSessionEvents).mockResolvedValue([
+			{ ...modelSession, models: [{ ...opus, outputTokens: 900 }, haiku] },
+		]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		const row = await query<{ output_tokens: number }>(
+			"SELECT output_tokens FROM session_model_usage WHERE model = 'claude-opus-5'",
+		);
+		expect(row).toEqual([{ output_tokens: 900 }]);
+	});
+
+	it("still projects a session that dropped a model", async () => {
+		// The split is replaced WHOLESALE, so a shrinking set is a real write even
+		// though every surviving row is identical — comparing only the rows the
+		// event carries would leave the dropped one behind forever.
+		vi.mocked(collectSessionEvents).mockResolvedValue([modelSession]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		vi.mocked(collectSessionEvents).mockResolvedValue([
+			{ ...modelSession, models: [(modelSession.models ?? [])[0]] },
+		]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		const rows = await query<{ model: string }>("SELECT model FROM session_model_usage ORDER BY model");
+		expect(rows).toEqual([{ model: "claude-opus-5" }]);
+	});
+
+	it("still projects a session that swapped one model for another", async () => {
+		// Equal cardinality, so the size check passes and only the per-key lookup can
+		// tell these apart. A rename is the ordinary way this happens.
+		vi.mocked(collectSessionEvents).mockResolvedValue([modelSession]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		const [opus, haiku] = modelSession.models ?? [];
+		vi.mocked(collectSessionEvents).mockResolvedValue([
+			{ ...modelSession, models: [opus, { ...haiku, model: "claude-haiku-5" }] },
+		]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		const rows = await query<{ model: string }>("SELECT model FROM session_model_usage ORDER BY model");
+		expect(rows).toEqual([{ model: "claude-haiku-5" }, { model: "claude-opus-5" }]);
+	});
+
+	it("still projects a session whose model was repriced", async () => {
+		// Same tokens, different cost — a `PRICES_AS_OF` bump re-costing an existing
+		// split. Nothing in the token columns moves, so the cost is the only witness.
+		vi.mocked(collectSessionEvents).mockResolvedValue([modelSession]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		const [opus, haiku] = modelSession.models ?? [];
+		vi.mocked(collectSessionEvents).mockResolvedValue([
+			{ ...modelSession, models: [{ ...opus, estCostUsd: 0.75 }, haiku] },
+		]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		const row = await query<{ est_cost_usd: number }>("SELECT est_cost_usd FROM sessions WHERE session_id = 's1'");
+		expect(row).toEqual([{ est_cost_usd: 0.75 }]);
+	});
+
+	it("still projects a session whose cost moved with no model split to explain it", async () => {
+		// `est_cost_usd` cannot ride with the verbatim COALESCE'd columns — a split
+		// makes its written value a SUM — so it is compared on its own. This is the
+		// no-split half of that comparison.
+		vi.mocked(collectSessionEvents).mockResolvedValue([richSession]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		vi.mocked(collectSessionEvents).mockResolvedValue([{ ...richSession, estCostUsd: 0.99 }]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		const row = await query<{ est_cost_usd: number }>("SELECT est_cost_usd FROM sessions WHERE session_id = 's1'");
+		expect(row).toEqual([{ est_cost_usd: 0.99 }]);
+	});
+
+	it("still projects a session whose stored display model went stale", async () => {
+		// `sessions.model` is COALESCE'd and derived (highest-token model), so it can
+		// disagree with a split that itself matches — an older build that picked the
+		// primary differently leaves exactly this state behind. Compared separately
+		// for that reason; the split alone would call this session unchanged.
+		vi.mocked(collectSessionEvents).mockResolvedValue([modelSession]);
+		await dbBackfillRepo({ repo, dbPath });
+		await withDashboardDb((db) => db.prepare("UPDATE sessions SET model = 'claude-haiku-4-5'").run(), { dbPath });
+
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		const row = await query<{ model: string }>("SELECT model FROM sessions WHERE session_id = 's1'");
+		expect(row).toEqual([{ model: "claude-opus-5" }]);
+	});
+
+	it("does not re-enqueue a usage-less re-read carrying an empty model split", async () => {
+		// `models: []` with no scalar tokens is "unobserved", not "no models": the
+		// projection's delete is gated on `hasUsage`, so it writes NOTHING and the
+		// stored split survives. Comparing the empty list against the stored rows
+		// would call that a difference and re-project on every pass.
+		vi.mocked(collectSessionEvents).mockResolvedValue([modelSession]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		const { models: _dropped, tokenCoverage: _coverage, ...bare } = modelSession;
+		vi.mocked(collectSessionEvents).mockResolvedValue([{ ...bare, models: [] }]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(1);
+		const rows = await query<{ model: string }>("SELECT model FROM session_model_usage ORDER BY model");
+		expect(rows).toEqual([{ model: "claude-haiku-4-5" }, { model: "claude-opus-5" }]);
+	});
+
+	it("does not re-enqueue an unobserved re-read that restates the stored coverage", async () => {
+		// No tokens and no split, so the projection carries the stored values
+		// forward and only `token_coverage` is even eligible to move. Restating the
+		// value it already holds is not a move.
+		const unobserved: SessionUpsertedEvent = { ...sessionEvent, tokenCoverage: "sessions-only" };
+		vi.mocked(collectSessionEvents).mockResolvedValue([unobserved]);
+		await dbBackfillRepo({ repo, dbPath });
+		expect(await loggedSessions("s1")).toBe(1);
+
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(1);
+	});
+
+	it("still projects an unobserved re-read whose cost moved", async () => {
+		// `est_cost_usd` is the one derived column that does not ride on `hasUsage`:
+		// its fallback chain reaches the event's own scalar BEFORE the stored value,
+		// so a token-less event carrying a price writes it. Comparing only
+		// `token_coverage` on this branch skipped such an event forever, and the
+		// price it brought never reached the row.
+		const priced: SessionUpsertedEvent = { ...sessionEvent, estCostUsd: 0.25 };
+		vi.mocked(collectSessionEvents).mockResolvedValue([priced]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		vi.mocked(collectSessionEvents).mockResolvedValue([{ ...priced, estCostUsd: 0.4 }]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		const row = await query<{ est_cost_usd: number }>("SELECT est_cost_usd FROM sessions WHERE session_id = 's1'");
+		expect(row).toEqual([{ est_cost_usd: 0.4 }]);
+	});
+
+	it("does not re-enqueue an unobserved re-read restating the stored cost", async () => {
+		// The other half of the check above: hoisting the cost comparison ahead of
+		// the carry-forward return must not turn a token-less session into one that
+		// re-projects on every pass just because it carries a price at all.
+		vi.mocked(collectSessionEvents).mockResolvedValue([{ ...sessionEvent, estCostUsd: 0.25 }]);
+		await dbBackfillRepo({ repo, dbPath });
+		expect(await loggedSessions("s1")).toBe(1);
+
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(1);
+	});
+
+	it("does not re-enqueue a session whose tokens are observed without a coverage claim", async () => {
+		// An event that observed usage but names no coverage is written as
+		// `sessions-only`, so the comparison has to apply the same default rather
+		// than reading the absent field as "no opinion".
+		const { tokenCoverage: _absent, ...unclaimed } = richSession;
+		vi.mocked(collectSessionEvents).mockResolvedValue([unclaimed]);
+		await dbBackfillRepo({ repo, dbPath });
+		expect(await loggedSessions("s1")).toBe(1);
+
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(1);
+	});
+
+	it("does not re-enqueue a session whose tool calls are unchanged", async () => {
+		vi.mocked(collectSessionEvents).mockResolvedValue([toolSession]);
+		await dbBackfillRepo({ repo, dbPath });
+		expect(await loggedSessions("s1")).toBe(1);
+
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(1);
+	});
+
+	it("still projects a session whose tool call count moved", async () => {
+		vi.mocked(collectSessionEvents).mockResolvedValue([toolSession]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		const [bash, recall] = toolSession.tools ?? [];
+		vi.mocked(collectSessionEvents).mockResolvedValue([
+			{ ...toolSession, tools: [{ ...bash, calls: 41 }, recall] },
+		]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		const row = await query<{ calls: number }>("SELECT calls FROM session_tool_use WHERE tool_name = 'Bash'");
+		expect(row).toEqual([{ calls: 41 }]);
+	});
+
+	it("still projects a session that dropped a tool", async () => {
+		vi.mocked(collectSessionEvents).mockResolvedValue([toolSession]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		vi.mocked(collectSessionEvents).mockResolvedValue([{ ...toolSession, tools: [(toolSession.tools ?? [])[0]] }]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		const rows = await query<{ tool_name: string }>("SELECT tool_name FROM session_tool_use");
+		expect(rows).toEqual([{ tool_name: "Bash" }]);
+	});
+
+	it("still projects a session whose tool list repeats one name and kind", async () => {
+		// A repeated `(name, kind)` COLLAPSES on insert — the pair is that table's
+		// key — so N entries can produce fewer than N rows. Counting entries against
+		// stored rows is therefore not enough on its own: here two entries meet two
+		// stored rows, and projecting would leave ONE, deleting `Read`.
+		const bash = { name: "Bash", kind: "builtin", calls: 40, lastCallAtMs: 1_700_000_040_000 } as const;
+		vi.mocked(collectSessionEvents).mockResolvedValue([
+			{ ...sessionEvent, tools: [bash, { name: "Read", kind: "builtin", calls: 3 }] },
+		]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		vi.mocked(collectSessionEvents).mockResolvedValue([{ ...sessionEvent, tools: [bash, bash] }]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		const rows = await query<{ tool_name: string }>("SELECT tool_name FROM session_tool_use ORDER BY tool_name");
+		expect(rows).toEqual([{ tool_name: "Bash" }]);
+	});
+
+	it("still projects a session that swapped one tool for another", async () => {
+		vi.mocked(collectSessionEvents).mockResolvedValue([toolSession]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		const [bash, recall] = toolSession.tools ?? [];
+		vi.mocked(collectSessionEvents).mockResolvedValue([
+			{ ...toolSession, tools: [bash, { ...recall, name: "jollimemory.search" }] },
+		]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		const rows = await query<{ tool_name: string }>("SELECT tool_name FROM session_tool_use ORDER BY tool_name");
+		expect(rows).toEqual([{ tool_name: "Bash" }, { tool_name: "jollimemory.search" }]);
+	});
+
+	it("still projects a session whose MCP tool changed server", async () => {
+		// `server` is not part of the key, so a tool that moved between servers keeps
+		// its row identity — only the column moves, and only this check sees it.
+		vi.mocked(collectSessionEvents).mockResolvedValue([toolSession]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		const [bash, recall] = toolSession.tools ?? [];
+		vi.mocked(collectSessionEvents).mockResolvedValue([
+			{ ...toolSession, tools: [bash, { ...recall, server: "jollimemory-remote" }] },
+		]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		const row = await query<{ server: string }>("SELECT server FROM session_tool_use WHERE kind = 'mcp'");
+		expect(row).toEqual([{ server: "jollimemory-remote" }]);
+	});
+
+	it("still projects a session whose tool lost its recorded instant", async () => {
+		// The MAX around `last_call_at_ms` cannot save the stored instant here: the
+		// projection DELETEs the tool rows before inserting, so there is no
+		// conflicting row for it to consult and the re-read's absent time lands as
+		// NULL. That erasure is a real write, which is exactly why this comparison
+		// may not treat "no instant" as equal to a stored one.
+		vi.mocked(collectSessionEvents).mockResolvedValue([toolSession]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		const [bash, recall] = toolSession.tools ?? [];
+		const { lastCallAtMs: _gone, ...timeless } = bash;
+		vi.mocked(collectSessionEvents).mockResolvedValue([{ ...toolSession, tools: [timeless, recall] }]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+	});
 });
 
 describe("multiple checkouts of one project (§10.2)", () => {

--- a/cli/src/dashboard/DbBackfill.ts
+++ b/cli/src/dashboard/DbBackfill.ts
@@ -36,6 +36,7 @@ import { isJolliInternalRef } from "../core/JolliRefs.js";
 import type { StorageProvider } from "../core/StorageProvider.js";
 import { getIndex, resolveReadStorage } from "../core/SummaryStore.js";
 import { createLogger, errMsg, ORPHAN_BRANCH } from "../Logger.js";
+import type { ToolCallCount } from "../Types.js";
 import {
 	collectCommitEvents,
 	// collectRepoGraph,  // parked with `repo_graphs` — see SotSchema
@@ -46,7 +47,15 @@ import {
 } from "./DashboardCollector.js";
 import type { DashboardDbHandle } from "./DashboardDb.js";
 import { inTransaction, withDashboardDb } from "./DashboardDb.js";
-import type { CommitCreatedEvent, ProducerKind, StatsEvent, StatsEventEnvelope } from "./DashboardModel.js";
+import type {
+	CommitCreatedEvent,
+	CommitSummaryEvent,
+	ProducerKind,
+	SessionUpsertedEvent,
+	StatsEvent,
+	StatsEventEnvelope,
+	StatsModelUsage,
+} from "./DashboardModel.js";
 import { existingWorktrees, hasLiveWorktree, type RegisteredRepo, readRepoCutoverFence } from "./RepoRegistry.js";
 import {
 	countMemoriesAbsentFromListing,
@@ -416,6 +425,385 @@ function unchangedCommitEvent(
 	return true;
 }
 
+/**
+ * Session rows this repo already has, keyed `<source>\0<sessionId>` → the row's
+ * `token_coverage`.
+ *
+ * The one thing {@link unchangedSummaryEvent} cannot answer from the commits
+ * side: a summary's session links SEED rows, and whether that seed is a no-op
+ * depends on state in `sessions`, not on the summary.
+ */
+function storedSessionCoverage(db: DashboardDbHandle, repoIdentity: string): Map<string, string> {
+	const rows = db
+		.prepare(
+			`SELECT s.source, s.session_id, s.token_coverage
+			   FROM sessions s JOIN repos r ON r.id = s.repo_id
+			  WHERE r.repo_identity = ?`,
+		)
+		.all(repoIdentity) as ReadonlyArray<{ source: string; session_id: string; token_coverage: string }>;
+	return new Map(rows.map((r) => [`${r.source}\0${r.session_id}`, r.token_coverage]));
+}
+
+/**
+ * True when projecting `event` would write nothing new.
+ *
+ * The memory tier's counterpart to {@link unchangedCommitEvent}, and it exists
+ * for the same reason — with the asymmetry that made it necessary. The commit
+ * tier's gate is per-checkout (HEAD plus the ref list), so an ordinary pass
+ * usually skips collection outright; the summary gate is the index's CONTENT
+ * HASH, which moves the moment any one memory is written, and then re-collects
+ * the WHOLE set. So on a repo being actively developed the gate is open on
+ * essentially every pass and every stored summary was re-logged and re-projected
+ * — measured at 219 events per `jolli dashboard` run, every copy byte-identical
+ * (JOLLI-2224). The redo is idempotent in SQL and free in nothing else: it
+ * appends a write-ahead row per event and re-runs the projection's writes.
+ *
+ * The index hash cannot be narrowed to fix this (consolidation folds children
+ * into new roots, so per-entry cursors genuinely cannot work) — which is exactly
+ * why the answer is the same one the commit tier uses: collect everything,
+ * compare before projecting.
+ *
+ * MIRRORS {@link projectCommitSummary}, which writes THREE things and nothing
+ * else — the memory rows belong to the orphan import, not to this projection:
+ *
+ *  - The `commits` row. Its nullable columns are written `COALESCE(excluded.x,
+ *    commits.x)`, so an ABSENT value cannot change anything; a present one must
+ *    equal what is stored. `committed_at_ms` is deliberately NOT compared: the
+ *    conflict clause does not update it, so it is set on insert and never again.
+ *  - `commit_branches`, replace-when-present with exactly ONE branch — so a
+ *    present `branch` must already be the whole stored set. Absent leaves the
+ *    rows alone and is therefore not a difference (see `projectCommitSummary`
+ *    for why only `commit.created` may claim "no branch").
+ *  - The `sessions` seed. This is the half a commits-only comparison would get
+ *    wrong: a session older than the agents' own retention exists nowhere but in
+ *    these links, so skipping an event whose link has no row loses it silently.
+ *    The seed is a no-op only when the row already exists AND this link cannot
+ *    upgrade it — i.e. the link carries no models, or the row is already past
+ *    `sessions-only`.
+ *
+ * `commitPruned` is what stops the two tiers from ping-ponging. This projection
+ * CREATES the `commits` row when none exists, and `pruneUnreachableCommits`
+ * deletes it again on the next pass whenever git can no longer reach the hash —
+ * a rebased or squashed-away commit whose memory legitimately survives. Neither
+ * tier is wrong on its own, so the loop never converged: 74 events per run,
+ * forever. When the caller KNOWS the hash is unreachable, the row this event
+ * would create is one the prune has already removed in that same pass, so only
+ * the session seeding is left to decide the answer — which is why a missing row
+ * stops being an automatic "must project" and the commits comparisons are
+ * skipped rather than failed.
+ *
+ * The caller may only claim that from a COMPLETE collection: it runs before this
+ * tier and would have collected the commit if git still had it, so within such a
+ * pass "no row" and "no commit" are the same statement. With no reachable set —
+ * a failed read, or a cursor-skipped commit tier, in BOTH of which nothing was
+ * pruned either — a missing row is read the old way, because a summary really
+ * can arrive before its commit is swept.
+ */
+function unchangedSummaryEvent(
+	event: CommitSummaryEvent,
+	stored: { row: Record<string, unknown>; branches: Set<string> } | undefined,
+	sessionCoverage: ReadonlyMap<string, string>,
+	commitPruned: boolean,
+): boolean {
+	if (!stored && !commitPruned) return false;
+	if (stored) {
+		const { row, branches } = stored;
+		if (event.branch !== undefined && row.branch !== event.branch) return false;
+		if (event.message !== undefined && row.message !== event.message) return false;
+		if (event.branch !== undefined && (branches.size !== 1 || !branches.has(event.branch))) return false;
+	}
+	for (const link of event.sessionLinks ?? []) {
+		const coverage = sessionCoverage.get(`${link.source}\0${link.sessionId}`);
+		if (coverage === undefined) return false;
+		if (coverage === "sessions-only" && (link.models ?? []).length > 0) return false;
+	}
+	return true;
+}
+
+/**
+ * The `sessions` columns `projectSession` writes with `COALESCE(excluded.x,
+ * sessions.x)`, paired with the event field each is written from — one table
+ * rather than six near-identical comparisons, so adding a column to that
+ * conflict clause is one line here and cannot be half-done.
+ */
+const SESSION_COALESCED_COLUMNS: ReadonlyArray<
+	readonly [string, (event: SessionUpsertedEvent) => string | number | undefined]
+> = [
+	["title", (e) => e.title],
+	["started_at_ms", (e) => e.startedAtMs],
+	["message_count", (e) => e.messageCount],
+	["duration_ms", (e) => e.durationMs],
+	["prices_as_of", (e) => e.pricesAsOf],
+];
+
+/** A `session_model_usage` row, in the shape {@link sameModelSplit} compares. */
+interface StoredModelRow {
+	readonly input: number;
+	readonly output: number;
+	readonly cached: number;
+	readonly cost: number | null;
+}
+
+/** A `session_tool_use` row, in the shape {@link sameToolSet} compares. */
+interface StoredToolRow {
+	readonly server: string | null;
+	readonly calls: number;
+	readonly lastCallAtMs: number | null;
+}
+
+/**
+ * One session as it is currently stored: its own row plus BOTH child tables.
+ *
+ * The child maps are keyed the way their table is keyed — `session_model_usage`
+ * by `model`, `session_tool_use` by `(tool_name, kind)` — so a comparison that
+ * walks them cannot accidentally merge two rows the schema keeps apart (a skill
+ * and a builtin may share a name; see that table's DDL).
+ */
+interface StoredSession {
+	readonly row: Record<string, unknown>;
+	readonly models: ReadonlyMap<string, StoredModelRow>;
+	readonly tools: ReadonlyMap<string, StoredToolRow>;
+}
+
+/** `(tool_name, kind)` — the `session_tool_use` primary key, minus the session. */
+function toolKey(name: string, kind: string): string {
+	return `${name}\0${kind}`;
+}
+
+/** The session rows this repo already has, in the shape {@link unchangedSessionEvent} compares against. */
+function storedSessionRows(db: DashboardDbHandle, repoIdentity: string): Map<string, StoredSession> {
+	const rows = db
+		.prepare(
+			`SELECT s.source, s.session_id, s.title, s.started_at_ms, s.updated_at_ms, s.message_count,
+			        s.duration_ms, s.model, s.input_tokens, s.output_tokens, s.cached_tokens, s.est_cost_usd,
+			        s.token_coverage, s.prices_as_of
+			   FROM sessions s JOIN repos r ON r.id = s.repo_id
+			  WHERE r.repo_identity = ?`,
+		)
+		.all(repoIdentity) as ReadonlyArray<Record<string, unknown> & { source: string; session_id: string }>;
+	const sessions = new Map<string, StoredSession>(
+		rows.map((r) => [`${r.source}\0${r.session_id}`, { row: r, models: new Map(), tools: new Map() }]),
+	);
+
+	// Joined back through `sessions` rather than read by `session_event_id`: the
+	// id's shape is `statsEventId`'s business, and this way the child rows arrive
+	// keyed by the same `(source, sessionId)` pair the caller looks up with.
+	const modelRows = db
+		.prepare(
+			`SELECT s.source, s.session_id, u.model, u.input_tokens, u.output_tokens, u.cached_tokens, u.est_cost_usd
+			   FROM session_model_usage u
+			   JOIN sessions s ON s.event_id = u.session_event_id
+			   JOIN repos r    ON r.id = s.repo_id
+			  WHERE r.repo_identity = ?`,
+		)
+		.all(repoIdentity) as ReadonlyArray<{
+		source: string;
+		session_id: string;
+		model: string;
+		input_tokens: number;
+		output_tokens: number;
+		cached_tokens: number;
+		est_cost_usd: number | null;
+	}>;
+	for (const r of modelRows) {
+		const target = sessions.get(`${r.source}\0${r.session_id}`);
+		(target?.models as Map<string, StoredModelRow>)?.set(r.model, {
+			input: r.input_tokens,
+			output: r.output_tokens,
+			cached: r.cached_tokens,
+			cost: r.est_cost_usd,
+		});
+	}
+
+	const toolRows = db
+		.prepare(
+			`SELECT s.source, s.session_id, t.tool_name, t.kind, t.server, t.calls, t.last_call_at_ms
+			   FROM session_tool_use t
+			   JOIN sessions s ON s.event_id = t.session_event_id
+			   JOIN repos r    ON r.id = s.repo_id
+			  WHERE r.repo_identity = ?`,
+		)
+		.all(repoIdentity) as ReadonlyArray<{
+		source: string;
+		session_id: string;
+		tool_name: string;
+		kind: string;
+		server: string | null;
+		calls: number;
+		last_call_at_ms: number | null;
+	}>;
+	for (const r of toolRows) {
+		const target = sessions.get(`${r.source}\0${r.session_id}`);
+		(target?.tools as Map<string, StoredToolRow>)?.set(toolKey(r.tool_name, r.kind), {
+			server: r.server,
+			calls: r.calls,
+			lastCallAtMs: r.last_call_at_ms,
+		});
+	}
+	return sessions;
+}
+
+/**
+ * True when re-writing `models` would leave `session_model_usage` as it stands.
+ *
+ * The split is replaced WHOLESALE, so this is set equality and not containment:
+ * a shrinking set leaves a stale row behind, which is the whole reason
+ * `projectSession` deletes before inserting.
+ *
+ * `model` is that table's key, so duplicate entries in one event would violate
+ * the primary key on the plain INSERT — the projection would throw, not merge.
+ * Nothing to mirror here; a size check plus a per-key lookup is exact.
+ */
+function sameModelSplit(models: ReadonlyArray<StatsModelUsage>, stored: ReadonlyMap<string, StoredModelRow>): boolean {
+	if (models.length !== stored.size) return false;
+	for (const m of models) {
+		const row = stored.get(m.model);
+		if (!row) return false;
+		if (row.input !== m.inputTokens || row.output !== m.outputTokens || row.cached !== m.cachedTokens) return false;
+		if (row.cost !== (m.estCostUsd ?? null)) return false;
+	}
+	return true;
+}
+
+/**
+ * True when re-writing `tools` would leave `session_tool_use` as it stands.
+ *
+ * Set equality against `stored`, keyed by {@link toolKey} — same shape as
+ * {@link sameModelSplit}, and same reason (the set is replaced wholesale, so a
+ * dropped tool is a real write). Three facts about the write path make this one
+ * harder than the model split, and all three are load-bearing:
+ *
+ *  1. The insert carries `ON CONFLICT(session_event_id, tool_name, kind)`, so
+ *     two entries in ONE event that share a name and kind do not both land —
+ *     they merge, with `calls` taking the later entry's value, `last_call_at_ms`
+ *     taking the MAX, and `server` keeping the FIRST entry's value because the
+ *     conflict clause does not update it.
+ *  2. `last_call_at_ms` is written through `NULLIF(MAX(...), 0)`, so an entry
+ *     with no instant does not necessarily store NULL.
+ *  3. `server` is nullable on both sides, and `undefined` on the event becomes
+ *     NULL in the row.
+ *
+ * Only the FIRST of those needs an answer here, and the answer is to refuse
+ * rather than to restate it: a repeated key is reported CHANGED, so the event
+ * projects and the merge stays where it is written. Facts 2 and 3 then stop
+ * being reachable subtleties — the projection deletes before inserting, so with
+ * no repeat inside the event there is no conflicting row for the MAX to consult
+ * and each entry stores its own value, NULL included. That is what makes plain
+ * equality exact for every list this branch actually compares.
+ *
+ * Counting entries against stored rows does NOT subsume that refusal, though it
+ * looks like it should: a repeat collapses, so `[Bash, Bash]` is two entries and
+ * one row, and it meets a stored pair of `Bash` + `Read` at equal size. Skipping
+ * there would strand `Read` forever — the row the projection was about to drop.
+ */
+function sameToolSet(tools: ReadonlyArray<ToolCallCount>, stored: ReadonlyMap<string, StoredToolRow>): boolean {
+	const keys = new Set(tools.map((t) => toolKey(t.name, t.kind)));
+	if (keys.size !== tools.length) return false;
+	if (tools.length !== stored.size) return false;
+	for (const tool of tools) {
+		const row = stored.get(toolKey(tool.name, tool.kind));
+		if (!row) return false;
+		if (row.calls !== tool.calls) return false;
+		if (row.server !== (tool.server ?? null)) return false;
+		if (row.lastCallAtMs !== (tool.lastCallAtMs ?? null)) return false;
+	}
+	return true;
+}
+
+/**
+ * True when projecting `event` would write nothing new.
+ *
+ * The session tier has NO gate whatever — its cursor is recorded for
+ * observability and never consulted, deliberately, because a global
+ * max-updatedAt would miss a session updated out of order. So every
+ * discoverable session was re-logged and re-projected on every pass; measured,
+ * half of them carry no usage at all and are byte-identical repeats
+ * (JOLLI-2224).
+ *
+ * The child tables are covered for a measured reason, not for symmetry. A first
+ * version skipped any event carrying a split or a tool list, on the grounds that
+ * their merge rules were the risky half to mirror. Two back-to-back `jolli
+ * dashboard` runs then still re-projected 17 sessions each, byte-identical, and
+ * 14 of the 17 had not been touched for a day — the carve-out WAS the remaining
+ * churn, because a real session almost always carries both.
+ *
+ * MIRRORS `projectSession`, including both child tables. It compares against the
+ * ROWS THOSE WRITES WOULD PRODUCE, never against the merge rules that produce
+ * them — the rules (the `hasUsage` gate `models: []` once fell through, the
+ * MAX/NULLIF on the tool timestamp) are exactly what a restatement would drift
+ * from, and a drifted gate fails by silently dropping data. The one rule that IS
+ * restated is `hasUsage` itself, because it decides whether a write happens at
+ * all rather than what it writes:
+ *
+ *  - `updated_at_ms` is written unconditionally, so it is always compared.
+ *  - The `COALESCE`d columns cannot be changed by an ABSENT value; a present one
+ *    must already match.
+ *  - The token scalars and `token_coverage` are written unconditionally, but the
+ *    value written comes from the model split WHEN THERE IS ONE — so the
+ *    comparison derives them the same way rather than reading the event's own
+ *    scalar fields, which a split makes advisory. When the event observed no
+ *    usage at all the stored values carried forward, so nothing can move.
+ *  - `model` and `est_cost_usd` are `COALESCE`d, but their written value is
+ *    DERIVED from the split (primary model, summed cost), so they cannot ride in
+ *    {@link SESSION_COALESCED_COLUMNS} with the fields that are copied verbatim.
+ *    And `est_cost_usd` is the one derived column that does NOT ride on
+ *    `hasUsage`: it falls back to the event's own `estCostUsd` before the stored
+ *    value, so a token-less event carrying a price still writes it, and its
+ *    comparison has to happen ahead of the carry-forward return.
+ *  - Both child tables are replace-when-observed, under the same predicate
+ *    `projectSession` uses to decide it wrote at all.
+ */
+function unchangedSessionEvent(event: SessionUpsertedEvent, stored: StoredSession | undefined): boolean {
+	if (!stored) return false;
+	const { row } = stored;
+	if (row.updated_at_ms !== event.updatedAtMs) return false;
+	for (const [column, read] of SESSION_COALESCED_COLUMNS) {
+		const value = read(event);
+		if (value !== undefined && row[column] !== value) return false;
+	}
+
+	const models = event.models ?? [];
+	// The SAME predicate `projectSession` computes, `models.length > 0` term and
+	// all. Dropping that term is not a near-miss: it routes a split-carrying event
+	// into the carry-forward branch below, which compares no tokens at all.
+	const hasUsage =
+		models.length > 0 || event.inputTokens != null || event.outputTokens != null || event.cachedTokens != null;
+
+	// Replace-when-observed, both of them. The model split's guard is `hasUsage`
+	// AND presence — an event that carries `models: []` with no scalar tokens is
+	// "unobserved", and the projection leaves the stored split alone.
+	if (hasUsage && event.models !== undefined && !sameModelSplit(models, stored.models)) return false;
+	if (event.tools !== undefined && !sameToolSet(event.tools, stored.tools)) return false;
+
+	const sum = (read: (m: StatsModelUsage) => number): number => models.reduce((total, m) => total + read(m), 0);
+	// `COALESCE`d, so only a non-null derived value can move it — but compared
+	// BEFORE the carry-forward return below, because cost does not ride on
+	// `hasUsage`. Its fallback chain is the event's own scalar first, so an event
+	// that observed no tokens at all can still carry a price, and that price is
+	// written on both branches. Gating this on `hasUsage` skipped such an event
+	// forever: the cost it brought would never reach the row, silently.
+	const cost = models.some((m) => m.estCostUsd != null) ? sum((m) => m.estCostUsd ?? 0) : event.estCostUsd;
+	if (cost != null && row.est_cost_usd !== cost) return false;
+
+	if (!hasUsage) return event.tokenCoverage === undefined || row.token_coverage === event.tokenCoverage;
+
+	const split = models.length > 0;
+	// `COALESCE`d, so only a non-null derived value can move it. Unlike cost this
+	// one cannot outlive `hasUsage` — it is derived from the split alone, which is
+	// empty on the carry-forward branch, so it is always absent there.
+	const primaryModel = [...models].sort(
+		(a, b) => b.inputTokens + b.outputTokens - (a.inputTokens + a.outputTokens),
+	)[0]?.model;
+	if (primaryModel !== undefined && row.model !== primaryModel) return false;
+
+	return (
+		row.input_tokens === (split ? sum((m) => m.inputTokens) : (event.inputTokens ?? 0)) &&
+		row.output_tokens === (split ? sum((m) => m.outputTokens) : (event.outputTokens ?? 0)) &&
+		row.cached_tokens === (split ? sum((m) => m.cachedTokens) : (event.cachedTokens ?? 0)) &&
+		row.token_coverage === (event.tokenCoverage ?? "sessions-only")
+	);
+}
+
 /** Wraps events in envelopes and applies them in small batches. */
 function applyBatches(
 	db: DashboardDbHandle,
@@ -597,6 +985,11 @@ export async function dbBackfillRepo(opts: DbBackfillOptions): Promise<DbBackfil
 			const gitCursor = fingerprints.length > 0 ? fingerprints.sort().join(" ") : null;
 			const commitCursor = readCursor(db, repo.repoIdentity, CURSOR_GIT);
 			const commitsUnchanged = !isBootstrap && gitCursor !== null && commitCursor === gitCursor;
+			// Set only by a COMPLETE collection below — the same condition that
+			// licenses the prune, and for the same reason. The summary tier reads it
+			// to tell "this commit is gone" from "its sweep has not run yet"; null
+			// means it may not distinguish them. See `unchangedSummaryEvent`.
+			let reachableHashes: Set<string> | null = null;
 
 			if (isBootstrap) {
 				db.prepare("UPDATE repos SET bootstrap_state = 'in-progress' WHERE repo_identity = ?").run(
@@ -714,6 +1107,7 @@ export async function dbBackfillRepo(opts: DbBackfillOptions): Promise<DbBackfil
 				).applied;
 				if (collectionComplete) {
 					const reachable = new Set(commitEvents.map((e) => e.hash));
+					reachableHashes = reachable;
 					// Prune against the UNION: pruning per worktree would delete commits that
 					// only the other checkout can reach, and the next pass would re-add them —
 					// a delete/insert cycle on every run.
@@ -750,7 +1144,25 @@ export async function dbBackfillRepo(opts: DbBackfillOptions): Promise<DbBackfil
 					cwd,
 					storage: orphanStorage,
 				});
-				const summaryApply = applyBatches(db, summaries.events, producerKind, now);
+				// Same two-step as the commit tier: the COLLECTION stays whole (the
+				// cursor below is the index's content hash, and `summaries.complete`
+				// is a claim about that whole read), only the PROJECTION is narrowed.
+				const summaryRows = storedCommitRows(db, repo.repoIdentity);
+				const sessionCoverage = storedSessionCoverage(db, repo.repoIdentity);
+				const pruned = (hash: string): boolean => reachableHashes !== null && !reachableHashes.has(hash);
+				const changedSummaries = summaries.events.filter(
+					(event) =>
+						!unchangedSummaryEvent(event, summaryRows.get(event.hash), sessionCoverage, pruned(event.hash)),
+				);
+				if (changedSummaries.length !== summaries.events.length) {
+					log.info(
+						"%s: %d of %d summary events unchanged, skipping their projection",
+						repo.repoName,
+						summaries.events.length - changedSummaries.length,
+						summaries.events.length,
+					);
+				}
+				const summaryApply = applyBatches(db, changedSummaries, producerKind, now);
 				applied += summaryApply.applied;
 				// Same rule as the commit tier's `collectionComplete` above, and for
 				// the same reason: this cursor is the index's content hash, so
@@ -770,17 +1182,30 @@ export async function dbBackfillRepo(opts: DbBackfillOptions): Promise<DbBackfil
 				}
 			}
 
-			// Sessions: always re-project the currently discoverable set. A global
+			// Sessions: always re-COLLECT the currently discoverable set. A global
 			// max-updatedAt cursor would miss an old session updated out of order,
 			// so the cursor only records progress for observability — it is never
-			// used to skip.
+			// used to skip. The projection is narrowed per event instead, exactly as
+			// in the two tiers above; see `unchangedSessionEvent`.
 			opts.onProgress?.({ repoName: repo.repoName, kind: "sessions", done: 0 });
 			const sessionEvents = await collectSessionEvents({
 				repoIdentity: repo.repoIdentity,
 				cwd,
 				...(opts.loadSessions ? { loadSessions: opts.loadSessions } : {}),
 			});
-			applied += applyBatches(db, sessionEvents, producerKind, now, (done, total) =>
+			const storedSessions = storedSessionRows(db, repo.repoIdentity);
+			const changedSessions = sessionEvents.filter(
+				(event) => !unchangedSessionEvent(event, storedSessions.get(`${event.source}\0${event.sessionId}`)),
+			);
+			if (changedSessions.length !== sessionEvents.length) {
+				log.info(
+					"%s: %d of %d session events unchanged, skipping their projection",
+					repo.repoName,
+					sessionEvents.length - changedSessions.length,
+					sessionEvents.length,
+				);
+			}
+			applied += applyBatches(db, changedSessions, producerKind, now, (done, total) =>
 				opts.onProgress?.({ repoName: repo.repoName, kind: "sessions", done, total }),
 			).applied;
 			const maxUpdated = sessionEvents.reduce((max, e) => Math.max(max, e.updatedAtMs), 0);


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Quick recap

The developer added unchanged-event detection to the dashboard's background data refresh. Each pass now compares collected memories and sessions against what is already stored and rewrites only the records that genuinely changed, leaving the rest untouched. On a live machine, the number of writes per refresh dropped from roughly three hundred to about twenty, with repeated runs producing zero duplicate rows and zero missing records. Records that report no token usage but carry a new price now have that price applied on the next refresh pass. Commits pruned from git history stay gone across refreshes, and the recurring re-create-and-delete cycle is gone.

---

## Topic (1)
<details>
<summary><strong>01 · Dashboard backfill skips re-projecting unchanged events and honors price-only updates</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Every refresh of the dashboard's background data feed rewrote each stored memory and session as byte-identical duplicates, and repeated runs on a real machine filled a third of the local dashboard database with pure repeats. Commits pruned as unreachable could also be re-created on the next sweep, so the churn never converged and kept cycling through re-create-and-delete passes.

**💡 Decisions Behind the Code**

- **Compare content, not checkpoints**: Consolidation folds child commits into new roots, so a per-entry checkpoint genuinely cannot track a memory's changes — but that only rules out checkpoints, not a per-event content comparison. The fix collects the whole set, compares each entry against what is stored, and skips anything identical — the same guarantee with no way to drift out of sync.
- **Compare stored results, not restated write rules**: The child tables merge new data through subtle rules (which usage counts as real, and once-recorded tool timestamps are never erased by a missing value), so restating those rules inside the skip check was rejected — a drifted restatement fails by silently dropping data. Comparing what a write would produce against what is stored is exact today and stays correct if the rules change, at the cost of a couple of small reads per event. This was adopted after starting conservative, when usage-carrying sessions were first never skipped.
- **Cost checked before the fast path, not inside it**: Cost is the one derived column independent of token usage — its fallback chain reaches the event's own price scalar before the stored value, so a token-less event can still carry a price both write paths apply. Gating the comparison on usage hid those writes permanently, so the check moved ahead of the early return and was pinned with both a positive test (a moved price re-projects) and a negative test (a restated price stays skipped).
- **Trust only a complete pass to declare a commit gone**: The create-and-prune loop for rebased-away commits could only be broken because the commit collection runs first and, when complete, would have found any commit git still has — a missing row in a complete pass really means the commit is gone. When the git read fails or that tier is skipped, the code falls back to the old behavior, since a summary can legitimately arrive before its commit is swept.
- **Prefer a rare extra write over restating one more rule**: When a single event's tool list repeats the same tool twice — a case whose merge behavior is nuanced — the check treats the session as changed and lets the normal write path collapse it. One rare wasted write buys guaranteed correctness, and that rule stays out of the skip gate.

**✅ What Was Implemented**

- Added two projection-skip predicates in cli/src/dashboard/DbBackfill.ts — unchangedSummaryEvent and unchangedSessionEvent — that compare each collected event against already-stored rows before projecting, reading stored rows once per sweep in a batch rather than one event at a time. The summary comparison covers all three writes (the commits row with committed_at_ms intentionally excluded, the commit_branches row, and the sessions seed); the session comparison always checks updated_at_ms and never skips an event carrying a model split or tool calls.
- Extended the session skip to usage-carrying records with sameModelSplit and sameToolSet set-equality helpers, comparing each event's model split and tool list against the stored session_model_usage / session_tool_use rows the writes would produce; a tool list repeating a (name, kind) pair is reported as changed so the projection's own collapse logic handles that merge.
- Hoisted the est_cost_usd comparison ahead of the hasUsage carry-forward return in unchangedSessionEvent so a token-less event carrying a price writes on both branches; the docstring now notes cost is the one derived column that does not ride on hasUsage. A regression test confirms a cost-only re-read (estCostUsd 0.25 to 0.4) re-projects, while a token-less session restating the same cost is not re-enqueued.
- Added a reachableHashes gate tied to the commit-prune condition so the summary projection cannot re-create a commits row for a hash git can no longer reach, ending the recurring create-and-prune ping-pong; without a complete collection the old behavior holds.
- Refactored the session comparison's near-duplicate column checks into a table-driven SESSION_COALESCED_COLUMNS list and fixed three latent bugs the removed early-return had masked (the missing "models present" term, scalar tokens that must be summed from the split when one exists, and derived model / est_cost_usd columns that could not ride in the coalesced list). Added 19 tests, each first seen failing, including guards for changed branches/messages/session links, pruned-commit session seeding, and unchanged, moved, dropped, swapped, and repriced splits and tool sets. Validated on a real machine: per-run event volume dropped from 269–308 to 21 against a live multi-hundred-megabyte database, with snapshots confirming all stored rows byte-for-byte identical across runs — zero duplicates, zero missing rows.

**📋 Future Enhancements**

- Consider replacing the three hand-mirrored projection comparisons with a direct comparison against the previous write-ahead-log payload for the same event, which cannot drift as projection columns evolve but trusts the log over destination rows.
- Mark JOLLI-2224 as In Review pending the user's call; re-run the full pre-commit gate on an idle machine or in CI — four attempts failed on environment issues (test timeouts and a coverage-writer crash), never on assertions.
- Watch whether the small fixed number of residual per-run writes grows as the session retention window expands before considering any further tightening.

**📁 FILES**
- `cli/src/dashboard/DbBackfill.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 14, 2026 at 4:45 PM · via Local agent - OpenCode*
<!-- jollimemory-summary-end -->