### PR TITLE
Overhaul dashboard Spend card accuracy, layout, and hygiene

### DIFF
--- a/cli/src/dashboard/DashboardDb.test.ts
+++ b/cli/src/dashboard/DashboardDb.test.ts
@@ -261,7 +261,7 @@ describe("withDashboardDb", () => {
 		).rejects.toThrow(/FOREIGN KEY/i);
 	});
 
-	it("never deletes repo rows — the v7 policy trigger blocks it, disable is an UPDATE", async () => {
+	it("refuses to delete a repo that owns rows — now on the foreign key, not the retired trigger", async () => {
 		const result = await withDashboardDb(
 			(db) => {
 				db.prepare(
@@ -270,8 +270,13 @@ describe("withDashboardDb", () => {
 				db.prepare(
 					"INSERT INTO sessions (event_id, repo_id, source, session_id, updated_at_ms) VALUES ('e', (SELECT id FROM repos WHERE repo_identity = 'r'), 'claude', 's', 1)",
 				).run();
-				expect(() => db.prepare("DELETE FROM repos WHERE repo_identity = 'r'").run()).toThrow(/never deleted/i);
-				// The sanctioned path: soft-disable in place, children untouched.
+				// `repos_no_delete` used to abort this with "never deleted". With the
+				// trigger dropped (REPOS_DELETE_ALLOWED_DDL) the guarantee that matters
+				// — a repo's memories cannot be silently wiped — is carried by the NO
+				// ACTION foreign keys, which hold because `foreign_keys` is ON in both
+				// WRITE_PRAGMAS and READ_PRAGMAS.
+				expect(() => db.prepare("DELETE FROM repos WHERE repo_identity = 'r'").run()).toThrow(/FOREIGN KEY/i);
+				// The sanctioned path is still soft-disable in place, children untouched.
 				db.prepare("UPDATE repos SET disabled_at = 'now' WHERE repo_identity = 'r'").run();
 				return {
 					sessions: (db.prepare("SELECT COUNT(*) AS n FROM sessions").get() as { n: number }).n,
@@ -286,6 +291,22 @@ describe("withDashboardDb", () => {
 		);
 		expect(result.sessions).toBe(1);
 		expect(result.disabled).toBe("now");
+	});
+
+	it("allows deleting a repo that owns nothing — the case the trigger used to block", async () => {
+		const remaining = await withDashboardDb(
+			(db) => {
+				db.prepare(
+					"INSERT INTO repos (repo_identity, repo_name, worktree_root, enabled_at) VALUES ('empty', 'e', '/e', 't')",
+				).run();
+				db.prepare("DELETE FROM repos WHERE repo_identity = 'empty'").run();
+				return (
+					db.prepare("SELECT COUNT(*) AS n FROM repos WHERE repo_identity = 'empty'").get() as { n: number }
+				).n;
+			},
+			{ dbPath },
+		);
+		expect(remaining).toBe(0);
 	});
 
 	it("still cascades intra-repo deletes — removing a commit clears its branch rows", async () => {
@@ -726,11 +747,34 @@ describe("the migration log — identity is the name, not the slot", () => {
 		// which is a guess, and says so in the outcome rather than posing as an
 		// observation.
 		expect(seeded?.map((r) => r.name)).toEqual(MIGRATIONS.slice(0, 5).map((m) => m.name));
-		// The entry that created the table is the only observed one, and its row
-		// comes after the seeds so `seq` order still reads as history.
+		// Everything from the version stamp onward really ran — starting with the
+		// entry that created the table — and those rows come after the seeds, so
+		// `seq` order still reads as history. Derived from MIGRATIONS rather than
+		// spelled out: a hardcoded tail breaks on the next append for no reason.
 		const observed = rows?.filter((r) => r.outcome === "applied");
-		expect(observed?.map((r) => r.name)).toEqual(["SCHEMA_MIGRATIONS_DDL"]);
+		expect(observed?.map((r) => r.name)).toEqual(MIGRATIONS.slice(5).map((m) => m.name));
 		expect(observed?.[0]?.seq).toBeGreaterThan(seeded?.[4]?.seq ?? 0);
+	});
+
+	it("drops repos_no_delete when upgrading a database that predates the entry", async () => {
+		// The behaviour REPOS_DELETE_ALLOWED_DDL exists for, on the path that
+		// matters: an existing install, not a fresh one. `BASELINE_DDL` is frozen
+		// and still creates the trigger, so every database ever made has it and
+		// only this entry takes it away.
+		await buildLegacyDb(dbPath, 5);
+		const before = await rawDb(dbPath);
+		try {
+			expect(before.prepare("SELECT name FROM sqlite_master WHERE type = 'trigger'").all()).toEqual([
+				{ name: "repos_no_delete" },
+			]);
+		} finally {
+			before.close();
+		}
+		const after = await withDashboardDb(
+			(db) => db.prepare("SELECT name FROM sqlite_master WHERE type = 'trigger'").all(),
+			{ dbPath },
+		);
+		expect(after).toEqual([]);
 	});
 
 	it("re-applies a MISSING name on a database that is already past it — the self-heal", async () => {

--- a/cli/src/dashboard/DashboardDb.ts
+++ b/cli/src/dashboard/DashboardDb.ts
@@ -35,6 +35,7 @@ import {
 	EVENT_FAILED_KIND_DDL,
 	MEMORY_SOT_DDL,
 	RECALL_RECEIPTS_DDL,
+	REPOS_DELETE_ALLOWED_DDL,
 	SCHEMA_MIGRATIONS_DDL,
 	SKILL_CONTEXT_KIND_DDL,
 	TOOL_CALL_TIME_DDL,
@@ -81,7 +82,7 @@ const log = createLogger("DashboardDb");
  * user's database (other processes may hold the file open, and the memory half
  * is the only copy there is).
  */
-export const DASHBOARD_SCHEMA_VERSION = 6;
+export const DASHBOARD_SCHEMA_VERSION = 7;
 
 /**
  * NOTE ON COMPATIBILITY, because its absence here is a decision.
@@ -326,6 +327,7 @@ BEGIN SELECT RAISE(ABORT, 'repos are never deleted: set disabled_at instead'); E
 	{ name: "EVENT_FAILED_KIND_DDL", ddl: EVENT_FAILED_KIND_DDL },
 	{ name: "TOOL_CALL_TIME_DDL", ddl: TOOL_CALL_TIME_DDL },
 	{ name: "SCHEMA_MIGRATIONS_DDL", ddl: SCHEMA_MIGRATIONS_DDL },
+	{ name: "REPOS_DELETE_ALLOWED_DDL", ddl: REPOS_DELETE_ALLOWED_DDL },
 ];
 
 /** Reads the stored schema version, treating a fresh DB as 0. */

--- a/cli/src/dashboard/DashboardModel.ts
+++ b/cli/src/dashboard/DashboardModel.ts
@@ -829,8 +829,9 @@ export interface RepoOption {
 	readonly sessionsThisWeek: number;
 	/**
 	 * Present and `true` only for a PAUSED repo (`repos.disabled_at` set). The list
-	 * carries paused repos rather than dropping them: their rows are never deleted
-	 * and they keep counting in the aggregate KPIs, so hiding them made an
+	 * carries paused repos rather than dropping them: pausing is an UPDATE that
+	 * stamps `disabled_at`, never a delete, and they keep counting in the
+	 * aggregate figures, so hiding them made an
 	 * all-paused dashboard read as "No repositories yet". Absent on an active repo,
 	 * so an active row's shape is unchanged.
 	 */
@@ -850,14 +851,6 @@ export interface RepoOption {
 /** `today` and `2w` remain accepted for older deep links; the dashboard picker
  * intentionally presents the clearer 7d / 30d / 90d choices. */
 export type DashboardRange = "today" | "week" | "2w" | "month" | "3m" | "custom";
-
-/** One KPI card on the Stats page. */
-export interface KpiCard {
-	readonly key: string;
-	readonly label: string;
-	readonly value: string;
-	readonly hint?: string;
-}
 
 /** One local calendar day in the cost/token series. `date` is `YYYY-MM-DD` local. */
 export interface DaySeriesPoint {
@@ -1059,7 +1052,6 @@ export interface DecisionsCard {
 
 /** The Stats page payload. */
 export interface StatsModel {
-	readonly kpis: ReadonlyArray<KpiCard>;
 	readonly series: ReadonlyArray<DaySeriesPoint>;
 	/** Series keys present in `series[].bySeries`, in render order. */
 	readonly seriesKeys: ReadonlyArray<string>;
@@ -1067,12 +1059,16 @@ export interface StatsModel {
 	readonly seriesDimension: SeriesDimension;
 	readonly heatmap: ReadonlyArray<HeatmapCell>;
 	readonly hours: ReadonlyArray<HourBucket>;
-	/** Token volume by type, over the range — available at every tier, like `kpis`. */
+	/** Token volume by type, over the range — available at every tier. */
 	readonly tokenBreakdown: TokenBreakdown;
 	/**
-	 * Est. cost vs the immediately preceding window of equal length — Cost &
-	 * tokens' own self-trend. Absent when the previous window has no priced
-	 * sessions to compare against.
+	 * Est. cost vs the immediately preceding window of equal length — the Spend
+	 * card's own self-trend.
+	 *
+	 * Both ends are summed over {@link series}, along the SAME dimension, by the
+	 * same rule the card's headline uses — so the arrow trends the number it is
+	 * printed beside. Absent when the previous window drew no cost to compare
+	 * against.
 	 */
 	readonly costTrendPct?: number;
 	readonly fun: FunStats;
@@ -1084,6 +1080,16 @@ export interface StatsModel {
 	readonly recentSessions: ReadonlyArray<RecentSession>;
 	/** The tier-1+ feed. Empty at the local tier (no summaries to draw from). */
 	readonly memoryCards: ReadonlyArray<MemoryCard>;
+	/**
+	 * {@link memoryCards} hit {@link MEMORY_CARDS_LIMIT} — i.e. the window holds
+	 * more memories than the feed is showing.
+	 *
+	 * The card's subtitle is the whole reason this travels: `memoryCards.length`
+	 * alone cannot tell "20 memories in this window" from "the 20 most recent of
+	 * 300", and the page has no other way to know the cap. Absent (not `false`)
+	 * when the feed is complete, matching the other optional fields here.
+	 */
+	readonly memoryCardsCapped?: boolean;
 	/**
 	 * Commits in the window, memory tier or not — the denominator behind Memory
 	 * Activity's "X of Y captured" line and the source of its gap count

--- a/cli/src/dashboard/DashboardQuery.test.ts
+++ b/cli/src/dashboard/DashboardQuery.test.ts
@@ -11,12 +11,11 @@ import type {
 	StatsModel,
 	ToolUsageRow,
 } from "./DashboardModel.js";
-import { TOOL_ROWS_LIMIT } from "./DashboardModel.js";
+import { MEMORY_CARDS_LIMIT, TOOL_ROWS_LIMIT } from "./DashboardModel.js";
 import {
 	addLocalDays,
 	buildDashboardModel,
 	buildToolUsagePage,
-	computeStreak,
 	localDayKey,
 	localHour,
 	machineTimeZone,
@@ -55,6 +54,71 @@ async function seedTopicRows(
 					"INSERT INTO memory_topics (repo_id, commit_hash, pos, category, title) VALUES (?, ?, ?, ?, ?)",
 				).run(id, hash, pos, category, `topic ${pos}`);
 			});
+		},
+		{ dbPath },
+	);
+}
+
+/**
+ * Adds one SUPERSEDED predecessor of `rootHash` — the row an amend or a squash
+ * leaves behind. It carries the same tokens/cost as the memory it precedes
+ * (production copies them forward), gets its own `commits` row on the same
+ * branch, and is marked as a non-root generation via `parent_hash`.
+ *
+ * The `commits` row is the point: an INNER JOIN on `commits` looks like it
+ * filters these out and does not — `commits` keeps rows that git can no longer
+ * reach, which is why `memoriesCreated` carries a separate `isReachable` pass.
+ */
+async function seedSupersededPredecessor(
+	dbPath: string,
+	rootHash: string,
+	predHash: string,
+	opts: {
+		branch: string;
+		childPos: number;
+		tokens: number;
+		estCostUsd: number;
+		committedAtMs: number;
+		/** Topics the predecessor recorded — a superseded generation keeps its own. */
+		topics?: ReadonlyArray<Record<string, unknown>>;
+	},
+): Promise<void> {
+	await withDashboardDb(
+		(db) => {
+			const { id: repoId } = db.prepare("SELECT id FROM repos WHERE repo_identity = 'repo-1'").get() as {
+				id: number;
+			};
+			db.prepare(
+				`INSERT INTO commits (event_id, repo_id, hash, branch, message, committed_at_ms)
+				 VALUES (?, ?, ?, ?, 'superseded', ?)`,
+			).run(`ev-${predHash}`, repoId, predHash, opts.branch, opts.committedAtMs);
+			const { id: commitId } = db
+				.prepare("SELECT id FROM commits WHERE repo_id = ? AND hash = ?")
+				.get(repoId, predHash) as { id: number };
+			db.prepare("INSERT OR IGNORE INTO branches (name) VALUES (?)").run(opts.branch);
+			const { id: branchId } = db.prepare("SELECT id FROM branches WHERE name = ?").get(opts.branch) as {
+				id: number;
+			};
+			db.prepare("INSERT INTO commit_branches (commit_id, branch_id) VALUES (?, ?)").run(commitId, branchId);
+			db.prepare(
+				`INSERT INTO memories (repo_id, commit_hash, parent_hash, child_pos, root_hash, depth,
+				                       summary_json, first_seen_ms, written_at_ms, commit_date_ms)
+				 VALUES (?, ?, ?, ?, ?, 1, ?, 1, 1, ?)`,
+			).run(
+				repoId,
+				predHash,
+				rootHash,
+				opts.childPos,
+				rootHash,
+				JSON.stringify({
+					commitHash: predHash,
+					conversationTokens: opts.tokens,
+					estimatedCostUsd: opts.estCostUsd,
+					ticketId: "JOLLI-2069",
+					...(opts.topics ? { topics: opts.topics } : {}),
+				}),
+				opts.committedAtMs,
+			);
 		},
 		{ dbPath },
 	);
@@ -160,25 +224,6 @@ describe("time-zone engine", () => {
 
 	it("machineTimeZone returns a resolvable IANA name", () => {
 		expect(() => new Intl.DateTimeFormat("en", { timeZone: machineTimeZone() })).not.toThrow();
-	});
-});
-
-describe("computeStreak", () => {
-	const now = Date.parse("2026-07-30T12:00:00Z");
-	const day = (offset: number) => addLocalDays(now, offset, "UTC") + 3_600_000;
-
-	it("counts consecutive days ending today", () => {
-		expect(computeStreak([day(0), day(-1), day(-2)], "UTC", now)).toBe(3);
-	});
-
-	it("tolerates an inactive morning — a streak ending yesterday still counts", () => {
-		expect(computeStreak([day(-1), day(-2)], "UTC", now)).toBe(2);
-	});
-
-	it("breaks on a gap and is 0 with no recent activity", () => {
-		expect(computeStreak([day(0), day(-2)], "UTC", now)).toBe(1);
-		expect(computeStreak([day(-5)], "UTC", now)).toBe(0);
-		expect(computeStreak([], "UTC", now)).toBe(0);
 	});
 });
 
@@ -319,7 +364,7 @@ describe("buildDashboardModel", () => {
 		expect(model.stats?.pricesAsOf).toBeUndefined();
 	});
 
-	it("scopes KPIs and the series to the requested range, and labels them with it", async () => {
+	it("scopes the session feed and the series to the requested range", async () => {
 		await seed();
 		const forRange = async (range: "today" | "week" | "2w" | "month") =>
 			withDashboardDb(
@@ -330,18 +375,15 @@ describe("buildDashboardModel", () => {
 
 		// today-1 is an hour ago; yesterday-1 is 26 h back; old-1 is 10 days back.
 		const today = await forRange("today");
-		expect(today.stats?.kpis.find((k) => k.key === "sessions")).toMatchObject({
-			value: "1",
-			label: "sessions today",
-		});
+		expect(today.stats?.recentSessions).toHaveLength(1);
 		expect(today.stats?.series).toHaveLength(1); // one day bucket
 
 		const week = await forRange("week");
-		expect(week.stats?.kpis.find((k) => k.key === "sessions")?.value).toBe("2"); // old-1 excluded
+		expect(week.stats?.recentSessions).toHaveLength(2); // old-1 excluded
 		expect(week.stats?.series).toHaveLength(7);
 
 		const month = await forRange("month");
-		expect(month.stats?.kpis.find((k) => k.key === "sessions")?.value).toBe("3");
+		expect(month.stats?.recentSessions).toHaveLength(3);
 		expect(month.stats?.series).toHaveLength(30);
 
 		// The heatmap is deliberately NOT range-scoped — it is the 12-week long view.
@@ -349,7 +391,7 @@ describe("buildDashboardModel", () => {
 		expect(month.stats?.heatmap).toHaveLength(84);
 	});
 
-	it("assembles the stats view with KPIs, heatmap, hours and recent sessions", async () => {
+	it("assembles the stats view with the series, heatmap, hours and recent sessions", async () => {
 		await seed();
 		const model = await withDashboardDb(
 			(db) => buildDashboardModel(db, { view: "stats", scope: { kind: "all" }, timeZone: "UTC", nowMs }),
@@ -367,16 +409,11 @@ describe("buildDashboardModel", () => {
 
 		const stats = model.stats;
 		if (!stats) throw new Error("stats missing");
-		// KPIs cover the SELECTED RANGE, default 30 days, and
-		// the labels carry that window so a figure can't be misread as today's.
+		// Everything below covers the SELECTED RANGE, default 30 days.
 		expect(stats.range).toBe("month");
 		// today-1 + yesterday-1 + old-1 (10 days back) all fall inside 30 days;
 		// only the two Claude ones carry tokens (cursor is sessions-only).
-		expect(stats.kpis.find((k) => k.key === "sessions")).toMatchObject({ value: "3", label: "sessions · 30d" });
-		expect(stats.kpis.find((k) => k.key === "tokens")?.value).toBe("3.2k");
-		expect(stats.kpis.find((k) => k.key === "cost")?.value).toBe("$3.00");
-		// cached share = 200 cached / (2000 input + 200 cached)
-		expect(stats.kpis.find((k) => k.key === "cached")?.value).toBe("9%");
+		expect(stats.recentSessions).toHaveLength(3);
 		// Tokens: today-1 + old-1 carry the default model tokens;
 		// yesterday-1 is sessions-only (cursor) and contributes nothing.
 		expect(stats.tokenBreakdown).toMatchObject({ input: 2000, output: 1000, cached: 200 });
@@ -422,7 +459,7 @@ describe("buildDashboardModel", () => {
 	it("reports a cost trend once the preceding window has priced sessions", async () => {
 		await seed();
 		// 40 days back: inside the prior 30-day window (days 30–60 back), outside
-		// the current one — so it moves costTrendPct without touching stats.kpis.
+		// the current one — so it moves costTrendPct without touching the series.
 		await applySummaryEvents(
 			[
 				session({
@@ -447,7 +484,7 @@ describe("buildDashboardModel", () => {
 			{ dbPath },
 		);
 		// Current window's $3.00 (unchanged) vs the prior window's $2.00 → +50%.
-		expect(model.stats?.kpis.find((k) => k.key === "cost")?.value).toBe("$3.00");
+		expect(model.stats?.series.reduce((sum, p) => sum + p.estCostUsd, 0)).toBe(3);
 		expect(model.stats?.costTrendPct).toBe(50);
 	});
 
@@ -636,7 +673,7 @@ describe("buildDashboardModel", () => {
 		expect(scoped.stats?.recentSessions.map((s) => s.sessionId)).toEqual(["other-1"]);
 	});
 
-	it("renders sensibly from an empty database — zero KPIs, empty fun stats, no series keys", async () => {
+	it("renders sensibly from an empty database — empty fun stats, no series keys", async () => {
 		await applySummaryEvents([], { producerKind: "cli", dbPath }); // create schema only
 		const model = await withDashboardDb(
 			(db) => buildDashboardModel(db, { view: "stats", scope: { kind: "all" }, timeZone: "UTC", nowMs }),
@@ -644,8 +681,8 @@ describe("buildDashboardModel", () => {
 		);
 		const stats = model.stats;
 		if (!stats) throw new Error("stats missing");
-		expect(stats.kpis.find((k) => k.key === "sessions")?.value).toBe("0");
-		expect(stats.kpis.find((k) => k.key === "cached")?.value).toBe("—");
+		expect(stats.recentSessions).toEqual([]);
+		expect(stats.tokenBreakdown).toMatchObject({ input: 0, output: 0, cached: 0 });
 		expect(stats.seriesKeys).toEqual([]);
 		expect(stats.fun).toMatchObject({ legendarySessionMinutes: 0, biggestDayTokens: 0, nightOwlSharePct: 0 });
 		expect(stats.fun.legendarySessionTitle).toBeUndefined();
@@ -816,17 +853,18 @@ describe("buildDashboardModel", () => {
 			});
 		});
 
-		it("scopes the KPIs to an explicit window, inclusive at both ends", async () => {
+		it("scopes the window to an explicit range, inclusive at both ends", async () => {
 			await seed();
 			// Seeded sessions land on Jul 30 (×1), Jul 29 (×1) and Jul 20 (×1).
 			const july29 = await stats({ range: "custom", customFrom: "2026-07-29", customTo: "2026-07-29" });
 			expect(july29.range).toBe("custom");
-			expect(july29.kpis.find((k) => k.key === "sessions")?.value).toBe("1");
-			// The label carries the window so a KPI can never be misread as today's.
-			expect(july29.kpis.find((k) => k.key === "sessions")?.label).toBe("sessions · 07-29→07-29");
+			expect(july29.recentSessions).toHaveLength(1);
+			// The resolved bounds are echoed back, so a clamped request reads as
+			// the window it actually got.
+			expect(july29).toMatchObject({ rangeFrom: "2026-07-29", rangeTo: "2026-07-29" });
 
 			const spanning = await stats({ range: "custom", customFrom: "2026-07-29", customTo: "2026-07-30" });
-			expect(spanning.kpis.find((k) => k.key === "sessions")?.value).toBe("2");
+			expect(spanning.recentSessions).toHaveLength(2);
 		});
 
 		it("clamps a future `to` and an over-long `from` instead of rejecting them", async () => {
@@ -882,7 +920,6 @@ describe("buildDashboardModel", () => {
 				{ producerKind: "cli", dbPath },
 			);
 			const old = await stats({ range: "custom", customFrom: "2026-01-10", customTo: "2026-01-12" });
-			expect(old.kpis.find((k) => k.key === "sessions")?.value).toBe("1");
 			// The feed follows the range, so it shows the window's session — not
 			// whatever happens to be most recent overall.
 			expect(old.recentSessions.map((s) => s.title)).toEqual(["Old work"]);
@@ -1741,6 +1778,51 @@ describe("buildDashboardModel — memory tier (phase 2)", () => {
 		expect(model.stats?.memoryCards?.[0]?.committedAtMs).toBe(nowMs - 3 * 3_600_000);
 	});
 
+	it("flags memoryCardsCapped only once the window holds more than one page", async () => {
+		const bulk = (from: number, count: number) =>
+			applySummaryEvents(
+				Array.from({ length: count }, (_, i) => ({
+					producerKind: "bootstrap" as const,
+					event: {
+						type: "commit.summary" as const,
+						repoIdentity: "repo-1",
+						hash: `bulk${from + i}`,
+						committedAtMs: nowMs - 2 * 3_600_000,
+						branch: "main",
+						message: `chore: bulk ${from + i}`,
+						turns: 1,
+						tokens: 10,
+						estCostUsd: 0.1,
+						insights: [],
+						references: [],
+						sessionLinks: [],
+					},
+				})),
+				{ producerKind: "cli", dbPath },
+			);
+		const readStats = async () =>
+			(
+				await withDashboardDb(
+					(db) => buildDashboardModel(db, { view: "stats", scope: { kind: "all" }, timeZone: "UTC", nowMs }),
+					{ dbPath },
+				)
+			).stats;
+
+		await seedMemory();
+		await bulk(0, MEMORY_CARDS_LIMIT - 2);
+		const full = await readStats();
+		// Exactly one page with nothing behind it: the feed IS the window, so the
+		// subtitle must not claim a truncation that has not happened. `>= LIMIT`
+		// cannot tell this case from the next one — only the un-cut count can.
+		expect(full?.memoryCards).toHaveLength(MEMORY_CARDS_LIMIT);
+		expect(full?.memoryCardsCapped).toBeUndefined();
+
+		await bulk(100, 1);
+		const cut = await readStats();
+		expect(cut?.memoryCards).toHaveLength(MEMORY_CARDS_LIMIT);
+		expect(cut?.memoryCardsCapped).toBe(true);
+	});
+
 	it("credits a rewritten commit as captured through commit_aliases, decision included", async () => {
 		await seedMemory();
 		// Simulate mem1 getting rebased/amended after it was summarized: the live
@@ -1881,6 +1963,204 @@ describe("buildDashboardModel — memory tier (phase 2)", () => {
 		expect(total).toBe(28000);
 	});
 
+	/**
+	 * The shape a rebase leaves behind. `commits` moves to the new hash — the ROW
+	 * survives, so its `commit_branches` links and its committer date come with it
+	 * — while the memory stays filed under the old hash, reachable only through
+	 * `commit_aliases`. Nothing is left carrying the memory's own hash, which is
+	 * what `pruneUnreachableCommits` guarantees and what makes the alias the only
+	 * path to it.
+	 */
+	async function rebaseMem1(authorDaysAgo?: number): Promise<void> {
+		await withDashboardDb(
+			(db) => {
+				const { id: repoId } = db.prepare("SELECT id FROM repos WHERE repo_identity = 'repo-1'").get() as {
+					id: number;
+				};
+				db.prepare("UPDATE commits SET hash = 'mem1-rebased' WHERE repo_id = ? AND hash = 'mem1'").run(repoId);
+				db.prepare(
+					"INSERT INTO commit_aliases (repo_id, old_hash, target_hash, created_ms) VALUES (?, ?, ?, ?)",
+				).run(repoId, "mem1-rebased", "mem1", 1);
+				if (authorDaysAgo != null) {
+					db.prepare("UPDATE memories SET commit_date_ms = ? WHERE repo_id = ? AND commit_hash = 'mem1'").run(
+						nowMs - authorDaysAgo * 24 * 3_600_000,
+						repoId,
+					);
+				}
+			},
+			{ dbPath },
+		);
+	}
+
+	it.each(["branch", "ticket"] as const)(
+		"keeps a rebased commit's spend on the %s axis, bucketed on its landed date",
+		async (dimension) => {
+			await seedMemory();
+			// Two ways to lose mem1's 20k here, and this fixture arms both: joining
+			// `m.commit_hash = c.hash` never reaches a memory whose hash was rewritten
+			// away, and its own `commit_date_ms` is an AUTHOR date 400 days back, which
+			// would fall outside the series even once the row is found.
+			await rebaseMem1(400);
+			const model = await withDashboardDb(
+				(db) =>
+					buildDashboardModel(db, {
+						view: "stats",
+						scope: { kind: "all" },
+						dimension,
+						timeZone: "UTC",
+						nowMs,
+					}),
+				{ dbPath },
+			);
+			const stats = model.stats;
+			if (!stats) throw new Error("stats missing");
+			expect(stats.seriesDimension).toBe(dimension);
+			expect(stats.series.reduce((sum, p) => sum + p.tokens, 0)).toBe(28000);
+			// On TODAY — the rebased commit's committer date — and under the branch
+			// the surviving `commit_branches` row still carries.
+			const today = stats.series[stats.series.length - 1];
+			expect(today.bySeries[dimension === "branch" ? "feature/dash" : "JOLLI-2069"]).toBe(20000);
+		},
+	);
+
+	it("buckets a rebased memory's category spend on the landed committer date", async () => {
+		await seedMemory();
+		await seedTopicRows(dbPath, "mem1", ["bugfix", "feature", "bugfix", "security"], { tokens: 20000 });
+		await seedTopicRows(dbPath, "mem2", [], { tokens: 8000, commitDateMs: nowMs - 26 * 3_600_000 });
+		// The author date is stamped by the rebase helper, not by `seedTopicRows`:
+		// that one is an INSERT OR IGNORE, so on a memory `seedMemory` already wrote
+		// it silently changes nothing — and a fixture that cannot move the date
+		// cannot exercise the fallback this test is about.
+		await rebaseMem1(400);
+		const model = await withDashboardDb(
+			(db) =>
+				buildDashboardModel(db, {
+					view: "stats",
+					scope: { kind: "all" },
+					dimension: "category",
+					timeZone: "UTC",
+					nowMs,
+				}),
+			{ dbPath },
+		);
+		const stats = model.stats;
+		if (!stats) throw new Error("stats missing");
+		const today = stats.series[stats.series.length - 1];
+		expect(today.bySeries).toEqual({ bugfix: 10000, feature: 5000, security: 5000 });
+		expect(stats.series.reduce((sum, p) => sum + p.tokens, 0)).toBe(28000);
+	});
+
+	it("keeps a rebased memory in the feed when reachability is checked", async () => {
+		await seedMemory();
+		await rebaseMem1();
+		const model = await withDashboardDb(
+			(db) =>
+				buildDashboardModel(db, {
+					view: "stats",
+					scope: { kind: "all" },
+					timeZone: "UTC",
+					nowMs,
+					// What the server passes for this view: hashes reachable from a ref.
+					// The memory's own hash is not one of them any more — asking about it
+					// instead of the live one drops the very card the "N of M captured"
+					// line beside it has just counted through the alias.
+					reachableCommits: new Map([["repo-1", new Set(["mem1-rebased", "mem2"])]]),
+				}),
+			{ dbPath },
+		);
+		expect(model.stats?.memoriesCreated).toBe(2);
+		expect(model.stats?.memoryCards?.map((c) => c.commitHash)).toContain("mem1");
+	});
+
+	it("stamps a rebased memory's card with the landed date, not the author date", async () => {
+		await seedMemory();
+		// The half of the ordering rule the non-rebased fixture cannot reach. Once
+		// nothing carries the memory's own hash the payload query has no `commits`
+		// row to read, so a COALESCE that skips the alias hop falls all the way to
+		// `commit_date_ms` — an AUTHOR date, here 400 days outside the window the
+		// key query just selected this row FOR. Both queries read the same
+		// `memory_landing.at_ms` precisely so they cannot answer differently.
+		await rebaseMem1(400);
+		const model = await withDashboardDb(
+			(db) =>
+				buildDashboardModel(db, {
+					view: "stats",
+					scope: { kind: "all" },
+					timeZone: "UTC",
+					nowMs,
+					reachableCommits: new Map([["repo-1", new Set(["mem1-rebased", "mem2"])]]),
+				}),
+			{ dbPath },
+		);
+		// The rebased commit's own committer date — mem1 landed today, so it also
+		// still leads the feed over yesterday's mem2.
+		expect(model.stats?.memoryCards?.map((c) => c.commitHash)).toEqual(["mem1", "mem2"]);
+		expect(model.stats?.memoryCards?.[0]?.committedAtMs).toBe(nowMs - 3 * 3_600_000);
+	});
+
+	it("keeps a day's cost in the trend when a series key shadows Object.prototype", async () => {
+		// A branch really can be named `constructor`, and `bySeries` is a plain
+		// object — so on a day that branch recorded nothing, the lookup hands back
+		// the INHERITED function. Read with `??` it reaches the arithmetic:
+		// `number + function` is a string, the `> 0` test deciding whether a day was
+		// drawn is then false, and that day's money leaves the headline the trend is
+		// computed against. Both windows here hold exactly one such day.
+		const summary = (hash: string, branch: string, committedAtMs: number, tokens: number, estCostUsd: number) => ({
+			producerKind: "bootstrap" as const,
+			event: {
+				type: "commit.summary" as const,
+				repoIdentity: "repo-1",
+				hash,
+				committedAtMs,
+				branch,
+				message: `chore: ${hash}`,
+				turns: 1,
+				tokens,
+				estCostUsd,
+				insights: [],
+				references: [],
+				sessionLinks: [],
+			},
+		});
+		await applySummaryEvents(
+			[
+				{
+					producerKind: "cli",
+					event: {
+						type: "repo.enabled",
+						repoIdentity: "repo-1",
+						repoName: "jolli",
+						worktreeRoot: "/w",
+						enabledAt: "t",
+					},
+				},
+				summary("today-main", "main", nowMs - 3 * 3_600_000, 20_000, 2),
+				// The `constructor` series exists in this window but not on the day
+				// above — which is what makes the day above read its inherited value.
+				summary("yesterday-ctor", "constructor", nowMs - 27 * 3_600_000, 10_000, 1),
+				// The prior window, whose only series is `main` — so it is priced the
+				// same either way and the comparison isolates the current window.
+				summary("prior-main", "main", nowMs - 40 * 24 * 3_600_000, 10_000, 1),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		const model = await withDashboardDb(
+			(db) =>
+				buildDashboardModel(db, {
+					view: "stats",
+					scope: { kind: "all" },
+					dimension: "branch",
+					timeZone: "UTC",
+					nowMs,
+				}),
+			{ dbPath },
+		);
+		expect(model.stats?.seriesKeys).toEqual(["constructor", "main"]);
+		// $3 drawn against the prior window's $1. Losing the shadowed days to the
+		// inherited value reads 0% here — a flat trend over a window that tripled.
+		expect(model.stats?.costTrendPct).toBe(200);
+	});
+
 	it("apportions a multi-branch commit so the day totals do not multiply", async () => {
 		await seedMemory();
 		// `commit_branches` is a per-branch `git rev-list` union, so a commit on
@@ -1955,6 +2235,81 @@ describe("buildDashboardModel — memory tier (phase 2)", () => {
 		// Sharing keeps the axis summing to the real total — the property the old
 		// per-commit mode existed to protect.
 		expect(stats.series.reduce((sum, p) => sum + p.tokens, 0)).toBe(28000);
+	});
+
+	it.each(["category", "branch", "ticket"] as const)(
+		"counts a memory once on the %s axis however many predecessors it was amended over",
+		async (dimension) => {
+			await seedMemory();
+			await seedTopicRows(dbPath, "mem1", ["feature"], { tokens: 20000, commitDateMs: nowMs - 3 * 3_600_000 });
+			const read = async () => {
+				const model = await withDashboardDb(
+					(db) =>
+						buildDashboardModel(db, {
+							view: "stats",
+							scope: { kind: "all" },
+							dimension,
+							timeZone: "UTC",
+							nowMs,
+						}),
+					{ dbPath },
+				);
+				const stats = model.stats;
+				if (!stats) throw new Error("stats missing");
+				return {
+					tokens: stats.series.reduce((sum, p) => sum + p.tokens, 0),
+					cost: stats.series.reduce((sum, p) => sum + p.estCostUsd, 0),
+				};
+			};
+			const before = await read();
+
+			// Three amends over the same piece of work. Each leaves a `memories`
+			// row AND a `commits` row behind, so an INNER JOIN on `commits` does
+			// not filter them — only `parent_hash IS NULL` does.
+			for (const n of [1, 2, 3]) {
+				await seedSupersededPredecessor(dbPath, "mem1", `mem1-old-${n}`, {
+					branch: "feature/dash",
+					childPos: n,
+					tokens: 20000,
+					estCostUsd: 3,
+					committedAtMs: nowMs - 3 * 3_600_000,
+				});
+			}
+
+			// Unchanged: superseded history is the same work, not new spend.
+			expect(await read()).toEqual(before);
+		},
+	);
+
+	it("counts a decision once however many predecessors recorded it", async () => {
+		await seedMemory();
+		const read = async () => {
+			const model = await withDashboardDb(
+				(db) => buildDashboardModel(db, { view: "stats", scope: { kind: "all" }, timeZone: "UTC", nowMs }),
+				{ dbPath },
+			);
+			return { captured: model.stats?.decisionsCaptured, kept: model.stats?.decisions?.keptCount };
+		};
+		const before = await read();
+		expect(before.captured).toBeGreaterThan(0);
+
+		// The same defect as the axis test above, one card over: a predecessor
+		// keeps its OWN topics, and every consumer of TOPIC_INSIGHTS_CTE joins
+		// `commits`, which keeps the predecessor's row. Unfiltered, the decision
+		// this branch reached once is counted once per amend — right beside
+		// `memoriesCreated`, which filters the same history out via isReachable.
+		for (const n of [1, 2]) {
+			await seedSupersededPredecessor(dbPath, "mem1", `mem1-dec-${n}`, {
+				branch: "feature/dash",
+				childPos: 10 + n,
+				tokens: 20000,
+				estCostUsd: 3,
+				committedAtMs: nowMs - 3 * 3_600_000,
+				topics: [{ title: "Retry policy", category: "bugfix", decisions: "- Keep jittered backoff." }],
+			});
+		}
+
+		expect(await read()).toEqual(before);
 	});
 
 	it("builds the ticket dimension with a (no ticket) bucket", async () => {

--- a/cli/src/dashboard/DashboardQuery.ts
+++ b/cli/src/dashboard/DashboardQuery.ts
@@ -38,7 +38,6 @@ import type {
 	HeatmapCell,
 	HourBucket,
 	KnowledgeModel,
-	KpiCard,
 	McpServerRow,
 	MemoryCard,
 	RecentSession,
@@ -92,15 +91,6 @@ type PresetRange = Exclude<DashboardRange, "custom">;
 
 /** Local days each preset range covers, counting today. */
 const RANGE_DAYS: Readonly<Record<PresetRange, number>> = { today: 1, week: 7, "2w": 14, month: 30, "3m": 90 };
-
-/** KPI label suffix per range — "sessions today" vs "sessions · 30d". */
-const RANGE_LABEL: Readonly<Record<PresetRange, string>> = {
-	today: "today",
-	week: "· 7d",
-	"2w": "· 14d",
-	month: "· 30d",
-	"3m": "· 90d",
-};
 
 /** The range a malformed or empty custom request falls back to. */
 const DEFAULT_RANGE: PresetRange = "month";
@@ -244,7 +234,7 @@ export function addLocalDays(ms: number, days: number, timeZone: string): number
 
 // ── Range resolution ────────────────────────────────────────────────────────
 
-/** A range request resolved into concrete bounds, labels and day keys. */
+/** A range request resolved into concrete bounds and day keys. */
 interface ResolvedWindow {
 	/** What the page ended up showing — `custom` only if the request survived. */
 	readonly range: DashboardRange;
@@ -254,8 +244,6 @@ interface ResolvedWindow {
 	readonly endMs: number;
 	readonly from: string;
 	readonly to: string;
-	/** KPI label suffix ("today", "· 14d", "· 07-01→07-15"). */
-	readonly label: string;
 }
 
 /**
@@ -296,9 +284,6 @@ function resolveCustomWindow(
 		endMs: addLocalDays(lastDay, 1, timeZone),
 		from,
 		to,
-		// Year is dropped: the picker beside it always shows the full dates, and
-		// "· 2026-07-01→2026-07-15" does not fit a KPI label.
-		label: `· ${from.slice(5)}→${to.slice(5)}`,
 	};
 }
 
@@ -322,7 +307,6 @@ function resolveWindow(
 		endMs: addLocalDays(nowMs, 1, timeZone),
 		from: localDayKey(startMs, timeZone),
 		to: localDayKey(nowMs, timeZone),
-		label: RANGE_LABEL[preset],
 	};
 }
 
@@ -538,6 +522,14 @@ function commitsInRange(
  * decision row holds is the whole `decisions` block, which is prose and has no
  * title in it to recover. Both branches select it so the column exists whatever
  * `kind` a consumer filters to.
+ *
+ * **Both branches filter `m.parent_hash IS NULL`** — the same "current
+ * generation" rule {@link buildSeries} states at length, for the same reason and
+ * with the same trap. `memories` holds one row per GENERATION, so a branch
+ * amended or squashed four times keeps its predecessors' topics, and every
+ * consumer of this CTE joins `commits`, which retains the predecessors' rows.
+ * Unfiltered, one decision is counted once per rewrite — directly beside
+ * `memoriesCreated`, which filters the same history out via `isReachable`.
  */
 const TOPIC_INSIGHTS_CTE = `WITH topic_insights AS (
 	SELECT m.repo_id, m.commit_hash, 'decision' AS kind,
@@ -545,25 +537,130 @@ const TOPIC_INSIGHTS_CTE = `WITH topic_insights AS (
 	       TRIM(COALESCE(json_extract(t.value, '$.title'), '')) AS topic_title,
 	       NULL AS addressed_to, t.key * 2 AS ord
 	  FROM memories m, json_each(m.summary_json, '$.topics') t
-	 WHERE TRIM(COALESCE(json_extract(t.value, '$.decisions'), '')) <> ''
+	 WHERE m.parent_hash IS NULL
+	   AND TRIM(COALESCE(json_extract(t.value, '$.decisions'), '')) <> ''
 	UNION ALL
 	SELECT m.repo_id, m.commit_hash, 'todo' AS kind,
 	       TRIM(json_extract(t.value, '$.todo')) AS text,
 	       TRIM(COALESCE(json_extract(t.value, '$.title'), '')) AS topic_title,
 	       NULL AS addressed_to, t.key * 2 + 1 AS ord
 	  FROM memories m, json_each(m.summary_json, '$.topics') t
-	 WHERE TRIM(COALESCE(json_extract(t.value, '$.todo'), '')) <> ''
+	 WHERE m.parent_hash IS NULL
+	   AND TRIM(COALESCE(json_extract(t.value, '$.todo'), '')) <> ''
 )`;
+
+/**
+ * Where a memory LANDED: the commit its work sits on today, and that commit's
+ * committer date.
+ *
+ * **One of TWO spellings of that rule.** This one is for callers that need the
+ * landing as DATA — the `category` axis windows on `at_ms`, and
+ * {@link buildMemoryCards} needs both `at_ms` and `live_hash`. Callers that only
+ * need to know which memory belongs to a commit they already have use
+ * {@link MEMORY_FOR_COMMIT} instead, and the choice between them is a measured
+ * performance fact, not a style preference — see that constant's note.
+ *
+ * The three queries here join it on `commit_hash`, a REAL column, which is what
+ * keeps it cheap (38 ms against the pre-alias query's 43 ms on a 165 MB
+ * database). `live_hash` is a COALESCE and therefore unindexable: joining on
+ * THAT is what cost 3,146 ms.
+ *
+ * A hash rewritten after it was summarized leaves the memory filed under the
+ * PRE-rewrite hash while `commits` moves on to the new one, so `m.commit_hash`
+ * alone answers neither question. `commit_aliases` maps the surviving hash back
+ * (`old_hash` -> the memory's `target_hash`), which is the direction
+ * {@link commitsInRange} and {@link buildDecisionsCard} enter from; this CTE
+ * walks it BACKWARDS, from the memory to whichever live commit points at it.
+ *
+ * Two consequences that are the whole reason it exists:
+ *
+ * - **`live_hash` is what a reachability check has to be asked about.** The
+ *   memory's own hash was rewritten away, so `isReachable` answers `false` for
+ *   it forever — dropping a memory from the feed that `memoriesCreated`, which
+ *   enters from the live commit, has just counted.
+ * - **`at_ms` is the LANDED committer date.** The old fallback went straight to
+ *   `m.commit_date_ms`, which is `CommitSummary.commitDate` — an AUTHOR date
+ *   (`%aI`), while every window in this file is a committer-date window. For a
+ *   rebase or a cherry-pick those are different days, and for a rewritten
+ *   commit the fallback was not an edge case but the permanent state: no
+ *   `commits` row will ever carry the memory's own hash again. `commit_date_ms`
+ *   survives as the third choice, for a memory whose commit this database has
+ *   not collected at all.
+ *
+ * **The alias sub-select is grouped, and the JOIN onto `commits` is what keeps
+ * that honest.** A memory rewritten more than once collects an alias row per
+ * rewrite, and `live_hash`/`at_ms` have to come from ONE of them — but only
+ * aliases whose commit still EXISTS survive that join, and
+ * `pruneUnreachableCommits` deletes every superseded link in the chain, so the
+ * group is normally a single row. `MAX(c.committed_at_ms)` picks the newest for
+ * the window before it converges, and `c.hash` rides along as a bare column,
+ * which SQLite documents as coming from that same max row. Two live commits
+ * aliasing one memory at the identical millisecond is the only case that would
+ * make the pair ambiguous, and it resolves to a real commit either way.
+ *
+ * **`cm` wins over `al` when both resolve.** A tree-hash alias is not proof the
+ * memory moved: cherry-picking a commit onto two branches gives it aliases while
+ * its own commit is still very much alive, and that memory belongs to its own
+ * commit. So the alias is consulted only when nothing carries the memory's own
+ * hash — the same order as `getSummary`'s direct-then-alias lookup.
+ *
+ * `parent_hash IS NULL` for the same reason every caller states it: `memories`
+ * holds one row per GENERATION.
+ */
+const MEMORY_LANDING_CTE = `WITH memory_landing AS (
+	SELECT m.repo_id, m.commit_hash,
+	       COALESCE(cm.hash, al.live_hash, m.commit_hash) AS live_hash,
+	       COALESCE(cm.committed_at_ms, al.at_ms, m.commit_date_ms) AS at_ms
+	  FROM memories m
+	  LEFT JOIN commits cm ON cm.repo_id = m.repo_id AND cm.hash = m.commit_hash
+	  LEFT JOIN (
+	      SELECT a.repo_id, a.target_hash, c.hash AS live_hash, MAX(c.committed_at_ms) AS at_ms
+	        FROM commit_aliases a
+	        JOIN commits c ON c.repo_id = a.repo_id AND c.hash = a.old_hash
+	       GROUP BY a.repo_id, a.target_hash
+	  ) al ON al.repo_id = m.repo_id AND al.target_hash = m.commit_hash
+	 WHERE m.parent_hash IS NULL
+)`;
+
+/**
+ * The same landing rule as {@link MEMORY_LANDING_CTE}, read from the COMMIT end:
+ * "which memory belongs to this commit". Joins as
+ * `JOIN memories m ON m.repo_id = c.repo_id AND (${MEMORY_FOR_COMMIT})`, with the
+ * commit aliased `c`.
+ *
+ * **Two spellings of one rule is a deliberate, measured exception**, so the
+ * numbers matter. The CTE exposes `live_hash` as a COALESCE — a computed column,
+ * which SQLite cannot index — so an axis that enters from `commits` and joins
+ * `ml.live_hash = c.hash` re-scans the whole materialised CTE per commit. On the
+ * author's 165 MB database (1,123 memories / 2,434 commits / 87 aliases), the
+ * branch axis measured:
+ *
+ * - joining the CTE on `live_hash`: **3,146 ms** (`MATERIALIZED` hint: 94 ms)
+ * - this predicate: **1.1 ms**, against 0.9 ms for the pre-alias query it replaces
+ *
+ * `buildSeries` runs twice per render (the window and its predecessor), so the
+ * CTE spelling was a ~6 s page. The axes that keep the CTE — `category` and
+ * `buildMemoryCards` — join it on `commit_hash`, a REAL column, and measured
+ * 38 ms against the old query's 43 ms.
+ *
+ * **`NOT EXISTS` is what makes this safe, and it is the `cm`-beats-`al`
+ * precedence written from the other side.** Without it the alias branch fires
+ * while the memory's own commit row is still present, so the pre-rewrite commit
+ * matches the memory directly AND the live one matches it through the alias —
+ * measured 2x on a synthetic prune-window fixture. With it, exactly one commit
+ * claims each memory in every state: the memory's own row while it survives, the
+ * aliasing commit once `pruneUnreachableCommits` has removed it. All four
+ * variants were verified to return byte-identical rows on the real database.
+ */
+const MEMORY_FOR_COMMIT = `m.commit_hash = c.hash
+	     OR (m.commit_hash = (SELECT a.target_hash FROM commit_aliases a
+	                           WHERE a.repo_id = c.repo_id AND a.old_hash = c.hash)
+	         AND NOT EXISTS (SELECT 1 FROM commits c2
+	                          WHERE c2.repo_id = c.repo_id AND c2.hash = m.commit_hash))`;
 
 const totalTokens = (row: SessionRow): number => row.input_tokens + row.output_tokens + row.cached_tokens;
 
 // ── Stats page ──────────────────────────────────────────────────────────────
-
-function formatTokens(n: number): string {
-	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-	return String(n);
-}
 
 /**
  * Detects the adoption tier from the data itself: the memory tier is "the
@@ -593,6 +690,41 @@ interface SeriesResult {
  * `branch`/`ticket` read the memory-enriched commit columns (and silently fall
  * back to `model` below the memory tier, so a stale URL cannot render an empty
  * chart pretending to be data).
+ *
+ * **Every memory-driven axis filters `m.parent_hash IS NULL`.** `memories` holds
+ * one row per GENERATION, not per memory: amending or squashing a commit leaves
+ * its predecessor behind as a child row carrying the same cost, so an unfiltered
+ * SUM bills one piece of work once per rewrite. `parent_hash IS NULL` is the
+ * repo-wide spelling of "current generation" (`MemoriesQuery.ts`,
+ * {@link TOPIC_INSIGHTS_CTE} above, `buildMemoryCards` below) — never "has no
+ * children", which is a different set.
+ *
+ * The INNER JOIN on `commits` is NOT a substitute, though it looks like one: it
+ * drops only predecessors whose commit row is gone, and `commits` deliberately
+ * retains unreachable rows (see the `isReachable` filter on `memoriesCreated`).
+ * Measured on a real database before this filter existed: the ticket axis read
+ * $150.97 against a true $92.93 (1.6x) and the LEFT-JOINed category axis read
+ * $3,490.47 against $366.03 (9.5x).
+ *
+ * **And every memory-driven axis resolves a rewritten commit, by one of the two
+ * spellings of the landing rule.** `category` windows on the landing DATE, so it
+ * carries {@link MEMORY_LANDING_CTE}; `branch` and `ticket` only need the memory
+ * that belongs to a commit they already have in hand, so they enter from
+ * `commits` with {@link MEMORY_FOR_COMMIT}. That split is a measured performance
+ * fact — the CTE spelling made the branch axis a 3,146 ms query — and NOT an
+ * invitation to unify them the other way.
+ *
+ * What neither spelling may become is the naive repair. Joining plain
+ * `m.commit_hash = c.hash` drops a rewritten commit's memory outright (its hash
+ * moved, the memory's did not) — that is the bug this PR fixes, where `branch`
+ * and `ticket` lost spend that Memory Activity and Decisions, both of which walk
+ * the alias, went on counting. But adding a bare `OR c.hash = al.target_hash`
+ * trades the hole for a double count: until `pruneUnreachableCommits` sweeps,
+ * the pre-rewrite commit row is still there and matches the memory directly
+ * while the live one matches it through the alias, so one piece of work bills
+ * twice (measured 2x). `MEMORY_FOR_COMMIT`'s `NOT EXISTS` is precisely what
+ * closes that, and it is why the predicate is longer than it looks like it
+ * needs to be.
  */
 function buildSeries(
 	db: DashboardDbHandle,
@@ -657,20 +789,25 @@ function buildSeries(
 		// figures are apportioned by design, not exact per-topic spend.
 		// The LEFT JOIN keeps memories with no topics on the axis: their window
 		// COUNT(*) is 1 and their whole spend lands in '(uncategorised)'.
+		//
+		// `parent_hash IS NULL` — see the note above `buildSeries`. This axis is
+		// where the double-count was worst (measured 9.5x) precisely because the
+		// LEFT JOIN keeps predecessors whose commit row is gone.
 		rows = db
 			.prepare(
-				`SELECT COALESCE(cm.committed_at_ms, m.commit_date_ms) AS at_ms,
+				`${MEMORY_LANDING_CTE}
+				 SELECT ml.at_ms AS at_ms,
 				        COALESCE(t.category, '(uncategorised)') AS key,
 				        COALESCE(m.tokens, 0) * 1.0
 				          / COUNT(*) OVER (PARTITION BY m.repo_id, m.commit_hash) AS tokens,
 				        COALESCE(m.est_cost_usd, 0) * 1.0
 				          / COUNT(*) OVER (PARTITION BY m.repo_id, m.commit_hash) AS cost
 				   FROM memories m
+				   JOIN memory_landing ml ON ml.repo_id = m.repo_id AND ml.commit_hash = m.commit_hash
 				   LEFT JOIN memory_topics t ON t.repo_id = m.repo_id AND t.commit_hash = m.commit_hash
-				   LEFT JOIN commits cm ON cm.repo_id = m.repo_id AND cm.hash = m.commit_hash
 				  WHERE m.tokens IS NOT NULL
-				    AND COALESCE(cm.committed_at_ms, m.commit_date_ms) >= ?
-				    AND COALESCE(cm.committed_at_ms, m.commit_date_ms) < ?${filter.sql}`,
+				    AND m.parent_hash IS NULL
+				    AND ml.at_ms >= ? AND ml.at_ms < ?${filter.sql}`,
 			)
 			.all(fromMs, toMs, ...filter.params) as UsageRow[];
 	} else if (effective === "branch") {
@@ -696,10 +833,12 @@ function buildSeries(
 				          / COUNT(*) OVER (PARTITION BY c.repo_id, c.hash) AS tokens,
 				        COALESCE(m.est_cost_usd, 0) * 1.0
 				          / COUNT(*) OVER (PARTITION BY c.repo_id, c.hash) AS cost
-				   FROM commits c JOIN commit_branches b ON b.commit_id = c.id
-			                        JOIN branches br ON br.id = b.branch_id
-			                        JOIN memories m ON m.repo_id = c.repo_id AND m.commit_hash = c.hash
-				  WHERE m.tokens IS NOT NULL AND c.committed_at_ms >= ? AND c.committed_at_ms < ?${filter.sql}`,
+				   FROM commits c
+				   JOIN commit_branches b ON b.commit_id = c.id
+				   JOIN branches br ON br.id = b.branch_id
+				   JOIN memories m ON m.repo_id = c.repo_id AND (${MEMORY_FOR_COMMIT})
+				  WHERE m.tokens IS NOT NULL AND m.parent_hash IS NULL
+				    AND c.committed_at_ms >= ? AND c.committed_at_ms < ?${filter.sql}`,
 			)
 			.all(fromMs, toMs, ...filter.params) as UsageRow[];
 	} else {
@@ -708,8 +847,10 @@ function buildSeries(
 			.prepare(
 				`SELECT c.committed_at_ms AS at_ms, COALESCE(m.ticket_id, '(no ticket)') AS key,
 				        COALESCE(m.tokens, 0) AS tokens, COALESCE(m.est_cost_usd, 0) AS cost
-				   FROM commits c JOIN memories m ON m.repo_id = c.repo_id AND m.commit_hash = c.hash
-				  WHERE m.tokens IS NOT NULL AND c.committed_at_ms >= ? AND c.committed_at_ms < ?${filter.sql}`,
+				   FROM commits c
+				   JOIN memories m ON m.repo_id = c.repo_id AND (${MEMORY_FOR_COMMIT})
+				  WHERE m.tokens IS NOT NULL AND m.parent_hash IS NULL
+				    AND c.committed_at_ms >= ? AND c.committed_at_ms < ?${filter.sql}`,
 			)
 			.all(fromMs, toMs, ...filter.params) as UsageRow[];
 	}
@@ -741,6 +882,37 @@ function buildSeries(
 		seriesKeys: [...seriesKeys].sort(),
 		seriesDimension: effective,
 	};
+}
+
+/**
+ * The cost the Spend card actually DRAWS, which is not quite the sum of
+ * `estCostUsd`.
+ *
+ * `apportionedCost` in `stats.js` spreads each day's measured total across that
+ * day's series keys by token share, so a day whose per-key tokens all round to
+ * zero — the category axis apportions a commit across its topics and rounds —
+ * spreads to nothing and draws no bar. The headline is the sum of what is drawn,
+ * deliberately: money that is not drawn must not be in the total either.
+ *
+ * Anything compared AGAINST that headline has to sum the same way, or the two
+ * disagree by exactly those days. Hence this being one function rather than a
+ * `reduce` at each site.
+ */
+function drawnCost(result: SeriesResult): number {
+	// Read by TYPE, not with `??`. `bySeries` is a plain object here
+	// (`Object.fromEntries`) and in the browser (`JSON.parse`), so a series key
+	// colliding with an Object.prototype member — a branch really can be named
+	// `constructor` — hands back the INHERITED function on any day that key is
+	// absent, which is most days. `?? 0` passes it through: `number + function`
+	// is string concatenation, `> 0` on the result is false, and that day's cost
+	// leaves the headline silently. Same read as `apportionedCost` and
+	// `JD.topSeries`, which were hardened first.
+	const read = (point: DaySeriesPoint, key: string): number =>
+		typeof point.bySeries[key] === "number" ? point.bySeries[key] : 0;
+	return result.series.reduce((sum, point) => {
+		const tokens = result.seriesKeys.reduce((n, key) => n + read(point, key), 0);
+		return tokens > 0 ? sum + point.estCostUsd : sum;
+	}, 0);
 }
 
 /** Price-table date behind the cost figures, from the newest priced session. */
@@ -909,16 +1081,11 @@ function buildStats(
 		? windowSessions.filter((s) => inWindow(s.updated_at_ms))
 		: sessionsInRange(db, scope, window.startMs, window.endMs);
 
-	// KPI row, scoped to the range. Labels carry the window so "6 sessions" can
-	// never be misread as today's when the user is looking at a month.
-	const rangeTokens = rangeSessions.reduce((sum, s) => sum + totalTokens(s), 0);
-	const rangeCost = rangeSessions.reduce((sum, s) => sum + (s.est_cost_usd ?? 0), 0);
 	const rangeCached = rangeSessions.reduce((sum, s) => sum + s.cached_tokens, 0);
-	const rangeInput = rangeSessions.reduce((sum, s) => sum + s.input_tokens + s.cached_tokens, 0);
 
-	// "Tokens" — input/output/cache over the range, day-bucketed
-	// for the card's chart. Reuses `rangeSessions`, already swept above for the
-	// KPI row, rather than a second query.
+	// "Tokens" — input/output/cache over the range, day-bucketed for the card's
+	// chart. Reuses `rangeSessions`, already swept above, rather than a second
+	// query.
 	const perDayTokens = new Map<string, { input: number; output: number; cached: number }>();
 	for (let dayStart = window.startMs; dayStart < window.endMs; dayStart = addLocalDays(dayStart, 1, timeZone)) {
 		perDayTokens.set(localDayKey(dayStart, timeZone), { input: 0, output: 0, cached: 0 });
@@ -938,34 +1105,24 @@ function buildStats(
 		perDay: [...perDayTokens.entries()].map(([date, v]) => ({ date, ...v })),
 	};
 
-	// Cost vs the immediately preceding window of equal length — the Spend
-	// card's own self-trend.
-	const priorRangeFrom = window.startMs - (window.endMs - window.startMs);
-	const priorRangeCost = (
-		priorRangeFrom >= heatmapStart
-			? windowSessions.filter((s) => s.updated_at_ms >= priorRangeFrom && s.updated_at_ms < window.startMs)
-			: sessionsInRange(db, scope, priorRangeFrom, window.startMs)
-	).reduce((sum, s) => sum + (s.est_cost_usd ?? 0), 0);
-	const costTrendPct =
-		priorRangeCost > 0 ? Math.round(((rangeCost - priorRangeCost) / priorRangeCost) * 100) : undefined;
+	// Cost/token series along the requested dimension, over the range.
+	const seriesResult = buildSeries(db, scope, dimension, tier, window.startMs, window.endMs, timeZone);
 
-	const streakDays = computeStreak(
-		[...windowSessions.map((s) => s.updated_at_ms), ...windowCommits.map((c) => c.committed_at_ms)],
-		timeZone,
-		nowMs,
-	);
-	const suffix = window.label;
-	const kpis: KpiCard[] = [
-		{ key: "sessions", label: `sessions ${suffix}`, value: String(rangeSessions.length) },
-		{ key: "tokens", label: `tokens ${suffix}`, value: formatTokens(rangeTokens) },
-		{ key: "cost", label: `est. cost ${suffix}`, value: `$${rangeCost.toFixed(2)}` },
-		{
-			key: "cached",
-			label: "% cached",
-			value: rangeInput > 0 ? `${Math.round((rangeCached / rangeInput) * 100)}%` : "—",
-		},
-		{ key: "streak", label: "streak", value: `${streakDays}d 🔥` },
-	];
+	// Cost vs the immediately preceding window of equal length — the Spend card's
+	// own self-trend, and BOTH ends are the same series the card draws.
+	//
+	// It used to be a sum of `sessions.est_cost_usd` over each window, which is a
+	// different clock AND a different population from the headline directly above
+	// it: on `branch`/`ticket`/`category` the series is memory rows windowed on
+	// committer date, so a window with sessions but no summarized commits read
+	// "$0.00" with an arrow beside it claiming +200%. Even on `model` the two
+	// disagree — the series reads `session_model_usage`, not `sessions`. A
+	// self-trend is only worth printing if it trends the number it sits next to.
+	const priorRangeFrom = window.startMs - (window.endMs - window.startMs);
+	const priorSeries = buildSeries(db, scope, dimension, tier, priorRangeFrom, window.startMs, timeZone);
+	const priorDrawn = drawnCost(priorSeries);
+	const costTrendPct =
+		priorDrawn > 0 ? Math.round(((drawnCost(seriesResult) - priorDrawn) / priorDrawn) * 100) : undefined;
 
 	// Memory-tier KPI sub-lines. `undefined` below the tier so the card renders
 	// the mockup's "—" instead of asserting a real zero.
@@ -990,9 +1147,6 @@ function buildStats(
 		tier === "installed" ? undefined : buildDecisionsCard(db, scope, window.startMs, window.endMs, timeZone);
 
 	const pricesAsOf = readPricesAsOf(db, scope);
-
-	// Cost/token series along the requested dimension, over the same window.
-	const seriesResult = buildSeries(db, scope, dimension, tier, window.startMs, window.endMs, timeZone);
 
 	// Heatmap + hour histogram from the same window sweep. Commits count as
 	// their own dimension: sessions older than the live-log window survive only
@@ -1050,18 +1204,22 @@ function buildStats(
 	// The memory-tier feed. Built unconditionally: an installed-tier repo simply
 	// has no summarized commits, so this comes back empty and the renderer shows
 	// the session list instead.
-	const memoryCards = buildMemoryCards(db, scope, window, reachable);
+	const memoryFeed = buildMemoryCards(db, scope, window, reachable);
 
 	return {
-		kpis,
 		...seriesResult,
 		heatmap,
 		hours,
 		tokenBreakdown,
 		...(costTrendPct !== undefined ? { costTrendPct } : {}),
+		// Reported by the builder, not inferred from the page it returned: the feed
+		// is cut inside it, so `length === MEMORY_CARDS_LIMIT` is equally "the
+		// window holds exactly that many" and "the twenty most recent of three
+		// hundred" — and the page has no constant to compare against either way.
+		...(memoryFeed.capped ? { memoryCardsCapped: true } : {}),
 		fun,
 		recentSessions,
-		memoryCards,
+		memoryCards: memoryFeed.cards,
 		totalCommits: rangeCommits.length,
 		range: window.range,
 		rangeFrom: window.from,
@@ -1083,25 +1241,6 @@ function toRecentSession(s: SessionRow, nowMs: number): RecentSession {
 		repoName: s.repo_name,
 		isLive: nowMs - s.updated_at_ms < LIVE_WINDOW_MS,
 	};
-}
-
-/**
- * Consecutive active local days ending today (or yesterday — a streak is not
- * broken by a morning where you have not started yet).
- */
-export function computeStreak(activityMs: ReadonlyArray<number>, timeZone: string, nowMs: number): number {
-	const activeDays = new Set(activityMs.map((ms) => localDayKey(ms, timeZone)));
-	let cursor = startOfLocalDay(nowMs, timeZone);
-	if (!activeDays.has(localDayKey(cursor, timeZone))) {
-		cursor = addLocalDays(cursor, -1, timeZone);
-		if (!activeDays.has(localDayKey(cursor, timeZone))) return 0;
-	}
-	let streak = 0;
-	while (activeDays.has(localDayKey(cursor, timeZone))) {
-		streak += 1;
-		cursor = addLocalDays(cursor, -1, timeZone);
-	}
-	return streak;
 }
 
 // ── Standup page ────────────────────────────────────────────────────────────
@@ -1314,6 +1453,19 @@ function dominantWorkingModel(summary: CommitSummary): string | undefined {
 	return best?.model;
 }
 
+interface MemoryCardFeed {
+	readonly cards: MemoryCard[];
+	/**
+	 * More memories in the window than {@link cards} carries.
+	 *
+	 * Travels out of here rather than being inferred from `cards.length`,
+	 * because that length cannot tell a window holding exactly
+	 * {@link MEMORY_CARDS_LIMIT} memories (complete) from one holding three
+	 * hundred (cut). Only this function still holds the un-cut set.
+	 */
+	readonly capped: boolean;
+}
+
 /**
  * The "What my agents did" feed at the memory tier: commits paired with the
  * session summary that produced them.
@@ -1329,7 +1481,7 @@ function buildMemoryCards(
 	scope: DashboardScope,
 	window: ResolvedWindow,
 	reachable?: ReachableCommits,
-): MemoryCard[] {
+): MemoryCardFeed {
 	// `repo_id` belongs to the memory row (`c`), not the joined repo lookup
 	// (`r`).  Using `r.repo_id` only breaks the scoped form of the query; the
 	// catch below then intentionally degrades to an empty feed, which used to
@@ -1338,6 +1490,7 @@ function buildMemoryCards(
 	const filter = scopeFilter(repoScope, "c.repo_id");
 	let rows: ReadonlyArray<MemoryCardRow>;
 	let decisionCounts: ReadonlyMap<string, number> = new Map();
+	let capped = false;
 	try {
 		// Two steps, because the reachability filter can only run in JS (git, not
 		// the DB — see `ReachableCommits`) and a rewritten-away commit keeps its
@@ -1345,52 +1498,64 @@ function buildMemoryCards(
 		// showing the two survivors of the twenty most recent rows instead of the
 		// twenty most recent surviving memories. Step one is deliberately narrow —
 		// the payload blob is only read for the page that is actually rendered.
-		// Windowed on the COMMITTER date, falling back to the memory's own
-		// `commit_date_ms` only when no `commits` row exists yet. Those two are
-		// different clocks: `commit_date_ms` comes from `CommitSummary.commitDate`,
-		// which `GitOps.getHeadCommitInfo` reads with `%aI` (author date), while
-		// `commits.committed_at_ms` is collected with `%cI` — deliberately, since
-		// every other window in this file is a committer-date window. Filtering
-		// the cards on the author date put a rebased or cherry-picked commit in a
-		// different bucket from the "N of M captured" line directly above the
-		// list, so the header counted memories the feed did not show.
+		//
+		// Windowed, sorted and stamped on {@link MEMORY_LANDING_CTE}'s `at_ms` —
+		// the LANDED committer date — for the reason stated there: the memory's own
+		// `commit_date_ms` is an author date (`%aI` via `CommitSummary.commitDate`,
+		// against the `%cI` every other window in this file uses), so windowing on
+		// it put a rebased or cherry-picked commit in a different bucket from the
+		// "N of M captured" line directly above the list, and the header counted
+		// memories the feed did not show.
 		const keys = db
 			.prepare(
-				`SELECT c.commit_hash, r.repo_identity
+				`${MEMORY_LANDING_CTE}
+				 SELECT c.commit_hash, ml.live_hash, r.repo_identity
 				   FROM memories c
 				   JOIN repos r ON r.id = c.repo_id
-				   LEFT JOIN commits cm ON cm.repo_id = c.repo_id AND cm.hash = c.commit_hash
+				   JOIN memory_landing ml ON ml.repo_id = c.repo_id AND ml.commit_hash = c.commit_hash
 				  WHERE c.parent_hash IS NULL
-				    AND COALESCE(cm.committed_at_ms, c.commit_date_ms) >= ?
-				    AND COALESCE(cm.committed_at_ms, c.commit_date_ms) < ?${filter.sql}
-				  ORDER BY COALESCE(cm.committed_at_ms, c.commit_date_ms) DESC`,
+				    AND ml.at_ms >= ? AND ml.at_ms < ?${filter.sql}
+				  ORDER BY ml.at_ms DESC`,
 			)
 			.all(window.startMs, window.endMs, ...filter.params) as ReadonlyArray<{
 			commit_hash: string;
+			live_hash: string;
 			repo_identity: string;
 		}>;
-		const page = keys
-			.filter((k) => isReachable(reachable, k.repo_identity, k.commit_hash))
-			.slice(0, MEMORY_CARDS_LIMIT);
-		if (page.length === 0) return [];
+		// Reachability is asked about `live_hash`, never the memory's own hash: a
+		// rewritten commit's memory stays filed under a hash no ref reaches, so
+		// asking about that one drops from the feed exactly the memories
+		// `memoriesCreated` has just counted through the alias — the two figures
+		// sit in the same card.
+		const eligible = keys.filter((k) => isReachable(reachable, k.repo_identity, k.live_hash));
+		const page = eligible.slice(0, MEMORY_CARDS_LIMIT);
+		// Decided HERE, where the un-cut set is still in hand. `cards.length` cannot
+		// answer it: a window holding exactly the limit is complete, and reporting
+		// it as capped makes the card say "showing the 20 most recent" of 20.
+		capped = eligible.length > MEMORY_CARDS_LIMIT;
+		if (page.length === 0) return { cards: [], capped: false };
 		const holes = page.map(() => "?").join(",");
 		rows = db
 			.prepare(
-				// Same COALESCE as the key query above, for both the sort and the
-				// timestamp the card renders. Ordering on `c.commit_date_ms` alone
-				// re-sorted the page by AUTHOR date after it had been selected and
-				// windowed on the committer date, so a rebased or cherry-picked commit
-				// landed out of order and rendered a timestamp that could fall outside
-				// the window it was selected for.
-				`SELECT c.commit_hash, c.commit_message,
-				        COALESCE(cm.committed_at_ms, c.commit_date_ms) AS committed_at_ms,
+				// {@link MEMORY_LANDING_CTE}'s `at_ms` again — the SAME expression the
+				// key query selected and windowed on, not a restatement of it. Both the
+				// sort and the timestamp the card renders have to come from that one
+				// clock: ordering on `c.commit_date_ms` re-sorted the page by AUTHOR
+				// date after it had been selected on the committer date, and STAMPING a
+				// row with it rendered a date that can fall outside the window the row
+				// was selected for. A near-miss spelling is what this replaces —
+				// `COALESCE(cm.committed_at_ms, c.commit_date_ms)` agrees with `at_ms`
+				// only while the memory's own commit row survives, and skips the alias
+				// hop in exactly the rewritten case both queries exist to handle.
+				`${MEMORY_LANDING_CTE}
+				 SELECT c.commit_hash, c.commit_message, ml.at_ms AS committed_at_ms,
 				        c.recap, c.turns, c.est_cost_usd,
 				        c.branch, c.insertions, c.deletions, c.summary_json, r.repo_identity, r.repo_name
 				   FROM memories c
 				   JOIN repos r ON r.id = c.repo_id
-				   LEFT JOIN commits cm ON cm.repo_id = c.repo_id AND cm.hash = c.commit_hash
+				   JOIN memory_landing ml ON ml.repo_id = c.repo_id AND ml.commit_hash = c.commit_hash
 				  WHERE c.parent_hash IS NULL AND c.commit_hash IN (${holes})${filter.sql}
-				  ORDER BY COALESCE(cm.committed_at_ms, c.commit_date_ms) DESC`,
+				  ORDER BY ml.at_ms DESC`,
 			)
 			.all(...page.map((k) => k.commit_hash), ...filter.params) as ReadonlyArray<MemoryCardRow>;
 		// `IN (hashes)` is keyed on the hash alone, so an unscoped dashboard whose
@@ -1412,10 +1577,10 @@ function buildMemoryCards(
 		// The feed is one card on one page; a query failure degrades it to the
 		// tier-0 session list rather than taking the whole dashboard down.
 		log.warn("memory cards unavailable: %s", errMsg(err));
-		return [];
+		return { cards: [], capped: false };
 	}
 
-	return rows.map((row) => {
+	const cards = rows.map((row) => {
 		// Not guarded: `memories` computes STORED generated columns with
 		// `json_extract`, so SQLite rejects a malformed payload at INSERT
 		// ("malformed JSON") — no unparseable row can exist to read here. Pinned by
@@ -1448,6 +1613,7 @@ function buildMemoryCards(
 			repoName: row.repo_name,
 		};
 	});
+	return { cards, capped };
 }
 
 /**
@@ -2050,8 +2216,9 @@ export function buildDashboardModel(db: DashboardDbHandle, opts: QueryOptions): 
 	// `sessionsThisWeek` is the repo picker's per-repo meta figure, computed here so
 	// the shell needs no second round trip.
 	//
-	// PAUSED repos are listed too, not filtered out. Their rows are never deleted
-	// (`repos_no_delete`) and they keep counting in the aggregate KPIs, so a
+	// PAUSED repos are listed too, not filtered out. Pausing is an UPDATE that
+	// stamps `disabled_at`, never a delete, and they keep counting in the
+	// aggregate figures, so a
 	// `disabled_at IS NULL` filter here made an all-paused dashboard read as "No
 	// repositories yet" while its numbers still had the paused repo's activity in
 	// them. `disabled_at IS NOT NULL` sorts the paused ones to the bottom of the

--- a/cli/src/dashboard/DashboardServer.test.ts
+++ b/cli/src/dashboard/DashboardServer.test.ts
@@ -46,6 +46,7 @@ import { unlink } from "node:fs/promises";
 import * as gitOps from "../core/GitOps.js";
 import { initTelemetry, shutdownTelemetry } from "../core/Telemetry.js";
 import { readTelemetryEvents } from "../core/TelemetryBuffer.js";
+import { TRANSCRIPT_SOURCE_LABELS } from "../core/TranscriptSourceLabel.js";
 import * as installer from "../install/Installer.js";
 import { withDashboardDb } from "./DashboardDb.js";
 import { type DashboardModel, type DashboardScope, type DashboardView, TOOL_ROWS_LIMIT } from "./DashboardModel.js";
@@ -190,8 +191,9 @@ afterEach(async () => {
    wrote its own fixture into the developer's live database — a repo named
    `acme-api` at `/tmp/acme-api`, `enabled_at: "t"`, `disabled_at` NULL, which
    every read surface then showed as a real repo in the picker. It is also not
-   removable by the obvious means: `repos_no_delete` (DashboardDb.ts) aborts any
-   DELETE on `repos`, by design, so the only cleanup is stamping `disabled_at`.
+   removable while it owns any row: the NO ACTION foreign keys reject the
+   DELETE (`repos_no_delete` used to reject it outright, and was dropped by
+   REPOS_DELETE_ALLOWED_DDL), so the cleanup is stamping `disabled_at`.
    Nothing failed — the enable tests assert an exact `{ok, repoIdentity}` body,
    which is what a SUCCESSFUL projection returns — so this was silent both ways.
    `over` still spreads last: a test wanting a specific path passes one. */
@@ -814,6 +816,24 @@ describe("assembleDashboardHtml", () => {
 		// The model block still closes: the app scripts after it stay real tags.
 		expect(html).toContain("/* main.js */");
 		expect(html.indexOf("window.__JOLLI_DASHBOARD__")).toBeLessThan(html.indexOf("/* main.js */"));
+	});
+
+	// The agent-name half of `JD.sourceBadge`. Inlined from the CLI's own map so
+	// the page holds no copy of it — asserted against the constant rather than
+	// against literals, which is the whole point: a label added there must reach
+	// the dashboard without anyone editing an asset file.
+	it("inlines the transcript source labels ahead of the app scripts", () => {
+		const html = assembleDashboardHtml(assetsDir, "{}");
+		expect(html).toContain(`window.__JOLLI_SOURCE_LABELS__ = ${JSON.stringify(TRANSCRIPT_SOURCE_LABELS)}`);
+		expect(html.indexOf("__JOLLI_SOURCE_LABELS__")).toBeLessThan(html.indexOf("/* main.js */"));
+	});
+
+	// Unlike the token, which is omitted when absent: a page without the labels
+	// silently prints raw transcript tags (`cursor-cli`), and there is no caller
+	// that would want that.
+	it("inlines the labels even with no mutation token", () => {
+		expect(assembleDashboardHtml(assetsDir, "{}")).toContain("__JOLLI_SOURCE_LABELS__");
+		expect(assembleDashboardHtml(assetsDir, "{}")).not.toContain("__JOLLI_DASHBOARD_TOKEN__");
 	});
 });
 

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -100,6 +100,7 @@ import { listPushControlRepos, setRepoPushDisabledByIdentity, triggerReenableDra
 import { getGlobalConfigDir, loadConfigFromDir } from "../core/SessionTracker.js";
 import { trackAs } from "../core/Telemetry.js";
 import { isTelemetryEventName, type TelemetryEventName } from "../core/TelemetryEvents.js";
+import { TRANSCRIPT_SOURCE_LABELS } from "../core/TranscriptSourceLabel.js";
 import { resolveAssetsDir as resolveGraphAssetsDir } from "../graph/GraphExport.js";
 import { install } from "../install/Installer.js";
 import { createLogger, errMsg, isEnoent } from "../Logger.js";
@@ -275,6 +276,14 @@ export function resolveDashboardAssetsDir(baseDir: string = HERE): string {
  * the mutation-only credential `JD.post` attaches to every POST it makes
  * (see the module header for why GET stays token-free). Optional so the
  * many existing tests that call this with two arguments are unaffected.
+ *
+ * `window.__JOLLI_SOURCE_LABELS__` carries `TRANSCRIPT_SOURCE_LABELS` verbatim,
+ * so `JD.sourceLabel` names an agent without the page holding a copy of that
+ * map. The icons beside those labels DO live in `shell.js` and cannot come from
+ * here — they are markup, not a constant — but the names are one `JSON.stringify`
+ * away, and a label map that drifts is the cheap half of the same bug. Always
+ * inlined (unlike the token): it is a fixed, non-secret table, and a page that
+ * skipped it would silently print raw transcript tags.
  */
 export function assembleDashboardHtml(assetsDir: string, modelJson: string, token?: string): string {
 	const read = (...p: string[]) => readFileSync(join(assetsDir, ...p), "utf8");
@@ -287,6 +296,7 @@ export function assembleDashboardHtml(assetsDir: string, modelJson: string, toke
 		: "";
 	const scripts =
 		tokenScript +
+		`<script>window.__JOLLI_SOURCE_LABELS__ = ${escapeForInlineScript(JSON.stringify(TRANSCRIPT_SOURCE_LABELS))};</script>\n` +
 		`<script>window.__JOLLI_DASHBOARD__ = ${escapeForInlineScript(modelJson)};</script>\n` +
 		DASHBOARD_SCRIPT_FILES.map((f) => `<script>\n${read("js", f)}\n</script>`).join("\n");
 	const marker = /<!-- scripts:start -->[\s\S]*?<!-- scripts:end -->/;

--- a/cli/src/dashboard/FeedCardAsset.test.ts
+++ b/cli/src/dashboard/FeedCardAsset.test.ts
@@ -13,10 +13,27 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { MEMORY_CARD_MAJOR_LINES } from "./DashboardModel.js";
 
+interface SeriesPoint {
+	readonly date: string;
+	readonly bySeries: Record<string, number>;
+}
+
 interface JDNamespace {
 	renderStats: (model: unknown) => void;
 	repoToken: (model: unknown, identity: string) => string;
 	withParams: (query: string, params: Record<string, string | undefined>) => string;
+	stackedBars: (
+		series: ReadonlyArray<SeriesPoint>,
+		keys: ReadonlyArray<string>,
+		valueLabel: string,
+		fmt?: (n: number) => string,
+	) => string;
+	topSeries: (
+		series: ReadonlyArray<SeriesPoint>,
+		keys: ReadonlyArray<string>,
+		limit: number,
+	) => { keys: ReadonlyArray<string>; series: ReadonlyArray<SeriesPoint>; byKey: Record<string, number> };
+	fmtUsd: (n: number) => string;
 }
 
 /** Minimal element stub: enough for the renderer to write into and be read back. */
@@ -109,7 +126,6 @@ function model(over: Record<string, unknown> = {}, statsOver: Record<string, unk
 		],
 		usage: { available: false },
 		stats: {
-			kpis: [],
 			series: [],
 			seriesKeys: [],
 			seriesDimension: "model",
@@ -173,11 +189,14 @@ describe("Memory Activity — memory tier", () => {
 		expect(html).toContain("bugfix");
 		expect(html).toContain("3 turns");
 		expect(html).toContain("fix-auth-refresh");
-		expect(html).toContain("Open memory →");
+		// The TITLE is the link — there is no separate "Open memory →" action.
+		expect(html).not.toContain("Open memory");
 		// `detailRepo`, not `repo`: the link names which repo owns the memory
 		// without scoping the Memories tree to it (see wireTree in memories.js).
 		expect(html).toContain("&hash=h1&detailRepo=https%3A%2F%2Fgithub.com%2Fjolliai%2Fjolliai");
-		expect(html).toContain('" target="_blank" rel="noopener">Open memory →');
+		expect(html).toContain(
+			'<a class="mem-activity-title" href="/memories?repo=jolliai&range=month&dimension=model&hash=h1&detailRepo=https%3A%2F%2Fgithub.com%2Fjolliai%2Fjolliai" target="_blank" rel="noopener">fix: token refresh race in gateway retries</a>',
+		);
 		// The whole point of the runtime test: a renamed model field would show up here.
 		expect(html).not.toContain("undefined");
 		expect(html).not.toContain("NaN");
@@ -243,16 +262,29 @@ describe("Memory Activity — memory tier", () => {
 	});
 
 	it("shows the decisions this commit recorded, singular when there is one", () => {
-		expect(feedHtml(model({}, { memoryCards: [{ ...CARD, decisionCount: 3 }] }))).toContain("3 decisions</span>");
-		expect(feedHtml(model({}, { memoryCards: [{ ...CARD, decisionCount: 1 }] }))).toContain("1 decision</span>");
+		// The chip is an <a>, not a <span>: it jumps to `#what-changed` on the
+		// detail page rather than making the reader find the decisions themselves.
+		expect(feedHtml(model({}, { memoryCards: [{ ...CARD, decisionCount: 3 }] }))).toContain("3 decisions</a>");
+		expect(feedHtml(model({}, { memoryCards: [{ ...CARD, decisionCount: 1 }] }))).toContain("1 decision</a>");
+	});
+
+	it("links the decision count at the topics section, not the top of the memory", () => {
+		const html = feedHtml(model({}, { memoryCards: [{ ...CARD, decisionCount: 3 }] }));
+		expect(html).toContain(
+			'<a class="tag metric num" href="/memories?repo=jolliai&range=month&dimension=model&hash=h1&detailRepo=https%3A%2F%2Fgithub.com%2Fjolliai%2Fjolliai#what-changed" target="_blank" rel="noopener">3 decisions</a>',
+		);
+		// The title link is the same memory WITHOUT the anchor — the two chips
+		// lead to different places in one page on purpose.
+		expect(html).toContain('rel="noopener">fix: token refresh race in gateway retries</a>');
 	});
 
 	// Absent, not zero: the server omits the field when the commit recorded none,
 	// and a row of zeros is noise beside the chips that are already conditional.
 	it("prints no decision chip when the commit recorded none", () => {
 		const html = feedHtml(model());
-		expect(html).not.toContain("decisions</span>");
-		expect(html).not.toContain("decision</span>");
+		expect(html).not.toContain("decisions</a>");
+		expect(html).not.toContain("decision</a>");
+		expect(html).not.toContain("#what-changed");
 	});
 
 	it("labels the two nearest days Today/Yesterday, and leaves older groups as a bare date", () => {
@@ -397,7 +429,15 @@ describe("Decisions card footer", () => {
 	});
 });
 
-describe("equal-third card subtitles", () => {
+/**
+ * Every card built on `widgetHead` — the three in the equal-third band plus
+ * Tokens, which kept the head when it moved down to share a row with Spend. The
+ * shape is what they have in common (one-line title, explanation in a `title=`
+ * hint, no visible sub), not the column count.
+ */
+const WIDGET_HEAD_CARDS = ["Skills", "MCPs", "Decisions", "Tokens"];
+
+describe("widget card heads", () => {
 	/** A card's tooltip text with the hard wraps taken back out. */
 	const hintOf = (label: string): string => {
 		const title = /title="([^"]*)"/.exec(headOf(label));
@@ -447,7 +487,8 @@ describe("equal-third card subtitles", () => {
 		// `Last 30 days` came off the card: the topbar range control is the one
 		// place the window is set, and it says so there. What the tooltip carries
 		// instead is the thing the bars cannot show — why this card counts tokens
-		// while Spend counts dollars.
+		// while Spend counts dollars. Tokens has since moved out of the band and
+		// onto the row it shares with Spend, but the head shape came with it.
 		const head = headOf("Tokens");
 		expect(head).toContain('class="has-hint"');
 		expect(hintOf("Tokens")).toContain("Cache reads bill at 10% of input");
@@ -456,10 +497,25 @@ describe("equal-third card subtitles", () => {
 		expect(head).not.toContain('<div class="sub">');
 	});
 
+	it("puts the Decisions explanation in the title's tooltip", () => {
+		// Took Tokens' seat in the band, and with it the band's head: what was a
+		// visible sub is now a one-line title carrying its sentence as a hint.
+		// The window went the same way `Last 30 days` did on Tokens.
+		const head = headOf("Decisions");
+		expect(head).toContain('class="has-hint"');
+		expect(hintOf("Decisions")).toContain("Decisions your sessions made, accumulating across the range");
+		expect(hintOf("Decisions")).toContain("the knowledge Jolli banked, with the receipts behind it");
+		// "What Jolli decided to keep" is gone: it described the store rather than
+		// the reader's work.
+		expect(hintOf("Decisions")).not.toContain("What Jolli decided to keep");
+		expect(head).not.toContain("Last 30 days");
+		expect(head).not.toContain('<div class="sub">');
+	});
+
 	it("hard-wraps every tooltip — a native one does not wrap itself", () => {
 		// Unwrapped, a two-sentence hint renders as one line that runs past the
 		// card and off the viewport.
-		for (const label of ["Skills", "MCPs", "Tokens"]) {
+		for (const label of WIDGET_HEAD_CARDS) {
 			const lines = hintLines(label);
 			expect(lines.length, label).toBeGreaterThan(1);
 			for (const line of lines) expect(line.length, `${label}: ${line}`).toBeLessThanOrEqual(70);
@@ -469,7 +525,7 @@ describe("equal-third card subtitles", () => {
 	it("breaks only between words", () => {
 		// The wrap is by character count against a font the page cannot measure,
 		// so word boundaries are what keep it acceptable.
-		for (const label of ["Skills", "MCPs", "Tokens"]) {
+		for (const label of WIDGET_HEAD_CARDS) {
 			for (const line of hintLines(label)) {
 				expect(line.startsWith(" "), label).toBe(false);
 				expect(line.endsWith(" "), label).toBe(false);
@@ -478,7 +534,7 @@ describe("equal-third card subtitles", () => {
 	});
 
 	it("leaves no visible subtitle on any card in the band", () => {
-		for (const label of ["Skills", "MCPs", "Tokens"]) {
+		for (const label of WIDGET_HEAD_CARDS) {
 			expect(headOf(label), label).not.toContain('<div class="sub">');
 		}
 	});
@@ -516,7 +572,10 @@ describe("Memory Activity", () => {
 		expect(app.innerHTML).toContain('data-memory-activity-view="branch"');
 		expect(app.innerHTML).toContain('data-memory-activity-view="time"');
 		expect(app.innerHTML).toContain("&hash=h1&detailRepo=https%3A%2F%2Fgithub.com%2Fjolliai%2Fjolliai");
-		expect(app.innerHTML).toContain("Open memory →");
+		// One link per row, and it is the title: an action column of identical
+		// "Open memory →" links was the same word repeated down the card.
+		expect(app.innerHTML).toContain('<a class="mem-activity-title"');
+		expect(app.innerHTML).not.toContain("Open memory");
 	});
 });
 
@@ -617,6 +676,17 @@ describe("Decisions card", () => {
 		expect(html).toContain('target="_blank" rel="noopener"');
 	});
 
+	it("lands on the memory's topics, at the same anchor the feed's count uses", () => {
+		// `#what-changed` is the topics section's own header in `memories.js`. One
+		// anchor serves both callers, and neither can address anything finer: the
+		// feed's chip knows a decision COUNT, and `DecisionRecord` carries no topic
+		// index — `buildDecisionsCard`'s ordering settles which topic it MEANS, not
+		// where the link goes.
+		expect(decisionsHtml(DECISIONS)).toContain(
+			'href="/memories?repo=jolliai&range=month&dimension=model&hash=h1&detailRepo=https%3A%2F%2Fgithub.com%2Fjolliai%2Fjolliai#what-changed"',
+		);
+	});
+
 	// The card used to render the whole decisions block through an inline-only
 	// markdown renderer — measured at ~1,900 characters on a real memory.
 	it("renders no decision prose and no quote marks", () => {
@@ -639,6 +709,118 @@ describe("Decisions card", () => {
 	});
 });
 
+/**
+ * The per-row agent marks. Skills leads its rows with them; the two MCP lists
+ * keep text in the trailing slot they already spend on counts. Those are two
+ * different slots on opposite sides of the label, which is what `rankedList`'s
+ * `leadHtmlOf` / `kindHtmlOf` pair is for — the marks are ahead of the name in
+ * the DOM, not flipped there by CSS, so these cases assert real source order.
+ */
+describe("agent marks on ranked rows", () => {
+	const skillRow = (agents: ReadonlyArray<{ source: string; calls: number }>) => ({
+		skills: [{ name: "code-review", kind: "skill", sessions: 3, calls: 4, agents }],
+		skillsTotal: 1,
+		skillCallsTotal: 4,
+	});
+
+	it("puts one brand mark per agent on a skill row, naming each", () => {
+		const html = usageHtml("Skills", skillRow([{ source: "claude", calls: 3 }]));
+		// Claude's mark is its own hex on both themes, so the hue is part of the
+		// contract, not a token.
+		expect(html).toContain('stroke="#D97757"');
+		// The name is not lost with the text — it is the mark's tooltip and its
+		// accessible name.
+		expect(html).toContain('role="img" title="claude" aria-label="claude"');
+		// And the bare source name no longer sits in the row as text.
+		expect(html).not.toContain('<span class="rl-kind">claude</span>');
+	});
+
+	it("emits the mark ahead of the skill name in the markup, not just on screen", () => {
+		const html = usageHtml("Skills", skillRow([{ source: "claude", calls: 3 }]));
+		expect(html).toContain('<div class="rl-top"><span class="rl-lead">');
+		// A CSS `order` flip would pass a screenshot and fail this: what a screen
+		// reader announces and what a copy-paste yields is the source order.
+		expect(html.indexOf("rl-lead")).toBeLessThan(html.indexOf("rl-name"));
+	});
+
+	// The lead is a fixed-width COLUMN, so a row with no agents still reserves it
+	// — dropping the span would put that row's name 40px left of its neighbours'.
+	it("reserves the lead column on a row with no agents", () => {
+		const html = usageHtml("Skills", skillRow([]));
+		expect(html).toContain('<div class="rl-top"><span class="rl-lead"></span>');
+		expect(html).not.toContain("src-mark");
+	});
+
+	// Past two agents the lead collapses, because a lead that grows with the
+	// agent count is what makes the name column ragged.
+	it("collapses past two agents into the leader's mark plus a counter", () => {
+		const html = usageHtml(
+			"Skills",
+			skillRow([
+				{ source: "claude", calls: 30 },
+				{ source: "codex", calls: 8 },
+				{ source: "cursor", calls: 2 },
+			]),
+		);
+		// The leader keeps its mark; the other two become "+2".
+		expect(html).toContain('stroke="#D97757"');
+		expect(html).toContain(">+2</span>");
+		expect(html).not.toContain('stroke="#10A37F"');
+		// Their names are the counter's tooltip rather than being dropped.
+		expect(html).toContain('title="codex, cursor"');
+	});
+
+	it("shows both marks at exactly two agents, with no counter", () => {
+		const html = usageHtml(
+			"Skills",
+			skillRow([
+				{ source: "claude", calls: 30 },
+				{ source: "codex", calls: 8 },
+			]),
+		);
+		expect(html).toContain('stroke="#D97757"');
+		expect(html).toContain('stroke="#10A37F"');
+		expect(html).not.toContain("src-more");
+	});
+
+	it("keeps the server's order when two agents ran one skill", () => {
+		const html = usageHtml(
+			"Skills",
+			skillRow([
+				{ source: "codex", calls: 30 },
+				{ source: "claude", calls: 4 },
+			]),
+		);
+		// `sortAgents` ranks by volume, so codex leads — the marks must not resort.
+		expect(html.indexOf('stroke="#10A37F"')).toBeLessThan(html.indexOf('stroke="#D97757"'));
+	});
+
+	// Kimi ships no mark on any surface yet. The row must still say who ran it.
+	it("falls back to the agent's initial when no mark ships for it", () => {
+		const html = usageHtml("Skills", skillRow([{ source: "kimi", calls: 2 }]));
+		expect(html).toContain('<span class="src-letter" aria-hidden="true">K</span>');
+		expect(html).toContain('aria-label="kimi"');
+	});
+
+	// The MCP lists keep TEXT in the trailing slot, and it still goes through
+	// JD.esc — that slot stopped escaping for them when it started taking markup.
+	it("leaves the MCP lists on escaped text after the name", () => {
+		const html = usageHtml("MCPs", {
+			servers: [
+				{ server: "<img src=x>", sessions: 2, calls: 30, tools: 3, agents: [{ source: "codex", calls: 30 }] },
+			],
+			serversTotal: 1,
+			serverCallsTotal: 30,
+		});
+		expect(html).toContain('<span class="rl-kind">3 tools · codex</span>');
+		expect(html).not.toContain("<img src=x>");
+		// And no lead: an MCP row's agent stays inside that text, so the lead slot
+		// is Skills-only rather than something every list grew.
+		expect(html).not.toContain("rl-lead");
+		expect(html.indexOf("rl-name")).toBeLessThan(html.indexOf("rl-kind"));
+	});
+});
+
 describe("MCPs card footer", () => {
 	const withServers = (over: Record<string, unknown> = {}) =>
 		usageHtml("MCPs", {
@@ -658,8 +840,8 @@ describe("MCPs card footer", () => {
 		);
 	});
 
-	// The three caveats JOLLI-2191 removed. Each is asserted separately because
-	// they came from three different branches of the old note.
+	// The caveats removed from these cards. Each is asserted separately because
+	// they came from different branches of the old note.
 	it("drops the uncovered-sources, recall-scope and reconstructed-history caveats", () => {
 		const html = withServers({
 			uncoveredSources: ["copilot-chat"],
@@ -672,23 +854,41 @@ describe("MCPs card footer", () => {
 		expect(html).toContain("recall calls");
 	});
 
-	// The empty state is a different element with no session count to trim to,
-	// so it keeps the caveat that says why the list may be short.
-	it("keeps the coverage caveat in the empty state", () => {
-		const html = usageHtml("MCPs", { servers: [], uncoveredSources: ["copilot-chat"] });
-		expect(html).toContain("No MCP calls recorded in this window.");
-		expect(html).toContain("record no tool calls");
-	});
-
-	// Same helper, still printed by the other card that has one.
-	it("leaves the Skills card's own caveat alone", () => {
-		const html = usageHtml("Skills", {
+	// The uncovered-sources caveat is gone from EVERY branch now, empty states
+	// included — it named a parser capability where a reader expects data, in a
+	// footer that already states its own denominator. The server still computes
+	// `uncoveredSources`; nothing prints it.
+	it.each(["Skills", "MCPs"] as const)("prints no uncovered-sources caveat on the %s card", (label) => {
+		const populated = usageHtml(label, {
 			skills: [{ name: "jolli-recall", kind: "skill", sessions: 1, calls: 2, agents: [] }],
 			skillsTotal: 1,
 			skillCallsTotal: 2,
 			uncoveredSources: ["copilot-chat"],
 		});
-		expect(html).toContain("record no tool calls");
+		const empty = usageHtml(label, { skills: [], servers: [], uncoveredSources: ["copilot-chat"] });
+		for (const html of [populated, empty]) {
+			expect(html).not.toContain("record no tool calls");
+			expect(html).not.toContain("will not appear here");
+			expect(html).not.toContain("copilot-chat");
+		}
+		expect(empty).toContain("recorded in this window.");
+	});
+
+	// `<b>` is opened before the numerator and closed by "</b> of ", so the
+	// singular branch used to emit a second, unpaired `</b>`. Browsers swallow
+	// it, which is why it survived — assert the tags balance rather than the
+	// prose.
+	it("balances its bold tags on the singular session count", () => {
+		const html = usageHtml("Skills", {
+			skills: [{ name: "jolli-recall", kind: "skill", sessions: 1, calls: 2, agents: [] }],
+			skillsTotal: 1,
+			skillCallsTotal: 2,
+			sessionsWithTools: 1,
+			sessionsInWindow: 1,
+		});
+		const foot = html.slice(html.indexOf("w-foot"));
+		expect(foot).toContain("of 1 session in this window");
+		expect((foot.match(/<b>/g) ?? []).length).toBe((foot.match(/<\/b>/g) ?? []).length);
 	});
 });
 
@@ -746,5 +946,298 @@ describe("JD.withParams (shell.js)", () => {
 			"?hash=h1&detailRepo=https%3A%2F%2Fgithub.com%2Fjolliai%2Fjolliai",
 		);
 		expect(JD.withParams("?repo=x", { hash: "", detailRepo: undefined })).toBe("?repo=x");
+	});
+});
+
+/** The Spend card, sliced out of the rendered stats page. */
+function spendHtml(statsOver: Record<string, unknown>): string {
+	app.innerHTML = "";
+	JD.renderStats(model({}, statsOver));
+	const html = app.innerHTML;
+	const start = html.indexOf('aria-label="Spend"');
+	expect(start).toBeGreaterThan(-1);
+	return html.slice(start, html.indexOf("</section>", start));
+}
+
+/**
+ * One ordinary day plus the day that used to break the card: real cost, but
+ * every series key at zero tokens. Cost is apportioned by token share, so that
+ * day draws no bar at all — and the headline must not claim it either.
+ */
+const SPEND_SERIES = {
+	seriesKeys: ["alpha", "beta"],
+	series: [
+		{ date: "2026-07-29", tokens: 100, estCostUsd: 4, bySeries: { alpha: 60, beta: 40 } },
+		{ date: "2026-07-30", tokens: 0, estCostUsd: 5, bySeries: { alpha: 0, beta: 0 } },
+	],
+};
+
+describe("Spend card — headline, legend and footer read one source", () => {
+	it("totals what the bars draw, not `estCostUsd`, so an undrawable day cannot inflate it", () => {
+		const html = spendHtml(SPEND_SERIES);
+		// 4.00 is the drawn total; 9.00 would be the sum of estCostUsd.
+		expect(html).toContain("$4.00");
+		expect(html).not.toContain("$9.00");
+	});
+
+	it("splits the headline across the legend exactly", () => {
+		const html = spendHtml(SPEND_SERIES);
+		expect(html).toContain("$2.40"); // alpha: 60/100 of the drawn $4.00
+		expect(html).toContain("$1.60"); // beta:  40/100
+	});
+
+	it("names a busiest day that cannot exceed the headline", () => {
+		const html = spendHtml(SPEND_SERIES);
+		// Asserted POSITIVELY on purpose. The undrawable day carries the larger
+		// `estCostUsd` ($5.00), so a footer reading that field would name a
+		// busiest day worth more than the whole window — but it would also read
+		// `estCostUsd` off the apportioned series, where the field does not
+		// exist, and render no footer at all. A `not.toContain` passes on that.
+		expect(html).toContain("busiest day");
+		expect(html).toContain("2026-07-29 · $4.00");
+	});
+
+	it("states which clock the series is on", () => {
+		expect(spendHtml({ ...SPEND_SERIES, seriesDimension: "branch" })).toContain("by commit date");
+		expect(spendHtml({ ...SPEND_SERIES, seriesDimension: "category" })).toContain("by commit date");
+		// Not the requested dimension — the effective one. Below the memory tier a
+		// memory axis falls back to `model`, and the label has to follow it.
+		expect(spendHtml({ ...SPEND_SERIES, seriesDimension: "model" })).toContain("by session activity");
+		expect(spendHtml({ ...SPEND_SERIES, seriesDimension: "agent" })).toContain("by session activity");
+	});
+
+	it("names the axis it actually drew, in both places it says one", () => {
+		// Both the chart's aria-label and the "largest …" figure said "model" on
+		// every axis, so `?dimension=branch` announced a branch name as a model.
+		const branch = spendHtml({ ...SPEND_SERIES, seriesDimension: "branch" });
+		expect(branch).toContain("estimated spend by branch");
+		expect(branch).toContain("largest branch");
+		expect(branch).not.toContain("model");
+		const project = spendHtml({ ...SPEND_SERIES, seriesDimension: "project" });
+		expect(project).toContain("estimated spend by project");
+		expect(project).toContain("largest project");
+		// The effective dimension, not the requested one — same rule as the clock
+		// note above, and the case that has to keep saying "model".
+		const model = spendHtml({ ...SPEND_SERIES, seriesDimension: "model" });
+		expect(model).toContain("estimated spend by model");
+		expect(model).toContain("largest model");
+	});
+
+	it("degrades an unknown dimension to a neutral noun rather than a wrong one", () => {
+		// An older page against a newer server. Naming the axis wrongly is worse
+		// than not naming it, and `constructor` is the shape that would hand back
+		// an inherited value from a plain-object lookup table.
+		for (const dim of ["quantum", "constructor"]) {
+			const html = spendHtml({ ...SPEND_SERIES, seriesDimension: dim });
+			expect(html).toContain("estimated spend by series");
+			expect(html).toContain("largest series");
+			expect(html).not.toContain("function Object");
+		}
+	});
+
+	it("renders no stray undefined or NaN", () => {
+		const html = spendHtml(SPEND_SERIES);
+		expect(html).not.toContain("undefined");
+		expect(html).not.toContain("NaN");
+	});
+});
+
+describe("Memory Activity — subtitle counts the page, and says so", () => {
+	const twoCards = [CARD, { ...CARD, commitHash: "h2" }];
+
+	it("counts the window when the list is NOT capped", () => {
+		const html = feedHtml(model({}, { memoryCards: twoCards, memoryCardsCapped: false }));
+		expect(html).toContain("2 memories in this window");
+		// Claiming a truncation that did not happen is its own inaccuracy.
+		expect(html).not.toContain("showing the");
+	});
+
+	it("says 'showing the N most recent' only when the server capped the list", () => {
+		const html = feedHtml(model({}, { memoryCards: twoCards, memoryCardsCapped: true }));
+		expect(html).toContain("showing the 2 most recent");
+		// The original wording printed the page size as though it were the window
+		// total, directly above the coverage line that prints the real one.
+		expect(html).not.toContain("memories in this window");
+	});
+
+	it("keeps the uncapped singular readable", () => {
+		const html = feedHtml(model({}, { memoryCards: [CARD], memoryCardsCapped: false }));
+		expect(html).toContain("1 memory in this window");
+		expect(html).not.toContain("1 memories");
+	});
+});
+
+/** Axis tick labels, in draw order (bottom gridline first). */
+function axisTicks(svg: string): ReadonlyArray<string> {
+	return [...svg.matchAll(/class="num">([^<]*)<\/text>/g)].map((m) => m[1]);
+}
+
+/** Every `var(--sN)` fill in the legend, in render order. */
+function legendColors(html: string): ReadonlyArray<string> {
+	const legend = html.slice(
+		html.indexOf('<div class="legend'),
+		html.indexOf("</div>", html.indexOf('<div class="legend')),
+	);
+	return [...legend.matchAll(/background:(var\(--s\d\))/g)].map((m) => m[1]);
+}
+
+const DAY = (date: string, bySeries: Record<string, number>) => ({ date, bySeries });
+
+describe("JD.stackedBars — the caller owns the unit", () => {
+	it("formats the axis and the tooltip with the supplied formatter", () => {
+		const svg = JD.stackedBars([DAY("2026-07-29", { a: 2.4 })], ["a"], "spend", JD.fmtUsd);
+		// The defect: one chart function served both cards and hardcoded the token
+		// formatter, so money lost its `$` and its cents.
+		expect(axisTicks(svg).every((t) => t.startsWith("$"))).toBe(true);
+		expect(svg).toContain("· a · $2.40");
+		expect(svg).not.toContain("· a · 2.4<");
+	});
+
+	it("still formats tokens when no formatter is passed", () => {
+		const svg = JD.stackedBars([DAY("2026-07-29", { a: 1_200_000 })], ["a"], "tokens");
+		expect(svg).toContain("· a · 1.2M");
+		expect(axisTicks(svg).some((t) => t.endsWith("M"))).toBe(true);
+		expect(svg).not.toContain("$");
+	});
+
+	it("lands the axis on round ticks and never clips the tallest bar", () => {
+		// 8.7M used to read 0 / 2.2M / 4.3M / 6.5M / 8.7M — four arbitrary numbers.
+		const svg = JD.stackedBars([DAY("2026-07-29", { a: 8_700_000 })], ["a"], "tokens");
+		expect(axisTicks(svg)).toEqual(["0", "2.5M", "5.0M", "7.5M", "10.0M"]);
+	});
+
+	it("scales the step to the data, so a sub-dollar window is not flattened", () => {
+		// Regression on the seed, not just the ladder: the bar loop started `max`
+		// at 1, a "one token" floor that drew every sub-$1 window against a $1
+		// axis — four ticks of headroom above a $0.37 chart.
+		const svg = JD.stackedBars([DAY("2026-07-29", { a: 0.37 })], ["a"], "spend", JD.fmtUsd);
+		expect(axisTicks(svg)).toEqual(["$0.00", "$0.10", "$0.20", "$0.30", "$0.40"]);
+	});
+
+	it("survives a series key that shadows Object.prototype", () => {
+		// `topSeries` was hardened for this and hands a SHORT series straight back,
+		// so the raw JSON.parse'd object — prototype and all — reaches this function
+		// unchanged. `|| 0` then treats the inherited `constructor` function as a
+		// value on the day it is absent: it clears the `<= 0` guard, and every
+		// geometry expression downstream of it becomes NaN.
+		const svg = JD.stackedBars(
+			[DAY("2026-07-29", { constructor: 40 }), DAY("2026-07-30", { a: 60 })],
+			["constructor", "a"],
+			"tokens",
+		);
+		expect(svg).not.toContain("NaN");
+		expect(svg).toContain("· constructor · 40");
+		expect(axisTicks(svg)).toEqual(["0", "20", "40", "60", "80"]);
+	});
+
+	it("keeps the no-data axis on integers", () => {
+		// The seed moved into `niceAxisMax`, so this is the case that would
+		// otherwise read 0 / 0.25 / 0.5 / 0.75 / 1 tokens.
+		expect(axisTicks(JD.stackedBars([DAY("2026-07-29", { a: 0 })], ["a"], "tokens"))).toEqual([
+			"0",
+			"1",
+			"2",
+			"3",
+			"4",
+		]);
+	});
+});
+
+describe("JD.topSeries — ranked head plus a conserving Other bucket", () => {
+	const wide = {
+		keys: Array.from({ length: 23 }, (_, i) => `branch-${i}`),
+		series: [DAY("2026-07-29", Object.fromEntries(Array.from({ length: 23 }, (_, i) => [`branch-${i}`, i + 1])))],
+	};
+
+	it("caps the visible series at limit + Other", () => {
+		const top = JD.topSeries(wide.series, wide.keys, 4);
+		expect(top.keys).toHaveLength(5);
+		expect(top.keys[top.keys.length - 1]).toBe("Other");
+		// Ranked by total, so the largest series keeps the first colour.
+		expect(top.keys.slice(0, 4)).toEqual(["branch-22", "branch-21", "branch-20", "branch-19"]);
+	});
+
+	it("conserves the total — the tail is merged, never dropped", () => {
+		const top = JD.topSeries(wide.series, wide.keys, 4);
+		const before = wide.keys.reduce((sum, k) => sum + wide.series[0].bySeries[k], 0);
+		const after = top.keys.reduce((sum, k) => sum + top.series[0].bySeries[k], 0);
+		// 1..23. Dropping the tail instead of merging would lose 190 of 276 —
+		// and make the Spend headline smaller than its own chart.
+		expect(before).toBe(276);
+		expect(after).toBe(276);
+		expect(top.byKey.Other).toBe(190);
+	});
+
+	it("passes a short series through untouched, with no Other bucket", () => {
+		const short = [DAY("2026-07-29", { a: 1, b: 2 })];
+		const top = JD.topSeries(short, ["a", "b"], 4);
+		expect(top.keys).toEqual(["a", "b"]);
+		expect(top.series).toBe(short);
+		expect(top.byKey).toEqual({ a: 1, b: 2 });
+	});
+
+	it("survives a series key that shadows Object.prototype", () => {
+		// A branch really can be called `constructor`. Against a plain object the
+		// lookup hands back an inherited function, `+=` writes NaN, and the series
+		// silently vanishes from the chart.
+		const nasty = [DAY("2026-07-29", { constructor: 5, toString: 3, a: 1 })];
+		const top = JD.topSeries(nasty, ["constructor", "toString", "a"], 2);
+		expect(top.keys).toEqual(["constructor", "toString", "Other"]);
+		expect(top.byKey.constructor).toBe(5);
+		expect(top.byKey.Other).toBe(1);
+	});
+
+	it("does not let a series named Other collide with the roll-up bucket", () => {
+		// Series keys are user-controlled — a branch or a repo really can be named
+		// `Other`. Reusing the literal destroyed it in three places at once: its
+		// total was overwritten by the bucket's, its daily value was overwritten
+		// per point, and `keys` listed one string twice — so the legend drew two
+		// identical swatches and `stackedBars` summed that segment twice, lifting
+		// every bar and the axis above a headline computed before the roll-up.
+		const clash = [DAY("2026-07-29", { Other: 10, b: 4, c: 3, d: 2, e: 1 })];
+		const top = JD.topSeries(clash, ["Other", "b", "c", "d", "e"], 4);
+		expect(new Set(top.keys).size).toBe(top.keys.length);
+		// The real series keeps rank, colour and its own total.
+		expect(top.keys[0]).toBe("Other");
+		expect(top.byKey.Other).toBe(10);
+		// The bucket lands beside it under a free name, holding only the tail.
+		const bucket = top.keys[top.keys.length - 1];
+		expect(bucket).not.toBe("Other");
+		expect(top.byKey[bucket]).toBe(1);
+		// Conservation still holds, which is the property the whole roll-up exists for.
+		expect(top.keys.reduce((sum, k) => sum + top.series[0].bySeries[k], 0)).toBe(20);
+	});
+});
+
+describe("Spend card — the chart is readable back to its legend", () => {
+	const wideSpend = {
+		seriesKeys: Array.from({ length: 23 }, (_, i) => `branch-${i}`),
+		series: [
+			{
+				date: "2026-07-29",
+				tokens: 276,
+				estCostUsd: 27.6,
+				bySeries: Object.fromEntries(Array.from({ length: 23 }, (_, i) => [`branch-${i}`, i + 1])),
+			},
+		],
+	};
+
+	it("shows at most five series and never reuses a colour", () => {
+		const colors = legendColors(spendHtml(wideSpend));
+		expect(colors).toHaveLength(5);
+		// The bug: seriesColor cycles a five-colour palette, so 23 series reused
+		// every colour ~5x and the stack could not be read back.
+		expect(new Set(colors).size).toBe(5);
+	});
+
+	it("keeps the headline equal to the bars after the roll-up", () => {
+		const html = spendHtml(wideSpend);
+		// Rolling up must not change the total: $27.60 is the whole window.
+		expect(html).toContain("$27.60");
+		expect(html).toContain("Other");
+	});
+
+	it("renders the axis in dollars", () => {
+		expect(axisTicks(spendHtml(SPEND_SERIES)).every((t) => t.startsWith("$"))).toBe(true);
 	});
 });

--- a/cli/src/dashboard/MemoriesAsset.test.ts
+++ b/cli/src/dashboard/MemoriesAsset.test.ts
@@ -42,6 +42,7 @@ const PLAN_ROW = { kind: "plan", key: "plan-key", contextKey: "plan-key", title:
 function render(
 	context: ReadonlyArray<Record<string, unknown>>,
 	conversations: ReadonlyArray<Record<string, unknown>> = [],
+	topics: ReadonlyArray<Record<string, unknown>> = [],
 ): { rows: FakeRow[]; html: string } {
 	const rows: FakeRow[] = [
 		{
@@ -98,7 +99,7 @@ function render(
 				excluded: [],
 				activity: [],
 				activityUncoveredSources: [],
-				topics: [],
+				topics,
 				files: [],
 				e2e: [],
 			},
@@ -224,5 +225,82 @@ describe("memories.js — conversation rows", () => {
 		const { html } = render([], [conversation({ sessionId: undefined })]);
 		expect(html).toContain('<div class="gd-row">');
 		expect(html).not.toContain('title="Session');
+	});
+
+	// The row leads with the agent that produced the conversation, the same way
+	// VS Code's memory detail and IntelliJ's Working Memory panel do.
+	it("leads with the producing agent's brand mark instead of a generic glyph", () => {
+		const { html } = render([], [conversation({ source: "codex" })]);
+		expect(html).toContain('<span class="src-mark mem-row-icon" role="img" title="codex" aria-label="codex">');
+		expect(html).toContain('stroke="#10A37F"');
+	});
+
+	// The name moved into the mark rather than being dropped: it used to sit in
+	// the meta slot as raw text, competing with the title for width.
+	it("no longer prints the source tag as row text", () => {
+		const { html } = render([], [conversation({ source: "cursor" })]);
+		expect(html).not.toContain('<span class="mem-row-meta">cursor</span>');
+		expect(html).toContain('aria-label="cursor"');
+		expect(html).toContain("12 msgs");
+	});
+
+	// cursor-agent and the Cursor IDE are one brand — the same pairing the other
+	// three surfaces make, so the CLI does not render as an unknown agent.
+	it("rides the sibling brand for cursor-cli", () => {
+		const cli = render([], [conversation({ source: "cursor-cli" })]).html;
+		expect(cli).toContain('aria-label="cursor-cli"');
+		expect(cli).toContain("M8 1.5 14 5v6L8 14.5 2 11V5L8 1.5Z");
+	});
+});
+
+/**
+ * The anchor the Memory Activity card's "N decisions" chip links at.
+ *
+ * It is a FIXED id on the topics SECTION — the "What changed and why" header —
+ * not a per-topic index, because the card that links here knows only how many
+ * decisions a memory has (`MemoryCard.decisionCount`) and carries no topic list.
+ * It sat on the first `.decide` block before, which landed the reader below the
+ * topic heading that says what the decision is about.
+ */
+describe("topic anchors", () => {
+	const topic = (title: string, decisions: ReadonlyArray<string>) => ({
+		title,
+		category: "bugfix",
+		trigger: "t",
+		response: "r",
+		decisions,
+		files: [],
+		todo: "",
+	});
+
+	it("gives every topic an index anchor", () => {
+		const { html } = render([], [], [topic("T0", []), topic("T1", ["picked sqlite"])]);
+		expect(html).toContain('id="topic-0"');
+		expect(html).toContain('id="topic-1"');
+	});
+
+	it("puts #what-changed on the section header, above every topic", () => {
+		const { html } = render([], [], [topic("T0", []), topic("T1", ["picked sqlite"]), topic("T2", ["again"])]);
+		// Exactly once — a second copy would make the anchor ambiguous and send
+		// the reader to whichever the browser happened to find first.
+		expect(html.match(/id="what-changed"/g)).toHaveLength(1);
+		// On the section that carries the header, so the scroll lands on "What
+		// changed and why" with the first topic below it — not inside a topic.
+		expect(html).toContain('<section class="mem-section mem-topics" id="what-changed">');
+		expect(html.indexOf('id="what-changed"')).toBeLessThan(html.indexOf('id="topic-0"'));
+	});
+
+	// The section is the whole memory's topics, so it is there whenever any topic
+	// is — the decision count is what the LINK is gated on, not the target.
+	it("emits #what-changed even when no topic recorded a decision", () => {
+		const { html } = render([], [], [topic("T0", []), topic("T1", [])]);
+		expect(html).toContain('id="topic-1"');
+		expect(html).toContain('id="what-changed"');
+		expect(html).not.toContain("decide-title");
+	});
+
+	it("emits no #what-changed when the memory has no topics at all", () => {
+		const { html } = render([], [], []);
+		expect(html).not.toContain('id="what-changed"');
 	});
 });

--- a/cli/src/dashboard/MigrationFingerprints.test.ts
+++ b/cli/src/dashboard/MigrationFingerprints.test.ts
@@ -44,6 +44,7 @@ const EXPECTED: ReadonlyArray<readonly [name: string, fingerprint: string]> = [
 	["EVENT_FAILED_KIND_DDL", "a7cdc1abee65"],
 	["TOOL_CALL_TIME_DDL", "6393ea338cd8"],
 	["SCHEMA_MIGRATIONS_DDL", "151c9e7a7af7"],
+	["REPOS_DELETE_ALLOWED_DDL", "52561786c1b7"],
 ];
 
 describe("migration fingerprints", () => {

--- a/cli/src/dashboard/RepoRegistry.test.ts
+++ b/cli/src/dashboard/RepoRegistry.test.ts
@@ -31,6 +31,7 @@ import {
 	readRepoRegistry,
 	registerRepo,
 	resolveRepoIdentity,
+	sameRecordedRoot,
 	stampRegistryInstanceId,
 } from "./RepoRegistry.js";
 
@@ -178,6 +179,34 @@ describe("multiple checkouts of one project (§10.2)", () => {
 		await registerRepo({ cwd: "/home/dev/jolli", configDir, now: () => new Date(0) });
 		const again = await registerRepo({ cwd: "/home/dev/jolli/sub", configDir, now: () => new Date(1) });
 		expect(again.worktrees).toEqual(["/home/dev/jolli"]);
+	});
+
+	it("replaces a differently-spelled repeat instead of listing it twice", async () => {
+		// The spelling is whatever the calling surface passed; a trailing slash
+		// folds on every platform, so this asserts the fix without depending on
+		// the host's case sensitivity (see `sameRecordedRoot` below for that half).
+		vi.mocked(getProjectRootDir).mockResolvedValueOnce("/home/dev/jolli/");
+		await registerRepo({ cwd: "/home/dev/jolli/", configDir, now: () => new Date(0) });
+		vi.mocked(getProjectRootDir).mockResolvedValueOnce("/home/dev/jolli");
+		const again = await registerRepo({ cwd: "/home/dev/jolli", configDir, now: () => new Date(1) });
+		// One entry, and the freshest spelling won.
+		expect(again.worktrees).toEqual(["/home/dev/jolli"]);
+	});
+
+	it("ensureWorktreeListed no-ops on a checkout already listed under another spelling", async () => {
+		await registerRepo({ cwd: "/home/dev/jolli", configDir, now: () => new Date(0) });
+		vi.mocked(getProjectRootDir).mockResolvedValueOnce("/home/dev/jolli/");
+		const entry = await ensureWorktreeListed({ cwd: "/home/dev/jolli/", configDir });
+		// Adds nothing AND rewrites nothing — the stored spelling is untouched.
+		expect(entry?.worktrees).toEqual(["/home/dev/jolli"]);
+	});
+
+	it("sameRecordedRoot folds drive-letter case on win32 but not on linux", () => {
+		expect(sameRecordedRoot("C:\\Users\\dev\\repo", "c:\\Users\\dev\\repo", "win32")).toBe(true);
+		expect(sameRecordedRoot("C:\\Users\\dev\\repo", "c:\\Users\\dev\\repo", "linux")).toBe(false);
+		// Separator and trailing slash fold everywhere; distinct paths never do.
+		expect(sameRecordedRoot("/home/dev/repo/", "/home/dev/repo", "linux")).toBe(true);
+		expect(sameRecordedRoot("/home/dev/repo", "/home/dev/other", "win32")).toBe(false);
 	});
 
 	it("existingWorktrees drops paths that no longer exist, newest first", () => {

--- a/cli/src/dashboard/RepoRegistry.ts
+++ b/cli/src/dashboard/RepoRegistry.ts
@@ -28,7 +28,7 @@ import { writeFileAtomic } from "../core/AtomicJsonFile.js";
 import { getProjectRootDir } from "../core/GitOps.js";
 import { deriveRepoNameFromUrl, getCanonicalRepoUrl } from "../core/GitRemoteUtils.js";
 import { withRepoRegistryLock } from "../core/Locks.js";
-import { toForwardSlash } from "../core/PathUtils.js";
+import { normalizePathForCompareOn, toForwardSlash } from "../core/PathUtils.js";
 import { getGlobalConfigDir } from "../core/SessionTracker.js";
 import { createLogger, errMsg, isEnoent } from "../Logger.js";
 
@@ -62,6 +62,30 @@ export interface RegisteredRepo {
 	readonly enabledAt: string;
 	/** Set when the repo is disabled. Rows are kept so history stays queryable. */
 	readonly disabledAt?: string;
+}
+
+/**
+ * Whether two recorded paths name the same checkout.
+ *
+ * The spelling of a recorded path is inherited from whatever `cwd` the caller
+ * passed: `getProjectRootDir` ends in `resolve(cwd, …)`, which preserves the
+ * caller's drive-letter case. The callers are different surfaces — a
+ * PowerShell `jolli`, the ide-bridge, a git hook launched by a GUI client —
+ * and they do not agree on it. So a raw `!==` recorded `C:\…` and `c:\…` as
+ * two checkouts of one clone, and every {@link existingWorktrees} consumer
+ * then did the same idempotent work twice (the hook sync in
+ * `SettingsMutations`, the backfill sweep). The cutover is the one consumer
+ * already immune: `collectSources` keys on `realpath` of the common dir.
+ *
+ * Comparison ONLY — the stored value keeps the spelling git reported, so a
+ * path recorded here still matches what a later `git status` prints.
+ *
+ * The platform is a parameter for the same reason `normalizePathForCompareOn`
+ * takes one: case folds on win32/darwin and not on Linux, so a test asserting
+ * the drive-letter case cannot leave that to the host it runs on.
+ */
+export function sameRecordedRoot(a: string, b: string, platform: NodeJS.Platform = process.platform): boolean {
+	return normalizePathForCompareOn(a, platform) === normalizePathForCompareOn(b, platform);
 }
 
 /**
@@ -335,8 +359,13 @@ export async function registerRepo(opts: RegisterRepoOptions): Promise<Registere
 			// overwriting would leave the other clone's commits uncollected with nothing to
 			// show that it had been dropped. Existing paths are preserved in order, the new
 			// one moves to the end (newest), and vanished paths are filtered on read.
+			//
+			// Matched with `sameRecordedRoot`, not `!==`: a re-registration that spells
+			// this checkout differently must REPLACE the old spelling rather than add a
+			// second entry for it. Appending the new one last is what makes the freshest
+			// spelling win.
 			const previous = existing?.worktrees ?? (existing ? [existing.worktreeRoot] : []);
-			const worktrees = [...previous.filter((path) => path !== worktreeRoot), worktreeRoot];
+			const worktrees = [...previous.filter((path) => !sameRecordedRoot(path, worktreeRoot)), worktreeRoot];
 			const entry: RegisteredRepo = {
 				repoIdentity: identity,
 				repoName: deriveRepoName(worktreeRoot, remoteUrl),
@@ -377,7 +406,11 @@ export async function ensureWorktreeListed(opts: RegisterRepoOptions): Promise<R
 			if (!existing) return null;
 			const previous =
 				existing.worktrees && existing.worktrees.length > 0 ? existing.worktrees : [existing.worktreeRoot];
-			if (previous.includes(worktreeRoot)) return existing;
+			// `sameRecordedRoot`, not `includes`: a checkout already listed under a
+			// different spelling is already listed. Returning `existing` unchanged is
+			// also what keeps this function's "adds, never rewrites" contract — the
+			// freshest spelling is `registerRepo`'s business, not a stray hook's.
+			if (previous.some((path) => sameRecordedRoot(path, worktreeRoot))) return existing;
 			const entry: RegisteredRepo = { ...existing, worktrees: [...previous, worktreeRoot] };
 			const repos = [...registry.repos.filter((r) => r.repoIdentity !== identity), entry];
 			await writeRepoRegistry({ ...registry, version: 1, repos }, opts.configDir);

--- a/cli/src/dashboard/SotSchema.ts
+++ b/cli/src/dashboard/SotSchema.ts
@@ -18,7 +18,8 @@
  *    (revision monotonicity, pointer validation, two FTS mirrors, cascade
  *    emulation); each one hid a business rule in the schema, needed a migration
  *    to change, and had an execution order that had to be reasoned about. The
- *    one exception is documented on `repos_no_delete` in DashboardDb.
+ *    one exception, `repos_no_delete`, has since been dropped by
+ *    REPOS_DELETE_ALLOWED_DDL — so the rule now holds without exception.
  * 2. **One row per commit.** There is no revision table and no current-revision
  *    pointer: `Regenerator` overwrites via `storeSummary(force=true)`, so disk
  *    has only ever held one summary per commit and nothing reads history.
@@ -618,6 +619,34 @@ CREATE TABLE schema_migrations (
   ddl           TEXT    NOT NULL
 ) STRICT;
 CREATE INDEX ix_schema_migrations_name ON schema_migrations(name, seq);
+`;
+
+/**
+ * Drops `repos_no_delete`, the BEFORE DELETE trigger the baseline installed.
+ *
+ * Appended rather than edited out of `BASELINE_DDL`: a shipped entry's bytes are
+ * frozen, and every database on earth has already applied that one. So the
+ * baseline still creates the trigger and still carries its original comment
+ * arguing for it — that comment is now historical, and this is the entry that
+ * supersedes it.
+ *
+ * **What still protects a repo's memories, measured rather than assumed.** Every
+ * child table references `repos(id)` with the default NO ACTION, and
+ * `foreign_keys` is ON in both `WRITE_PRAGMAS` and `READ_PRAGMAS`, so deleting a
+ * repo that owns ANY row still fails — `FOREIGN KEY constraint failed` instead of
+ * the trigger's message. What the trigger added on top was the zero-data case:
+ * with it, a repo row could not be removed even when nothing referenced it.
+ *
+ * The one place that backstop does not hold is `migrateDashboardDb`, which runs
+ * with `PRAGMA foreign_keys = OFF` (see the comment there): a DELETE on `repos`
+ * inside a migration would succeed and orphan every child row. No migration does
+ * that today, and one that wants to must re-enable foreign keys around it.
+ *
+ * `IF EXISTS` because a database restored from a pre-baseline snapshot, or one
+ * whose trigger was dropped by hand, must not fail the migration.
+ */
+export const REPOS_DELETE_ALLOWED_DDL = `
+DROP TRIGGER IF EXISTS repos_no_delete;
 `;
 
 /**

--- a/cli/src/dashboard/ToolUsagePagingAsset.test.ts
+++ b/cli/src/dashboard/ToolUsagePagingAsset.test.ts
@@ -241,7 +241,6 @@ function model(toolUsageOver: Record<string, unknown> = {}): unknown {
 		],
 		usage: { available: false },
 		stats: {
-			kpis: [],
 			series: [],
 			seriesKeys: [],
 			seriesDimension: "model",
@@ -325,8 +324,9 @@ describe("ranked rows — the per-agent tag", () => {
 	it("emits no meta slot at all for a row with nothing to put in it", () => {
 		const h = loadHarness();
 		// `agents: []` is the shape `DashboardQuery`'s defensive `?? []` can hand a
-		// Skills row, and Skills is the one list whose meta slot is the agent tag
-		// ALONE — the MCP lists always spend it on a tool/session count first.
+		// row. Read on a Skills row because Skills passes NO kind at all, so this is
+		// the list where an accidental empty slot would show up first; the MCP lists
+		// always spend theirs on a tool/session count.
 		h.render(model({ skills: [{ ...skillRow(0), agents: [] }], skillsTotal: 1, skillCallsTotal: 20 }));
 		// An empty `.rl-kind` is not free: it is still a flex item, so it spends one of
 		// `.rl-top`'s 8px gaps and takes those pixels off the name, which is the only
@@ -339,13 +339,23 @@ describe("ranked rows — the per-agent tag", () => {
 		expect(h.html()).toContain('title="/skill00">/skill00</span><span class="rl-val num">20 runs</span>');
 	});
 
-	it("folds a Skills row too, where the tag is the whole meta slot", () => {
+	it("folds a Skills row too, in the LEAD rather than the meta slot", () => {
 		const h = loadHarness();
 		h.render(model({ skills: [{ ...skillRow(0), agents: FIVE_AGENTS }], skillsTotal: 1, skillCallsTotal: 20 }));
-		// Skills rows carry no tool/session count, so there is no leading `N tools ·`
-		// for the names to hang off — the join has to hold with an empty meta.
-		expect(h.html()).toContain('<span class="rl-kind" title="claude · codex · cursor-agent · opencode · kimi">');
-		expect(h.html()).toContain("claude · codex +3</span>");
+		// Skills states its agents as brand marks AHEAD of the name (`agentBadges`),
+		// not as the name list the MCP lists put in the trailing slot. So the fold
+		// that keeps a five-agent row from pushing the name to 0 wide happens in
+		// `.rl-lead`, past `LEAD_AGENT_MARKS` — and it folds harder, to one mark plus
+		// a count, because that slot's width is what holds every skill name at the
+		// same x.
+		expect(h.html()).toContain('<span class="src-more" title="codex, cursor-agent, opencode, kimi">+4</span>');
+		// `+4` is only honest if the four are reachable, which is what that title is
+		// for — the same bargain `.rl-kind`'s tooltip makes on an MCP row.
+		//
+		// And nothing lands in the trailing slot: asserted as name-then-value with
+		// nothing between, rather than as "no `rl-kind` anywhere", because `html()`
+		// is the whole page and the MCPs card below carries a populated one.
+		expect(h.html()).toContain('title="/skill00">/skill00</span><span class="rl-val num">20 runs</span>');
 	});
 });
 

--- a/cli/src/dashboard/assets/js/charts.js
+++ b/cli/src/dashboard/assets/js/charts.js
@@ -16,6 +16,118 @@ window.JD = window.JD || {};
 		return month && parts[2] ? month + " " + Number(parts[2]) : String(key);
 	};
 
+	/* The series palette holds FIVE colours and `JD.seriesColor` cycles them, so a
+	   sixth series is drawn in the first one's colour and the stack stops being
+	   readable back to a legend. Measured: `category` produces 10 series and
+	   `branch` 23, i.e. every colour reused ~5x.
+
+	   Extending the palette is not the fix. `--s1..--s5` reproduces a validated
+	   categorical order chosen for colour-vision separation (see the comment on
+	   `--s1` in main.css: the adjacent cat-1/cat-2 pair scores ΔE 2.3 under
+	   deuteranopia against a floor of 15), and there is no supply of 23 colours
+	   that stays distinguishable. Ranking and rolling up the tail is.
+
+	   `limit` is therefore FOUR, not five: the roll-up bucket is itself a series
+	   and needs the fifth colour. Five plus "Other" would wrap again — the exact
+	   bug this removes.
+
+	   It MERGES rather than truncates, and that is load-bearing: the Spend card's
+	   headline is the sum of the bars it draws, so dropping the tail would make
+	   the headline smaller than its own chart. The bucket keeps the total exact.
+
+	   Returns the per-key totals too, so a legend never recomputes them from the
+	   pre-roll-up keys — which would print an amount for a series that is no
+	   longer drawn, and none for the bucket that replaced it. */
+	var OTHER_KEY = "Other";
+	/* The bucket's key is a display label that also has to be UNIQUE, and series
+	   keys are user-controlled strings — a branch, a ticket or a repo really can
+	   be named `Other`. Colliding is not a cosmetic tie: `byKey[OTHER_KEY] = 0`
+	   overwrites that series' own total, the per-point `bySeries[OTHER_KEY]`
+	   overwrites its daily value, and `kept.concat` then lists one key TWICE — so
+	   the legend prints two identical swatches and `stackedBars`' `keys.forEach`
+	   sums that segment twice, inflating every bar and the axis bound with it.
+	   The Spend headline is computed before the roll-up, so the card would be back
+	   to disagreeing with its own chart.
+
+	   Suffixing until free is the whole fix. The loop runs zero times on every
+	   real dataset, and in the case it does fire a legend reading `Other` and
+	   `Other ` is strictly better than one series silently absorbing another. */
+	var otherKeyFor = (totals) => {
+		var key = OTHER_KEY;
+		while (key in totals) key += " ";
+		return key;
+	};
+	JD.topSeries = (series, keys, limit) => {
+		var totals = Object.create(null);
+		var read = (point, key) => (typeof point.bySeries[key] === "number" ? point.bySeries[key] : 0);
+		keys.forEach((key) => {
+			totals[key] = 0;
+		});
+		series.forEach((point) => {
+			keys.forEach((key) => {
+				totals[key] += read(point, key);
+			});
+		});
+		if (keys.length <= limit) return { keys: keys, series: series, byKey: totals };
+		/* Sorted by total, so the colours track magnitude rather than the server's
+		   alphabetical key order — and the tie-break is the key itself, so two
+		   equal series cannot swap places between renders of the same data. */
+		var kept = keys
+			.slice()
+			.sort((a, b) => totals[b] - totals[a] || (a < b ? -1 : a > b ? 1 : 0))
+			.slice(0, limit);
+		var isKept = Object.create(null);
+		kept.forEach((key) => {
+			isKept[key] = true;
+		});
+		var otherKey = otherKeyFor(totals);
+		var byKey = Object.create(null);
+		kept.forEach((key) => {
+			byKey[key] = totals[key];
+		});
+		byKey[otherKey] = 0;
+		var rolled = series.map((point) => {
+			var bySeries = Object.create(null);
+			var other = 0;
+			keys.forEach((key) => {
+				var value = read(point, key);
+				if (isKept[key]) bySeries[key] = value;
+				else other += value;
+			});
+			bySeries[otherKey] = other;
+			byKey[otherKey] += other;
+			return { ...point, bySeries: bySeries };
+		});
+		return { keys: kept.concat([otherKey]), series: rolled, byKey: byKey };
+	};
+
+	/* An axis bound that divides into four ROUND ticks.
+	 *
+	 * The bound was the data maximum itself, quartered — so a token axis read
+	 * `0 / 2.2M / 4.3M / 6.5M / 8.7M`, four arbitrary numbers whose only property
+	 * was summing back to the tallest bar.
+	 *
+	 * The step comes off a 1/2/2.5/5/10 ladder and the bound is four of them, so
+	 * the bound is always >= the data (a step is never smaller than max/4) and no
+	 * bar can overflow the top gridline. That containment is why the ticks cannot
+	 * simply be the issue's `0 / 2M / … / 8M` for a maximum of 8.7M: 8M would clip
+	 * the tallest bar. The honest equivalent is `0 / 2.5M / 5M / 7.5M / 10M`.
+	 *
+	 * Scale-free by construction, because the same axis draws dollars: a $0.37 day
+	 * gets a $0.10 step, not a $1 one that would flatten the whole chart. The bar
+	 * loop used to seed `max = 1`, which defeated exactly that — a floor of "one
+	 * token" means nothing in dollars, and every sub-$1 window was drawn against a
+	 * $1 axis. The no-data case is seeded HERE instead, at 4, so its four ticks
+	 * stay integers on the token axis rather than reading `0 / 0.25 / 0.5 / …`. */
+	var niceAxisMax = (max) => {
+		if (!(max > 0)) return 4;
+		var raw = max / 4;
+		var magnitude = Math.pow(10, Math.floor(Math.log10(raw)));
+		var frac = raw / magnitude;
+		var step = (frac <= 1 ? 1 : frac <= 2 ? 2 : frac <= 2.5 ? 2.5 : frac <= 5 ? 5 : 10) * magnitude;
+		return step * 4;
+	};
+
 	/* Tokens' and Spend's daily chart.
 	 *
 	 * **The date axis is the two ENDPOINTS, not a tick per bar.** It used to label
@@ -28,8 +140,15 @@ window.JD = window.JD || {};
 	 * Between the ends, per-bar identification is the same affordance
 	 * `JD.recallBars` relies on: every segment carries a `<title>` with its full
 	 * date, series key and value.
+	 *
+	 * **`fmt` formats the axis ticks AND that tooltip**, defaulting to
+	 * `JD.fmtTokens` because this began as the token chart and Spend was later
+	 * drawn with the same function — so a money axis read `0 / 17 / 34 / 50` with
+	 * no `$`, cents rounded away, and a $1,200 day labelled `1.2k`: a token suffix
+	 * on a currency. The caller owns the unit; this function never did.
 	 */
-	JD.stackedBars = (series, keys, valueLabel) => {
+	JD.stackedBars = (series, keys, valueLabel, fmt) => {
+		var format = fmt || JD.fmtTokens;
 		var W = 660;
 		var bottom = 214;
 		/* Baseline + room for the endpoint labels + the same 8px margin the right
@@ -39,14 +158,25 @@ window.JD = window.JD || {};
 		var plotW = W - left - 8;
 		var slot = plotW / Math.max(1, series.length);
 		var barW = slot * 0.58;
-		var max = 1;
+		/* Seeded at 0, not 1 — `niceAxisMax` owns the no-data case. */
+		var max = 0;
+		/* Typed read, not `|| 0`: `topSeries` hands its INPUT series straight back
+		   when the key count is within the limit, so `bySeries` here can still be
+		   the JSON.parse'd object with a prototype. A series named `constructor`
+		   then yields the inherited function on any day it is absent — `|| 0`
+		   treats it as a value, and the bar geometry below becomes NaN. */
+		var read = (point, key) => (typeof point.bySeries[key] === "number" ? point.bySeries[key] : 0);
 		series.forEach((point) => {
 			var total = 0;
 			keys.forEach((key) => {
-				total += point.bySeries[key] || 0;
+				total += read(point, key);
 			});
 			if (total > max) max = total;
 		});
+		/* The bars are scaled by this same bound, deliberately. Rounding only the
+		   LABELS would leave a tallest bar that touches the top gridline while the
+		   gridline claims a larger number. */
+		max = niceAxisMax(max);
 		var svg =
 			'<svg viewBox="0 0 ' +
 			W +
@@ -72,14 +202,14 @@ window.JD = window.JD || {};
 				'" y="' +
 				(y + 4) +
 				'" text-anchor="end" font-size="11" fill="var(--muted)" class="num">' +
-				JD.fmtTokens(Math.round((max * g) / 4)) +
+				format((max * g) / 4) +
 				"</text>";
 		}
 		series.forEach((point, dayIndex) => {
 			var x = left + dayIndex * slot + (slot - barW) / 2;
 			var yCursor = bottom;
 			keys.forEach((key, keyIndex) => {
-				var value = point.bySeries[key] || 0;
+				var value = read(point, key);
 				if (value <= 0) return;
 				var h = ((bottom - 10) * value) / max;
 				yCursor -= h;
@@ -95,7 +225,7 @@ window.JD = window.JD || {};
 					'" fill="' +
 					JD.seriesColor(keyIndex) +
 					'"><title>' +
-					JD.esc(point.date + " · " + key + " · " + JD.fmtTokens(value)) +
+					JD.esc(point.date + " · " + key + " · " + format(value)) +
 					"</title></rect>";
 			});
 		});
@@ -235,35 +365,14 @@ window.JD = window.JD || {};
 		return svg + "</svg>";
 	};
 
-	/* Ranked horizontal bars — the mockup's rendering for every non-model axis
-	   (agent / project / branch / ticket / category), where a stacked-by-day
-	   chart would be noise: what matters is the ordering of totals. */
-	JD.rankedBars = (rows) => {
-		var max = 1;
-		rows.forEach((r) => {
-			if (r.tokens > max) max = r.tokens;
-		});
-		var html = '<div class="ranked">';
-		rows.forEach((row, index) => {
-			html +=
-				'<div class="rrow">' +
-				'<span class="lbl mono">' +
-				JD.esc(row.key) +
-				"</span>" +
-				'<span class="track"><span class="bar" style="width:' +
-				((row.tokens / max) * 100).toFixed(1) +
-				"%;background:" +
-				JD.seriesColor(index) +
-				'"></span></span>' +
-				'<span class="val num">' +
-				JD.fmtTokens(row.tokens) +
-				'<span class="meta">' +
-				(row.cost > 0 ? JD.fmtUsd(row.cost) + " est" : "—") +
-				"</span></span>" +
-				"</div>";
-		});
-		return html + "</div>";
-	};
+	/* No `JD.rankedBars` here, deliberately. It rendered `{key, tokens, cost}`
+	   rows produced by a `rankRows` helper in stats.js, and nothing on any page
+	   ever called it — so when the Spend card moved to per-day apportionment and
+	   `rankRows` went away with it, the last thing that could ever fill `cost`
+	   went too. What was left was a function whose every row would have printed
+	   "—" for the estimate: an unwired renderer for a shape no code produces,
+	   which is worse than no renderer at all. Every axis now draws through
+	   `JD.stackedBars` + `JD.topSeries`. */
 
 	/* Per-day cost table — the mockup's `table view` toggle. One column per
 	   series key plus a total, so the chart's numbers are readable exactly. */

--- a/cli/src/dashboard/assets/js/memories.js
+++ b/cli/src/dashboard/assets/js/memories.js
@@ -26,6 +26,11 @@ window.JD = window.JD || {};
 	   reads. So we scroll only when the selected hash CHANGES. Reset to null on
 	   each page load (a fresh module), which is exactly when we DO want to scroll. */
 	JD.memLastScrolledHash = JD.memLastScrolledHash || null;
+	/* Same one-shot rule as the hash above, for the `#what-changed` anchor the
+	   Memory Activity card links at. The browser cannot honour it itself: the
+	   detail pane is written into the DOM after navigation, so by the time the
+	   element exists the automatic scroll has already happened and been lost. */
+	JD.memLastScrolledAnchor = JD.memLastScrolledAnchor || null;
 
 	const MEMORY_ICONS = {
 		database: '<ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v14c0 1.7 3.6 3 8 3s8-1.3 8-3V5"/><path d="M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3"/>',
@@ -315,6 +320,24 @@ window.JD = window.JD || {};
 		if (row && row.scrollIntoView) row.scrollIntoView({ block: "center" });
 	}
 
+	/* Scrolls to `location.hash` once the element it names actually exists.
+	   NOT recorded when the element is missing — the detail pane may still be
+	   rendering, or this tick may be showing a different memory, and recording it
+	   would burn the one chance to honour the anchor. Recorded on success, so the
+	   30s tick cannot keep yanking a reader back to it. */
+	function scrollToAnchor() {
+		/* `window` is whatever the host injected into this IIFE, so `location` is
+		   read defensively — the same reason every DOM touch below is guarded. It
+		   always exists in a browser; a host without it must not take the whole
+		   page down on the way to an optional scroll. */
+		var anchor = ((window.location && window.location.hash) || "").slice(1);
+		if (!anchor || anchor === JD.memLastScrolledAnchor) return;
+		var target = document.getElementById(anchor);
+		if (!target) return;
+		JD.memLastScrolledAnchor = anchor;
+		if (target.scrollIntoView) target.scrollIntoView({ block: "start" });
+	}
+
 	function renderToolbar(model) {
 		var memories = model.memories || {};
 		if (!(memories.items || []).length) return "";
@@ -407,8 +430,8 @@ window.JD = window.JD || {};
 			(c) =>
 				/* The session id is this row's tooltip, and that is what it is in the
 				   payload FOR — see MemoryConversationRow. Two conversations from the
-				   same source render identically otherwise (same glyph, same `claude`
-				   meta, and titles that a first-user-message fallback can make near
+				   same source render identically otherwise (same agent mark, and
+				   titles that a first-user-message fallback can make near
 				   duplicates), so a memory fed by three Claude sessions gave the user no
 				   way to tell which row is which, nor to match one against
 				   `sessions.json` or a log line. The whole attribute is omitted rather
@@ -417,11 +440,19 @@ window.JD = window.JD || {};
 				   false about the session. */
 				'<div class="gd-row"' +
 				(c.sessionId ? ' title="Session ' + esc(c.sessionId) + '"' : "") +
-				'><span class="mem-row-icon">' +
-				memoryIcon("message") +
-				'</span><span class="mem-row-title">' +
+				">" +
+				/* The row leads with the AGENT's brand mark rather than a generic
+				   speech bubble — the same row VS Code's memory detail renders and
+				   the same mark IntelliJ's Working Memory panel uses, so one
+				   conversation looks like itself on all three surfaces. It also
+				   replaces the `c.source` text that used to sit in the meta slot:
+				   the mark says the same thing in space the title wants, and the
+				   name survives as the mark's tooltip and accessible name. An agent
+				   with no mark shipped falls back to its initial there. */
+				JD.sourceBadge(c.source, "mem-row-icon") +
+				'<span class="mem-row-title">' +
 				esc(c.title || "(untitled)") +
-				'</span><span class="mem-row-meta">' + esc(c.source) + '</span><span class="mem-row-meta">' + c.messageCount + " msgs</span></div>",
+				'</span><span class="mem-row-meta">' + c.messageCount + " msgs</span></div>",
 			"No conversations linked yet.",
 		);
 		return (
@@ -530,10 +561,24 @@ window.JD = window.JD || {};
 	function topicsSection(detail) {
 		var esc = JD.esc;
 		if (!detail.topics.length) return "";
+		/* The deep-link target for both cards that point into a memory's topics —
+		   Memory Activity's "N decisions" chip and the Decisions card's Latest title.
+		   It sits on the SECTION, so the reader lands on the "What changed and why"
+		   header with the first topic below it.
+
+		   It used to be a per-topic id on the first `.decide` block that carried a
+		   decision, which put the reader mid-topic: `.decide` renders BELOW the
+		   topic's own <h3> and its trigger prose, so aligning it to the top of the
+		   pane scrolled past the heading naming the topic the decision belongs to.
+		   Landing one level up costs a short scroll and keeps that context.
+
+		   One fixed id rather than a per-topic one, because Memory Activity carries
+		   a decision COUNT (`MemoryCard.decisionCount`) and no topic list at all —
+		   it could never name a topic to aim at. */
 		return (
-			'<section class="mem-section mem-topics"><div class="gd-sec">What changed and why</div><div class="mem-topic-list">' +
+			'<section class="mem-section mem-topics" id="what-changed"><div class="gd-sec">What changed and why</div><div class="mem-topic-list">' +
 			detail.topics
-				.map((t) => {
+				.map((t, index) => {
 					var decisions = t.decisions.length
 						? '<div class="decide"><div class="decide-title">' +
 							memoryIcon("bulb") +
@@ -554,7 +599,9 @@ window.JD = window.JD || {};
 							"</div></div>"
 						: "";
 					return (
-						'<article class="topic"><div class="topic-head"><h3>' +
+						'<article class="topic" id="topic-' +
+						index +
+						'"><div class="topic-head"><h3>' +
 						esc(t.title) +
 						"</h3>" +
 						(t.category ? '<span class="tag">' + esc(t.category) + "</span>" : "") +
@@ -940,6 +987,7 @@ window.JD = window.JD || {};
 			wireTree(model);
 			wireDetail(model);
 			scrollSelectedIntoView(model);
+			scrollToAnchor();
 			return;
 		}
 		document.getElementById("app").innerHTML =
@@ -954,5 +1002,6 @@ window.JD = window.JD || {};
 		wireTree(model);
 		wireDetail(model);
 		scrollSelectedIntoView(model);
+		scrollToAnchor();
 	};
 })(window.JD);

--- a/cli/src/dashboard/assets/js/shell.js
+++ b/cli/src/dashboard/assets/js/shell.js
@@ -852,6 +852,124 @@ window.JD = window.JD || {};
 		return index >= 0 ? index : SOURCE_ORDER.length;
 	};
 
+	/* Brand marks for the AI agent behind a row — the Skills card's per-row agent
+	   and the memory detail's conversation rows.
+
+	   This is the FOURTH copy of one icon set, and the copies are structural
+	   rather than drift: `intellij/src/main/resources/icons/source-*.svg` holds
+	   the originals (plus `_dark` variants), and the two VS Code webviews
+	   (`SidebarScriptBuilder` / `SummaryScriptBuilder`) each carry a JS table
+	   because a webview cannot read a JVM resource. Ported from the VS Code
+	   tables rather than from the SVG files, because those already made the one
+	   adaptation this page needs: the neutral marks (Cursor / Copilot / OpenCode
+	   / Cline / Devin) draw with `currentColor` so ONE string serves light and
+	   dark, where IntelliJ ships a second file. The brand-coloured ones keep
+	   their hex on both themes (Claude #D97757, Codex #10A37F, Gemini and
+	   Antigravity gradients) — that is what makes them recognisable.
+
+	   Inline `<svg>`, never `<img>`/`data:` — the served page is one document
+	   with no external fetches, same constraint the webview CSP imposes.
+
+	   A source missing from here is not an error on any surface: it degrades to
+	   the letter fallback in `JD.sourceBadge`. So adding an agent means adding it
+	   to every copy, and forgetting one is silent. */
+	var SOURCE_ICON_SVG = {
+		claude:
+			'<svg viewBox="0 0 16 16" aria-hidden="true"><g stroke="#D97757" stroke-width="1.4" stroke-linecap="round">' +
+			'<line x1="8" y1="2" x2="8" y2="14"/><line x1="2" y1="8" x2="14" y2="8"/>' +
+			'<line x1="3.76" y1="3.76" x2="12.24" y2="12.24"/><line x1="12.24" y1="3.76" x2="3.76" y2="12.24"/>' +
+			'<line x1="11" y1="2.8" x2="5" y2="13.2"/><line x1="13.2" y1="5" x2="2.8" y2="11"/>' +
+			'<line x1="5" y1="2.8" x2="11" y2="13.2"/><line x1="2.8" y1="5" x2="13.2" y2="11"/></g></svg>',
+		codex:
+			'<svg viewBox="0 0 16 16" aria-hidden="true"><g fill="none" stroke="#10A37F" stroke-width="1.3">' +
+			'<ellipse cx="8" cy="8" rx="6.4" ry="2.9"/>' +
+			'<ellipse cx="8" cy="8" rx="6.4" ry="2.9" transform="rotate(60 8 8)"/>' +
+			'<ellipse cx="8" cy="8" rx="6.4" ry="2.9" transform="rotate(120 8 8)"/></g></svg>',
+		/* The gradient ids are page-global once several rows render at once. Both
+		   are safe to repeat because every copy DEFINES the same stops — the first
+		   wins and the rest resolve to an identical paint. A second gradient under
+		   either name would not be. */
+		gemini:
+			'<svg viewBox="0 0 16 16" aria-hidden="true"><defs>' +
+			'<linearGradient id="jd-src-gem" x1="2" y1="2" x2="14" y2="14" gradientUnits="userSpaceOnUse">' +
+			'<stop offset="0" stop-color="#4796E3"/><stop offset="1" stop-color="#9177C7"/></linearGradient></defs>' +
+			'<path fill="url(#jd-src-gem)" d="M8 1c.3 4.2 2.8 6.7 7 7-4.2.3-6.7 2.8-7 7-.3-4.2-2.8-6.7-7-7 4.2-.3 6.7-2.8 7-7Z"/></svg>',
+		cursor:
+			'<svg viewBox="0 0 16 16" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round">' +
+			'<path d="M8 1.5 14 5v6L8 14.5 2 11V5L8 1.5Z"/><path d="M8 1.5V8M8 8l6-3M8 8l-6-3M8 8v6.5"/></g></svg>',
+		copilot:
+			'<svg viewBox="0 0 16 16" aria-hidden="true"><g stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round">' +
+			'<line x1="8" y1="2.5" x2="8" y2="5"/><rect x="2.5" y="5" width="11" height="7" rx="3"/>' +
+			'<line x1="2.5" y1="8.5" x2="1.5" y2="8.5"/><line x1="13.5" y1="8.5" x2="14.5" y2="8.5"/></g>' +
+			'<g fill="currentColor"><circle cx="8" cy="2.2" r="1"/><circle cx="6" cy="8.7" r="1"/><circle cx="10" cy="8.7" r="1"/></g></svg>',
+		opencode:
+			'<svg viewBox="0 0 16 16" aria-hidden="true"><g fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">' +
+			'<path d="M3.5 5 7 8l-3.5 3"/><line x1="8.5" y1="11.5" x2="13" y2="11.5"/></g></svg>',
+		cline:
+			'<svg viewBox="0 0 16 16" aria-hidden="true"><circle cx="8" cy="2.1" r="1.05" fill="currentColor"/>' +
+			'<g fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round" stroke-linecap="round">' +
+			'<line x1="8" y1="3.15" x2="8" y2="4.7"/>' +
+			'<path d="M5.1 4.7h5.8a2.9 2.9 0 0 1 2.9 2.9v.5l1 1.7-1 1.7v.5a2.9 2.9 0 0 1-2.9 2.9H5.1a2.9 2.9 0 0 1-2.9-2.9v-.5l-1-1.7 1-1.7v-.5A2.9 2.9 0 0 1 5.1 4.7Z"/></g>' +
+			'<g fill="currentColor"><rect x="5.5" y="7.6" width="1.5" height="3.5" rx="0.75"/><rect x="9" y="7.6" width="1.5" height="3.5" rx="0.75"/></g></svg>',
+		devin:
+			'<svg viewBox="0 0 30 34" aria-hidden="true"><path fill="currentColor" d="M20.556 15c.715-.41 1.6-.41 2.314 0l1.849 1.067a.9.9 0 0 0 .229.087q.096.022.193.026h.01q.01 0 .02-.003a.8.8 0 0 0 .389-.105l.018-.008 3.694-2.133a.85.85 0 0 0 .427-.739V8.93a.85.85 0 0 0-.427-.74l-3.694-2.132a.86.86 0 0 0-.856 0l-3.695 2.132s-.01.008-.015.01a.8.8 0 0 0-.157.121l-.02.023a1 1 0 0 0-.11.144l-.016.026a.86.86 0 0 0-.11.422v2.132a2.312 2.312 0 0 1-3.472 2l-1.848-1.066a.9.9 0 0 0-.23-.087 1 1 0 0 0-.192-.026h-.028a.8.8 0 0 0-.392.103L14.42 12l-3.694 2.132a.85.85 0 0 0-.427.74v4.263a.85.85 0 0 0 .427.74l3.694 2.132.018.008a1 1 0 0 0 .184.075l.03.008a1 1 0 0 0 .178.023q.01.002.02.003h.01a.8.8 0 0 0 .194-.026q.02-.006.04-.01a1 1 0 0 0 .189-.077l1.848-1.066c.715-.41 1.599-.41 2.313 0a2.32 2.32 0 0 1 1.157 2.001v2.132q.001.105.026.2.003.02.01.041a1 1 0 0 0 .074.18l.016.026q.046.077.111.144l.021.023q.07.068.157.12.008.007.015.01l3.695 2.133a.85.85 0 0 0 .854 0l3.694-2.132a.85.85 0 0 0 .427-.74V20.82a.85.85 0 0 0-.427-.74l-3.694-2.132-.018-.008a1 1 0 0 0-.182-.075q-.014-.002-.028-.005a.7.7 0 0 0-.18-.023h-.028a.8.8 0 0 0-.193.026q-.02.006-.038.01a1 1 0 0 0-.188.077l-1.849 1.066c-.712.411-1.599.411-2.313 0a2.32 2.32 0 0 1-1.157-2.001c0-.822.442-1.59 1.157-2.001l-.003-.01zM.428 13.936l3.694 2.132a.85.85 0 0 0 .855 0l3.694-2.133s.01-.008.015-.01a.8.8 0 0 0 .157-.12l.02-.023q.062-.067.112-.144.008-.01.015-.026a.86.86 0 0 0 .111-.42v-2.133a2.312 2.312 0 0 1 3.471-2l1.849 1.066a.9.9 0 0 0 .229.087q.093.022.193.026h.01q.01-.002.02-.003a.8.8 0 0 0 .392-.106l.018-.008 3.694-2.133a.85.85 0 0 0 .427-.739V2.986a.85.85 0 0 0-.427-.74L15.283.114a.86.86 0 0 0-.856 0l-3.695 2.132s-.01.008-.015.01a.8.8 0 0 0-.157.121l-.02.023a1 1 0 0 0-.112.144q-.008.01-.015.026a.86.86 0 0 0-.11.422v2.132A2.315 2.315 0 0 1 6.83 7.125L4.983 6.06a.9.9 0 0 0-.23-.087 1 1 0 0 0-.193-.026h-.028a.8.8 0 0 0-.39.103l-.019.008L.43 8.189a.85.85 0 0 0-.427.74v4.263a.85.85 0 0 0 .427.74v.005zM18.972 26.008l-3.694-2.133-.018-.008a1 1 0 0 0-.183-.074l-.031-.008a1 1 0 0 0-.18-.023h-.028a.8.8 0 0 0-.193.026q-.02.006-.04.01a1 1 0 0 0-.187.077l-1.849 1.067a2.314 2.314 0 0 1-3.468-2.001v-2.133a.8.8 0 0 0-.036-.242 1 1 0 0 0-.075-.18q-.008-.01-.015-.026a.8.8 0 0 0-.111-.144l-.02-.023a1 1 0 0 0-.157-.12q-.008-.007-.015-.01L4.978 17.93a.86.86 0 0 0-.857 0L.427 20.063a.85.85 0 0 0-.427.739v4.263a.85.85 0 0 0 .427.74l3.694 2.132.018.008a1 1 0 0 0 .18.074l.031.008a1 1 0 0 0 .177.023l.021.002h.01q.098-.001.19-.026.021-.006.042-.01a1 1 0 0 0 .188-.077l1.848-1.066c.715-.41 1.599-.41 2.314 0a2.32 2.32 0 0 1 1.157 2.001v2.133q.001.102.026.2.004.02.01.041a1 1 0 0 0 .075.18q.008.01.015.026.046.077.111.144l.02.023q.07.068.157.12.007.007.016.01l3.694 2.133a.85.85 0 0 0 .855 0l3.694-2.132a.85.85 0 0 0 .427-.74V26.75a.85.85 0 0 0-.427-.74z"/></svg>',
+		antigravity:
+			'<svg viewBox="0 0 24 24" aria-hidden="true"><defs>' +
+			'<linearGradient id="jd-src-agy" x1="0" y1="0" x2="0" y2="1">' +
+			'<stop offset="0" stop-color="#EA4335"/><stop offset="0.13" stop-color="#F2942C"/>' +
+			'<stop offset="0.3" stop-color="#A6C24E"/><stop offset="0.47" stop-color="#4EAE83"/>' +
+			'<stop offset="0.65" stop-color="#3597CE"/><stop offset="1" stop-color="#3286FF"/></linearGradient></defs>' +
+			'<path fill="url(#jd-src-agy)" d="M1.33 22.06 Q1.44 20.51 2.1 19.73 Q2.77 18.96 3.21 18.19 Q3.65 17.42 4.04 16.64 ' +
+			"Q4.43 15.87 4.71 15.09 Q4.98 14.32 5.2 13.54 Q5.42 12.77 5.64 12 Q5.86 11.23 6.08 10.46 Q6.31 9.68 6.53 8.91 " +
+			"Q6.75 8.13 7.03 7.36 Q7.3 6.58 7.57 5.81 Q7.85 5.04 8.35 4.27 Q8.85 3.49 9.84 2.71 Q10.84 1.94 11.06 1.89 " +
+			"Q11.28 1.83 12.05 1.83 Q12.83 1.83 13.99 2.6 Q15.15 3.38 15.65 4.15 Q16.15 4.92 16.48 5.7 Q16.81 6.47 17.03 7.24 " +
+			"Q17.25 8.02 17.47 8.79 Q17.69 9.57 17.91 10.34 Q18.14 11.12 18.36 11.89 Q18.58 12.66 18.85 13.44 " +
+			"Q19.13 14.21 19.41 14.98 Q19.68 15.76 20.02 16.54 Q20.35 17.31 20.79 18.08 Q21.23 18.85 21.84 19.62 " +
+			"Q22.45 20.4 22.62 21.17 Q22.78 21.95 22.67 22 Q22.56 22.06 22.12 22.06 Q21.67 22.06 20.57 21.29 " +
+			"Q19.46 20.51 18.8 19.73 Q18.14 18.96 17.64 18.19 Q17.14 17.42 16.7 16.64 Q16.26 15.87 15.71 15.09 " +
+			"Q15.15 14.32 13.82 13.54 Q12.5 12.77 12 12.77 Q11.5 12.77 10.18 13.54 Q8.85 14.32 8.35 15.09 Q7.85 15.87 7.36 16.64 " +
+			'Q6.86 17.42 6.36 18.19 Q5.86 18.96 5.2 19.73 Q4.54 20.51 3.44 21.29 Q2.33 22.06 1.83 22.06 Z"/></svg>',
+	};
+	/* Three sources ride their sibling's mark rather than shipping a duplicate:
+	   the Copilot CLI and the Chat extension are one brand, as are Cline's
+	   extension and its CLI, and cursor-agent and the Cursor IDE. Same pairing
+	   the other three surfaces make. */
+	SOURCE_ICON_SVG["copilot-chat"] = SOURCE_ICON_SVG.copilot;
+	SOURCE_ICON_SVG["cline-cli"] = SOURCE_ICON_SVG.cline;
+	SOURCE_ICON_SVG["cursor-cli"] = SOURCE_ICON_SVG.cursor;
+
+	/* The agent's display name. Inlined by the server from the CLI's own
+	   `TRANSCRIPT_SOURCE_LABELS` (see assembleDashboardHtml), so this page has no
+	   copy of that map to keep in step — unlike the icons above, which are markup
+	   and cannot come from a TS constant. An absent map degrades to the raw
+	   transcript tag (`cursor-cli` rather than `Cursor CLI`), which is what the
+	   asset tests see and is wrong only in politeness. */
+	JD.sourceLabel = (source) => {
+		var name = String(source || "");
+		return (window.__JOLLI_SOURCE_LABELS__ || {})[name] || name || "Claude";
+	};
+
+	/* One agent's badge: its brand mark, or the label's first letter when no mark
+	   ships for it (Kimi today) — IntelliJ's own fallback, so an unrecognised
+	   agent degrades identically on every surface instead of vanishing. The label
+	   is both the tooltip and the accessible name; the mark itself is decorative,
+	   which is why every SVG above carries `aria-hidden`. */
+	JD.sourceBadge = (source, className) => {
+		var label = JD.sourceLabel(source);
+		var svg = SOURCE_ICON_SVG[String(source || "")];
+		return (
+			'<span class="src-mark' +
+			(className ? " " + className : "") +
+			'" role="img" title="' +
+			JD.esc(label) +
+			'" aria-label="' +
+			JD.esc(label) +
+			'">' +
+			(svg || '<span class="src-letter" aria-hidden="true">' + JD.esc(label.slice(0, 1).toUpperCase()) + "</span>") +
+			"</span>"
+		);
+	};
+
 	/* Category → colour, shared because TWO pages paint the same category chip:
 	   the stats page's Memory Activity rows and the standup board's columns, which
 	   are required to show the same commits with the same labels. It lives here

--- a/cli/src/dashboard/assets/js/stats.js
+++ b/cli/src/dashboard/assets/js/stats.js
@@ -1,6 +1,11 @@
 window.JD = window.JD || {};
 
 ((JD) => {
+	/* Four ranked series plus an "Other" bucket — exactly the five colours the
+	   palette has. See `JD.topSeries` in charts.js for why it is four and not
+	   five, and why extending the palette is not an option. */
+	var SERIES_LIMIT = 4;
+
 	var RANGE_SUB = { today: "Today", week: "Last 7 days", "2w": "Last 14 days", month: "Last 30 days", "3m": "Last 90 days" };
 
 	/* Prose name for the window a model was built over. A custom range has no
@@ -10,36 +15,79 @@ window.JD = window.JD || {};
 		return RANGE_SUB[stats.range] || stats.rangeFrom + " → " + stats.rangeTo;
 	}
 
-	/* Totals per series key, for the ranked-bar axes. */
-	function rankRows(stats) {
-		/* Prototype-less, same reason as memoryActivityCard's grouping: series keys
-		   are user-controlled strings (branch, ticket, model, repo). A branch named
-		   `constructor` makes `totals[key] || {…}` hand back an inherited function,
-		   so the row is never created — `+=` writes NaN onto Object.prototype and
-		   Object.keys() never lists it, silently dropping that series from the chart. */
-		var totals = Object.create(null);
-		stats.series.forEach((point) => {
+	/* The Spend card's SINGLE source of cost. Each day's measured total is spread
+	   across that day's series keys by token share — an estimate, stated as one in
+	   the card — and the bars, the legend, the headline and the footer all read
+	   this one result. That is the point: the card used to take its headline from
+	   `kpis.cost`, which windows `sessions` on their update time, while the bars
+	   below it came from memories/commits windowed on committer date. Two clocks,
+	   two populations, one card claiming both numbers answered the same question.
+
+	   It deliberately does NOT total `estCostUsd`, close as that is. `bySeries`
+	   carries TOKENS, so a day with real cost but zero tokens — the category axis
+	   apportions a commit across its topics and rounds — spreads to nothing and
+	   draws no bar. Money that is not drawn must not be in the headline either,
+	   or the card is back to disagreeing with itself, just by less. */
+	function apportionedCost(stats) {
+		/* Prototype-less throughout, same reason as memoryActivityCard's grouping:
+		   series keys are user-controlled strings (branch, ticket, model, repo). A
+		   branch named `constructor` makes a plain object hand back an inherited
+		   function, so `+=` writes NaN onto Object.prototype and Object.keys() never
+		   lists it — silently dropping that series from the chart. And `bySeries`
+		   comes off JSON.parse, so it has a prototype: read it with a typeof test
+		   rather than trusting `|| 0` to catch a function. */
+		var byKey = Object.create(null);
+		var total = 0;
+		var series = stats.series.map((point) => {
+			var read = (key) => (typeof point.bySeries[key] === "number" ? point.bySeries[key] : 0);
+			var tokenTotal = stats.seriesKeys.reduce((sum, key) => sum + read(key), 0);
+			var bySeries = Object.create(null);
+			var dayCost = 0;
 			stats.seriesKeys.forEach((key) => {
-				totals[key] = totals[key] || { key: key, tokens: 0, cost: 0 };
-				/* bySeries comes off JSON.parse, so it has a prototype — read it the
-				   same defensive way rather than trusting `|| 0` to catch a function. */
-				var value = point.bySeries[key];
-				totals[key].tokens += typeof value === "number" ? value : 0;
+				var cost = tokenTotal > 0 ? (point.estCostUsd * read(key)) / tokenTotal : 0;
+				bySeries[key] = cost;
+				byKey[key] = (byKey[key] || 0) + cost;
+				dayCost += cost;
 			});
+			total += dayCost;
+			return { date: point.date, bySeries: bySeries, cost: dayCost };
 		});
-		// Cost is only known per day, not per key, so spread it by token share —
-		// stated in the axis note rather than presented as an exact per-key cost.
-		var grandTokens = 0;
-		var grandCost = 0;
-		stats.series.forEach((p) => {
-			grandTokens += p.tokens;
-			grandCost += p.estCostUsd;
-		});
-		var rows = Object.keys(totals).map((key) => totals[key]);
-		rows.forEach((row) => {
-			row.cost = grandTokens > 0 ? (grandCost * row.tokens) / grandTokens : 0;
-		});
-		return rows.sort((a, b) => b.tokens - a.tokens);
+		var ranked = stats.seriesKeys
+			.map((key) => ({ key: key, cost: byKey[key] || 0 }))
+			.sort((a, b) => b.cost - a.cost);
+		return { series: series, byKey: byKey, ranked: ranked, total: total };
+	}
+
+	/* Which clock the series is on. The memory-driven axes window on committer
+	   date; the session-driven ones on session activity. Reading `seriesDimension`
+	   rather than the requested dimension is what keeps this honest — below the
+	   memory tier a memory axis falls back to `model`, and the label follows. */
+	function seriesClockNote(stats) {
+		var byCommit =
+			stats.seriesDimension === "branch" ||
+			stats.seriesDimension === "ticket" ||
+			stats.seriesDimension === "category";
+		return byCommit ? "by commit date" : "by session activity";
+	}
+
+	/* What the series is split BY, as a word. The Spend card names it twice — the
+	   chart's `aria-label` and the "largest …" figure — and both said "model" on
+	   every axis, so on `?dimension=branch` a screen reader announced a branch
+	   name as a model and the sighted label read "largest model: fix-auth-refresh".
+
+	   Reads `seriesDimension` rather than the requested dimension, for the same
+	   reason `seriesClockNote` above does: below the memory tier a memory axis
+	   falls back to `model` server-side, and the word has to follow the data that
+	   was actually drawn, not the one that was asked for.
+
+	   An unrecognised dimension degrades to the neutral "series" instead of
+	   asserting a wrong noun — the server owns this vocabulary and can extend it,
+	   and an older page reading a newer server must not mislabel the axis. The
+	   whitelist is an ARRAY, so a dimension colliding with an Object.prototype
+	   member cannot hand back an inherited value the way a plain-object map would. */
+	var AXIS_NOUNS = ["model", "agent", "project", "branch", "ticket", "category"];
+	function axisNoun(stats) {
+		return AXIS_NOUNS.indexOf(stats.seriesDimension) >= 0 ? stats.seriesDimension : "series";
 	}
 
 	/* Spend is the cost-only companion to Tokens. It never reuses the token
@@ -48,52 +96,59 @@ window.JD = window.JD || {};
 	function costCard(model) {
 		var esc = JD.esc;
 		var stats = model.stats;
-		var sub =
-			esc(rangeSub(stats)) +
-			" · estimated from local transcripts" +
-			(stats.pricesAsOf ? ' · prices as of <span class="mono">' + esc(stats.pricesAsOf) + "</span>" : "");
-		var costKpi = stats.kpis.find((k) => k.key === "cost");
-		var ranked = rankRows(stats);
-		var costSeries = stats.series.map((point) => {
-			var tokenTotal = stats.seriesKeys.reduce((sum, key) => sum + (point.bySeries[key] || 0), 0);
-			/* Prototype-less: keys are user-controlled series names — see rankRows. */
-			var bySeries = Object.create(null);
-			stats.seriesKeys.forEach((key) => {
-				bySeries[key] = tokenTotal > 0 ? (point.estCostUsd * (point.bySeries[key] || 0)) / tokenTotal : 0;
-			});
-			return { date: point.date, bySeries: bySeries };
-		});
+		var spend = apportionedCost(stats);
+		/* WHICH WINDOW and WHICH CLOCK — the two things that change what these
+		   numbers mean — ride in the head's `title=` hint rather than as a visible
+		   sub, the move every other card in the band already made. Each head on
+		   the page is then one line.
+
+		   RAW text, not `esc`aped: `hintAttr` wraps first and escapes per line, so
+		   pre-escaping would double-encode.
+
+		   It used to append `prices as of <date>`; that is a property of the price
+		   table, constant across every window and every card, so it read as noise
+		   on the line a user scans to orient themselves. `stats.pricesAsOf` is
+		   still sent, for a surface that wants to state it once. */
+		var hint = rangeSub(stats) + " · " + seriesClockNote(stats) + " · estimated from local transcripts";
 
 		/* Dollar in a circle — Lucide `circle-dollar-sign`. It was an axes-plus-
 		   trend-line glyph, which is the same "it's a chart" statement Tokens'
 		   bar chart already makes one card up; the only thing that distinguishes
 		   these two widgets is that this one is denominated in money, so that is
 		   what the icon has to say. */
+		/* span6, paired with Tokens rather than a full row of its own. The two ask
+		   one question in two units — the hint on Tokens' head is about the
+		   difference between them — and side by side is where that comparison can
+		   actually be made. What the halved width costs is chart resolution: the
+		   bars are a 660-wide viewBox drawn at `width="100%"`, so they scale rather
+		   than clip, and half a row is still wider than the third of a row Tokens
+		   drew them in before this. */
 		var html =
-			'<section class="card span12" aria-label="Spend"><div class="card-head">' +
-			widgetIcon(
-				"--s4",
-				'<circle cx="12" cy="12" r="10"/><path d="M16 8h-6a2 2 0 1 0 0 4h4a2 2 0 1 1 0 4H8"/>' +
-					'<path d="M12 18V6"/>',
-			) +
-			'<div style="flex:1 1 300px;min-width:0">' +
-			"<h2>Spend</h2>" +
-			'<div class="sub" style="margin-top:5px">' +
-			sub +
-			"</div></div>" +
-			'<div class="spacer"></div>' +
-			'<div style="text-align:right"><div class="num" style="font-size:18px;font-weight:650;color:var(--good-text)">' +
-			(costKpi ? costKpi.value : "$0.00") +
-			'</div><div class="sub">estimated spend<br>this window</div></div>' +
-			"</div>";
+			'<section class="card span6" aria-label="Spend">' +
+			widgetHead(
+				widgetIcon(
+					"--s4",
+					'<circle cx="12" cy="12" r="10"/><path d="M16 8h-6a2 2 0 1 0 0 4h4a2 2 0 1 1 0 4H8"/>' +
+						'<path d="M12 18V6"/>',
+				),
+				"Spend",
+				null,
+				hint,
+				'<div class="num" style="font-size:18px;font-weight:650;color:var(--good-text)">' +
+					JD.fmtUsd(spend.total) +
+					'</div><div class="sub">estimated spend<br>this window</div>',
+			);
 
 		html += '<div class="chart-box" style="margin-top:12px">';
 		if (stats.seriesKeys.length === 0) {
 			html += '<div class="empty-note">No estimated spend data yet.</div>';
 		} else {
+			/* Legend and bars read the SAME rolled-up keys, in the same order — the
+			   colour of a legend swatch is its index in this array and nothing else,
+			   so two arrays here would mislabel every series after the first. */
+			var top = JD.topSeries(spend.series, stats.seriesKeys, SERIES_LIMIT);
 			html += '<div class="legend">';
-			stats.seriesKeys.forEach((key, index) => {
-				var row = ranked.find((r) => r.key === key);
+			top.keys.forEach((key, index) => {
 				html +=
 					'<span><i style="background:' +
 					JD.seriesColor(index) +
@@ -102,20 +157,36 @@ window.JD = window.JD || {};
 					'">' +
 					esc(key) +
 					'</span> <b class="num">' +
-					(row ? JD.fmtUsd(row.cost) : "") +
+					JD.fmtUsd(top.byKey[key] || 0) +
 					"</b></span>";
 			});
-			html += "</div>" + JD.stackedBars(costSeries, stats.seriesKeys, "estimated spend by model");
+			html += "</div>" + JD.stackedBars(top.series, top.keys, "estimated spend by " + axisNoun(stats), JD.fmtUsd);
 		}
 		html += "</div>";
 
-		/* Comparison row — vs the prior window (server-computed, self-trend only),
-		   the largest key this window, and the single busiest day by cost. */
+		/* Comparison row — vs the prior window, the largest key this window, and
+		   the single busiest day by cost.
+
+		   `costTrendPct` is server-computed and self-trend only, but it is now the
+		   SAME population as the headline it sits under: the server sums the prior
+		   window's series along this same dimension, by the rule `apportionedCost`
+		   uses here (`drawnCost` in DashboardQuery.ts). It used to trend
+		   `sessions.est_cost_usd` instead — a different clock on the memory axes —
+		   so a "$0.00" headline could carry a "↑ 200%" beside it. */
 		if (stats.seriesKeys.length > 0) {
-			var top = ranked[0];
-			var totalCost = ranked.reduce((sum, r) => sum + r.cost, 0);
-			var busiest = stats.series.reduce(
-				(best, p) => (p.estCostUsd > best.v ? { date: p.date, v: p.estCostUsd } : best),
+			/* `largest`, not `top` — `var` is FUNCTION-scoped, so reusing the name
+			   the roll-up above bound would put two different shapes on one binding
+			   and leave this block working only because it runs second. Reordering
+			   the chart and comparison blocks would then read `.key`/`.cost` off a
+			   `topSeries` result and print "largest model: undefined, NaN%".
+			   Biome cannot catch it: `cli/biome.json` excludes `src/dashboard/assets`. */
+			var largest = spend.ranked[0];
+			var totalCost = spend.total;
+			/* From the apportioned series, not `estCostUsd`: the busiest day is
+			   printed as a share of the headline, so a day counted one way against
+			   a total counted the other can read as more than 100%. */
+			var busiest = spend.series.reduce(
+				(best, p) => (p.cost > best.v ? { date: p.date, v: p.cost } : best),
 				{ date: undefined, v: 0 },
 			);
 			html += '<div class="cmpline" style="display:flex;gap:20px;flex-wrap:wrap;margin-top:10px;font-size:11.5px;color:var(--muted)">';
@@ -125,13 +196,14 @@ window.JD = window.JD || {};
 					? "no prior window to compare"
 					: (stats.costTrendPct < 0 ? "↓ " : "↑ ") + Math.abs(stats.costTrendPct) + "%") +
 				"</b></span>";
-			if (top && totalCost > 0) {
+			if (largest && totalCost > 0) {
 				html +=
-					"<span>largest model" +
+					"<span>largest " +
+					axisNoun(stats) +
 					'<b style="display:block;font-size:12.5px;color:var(--ink);font-weight:650">' +
-					esc(top.key) +
+					esc(largest.key) +
 					", " +
-					Math.round((top.cost / totalCost) * 100) +
+					Math.round((largest.cost / totalCost) * 100) +
 					"%</b></span>";
 			}
 			if (busiest.v > 0) {
@@ -145,11 +217,15 @@ window.JD = window.JD || {};
 			html += "</div>";
 		}
 
-		return (
-			html +
-			'<div class="w-foot"><span class="w-chip">estimated, not a bill</span>' +
-			'<span class="w-measure">ⓘ model splits are apportioned by token share</span></div></section>'
-		);
+		/* No footer. Two notes used to sit here — "estimated, not a bill" and
+		   "model splits are apportioned by token share" — and the card states
+		   both of them earlier, where they are read rather than scrolled past:
+		   the subtitle already says "estimated from local transcripts", which
+		   carries the not-a-bill point in the same breath as where the numbers
+		   came from, and the legend presents the per-key figures as a split of
+		   one measured daily total. A caveat printed below the chart corrects a
+		   reading the reader has already made. */
+		return html + "</section>";
 	}
 
 	/* Time view's group header: "Today · Jul 31" / "Yesterday · Jul 30" for the
@@ -167,15 +243,52 @@ window.JD = window.JD || {};
 	}
 
 	/* The deep link into one memory's detail pane. Shared by the Memory Activity
-	   row's "Open memory →" and by the Decisions card's title, so a decision and
-	   the row it came from lead to the same place.
+	   row's TITLE and by the Decisions card's title, so a decision and the row it
+	   came from lead to the same place. Both are the thing being named rather
+	   than a separate "Open memory →" affordance beside it: the title is what a
+	   reader aims at, and a per-row action column of identical links is a column
+	   of the same word repeated.
 
 	   `detailRepo` names the memory's owning repo without scoping the page it
 	   lands on — see wireTree in memories.js. Whatever scope THIS page carries
 	   rides along through JD.query, so a repo-filtered dashboard still opens a
 	   repo-filtered tree. */
-	function memoryHref(model, commitHash, repoIdentity) {
-		return "/memories" + JD.withParams(JD.query(model, {}), { hash: commitHash, detailRepo: repoIdentity });
+	function memoryHref(model, commitHash, repoIdentity, anchor) {
+		return (
+			"/memories" +
+			JD.withParams(JD.query(model, {}), { hash: commitHash, detailRepo: repoIdentity }) +
+			(anchor ? "#" + anchor : "")
+		);
+	}
+
+	/* The id `memories.js` puts on the detail pane's topics section — the one whose
+	   header reads "What changed and why". One fixed anchor serves both callers,
+	   and neither could address anything finer: Memory Activity's "N decisions"
+	   knows only HOW MANY a memory recorded (`MemoryCard.decisionCount`), never
+	   which topic they sit under, and the Decisions card's Latest title names a
+	   topic that carries no index on the wire.
+
+	   It used to land on the decision block itself. That was one level too deep —
+	   `.decide` renders below its topic's own heading and trigger prose, so the
+	   scroll left the reader mid-topic with nothing above the fold saying which
+	   topic the decision belongs to. */
+	var TOPICS_ANCHOR = "what-changed";
+
+	/* What the list is: the window's memories, or the most recent slice of them.
+	   The distinction is `memoryCardsCapped`, and it has to come from the server —
+	   the feed is cut at MEMORY_CARDS_LIMIT before it is serialised, so a count of
+	   20 here means "20 in the window" and "the 20 most recent of 300" equally.
+
+	   Both wordings have shipped wrong. "N memories in this window" claimed the
+	   page size was the window total, directly above the coverage line that prints
+	   the real one; the fix for that then said "showing the N most recent"
+	   unconditionally, which asserts a truncation that usually has not happened —
+	   and reads "showing the 1 most recent" at N=1. Neither is "N of M": the
+	   coverage line's `memoriesCreated` counts COMMITS carrying a memory while
+	   this list counts memory rows, so that framing would be a third inaccuracy. */
+	function memoryActivitySub(count, capped) {
+		if (capped) return "showing the " + count + " most recent";
+		return count === 1 ? "1 memory in this window" : count + " memories in this window";
 	}
 
 	/* Memory Activity: Branch answers "what landed on this line of work?" while
@@ -210,9 +323,11 @@ window.JD = window.JD || {};
 			   other item here is conditional, and a row of zeros is noise. */
 			if (card.decisionCount)
 				meta.push(
-					'<span class="tag metric num">' +
+					'<a class="tag metric num" href="' +
+						memoryHref(model, card.commitHash, card.repoIdentity, TOPICS_ANCHOR) +
+						'" target="_blank" rel="noopener">' +
 						esc(card.decisionCount) +
-						(card.decisionCount === 1 ? " decision</span>" : " decisions</span>"),
+						(card.decisionCount === 1 ? " decision</a>" : " decisions</a>"),
 				);
 			if (card.branch && view === "time") meta.push('<span class="tag mono">' + esc(card.branch) + "</span>");
 			/* The repo tag earns its space only when the page is showing more than
@@ -223,15 +338,15 @@ window.JD = window.JD || {};
 			return (
 				'<article class="mem-activity-row" style="--memory-color:' +
 				(catColor(card.category || "feature")) +
-				'"><div class="mem-activity-copy"><div class="mem-activity-title">' +
+				'"><div class="mem-activity-copy"><a class="mem-activity-title" href="' +
+				openHref(card) +
+				'" target="_blank" rel="noopener">' +
 				esc(card.title) +
-				'</div><div class="mem-activity-meta">' +
+				'</a><div class="mem-activity-meta">' +
 				meta.join("") +
 				"</div></div><div class=\"mem-activity-action\"><time>" +
 				esc(cardWhen(card.committedAtMs, model.timeZone)) +
-				'</time><a href="' +
-				openHref(card) +
-				'" target="_blank" rel="noopener">Open memory →</a></div></article>'
+				"</time></div></article>"
 			);
 		};
 		var body = groups.map((group) => '<section class="mem-activity-group"><h3>' + esc(group.label) + "</h3>" + group.cards.map(row).join("") + "</section>").join("");
@@ -239,8 +354,8 @@ window.JD = window.JD || {};
 			'<section class="card span12 mem-activity" aria-label="Memory Activity"><div class="card-head">' +
 			widgetIcon("--s4", '<path d="M7 3h10v18H7z"/><path d="M9 7h6M9 11h6M9 15h4"/>') +
 			'<div><h2>Memory Activity</h2><div class="sub">' +
-			cards.length +
-			" memories in this window</div></div><div class=\"spacer\"></div>" +
+			memoryActivitySub(cards.length, model.stats.memoryCardsCapped) +
+			"</div></div><div class=\"spacer\"></div>" +
 			'<div class="seg seg-sm" role="group" aria-label="Memory Activity view"><button type="button" data-memory-activity-view="branch" aria-pressed="' +
 			String(view === "branch") +
 			'">Branch</button><button type="button" data-memory-activity-view="time" aria-pressed="' +
@@ -322,17 +437,39 @@ window.JD = window.JD || {};
 	   positioned at the pointer for chart readouts and needs listeners rebound on
 	   every 30 s refresh tick, and this needs no such thing. `esc` is what makes
 	   it safe in an attribute — it escapes both quote characters. */
-	function widgetHead(icon, title, sub, hint) {
+	/* `aside` is the card's headline figure, right-aligned on the head's own row —
+	   the shape Spend built inline, now shared so Tokens reads the same way.
+
+	   Two numbers in it are MEASURED, not chosen, and both come from Spend at
+	   `span6`. `flex:1 1 220px` (not 300) is what decides whether the figure sits
+	   beside the title or wraps under it: half a row on a ~1200px viewport is
+	   ~410px of head, enough for icon + 220 + the figure and not for icon + 300 +
+	   the figure. `margin-left:auto` is the other half — a WRAPPED flex line
+	   places its one item at the START, so without it a figure that did wrap
+	   lands left-aligned under a sub still styled to sit at the right edge.
+
+	   Both apply ONLY when there is an aside; a head without one keeps its plain
+	   `<div>` so the `span4` cards are untouched. That narrowness is the reason
+	   `.hdr-stat` — the rule this generalises — was dropped in the first place: a
+	   right-aligned headline does not fit a third of the row beside a two-line
+	   title (see the decisions section in main.css). Pass an aside from a
+	   `span6`-or-wider card with a single-line title, and from nowhere else. */
+	function widgetHead(icon, title, sub, hint, aside) {
 		return (
 			'<div class="card-head">' +
 			icon +
-			"<div><h2" +
+			(aside ? '<div style="flex:1 1 220px;min-width:0">' : "<div>") +
+			"<h2" +
 			(hint ? ' class="has-hint" title="' + hintAttr(hint) + '"' : "") +
 			">" +
 			title +
 			"</h2>" +
 			(sub ? '<div class="sub">' + sub + "</div>" : "") +
-			"</div></div>"
+			"</div>" +
+			(aside
+				? '<div class="spacer"></div><div style="text-align:right;margin-left:auto">' + aside + "</div>"
+				: "") +
+			"</div>"
 		);
 	}
 
@@ -371,17 +508,31 @@ window.JD = window.JD || {};
 		return lines.map((each) => JD.esc(each)).join("&#10;");
 	}
 
-	/* Decisions (span12) — the corpus of decisions itself: kept count, a
+	/* What this card counts and why it is worth looking at.
+	   "What Jolli decided to keep" is gone: it described the STORE rather than
+	   the reader's own work, and the card's subject is the decisions the reader's
+	   sessions made — Jolli is what banked them, not what made them. */
+	var DECISIONS_HINT =
+		"Decisions your sessions made, accumulating across the range — the knowledge Jolli banked, " +
+		"with the receipts behind it.";
+
+	/* Decisions (span4) — the corpus of decisions itself: kept count, a
 	   cumulative step chart, and the latest one as a single TITLE line.
 	   Distinct from the KPI sub-line (gone with the KPI strip) and from the
 	   feed's per-commit `decision` line — this is the standalone widget those
 	   always implied but never had. Carries no "recalled" figure — see
 	   DecisionsCard's doc comment in DashboardModel.ts.
 
-	   Full width because it is now alone on its row: it was a span6 paired with
-	   the Recall card, and removing that one (JOLLI-2193) left six empty columns
-	   beside it. The step chart stretches to fill them, which is also the only
-	   part of this card that gains anything from the width. */
+	   Third seat in the equal-third band, where Tokens used to sit. It was
+	   span12 — alone on its row after the Recall card beside it was removed
+	   (JOLLI-2193) — and the width bought nothing: the step chart draws with
+	   `preserveAspectRatio="none"`, so it fills whatever column it is given.
+	   Joining the band means adopting the band's head, which is why the
+	   description became a hint and the kept count moved below the title the way
+	   Tokens states its own: the old head hung a right-aligned `hdr-stat` off a
+	   two-line title, which needs more than a third of the row to sit on one
+	   line. The window went with it — the topbar range control is where that is
+	   set and stated, the same reason Tokens dropped its own `Last 30 days`. */
 	function decisionsCard(model) {
 		var esc = JD.esc;
 		var decisions = model.stats.decisions;
@@ -390,16 +541,11 @@ window.JD = window.JD || {};
 			'<path d="M9 18h6M10 22h4M12 2a6 6 0 0 0-4 10.4c.6.5 1 1.3 1 2.1V16h6v-1.5c0-.8.4-1.6 1-2.1A6 6 0 0 0 12 2Z"/>',
 		);
 		var head =
-			'<section class="card span12" aria-label="Decisions"><div class="card-head">' + icon + "<div><h2>Decisions</h2>" +
-			/* "…and whether it came back" until JOLLI-2193: the second half was the
-			   Recall card beside it, and the payload no longer carries a reuse
-			   signal of any kind, so the promise had nothing behind it. */
-			'<div class="sub">What Jolli decided to keep</div></div>';
+			'<section class="card span4" aria-label="Decisions">' + widgetHead(icon, "Decisions", null, DECISIONS_HINT);
 
 		if (!decisions) {
 			return (
 				head +
-				'<div class="spacer"></div></div>' +
 				'<div class="locked-panel"><p><b>Decisions need a summarized commit.</b></p>' +
 				"<p class=\"why\">Each decision is mined from a commit's memory — enable Jolli Memory to start " +
 				"recording them.</p>" +
@@ -409,12 +555,9 @@ window.JD = window.JD || {};
 
 		var html =
 			head +
-			'<div class="hdr-stat"><b class="num">' +
+			'<div class="bignum num" style="font-size:22px;font-weight:650;margin-top:2px">' +
 			decisions.keptCount +
-			' kept</b><span>decisions · ' +
-			esc(rangeSub(model.stats)) +
-			"</span></div>" +
-			'<div class="spacer"></div></div>';
+			' kept<div class="sub" style="font-weight:400;margin-top:2px">decisions in this window</div></div>';
 
 		/* Cumulative step chart over `perDay` — an empty window still draws a
 		   flat baseline rather than an empty box. */
@@ -454,6 +597,17 @@ window.JD = window.JD || {};
 		   no-op: the newest decision's commit is usually the newest memory, so the
 		   scroll lands on the row already at the top of the list.
 
+		   It lands on the memory's topics rather than the top of the page, which is
+		   where the decision it names actually lives — `buildDecisionsCard` takes
+		   `rows[0]` of `ORDER BY committed_at_ms DESC, i.ord`, and `ord` is `t.key *
+		   2` over the topics carrying a non-empty decisions block, so this title is
+		   the first decision-carrying topic of that memory. The section anchor makes
+		   that ordering argument load-bearing for the WORDING only, never for the
+		   destination: both callers land on the same header whatever the topic list
+		   turns out to hold, so a decisions block that survives the query's TRIM but
+		   that `splitDecisionBullets` empties can no longer send a reader somewhere
+		   the card did not mean.
+
 		   Skipped entirely when the title came back empty, which needs a payload
 		   carrying neither a topic title nor a parseable decision line. */
 		if (decisions.latest && decisions.latest.title) {
@@ -461,7 +615,7 @@ window.JD = window.JD || {};
 				'<div class="dec-quote"><span class="qlab">Latest · ' +
 				esc(decisions.latest.repoName) +
 				'</span><a class="dec-jump" href="' +
-				memoryHref(model, decisions.latest.commitHash, decisions.latest.repoIdentity) +
+				memoryHref(model, decisions.latest.commitHash, decisions.latest.repoIdentity, TOPICS_ANCHOR) +
 				'" target="_blank" rel="noopener"><strong>' +
 				esc(decisions.latest.title) +
 				"</strong></a></div>";
@@ -570,11 +724,30 @@ window.JD = window.JD || {};
 		);
 	}
 
-	/* Ranked rows shared by Skills and MCP servers: label (+ optional kind),
-	   value, a bare colour bar underneath sized against the top row. `list` names
-	   which pageable list this is, so `capToolLists` can find the <ul> again after
-	   the render. */
-	function rankedList(rows, colorVar, valueOf, labelOf, kindOf, unit, list) {
+	/* Ranked rows shared by Skills and MCP servers: an optional lead mark, the
+	   label, an optional kind, the value, and a bare colour bar underneath sized
+	   against the top row. `list` names which pageable list this is, so
+	   `capToolLists` can find the <ul> again after the render.
+
+	   The two optional slots are on OPPOSITE sides of the label and are not
+	   interchangeable. Skills puts its agent marks in the LEAD, where an icon
+	   reads as an attribute of the name it precedes; the MCP lists put a count in
+	   the trailing kind, where it reads as a qualifier. A single slot with a CSS
+	   `order` flip was the cheaper version of this and is the wrong one — it
+	   leaves the DOM saying the opposite of the screen, which is what a screen
+	   reader and a copy-paste both get.
+
+	   The two slots return different things, and each has exactly ONE contract —
+	   a parameter that is raw for some callers and escaped for others is the trap
+	   this avoids. The LEAD returns HTML, because it carries markup: its only
+	   producer is `agentBadges`, which escapes the names inside its own marks.
+	   The KIND returns `{ text, title }` and is escaped here, because its only
+	   producer is `withAgents` and that text is transcript-derived. The row LABEL
+	   is escaped here for the same reason.
+
+	   Arguments run in the row's own left-to-right order (lead, label, kind,
+	   value) so a call site reads like the row it builds. */
+	function rankedList(rows, colorVar, valueOf, leadHtmlOf, labelOf, kindOf, unit, list) {
 		if (rows.length === 0) return "";
 		// The real maximum, not `rows[0]` — that is only the biggest value when the
 		// list's rank order happens to be the metric the bars measure, and Skills
@@ -603,7 +776,14 @@ window.JD = window.JD || {};
 			   so emitted no slot at all; this keeps that. */
 			var kind = kindOf ? kindOf(row) : null;
 			html +=
-				'<li><div class="rl-top"><span class="rl-name mono" title="' +
+				'<li><div class="rl-top">' +
+				// Emitted for every row of a list that HAS a lead, including rows whose
+				// own lead comes back empty. The span is a fixed-width column (see
+				// .rl-lead), so skipping it on a row with no agents would put that row's
+				// name 40px left of its neighbours' — the raggedness the fixed width
+				// exists to remove, reintroduced by the empty case.
+				(leadHtmlOf ? '<span class="rl-lead">' + leadHtmlOf(row) + "</span>" : "") +
+				'<span class="rl-name mono" title="' +
 				JD.esc(label) +
 				'">' +
 				JD.esc(label) +
@@ -635,11 +815,16 @@ window.JD = window.JD || {};
 	   same tag the Tokens chart's Agent axis prints, so the two panels can be
 	   read against each other without a mapping in the reader's head.
 
+	   This is the MCP lists' form of that signal, in the trailing kind slot;
+	   Skills states the same thing as brand marks in the row's LEAD instead (see
+	   `agentBadges`). Between them they are the only per-agent signal on either
+	   card — the `by agent · 12 claude` header line that carried the same split
+	   with volume was removed, so nothing states a whole-window per-agent total
+	   any more.
+
 	   Counts are deliberately left OFF the per-row tag: the row already prints
 	   its own total beside the name, and a second set of numbers at that size
-	   reads as noise. This is now the ONLY per-agent signal on either card — the
-	   `by agent · 12 claude` header line that carried the same split with volume
-	   was removed, so nothing states a whole-window per-agent total any more. */
+	   reads as noise. */
 	/**
 	 * How many agent names ride on a row before the rest fold into `+N`.
 	 *
@@ -688,6 +873,46 @@ window.JD = window.JD || {};
 		};
 	}
 
+	/* The Skills row's LEAD: one brand mark per agent that ran the skill, in
+	   place of the name list `agentTag` writes. It sits ahead of the skill name
+	   rather than after it, which is where an icon belongs — the mark qualifies
+	   the name, and reading it first means the eye picks up "who" before "what"
+	   without scanning to the end of a truncating label. "Who ran this" is also a
+	   question a logo answers faster than a word at 11px. The name is not lost:
+	   it is each mark's tooltip and its accessible name, via `JD.sourceBadge`.
+
+	   Ordered as the server sent them, which is `sortAgents` — by volume, so the
+	   agent that ran the skill most leads. */
+	/* How many marks the lead shows before it collapses the rest into `+N`.
+
+	   The cap exists for ALIGNMENT, not for width: a lead that grows with the
+	   agent count puts every skill name at a different x, and the names are the
+	   column a reader scans. Two marks plus the row's 4px gap is exactly the
+	   fixed width `.rl-lead` reserves, and `+N` occupies the second slot when it
+	   is needed — so the name starts in the same place whether a skill was run by
+	   one agent or five. Two rather than one because a skill shared between
+	   Claude and Codex is a real and interesting case, where "+1" would hide the
+	   more informative half of it. */
+	var LEAD_AGENT_MARKS = 2;
+
+	function agentBadges(row) {
+		var agents = row.agents || [];
+		if (agents.length === 0) return "";
+		if (agents.length <= LEAD_AGENT_MARKS) return agents.map((a) => JD.sourceBadge(a.source)).join("");
+		/* Past the cap the leading (highest-volume) agent keeps its mark and the
+		   remainder becomes a count. The names are not dropped — they are the
+		   counter's tooltip, which is the same bargain every mark makes. */
+		var rest = agents.slice(1);
+		return (
+			JD.sourceBadge(agents[0].source) +
+			'<span class="src-more" title="' +
+			JD.esc(rest.map((a) => JD.sourceLabel(a.source)).join(", ")) +
+			'">+' +
+			rest.length +
+			"</span>"
+		);
+	}
+
 	/*
 	 * `agentLine` used to render the per-agent header line on both cards —
 	 * `by agent · 12 claude`, one `<b>calls</b> source` part per agent, from the
@@ -705,25 +930,14 @@ window.JD = window.JD || {};
 	 * with volume is not stated anywhere.
 	 */
 
-	/* The "…so this list is not everything" caveat, shared by both cards.
-	   `uncoveredSources` is a PARSER capability the server computed, not "these
-	   agents happened to call nothing" — see ToolUsage in DashboardModel. */
-	function uncoveredNote(usage, noun) {
-		if (usage.uncoveredSources.length === 0) return "";
-		return (
-			" · <b>" +
-			JD.esc(usage.uncoveredSources.join(", ")) +
-			"</b> record no tool calls, so " +
-			noun +
-			" used only from those agents will not appear here"
-		);
-	}
-
 	/* Skills (span6) — split out of the old combined "Skills & tools" card so
 	   each half gets its own icon, stat line and footer, matching jolli-design's
-	   per-card anatomy. Every row names the agents that ran it; which agents can
-	   be read at all is the footer's `uncoveredSources` caveat, not a fixed list
-	   here (it was hard-coded to Claude and went stale the day Codex landed). */
+	   per-card anatomy. Every row names the agents that ran it, rather than the
+	   fixed list this used to carry (hard-coded to Claude, stale the day Codex
+	   landed). The server still computes `ToolUsage.uncoveredSources` — the
+	   agents whose transcripts cannot record a tool call at all — but no card
+	   prints it: it was a second sentence in a footer that already states its own
+	   denominator, and it named parser capability where a reader expects data. */
 	/* Skill invocations only — NOT commands or subagents. `parseToolUse` promotes
 	   a call to a skill row exactly when the tool is `Skill` and carries an
 	   `input.skill` (TranscriptParser.ts); a subagent is the `Task` tool and
@@ -754,7 +968,6 @@ window.JD = window.JD || {};
 			return (
 				html +
 				'<div class="empty-note">No skill invocations recorded in this window.' +
-				uncoveredNote(usage, "a skill") +
 				"</div></section>"
 			);
 		}
@@ -776,8 +989,9 @@ window.JD = window.JD || {};
 			usage.skills,
 			"--s2",
 			(r) => r.calls,
+			agentBadges,
 			(r) => "/" + r.name,
-			withAgents(null),
+			null,
 			"run",
 			"skill",
 		);
@@ -789,9 +1003,8 @@ window.JD = window.JD || {};
 			usage.sessionsWithTools +
 			"</b> of " +
 			usage.sessionsInWindow +
-			(usage.sessionsInWindow === 1 ? " session</b>" : " sessions") +
+			(usage.sessionsInWindow === 1 ? " session" : " sessions") +
 			" in this window" +
-			uncoveredNote(usage, "a skill") +
 			"</span></div></section>"
 		);
 	}
@@ -822,6 +1035,7 @@ window.JD = window.JD || {};
 					usage.mcpTools,
 					"--s1",
 					(r) => r.calls,
+					null,
 					(r) => r.name,
 					withAgents((r) => r.sessions + (r.sessions === 1 ? " session" : " sessions")),
 					"call",
@@ -834,6 +1048,7 @@ window.JD = window.JD || {};
 				usage.servers,
 				"--s1",
 				(r) => r.calls,
+				null,
 				(r) => r.server,
 				withAgents((r) => r.tools + (r.tools === 1 ? " tool" : " tools")),
 				"call",
@@ -878,7 +1093,6 @@ window.JD = window.JD || {};
 			return (
 				html +
 				'<div class="empty-note">No MCP calls recorded in this window.' +
-				uncoveredNote(usage, "a server") +
 				"</div></section>"
 			);
 		}
@@ -924,7 +1138,8 @@ window.JD = window.JD || {};
 		   If a caveat matters enough to say, it goes in the head's ⓘ (which
 		   EXPLAINS the card) or on the face; if it does not, it is not written.
 		   Two that used to hang here are now unwritten: the `uncoveredSources`
-		   list, and "the recall count is MCP-tool calls only".
+		   list (since removed from the card face too), and "the recall count is
+		   MCP-tool calls only".
 
 		   Never held the page-wide clause either ("older activity is reconstructed
 		   from commits and stored summaries") — that described the activity
@@ -1359,7 +1574,7 @@ window.JD = window.JD || {};
 		};
 	}
 
-	/* Tokens (span4) — input/output/cache, day-bucketed. Reuses
+	/* Tokens (span6) — input/output/cache, day-bucketed. Reuses
 	   `JD.stackedBars` (the same chart Cost & tokens draws) rather than a
 	   one-off SVG, so the two cards read as the same chart language. `cached`
 	   is one combined figure, not a cache-write/cache-read split — the database
@@ -1427,10 +1642,9 @@ window.JD = window.JD || {};
 		}
 		if (stats.seriesKeys.length === 0) return '<div class="empty-note">No token data yet in this window.</div>';
 
-		var ranked = rankRows(stats);
+		var top = JD.topSeries(stats.series, stats.seriesKeys, SERIES_LIMIT);
 		var html = '<div class="legend" style="margin-top:8px">';
-		stats.seriesKeys.forEach((key, index) => {
-			var row = ranked.find((r) => r.key === key);
+		top.keys.forEach((key, index) => {
 			html +=
 				'<span><i style="background:' +
 				JD.seriesColor(index) +
@@ -1439,11 +1653,11 @@ window.JD = window.JD || {};
 				'">' +
 				JD.esc(key) +
 				'</span> <b class="num">' +
-				JD.fmtTokens(row ? row.tokens : 0) +
+				JD.fmtTokens(top.byKey[key] || 0) +
 				"</b></span>";
 		});
 		html += "</div>";
-		return html + '<div class="chart-box" style="margin-top:16px">' + JD.stackedBars(stats.series, stats.seriesKeys, "tokens by " + wantDim) + "</div>";
+		return html + '<div class="chart-box" style="margin-top:16px">' + JD.stackedBars(top.series, top.keys, "tokens by " + wantDim) + "</div>";
 	}
 
 	/* Why this card counts tokens while Spend counts dollars — the one thing a
@@ -1462,35 +1676,50 @@ window.JD = window.JD || {};
 		   volume; the clock is still correct on the session feed below, which is
 		   the card it was presumably copied from. */
 		var icon = widgetIcon("--s3", '<path d="M3 3v16a2 2 0 0 0 2 2h16"/><path d="M18 17V9"/><path d="M13 17V5"/><path d="M8 17v-3"/>');
-		var html =
-			'<section class="card span4" aria-label="Tokens">' +
-			widgetHead(icon, "Tokens", null, TOKENS_HINT);
-
+		/* The empty state keeps a bare head: there is no figure to right-align,
+		   and an aside reading "0" beside "No token data yet" says the same
+		   nothing twice. */
 		if (total === 0) {
 			return (
-				html +
+				'<section class="card span6" aria-label="Tokens">' +
+				widgetHead(icon, "Tokens", null, TOKENS_HINT) +
 				'<div class="empty-note">No token data yet — Claude sessions report tokens; other agents count ' +
 				"sessions only.</div></section>"
 			);
 		}
 
-		html +=
-			'<div class="bignum num" style="font-size:22px;font-weight:650;margin-top:2px">' +
-			JD.fmtTokens(total) +
-			'<div class="sub" style="font-weight:400;margin-top:2px">captured tokens, ' +
-			Math.round((tb.cached / total) * 100) +
-			"% of them cache</div></div>";
+		/* Right-aligned in the head, matching Spend beside it. `span6` with a
+		   one-word title is exactly the case `widgetHead`'s aside was measured
+		   for. 18px, not the 22px it used at full width, so the two cards' figures
+		   are the same size. */
+		var html =
+			'<section class="card span6" aria-label="Tokens">' +
+			widgetHead(
+				icon,
+				"Tokens",
+				null,
+				TOKENS_HINT,
+				'<div class="num" style="font-size:18px;font-weight:650">' +
+					JD.fmtTokens(total) +
+					'</div><div class="sub">captured tokens<br>' +
+					Math.round((tb.cached / total) * 100) +
+					"% of them cache</div>",
+			);
 
 		var view = JD.tokSplitView || "type";
 		html += tokensViewChips(view);
 		html += tokensViewBody(stats, view);
 
-		return (
-			html +
-			'<div class="w-foot"><span class="w-chip">Claude only</span>' +
-			'<span class="w-chip">cache is one combined figure</span>' +
-			'<span class="w-measure">ⓘ volume, not spend</span></div></section>'
-		);
+		/* No footer. The three chips that were here — "Claude only", "cache is one
+		   combined figure", "volume, not spend" — were caveats about how the
+		   figures are SOURCED, not facts about this window, and the card already
+		   answers each of them where a reader is looking: the legend names Input /
+		   Output / Cache as three separate series, so the combined-cache point is
+		   made by the chart rather than asserted under it; the headline says
+		   "captured tokens"; and the ⓘ on the card head explains the rest. A
+		   caveat that has to be read after the chart to correct it belongs in the
+		   head, not in a strip below the fold. */
+		return html + "</section>";
 	}
 
 	/* Shared label/value stat list — same `.records` markup activityCard already
@@ -1648,20 +1877,22 @@ window.JD = window.JD || {};
 			document.getElementById("app").innerHTML = noReposCard();
 			return;
 		}
-		/* Order follows jolli-design's own Dashboard route (confirmed against a
-		   real screenshot of it): the equal-third band (what runs, what's
-		   called, what it cost in tokens) leads, then spend over time, then
-		   decisions, then the feed, then the two lower-priority cards. Decisions
-		   used to be paired with a Recall card beside it; that card was removed
-		   (JOLLI-2193) along with its whole query path, so Decisions took the
-		   whole row rather than leaving six empty columns. */
+		/* Two bands over the feed. The equal-third band leads with the three
+		   summary widgets — what ran, what was called, what was decided — and the
+		   half-and-half band under it carries the two cost views, which are one
+		   question in two units (see Tokens' hint) and so belong beside each other
+		   rather than stacked a scroll apart.
+
+		   Both are moves off the original jolli-design order, where Tokens held the
+		   third seat and Spend and Decisions each took a full row: Decisions was
+		   span12 only because the Recall card beside it was removed (JOLLI-2193),
+		   and neither it nor Spend draws anything that needs twelve columns. */
 		var html = skillsCard(model);
 		html += mcpCard(model);
-		html += tokensCard(model);
-
-		html += costCard(model);
-
 		html += decisionsCard(model);
+
+		html += tokensCard(model);
+		html += costCard(model);
 
 		/* The session-activity card (heatmap, hour histogram, records, share card)
 		   was removed — `stats.heatmap` / `stats.hours` / `stats.fun` stay in the

--- a/cli/src/dashboard/assets/styles/main.css
+++ b/cli/src/dashboard/assets/styles/main.css
@@ -381,10 +381,13 @@ body {
   }
   @media (min-width: 900px) {
     .span7 { grid-column: span 7; } .span5 { grid-column: span 5; }
+    /* Half-and-half band — Tokens beside Spend: one question in two units
+       (tokens vs dollars, which a rising cached share moves in opposite
+       directions), so the comparison needs them on one row. */
     .span6 { grid-column: span 6; }
-    /* Equal-third band — Skills / MCP servers / Tokens, matching
-       jolli-design's own three-up row: three widgets of the same weight, so
-       none of them leads. */
+    /* Equal-third band — Skills / MCPs / Decisions, matching jolli-design's own
+       three-up row: three widgets of the same weight, so none of them leads.
+       Tokens held the third seat until it paired off with Spend above. */
     .span4 { grid-column: span 4; }
   }
   .card h2 { margin: 0; font-size: 13px; font-weight: 600; letter-spacing: .01em; }
@@ -489,15 +492,6 @@ body {
      content rather than as the absence of it. */
   .empty-note { font-size: 12.5px; color: var(--muted); margin-top: 12px; line-height: 1.55; }
 
-  /* ---------- ranked bars ---------- */
-  .ranked { display: flex; flex-direction: column; gap: 10px; margin-top: 6px; }
-  .rrow { display: grid; grid-template-columns: 190px 1fr 92px; gap: 10px; align-items: center; }
-  .rrow .lbl { font-size: 12.5px; color: var(--ink-2); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .rrow .bar { height: 18px; border-radius: 0 4px 4px 0; background: var(--s1); min-width: 2px; position: relative; }
-  .rrow .track { background: transparent; border-left: 2px solid var(--baseline); padding-left: 0; height: 18px; display:flex; align-items:center; }
-  .rrow .val { font-size: 12.5px; text-align: right; color: var(--ink); }
-  .rrow .meta { font-size: 11px; color: var(--muted); display: block; }
-
   /* ---------- table view ---------- */
   .ttable { width: 100%; border-collapse: collapse; margin-top: 6px; font-size: 12.5px; }
   .ttable th { text-align: left; font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .05em; font-weight: 600; padding: 6px 8px; border-bottom: 1px solid var(--grid); }
@@ -529,6 +523,27 @@ body {
   .tag { font-size: 11px; padding: 2px 8px; border-radius: 999px; border: 1px solid var(--border); color: var(--ink-2); display: inline-flex; align-items: center; gap: 5px; }
   .tag i { width: 7px; height: 7px; border-radius: 50%; display: inline-block; }
   .tag.metric { border-color: transparent; background: var(--lock-bg); }
+  /* A metric chip that is also a link (Memory Activity's decision count jumps to
+     `#what-changed`). It keeps the chip's own colour rather than the link
+     accent — it reads as a count first and a link second — and states its
+     affordance on hover, where the rest of the row's chips have none. */
+  a.tag.metric { text-decoration: none; color: var(--ink-2); }
+  a.tag.metric:hover { background: var(--accent-soft); color: var(--accent); }
+  /* The AI agent's brand mark (JD.sourceBadge) — Skills rows and the memory
+     detail's conversation rows. Sized here rather than on each <svg> so the two
+     call sites cannot drift, and `color` is inherited on purpose: the neutral
+     marks (Cursor / Copilot / OpenCode / Cline / Devin) draw with
+     `currentColor`, so they take the surrounding slot's colour and stay legible
+     on both themes, while the brand-coloured ones ignore it. */
+  .src-mark { display: inline-flex; align-items: center; justify-content: center; flex: none; }
+  .src-mark svg { display: block; width: 14px; height: 14px; }
+  /* The same 14px box as an <svg>, not a bare glyph: measured at 7x10 without
+     it, which left a row of marks visibly ragged wherever one agent ships no
+     brand mark (Kimi today). */
+  .src-letter {
+    display: inline-flex; align-items: center; justify-content: center; width: 14px; height: 14px;
+    font-size: 10px; font-weight: 650; line-height: 1;
+  }
   .tag.reuse { display: none; border-color: transparent; background: var(--accent-soft); color: var(--accent); font-weight: 600; }
   .jd[data-tier="2"] .tag.reuse { display: inline-flex; }
   .sess-row { display: flex; gap: 12px; align-items: center; border: 1px solid var(--grid); border-radius: 8px; padding: 10px 14px; font-size: 12.5px; color: var(--ink-2); }
@@ -556,13 +571,16 @@ body {
   .jd[data-tier="2"] .t2hide { display: none; }
 
   /* ---------- decisions ----------
-     A span12 card: it was a span6 paired with the Recall card, and that one is
-     gone (JOLLI-2193), so it took the whole row rather than leaving six empty
-     columns. Carries no "recalled" figure of its own — see DecisionsCard's doc
-     comment. */
-  .hdr-stat { margin-left: auto; text-align: right; }
-  .hdr-stat b { display: block; font-size: 19px; font-weight: 650; letter-spacing: -.01em; }
-  .hdr-stat span { font-size: 10px; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); }
+     A span4 card, third seat in the equal-third band. It was span12 (span6 until
+     the Recall card beside it was removed, JOLLI-2193) and gave the width back:
+     the step chart below scales to any column, so nothing on the card was using
+     it. Carries no "recalled" figure of its own — see DecisionsCard's doc
+     comment.
+
+     The `.hdr-stat` rules that used to head this section went with that move —
+     a right-aligned headline beside a two-line title needs more than a third of
+     the row — and this card was their only user. The count is now a `.bignum`
+     under the title, styled inline exactly like Tokens' own. */
   .stepchart { margin-top: 10px; }
   .stepchart svg { display: block; width: 100%; height: 60px; }
   .dec-quote {
@@ -727,6 +745,18 @@ body {
      breathing room for the reading pane; a left inset reads as an accidental
      gap between the app navigation and this second-level navigator. */
   .wrap:has(.memories-page) { max-width: none; padding: 0 56px 0 0; }
+  /* `.main`'s 48px bottom padding is for pages that end; this one is sized to the
+     viewport (topbar + `calc(100vh - 58px)`), so the padding only makes the
+     DOCUMENT 48px taller than the window. That is not just dead scroll: the
+     topbar is `position: sticky`, so those 48px of root scrolling slide the
+     reading pane up UNDER it. `#what-changed` landed there — `scrollIntoView`
+     scrolls the pane and then the root, and the root's alignment runs out of
+     travel and clamps, so the section header the anchor exists to show finished
+     behind an opaque bar. Removing the overflow leaves the pane as the page's
+     only scroller, which is what the anchor's `scroll-margin-top` assumes.
+     Not applied at the ≤899px breakpoint below: there the pane goes
+     `height: auto` and the window is SUPPOSED to scroll. */
+  .main:has(.memories-page) { padding-bottom: 0; }
   .grid:has(.memories-page) { display: block; }
   .memories-page {
     display: grid; grid-template-columns: 344px minmax(0, 1fr);
@@ -880,6 +910,14 @@ body {
   .mem-row-icon .mem-icon { width: 14px; height: 14px; }
   .mem-row-title { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--ink); }
   .mem-row-meta { color: var(--muted); white-space: nowrap; font-size: 11px; }
+  /* The deep-link target from Memory Activity and the Decisions card. The scroll
+     lands the section's own header at the top edge of whatever is scrolling, so
+     this margin is the only thing keeping "What changed and why" off that edge.
+     Two values, because WHICH element scrolls changes: on desktop it is
+     `.mem-detail`, which has nothing overlapping it, so 18px is breathing room
+     alone; below 899px the pane goes `height: auto` and the WINDOW scrolls under
+     the 58px sticky topbar, so the same 16px of room needs 74. */
+  #what-changed { scroll-margin-top: 18px; }
   .mem-topic-list { display: flex; flex-direction: column; gap: 16px; }
   .mem-topics .topic {
     margin: 0; padding: 20px; border: 1px solid var(--border); border-radius: 10px;
@@ -929,6 +967,7 @@ body {
     .mem-tree { flex: none; height: min(42vh, 360px); }
     .mem-detail { height: auto; overflow: visible; border-radius: 0; border-inline: 0; }
     .mem-read-inner { padding: 28px 4px 48px; }
+    #what-changed { scroll-margin-top: 74px; }
   }
   .tok-bar { margin-top: 6px; display: flex; height: 8px; border-radius: 999px; overflow: hidden; background: var(--heat-track); }
   .tok-bar i { display: block; height: 100%; }
@@ -1061,6 +1100,27 @@ body {
      siblings are flex:none so the name is the only thing that gives. Every
      truncating label in this file carries its full text in a `title`. */
   .ranklist .rl-name { color: var(--ink); font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+  /* The Skills row's agent marks, ahead of the name.
+
+     The width is FIXED at two 14px marks plus their gap, and the contents are
+     right-aligned into it. That is what keeps every skill name starting at the
+     same x — a lead sized to its contents put a one-agent row's name 18px left
+     of a two-agent row's, and the names are the column a reader scans down.
+     `agentBadges` caps itself at the same two so nothing overflows the box.
+     Right-aligned rather than left so a single mark sits against the name it
+     belongs to instead of floating a slot away from it.
+
+     `align-self: center` overrides `.rl-top`'s baseline alignment — a 14px icon
+     on a text baseline hangs below the line. `--muted` is inherited by the
+     neutral marks' `currentColor` (Cursor / Copilot / OpenCode / Cline / Devin),
+     which keeps them a row attribute rather than a second focal point beside
+     the name. */
+  .ranklist .rl-lead {
+    display: inline-flex; align-items: center; justify-content: flex-end; gap: 4px;
+    flex: none; align-self: center; width: 32px; color: var(--muted);
+  }
+  /* The overflow counter, in the second mark's slot and on its baseline. */
+  .src-more { display: inline-flex; align-items: center; justify-content: center; min-width: 14px; height: 14px; font-size: 10px; font-weight: 650; line-height: 1; }
   .ranklist .rl-kind { color: var(--muted); font-size: 11px; flex: none; }
   .ranklist .rl-val { margin-left: auto; color: var(--ink-2); white-space: nowrap; flex: none; }
   .ranklist .rl-bar { height: 10px; margin-top: 10px; border-radius: 5px; background: var(--heat-track); overflow: hidden; }
@@ -1102,12 +1162,16 @@ body {
     border-left: 3px solid var(--memory-color); border-bottom: 1px solid var(--grid);
   }
   .mem-activity-copy { min-width: 0; }
-  .mem-activity-title { font-size: 13px; font-weight: 600; color: var(--ink); line-height: 1.4; }
+  /* The title IS the link, so it keeps the ink colour a heading has and picks
+     up the accent only on hover — a row of blue titles would read as a list of
+     links rather than a list of memories. `display: block` so the hit area is
+     the whole line, not just the glyphs. */
+  .mem-activity-title { display: block; font-size: 13px; font-weight: 600; color: var(--ink); line-height: 1.4; text-decoration: none; }
+  a.mem-activity-title:hover { color: var(--accent); text-decoration: underline; }
   .mem-activity-meta { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; margin-top: 6px; }
   .mem-activity-category { color: var(--memory-color); font-size: 11.5px; font-weight: 600; }
   .mem-activity-action { display: flex; align-items: center; gap: 14px; margin-left: auto; flex: none; white-space: nowrap; }
   .mem-activity-action time { font-size: 11.5px; color: var(--muted); }
-  .mem-activity-action a { color: var(--accent); font-size: 12.5px; font-weight: 600; }
   @media (max-width: 620px) {
     .mem-activity-row { align-items: flex-start; flex-direction: column; gap: 8px; }
     .mem-activity-action { margin-left: 0; }
@@ -1172,11 +1236,28 @@ body {
 
   .overlay { position: fixed; inset: 0; background: rgba(0,0,0,.4); display: none; align-items: center; justify-content: center; z-index: 80; padding: 20px; }
   .overlay.open { display: flex; }
-  .sheet { background: var(--surface); color: var(--ink); border: 1px solid var(--border); border-radius: 12px; width: min(640px, 100%); padding: 18px; }
+  /* The Context viewer is this class's only user, and what it holds is a whole
+     plan or note — agent-written markdown with no hard wrap, rendered as 12px
+     monospace. At the 640px this used to be, the body measured ~85 characters
+     (measured in Chrome, not derived), so nearly every line of a real plan
+     folded; 960px gives ~133 and leaves the wrapping to lines that are genuinely
+     long. `min(…, 100%)` still yields to a narrow window — 100% of the overlay's
+     content box, so its own 20px padding is already subtracted.
+
+     Height is the same argument one axis over: a fixed `60vh` on the body left a
+     tall window mostly empty while still scrolling. The sheet is a flex column
+     capped at the overlay's height instead, so a short document keeps a small
+     dialog and a long one gets every pixel there is. `min-height: 0` on the body
+     is what actually lets it scroll — a flex item's default `min-height: auto`
+     refuses to shrink below its content, so the sheet would grow past the cap. */
+  .sheet {
+    background: var(--surface); color: var(--ink); border: 1px solid var(--border); border-radius: 12px;
+    width: min(960px, 100%); max-height: 100%; padding: 18px; display: flex; flex-direction: column;
+  }
   .sheet h3 { margin: 0 0 2px; font-size: 14px; }
   .sheet .sub { font-size: 12px; color: var(--muted); margin: 2px 0 10px; }
   .ctx-body {
-    max-height: 60vh; overflow: auto; margin: 0; white-space: pre-wrap; word-break: break-word;
+    flex: 0 1 auto; min-height: 0; overflow: auto; margin: 0; white-space: pre-wrap; word-break: break-word;
     font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 12px; line-height: 1.6;
     color: var(--ink-2); background: var(--page); border: 1px solid var(--grid); border-radius: 8px; padding: 12px;
   }


### PR DESCRIPTION
<!-- jollimemory-summary-start -->



## E2E Test (5)
<details>
<summary><strong>1. Spend card headline matches the bars (no inflation from undrawable days)</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with at least a few days of commit activity and cost data visible on the Stats page. Ideally use a date range where some days have cost recorded but little or no token activity (e.g. a day with only a tiny squashed commit).

**Steps:**
1. Open the dashboard and go to the Stats page.
2. Look at the Spend card — note the dollar total shown in the headline at the top of the card.
3. Look at the stacked bars below the headline and mentally add up the visible cost across all bars.
4. Check that the headline total matches what the bars actually show — not a larger number that includes days with no visible bar.
5. Look at the "busiest day" line at the bottom of the card and check that the dollar figure shown there is not larger than the headline total.
6. Repeat with a different date range (e.g. switch from "30 days" to "7 days") and verify the headline and busiest-day figure stay consistent with the bars.

**Expected Results:**
- The headline dollar total should equal the sum of what the bars draw — it should never be higher than the bars can account for.
- The busiest-day callout at the bottom should name a day that actually has a visible bar, and its dollar figure should be less than or equal to the headline total.
- No day with no visible bar should be named the busiest day.

</blockquote>
</details>
<details>
<summary><strong>2. Spend card legend totals add up to the headline</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with memory-tier data (commits enriched with topics, branches, or tickets) so the Spend card shows multiple coloured series in the legend.

**Steps:**
1. Open the Stats page and find the Spend card.
2. Note the headline dollar total at the top of the card.
3. Look at the legend below the bars — each series (e.g. each topic or branch) should show its own dollar figure.
4. Add up all the per-series dollar figures shown in the legend.
5. Check that the sum of the legend figures equals the headline total.

**Expected Results:**
- The individual series dollar amounts in the legend should add up exactly to the headline total shown at the top of the Spend card.
- No series should show a dollar amount larger than the headline total.
- The page should contain no "undefined" or "NaN" text anywhere on the Spend card.

</blockquote>
</details>
<details>
<summary><strong>3. Spend card subtitle shows which clock the data is on</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with memory-tier data so you can switch between axes like "by branch" or "by category" as well as session-based axes like "by model".

**Steps:**
1. Open the Stats page and find the Spend card subtitle (the smaller text just below the card title).
2. While viewing a memory-based axis such as "by branch" or "by category," check what the subtitle says about the data source.
3. Switch to a session-based axis such as "by model" or "by agent" and check the subtitle again.

**Expected Results:**
- When viewing a memory-based axis (branch, category, ticket), the Spend card subtitle should include the words "by commit date."
- When viewing a session-based axis (model, agent), the subtitle should instead say "by session activity."
- The label should update immediately when you switch axes — it should never show the wrong clock for the currently displayed data.

</blockquote>
</details>
<details>
<summary><strong>4. Amended or squashed commits are not counted multiple times in the Spend card</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository where some commits have been amended or squashed (i.e. the same piece of work was rewritten one or more times before being finalised). The Spend card should show cost data for those commits.

**Steps:**
1. Open the Stats page and note the total cost shown in the Spend card headline.
2. Switch between the available axes — category, branch, and ticket — and note the headline total on each.
3. Check whether any axis shows a total that seems far higher than the others or far higher than you would expect based on actual work done.

**Expected Results:**
- The headline total should be consistent (or close to it) across all three axes — category, branch, and ticket.
- No axis should show a total that is several times larger than the others (for example, a category total of $350 when branch and ticket both show around $90 would indicate the bug is still present).
- Each piece of amended or squashed work should be counted once, not once per rewrite.

</blockquote>
</details>
<details>
<summary><strong>5. Memory Activity subtitle correctly describes a capped list</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository with enough memories that the Memory Activity card shows a list of recent memories.

**Steps:**
1. Open the Stats page and scroll to the Memory Activity card.
2. Read the subtitle text shown just below the card title.
3. Check whether the subtitle says something like "showing the N most recent" or whether it says "N memories in this window."
4. Compare the number in the subtitle to the coverage line further down the card (which shows the real total count for the window).

**Expected Results:**
- The subtitle should say "showing the N most recent" (where N is the number of items visible in the list).
- The subtitle should NOT say "N memories in this window" — that wording was incorrect because it presented the capped page size as the full window total.
- The number in the subtitle and the number in the coverage line below it should not contradict each other in a confusing way.

</blockquote>
</details>

---

## Topics (14)
<details>
<summary><strong>01 · Dashboard reorganized into summary band and cost band with Decisions promoted</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The dashboard layout had Decisions occupying a full-width row on its own, with Tokens and Spend in separate positions, making it hard to compare related figures at a glance.

**💡 Decisions Behind the Code**

- **Decisions in the equal-third band**: The step chart inside the Decisions card uses a scalable aspect ratio and fills whatever column width it is given, so moving from a full-width row to one-third costs nothing visually. The previous full-width position was an accident of an earlier card's removal rather than a deliberate layout choice.
- **Tokens and Spend side by side**: The two cards answer the same question in different units — token counts and dollars — and a rising cache-read share moves them in opposite directions. Placing them on the same row makes that comparison available without scrolling, which is the primary reason to show both cards at all.
- **Decisions head reshaped to match the band**: The previous Decisions head used a right-aligned headline block that requires more horizontal space than one-third of the row provides. Adopting the same one-line title with tooltip pattern used by Skills and MCPs keeps the head readable at the narrower width.

**✅ What Was Implemented**

- In `stats.js`, the card render order was changed so Skills, MCPs, and Decisions form the first equal-width three-card band, followed by Tokens and Spend side by side on a shared half-width row beneath it. The Decisions card was converted from full-width to one-third width and given the same compact head shape as its new neighbors: a one-line title, description moved to a tooltip, and count shown as a large number below the title. The Tokens card was changed from one-third to half width, and the Spend card from full-width to half width.
- In `main.css`, band comments were updated to reflect the new occupants, and the three right-aligned headline block rules previously used only by Decisions were deleted as dead code.
- The Decisions card tooltip text was updated to describe the card's purpose in plain language.

**📁 FILES**
- `cli/src/dashboard/assets/js/stats.js`
- `cli/src/dashboard/assets/styles/main.css`

</blockquote>
</details>
<details>
<summary><strong>02 · Token and spend figures moved into card headers with uniform layout</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Tokens card displayed its headline figure in a separate block below the card header, while the Spend card already showed its figure in the header, creating an inconsistent visual rhythm across the cost band.

**💡 Decisions Behind the Code**

- **Aside restricted to wide cards with single-line titles**: An earlier attempt applied the flex-basis styling unconditionally to all card heads, which broke the narrower one-third-width cards. The aside feature was constrained to activate only when content is passed, and comments document that callers must be at least half-row-wide cards with a one-word title. This preserves the existing layout of all other cards without any conditional logic at the call site.
- **Spend's subtitle moved to tooltip rather than deleted**: The window and clock context text was relocated to the hover tooltip on the heading — the same treatment every other card in the row had already received. This keeps the information accessible without consuming vertical space or breaking the one-line-head visual rhythm across the dashboard band.
- **Measured flex values carried forward unchanged**: The flex basis and margin values were not re-derived from first principles — they came from the Spend card's original hand-written implementation, which had been empirically tested at realistic viewport widths. Re-using them avoided re-introducing a layout regression where the figure wraps and then left-aligns under the title.

**✅ What Was Implemented**

- In `stats.js`, the `widgetHead` function was extended with an optional `aside` parameter. When provided, the title column receives a constrained flex basis and the aside content is rendered right-aligned. The aside path is explicitly guarded so cards without a figure keep their original plain structure.
- The Tokens card's large number and cache-percentage line were moved from a standalone block below the head into the new aside slot, with font size reduced to match the Spend card's figure. The empty-state branch retains a bare head with no aside.
- The Spend card was refactored from a hand-written head to use the shared `widgetHead` function with the aside parameter. Its visible subtitle line was removed; the window and clock context text now lives in the head's tooltip, matching the pattern every other card in the dashboard band already uses.

**📁 FILES**
- `cli/src/dashboard/assets/js/stats.js`

</blockquote>
</details>
<details>
<summary><strong>03 · Memory titles and decision chips made direct navigation links in the activity feed</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Memory Activity card had a dedicated "Open memory" action link at the end of each row, separate from the title, and the decision count chip had no navigation behavior at all.

**💡 Decisions Behind the Code**

- **Title as link over a separate action column**: The title is already what a reader reaches for; a separate "Open memory →" beside it restated the same destination in every row. Removing the action column eliminates a column of identical repeated words while keeping the affordance. Hover styling — accent color and underline — signals interactivity without making every row look like a hyperlink list at rest.
- **Ink color at rest, accent on hover**: Showing the accent color permanently on every title would make the card read as a list of links rather than a list of memories. Reserving the accent for hover preserves the card's visual hierarchy while still communicating that the title is tappable.
- **Fixed anchor over a per-topic index**: The Memory Activity card payload carries only a decision count, not a topic list, so it cannot know which topic index holds the decisions. A fixed identifier on the first decision-carrying topic is the only address both callers — the feed chip and the Decisions card's Latest link — can agree on without adding new fields to the wire format.
- **One-shot scroll guard**: The detail pane is written into the DOM after navigation completes, so the browser's native anchor scroll fires before the target element exists and is silently lost. The scroll function re-attempts on each render tick but records success and skips subsequent ticks, preventing the polling cycle from dragging a reader back to the anchor while they are reading further down the page.

**✅ What Was Implemented**

- In `stats.js`, the memory row template was restructured so the title element became an anchor pointing at the memory detail page. The separate "Open memory →" action link and its surrounding column were removed, leaving only the timestamp in the action area. The decision count chip was changed from a plain span to an anchor using a fixed fragment identifier targeting the first decision in the memory. The Decisions card's "Latest" title link was updated to use the same fragment.
- In `memories.js`, the topic section renderer was updated to stamp each topic with a sequential position identifier. The first topic containing at least one decision also receives a fixed identifier that both link types target. A scroll function was added that reads the URL fragment after each render cycle and scrolls the named element into view, recording success to avoid re-scrolling on subsequent ticks.
- In `main.css`, the title rule was updated to a full-line hit area with ink color at rest and accent color on hover. The old action-link rule was deleted. New hover rules were added for the decision chip to keep it reading as a count first and a navigation affordance second.
- In `FeedCardAsset.test.ts` and the Memory Activity integration test, assertions for the old "Open memory →" text were replaced with assertions confirming the title anchor's href and class, and confirming the old text is absent.

**📁 FILES**
- `cli/src/dashboard/assets/js/stats.js`
- `cli/src/dashboard/assets/js/memories.js`
- `cli/src/dashboard/assets/styles/main.css`

</blockquote>
</details>
<details>
<summary><strong>04 · Spend card headline, bars, trend arrow, and footer now share one cost source</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Spend card was showing numbers that contradicted each other: the headline total, the stacked bars, the trend arrow, and the busiest-day footer each read from different cost calculations on different clocks, causing the card to disagree with itself — especially when filtering by branch, ticket, or category.

**💡 Decisions Behind the Code**

- **Single source of truth over two close approximations**: The previous design computed cost two ways — once from session records for the headline and trend, once from the series for the bars — and accepted the small discrepancy as tolerable. The new design accepts that a day with zero drawable tokens contributes zero to the headline, even if it carries real cost in the raw data. Money that is not drawn must not appear in the headline or trend, or the card is back to disagreeing with itself by a smaller amount.
- **Per-day apportionment over global apportionment**: Cost is spread within each day's token distribution rather than across the whole window's token total. This prevents a day that is heavy in one series from distorting the per-key legend totals for the entire window, keeping the legend consistent with what the bars actually show.
- **Trend must measure what it annotates**: The old approach summed raw session costs, which is a different clock and a different population from the series the card actually renders. On non-default dimensions the two diverge visibly. Switching both ends of the comparison to the same drawn-cost function guarantees the arrow always trends the number printed beside it, at the cost of one extra series query for the prior window.
- **Label reads the effective dimension, not the requested one**: The clock-source note is derived from what the series actually contains, not what the user asked for. This keeps the label honest when the data tier does not support the requested grouping and a fallback is applied silently.

**✅ What Was Implemented**

- Introduced `apportionedCost()` in `stats.js`, which spreads each day's estimated cost across that day's series keys by token share, computed day by day. The headline, per-key legend totals, stacked bars, and busiest-day footer all now read from this single computed result. The old path that pulled the headline from a server-computed KPI field was removed entirely.
- Updated the busiest-day footer to pick the day with the highest apportioned cost from the new result rather than the highest raw cost field, preventing a day that draws no bar from being named the busiest day and preventing the busiest-day figure from exceeding the headline total.
- Replaced the prior-window cost calculation in `DashboardQuery.ts` with a call to the series builder over the prior window, then introduced a `drawnCost()` helper that sums only data points whose token total is non-zero — matching exactly what the chart renders. Both the current and prior window now use `drawnCost` so the trend percentage tracks the headline.
- Moved the series build for the current window earlier in `buildStats` so its result feeds both the headline and the trend calculation from a single series run, eliminating the previous split between session-clock totals and series-based rendering.
- Added a clock-source label to the card subtitle, derived from the effective series dimension rather than the requested one, so the label stays accurate when a memory-tier axis falls back to a session-tier grouping.

**📁 FILES**
- `cli/src/dashboard/assets/js/stats.js`
- `cli/src/dashboard/DashboardQuery.ts`
- `cli/src/dashboard/DashboardModel.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Spend card triple-counted costs for amended and squashed commits</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Spend card's category axis was showing totals far higher than actual spend — in some cases nearly ten times the true figure — because the database stores one row per generation of a memory and the queries summing costs were counting all generations rather than only the current one.

**💡 Decisions Behind the Code**

- **Measure before filtering branch and ticket axes**: The original plan assumed the inner join on commits was already dropping superseded rows on the branch and ticket axes, making the filter only necessary for the category axis. A measurement query on the real database showed the branch and ticket axes were still 1.6x overstated, so the filter was applied to all three. The comment in the code records the measured ratios so future readers understand the empirical basis for the decision.
- **`parent_hash IS NULL` over checking for absent child rows**: The filter follows the established convention used in several other queries across the codebase. The alternative — checking whether a row has no children pointing at it — would identify a different set of rows and has been explicitly ruled out in existing test comments, so the simpler and consistent predicate was used.
- **Verify the regression test actually catches the bug**: Before committing, the fix was temporarily reverted to confirm all three parameterized test cases failed without it and passed with it. This confirmed the helper correctly reproduces the production data shape that caused the overstatement, rather than testing a subtly different scenario.

**✅ What Was Implemented**

- Added `AND m.parent_hash IS NULL` to all three memory-driven series queries in `DashboardQuery.ts` (`buildSeries`): the category axis (worst-affected at 9.5x overstatement on the real database) and the branch and ticket axes (which used an inner join but still double-counted at 1.6x, contrary to the original assumption that the join structure would filter the extra rows). A detailed comment above `buildSeries` documents why the inner join is not a substitute for this filter, citing the measured overstatement ratios.
- Added a regression test in `DashboardQuery.test.ts` with a new `seedSupersededPredecessor` helper that inserts a predecessor memory row with its own commits entry — exactly the shape that the inner join was supposed to filter but did not. The test asserts that adding three amended predecessors to a memory leaves the series token and cost totals unchanged across all three axes. The fix was temporarily reverted before committing to confirm all three parameterized cases failed without it.

**📁 FILES**
- `cli/src/dashboard/DashboardQuery.ts`
- `cli/src/dashboard/DashboardQuery.test.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Decisions and to-do counts inflated by amended or squashed commits</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a commit had been amended or squashed multiple times, the decisions and to-do items extracted from its summary were counted once per rewrite rather than once for the current version, inflating the figures shown alongside memory activity on the Stats dashboard.

**💡 Decisions Behind the Code**

- **Apply the same generation filter everywhere**: The series builder already filtered to current-generation memory rows to avoid double-counting costs. The topic insights query joined the same table but lacked the filter, creating an inconsistency where one metric on the same card was correct and another was not. Applying the identical rule to both branches of the CTE was the minimal, consistent fix.
- **Test the upgrade path, not just the steady state**: A test that only checked a fresh database would not have caught this — the bug only manifests when predecessor rows exist. The test explicitly seeds superseded predecessors and verifies the aggregate is unchanged, which is the scenario that was broken.

**✅ What Was Implemented**

- Added `m.parent_hash IS NULL` filters to both branches of `TOPIC_INSIGHTS_CTE` in `DashboardQuery.ts`, matching the "current generation only" rule already applied by the series builder and memory card queries. The comment on the CTE was expanded to explain the trap and why the filter is necessary.
- Added a regression test in `DashboardQuery.test.ts` that seeds two superseded predecessors carrying the same topic, then asserts the decision count does not change after they are added. Extended `seedSupersededPredecessor` to accept an optional `topics` field so predecessors can carry realistic summary data.

**📁 FILES**
- `cli/src/dashboard/DashboardQuery.ts`
- `cli/src/dashboard/DashboardQuery.test.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Spend chart axis, tooltips, series palette, and top-series rollup corrected</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Spend chart shared a rendering function with the Tokens chart, and that function had the token unit hardcoded throughout. Dollar amounts appeared without currency symbols, cents were silently dropped, large values showed token-style suffixes, axis gridlines did not land on round dollar amounts, and charts with many series — particularly the branch dimension — reused colours so heavily that bar segments could not be matched to their legend entries.

**💡 Decisions Behind the Code**

- **Caller owns the unit, not the chart function**: Making the formatter a parameter rather than branching inside the function keeps the rendering logic unit-agnostic. A boolean flag or a separate function per card would have required the chart function to know about every unit type, making future card additions harder and the existing inconsistency structural rather than incidental.
- **Round axis bound, not round labels only**: The bars are scaled by the same `niceAxisMax` bound used for the labels. Rounding only the label text while leaving the scale at the raw maximum would produce a tallest bar that visually touches the top gridline while the gridline claims a larger number — a subtler but equally misleading mismatch.
- **Merge the tail rather than truncate it**: Dropping low-ranked series would make the chart's bar totals smaller than the headline figure sitting above it — the exact contradiction the Spend card fixes had just eliminated. Merging into "Other" keeps the sum exact, so the headline and the chart always agree.
- **Four named series, not five**: The roll-up bucket itself needs a colour slot. Keeping five named series plus "Other" would produce six entries and wrap the palette again, recreating the original colour-reuse bug at a smaller scale. Four named plus one bucket fills the palette exactly.
- **Colours track magnitude, not server key order**: Series are sorted by total before colour assignment, so the largest series always gets the first (most visually prominent) colour. A tie-break on the key string prevents the order from flickering between renders of identical data.

**✅ What Was Implemented**

- `JD.stackedBars` in `charts.js` now accepts an optional formatter argument. When the Spend card calls it, it passes `JD.fmtUsd`; the Tokens card omits the argument and gets the previous token formatter as the default. Both the axis tick labels and the per-segment hover tooltips use whichever formatter the caller supplies.
- A new `niceAxisMax` helper replaces the raw-maximum axis bound. It picks a step from a 1/2/2.5/5/10 ladder so that all four gridlines land on round numbers and the tallest bar never overflows the top gridline. The no-data case is now handled inside `niceAxisMax` itself.
- `JD.topSeries` was added to `charts.js`. It ranks series by their window total, keeps the top four, and merges the remainder into a single "Other" bucket. The result is always at most five series — four named plus "Other" — which exactly fills the five-colour palette without wrapping. The function uses a prototype-less accumulator to guard against series keys that shadow built-in object properties. Both the Spend card and the Tokens card in `stats.js` now call `JD.topSeries` before building their legend and passing data to `JD.stackedBars`.

**📁 FILES**
- `cli/src/dashboard/assets/js/charts.js`
- `cli/src/dashboard/assets/js/stats.js`

</blockquote>
</details>
<details>
<summary><strong>08 · Retire the repos-no-delete database trigger via a new migration</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The database had a trigger that permanently blocked deletion of any repository registry entry, even entries with no associated data, making it impossible to programmatically clean up orphaned records left behind by failed or isolated test runs.

**💡 Decisions Behind the Code**

- **New migration rather than editing the baseline**: The baseline DDL is frozen — every database ever shipped has already applied it, so editing it out would leave the trigger in place on all existing installs. Appending a new `DROP TRIGGER` migration is the only path that reaches those databases, and `IF EXISTS` makes it safe on any install where the trigger was already absent.
- **Rely on foreign keys rather than a trigger for the core safety guarantee**: The trigger's original purpose was to prevent accidental data loss by blocking all deletes. The foreign key constraints already enforce the same rule for any repo that owns data, and they are always active on normal connections. Removing the trigger only opens the zero-data case, which is exactly the case the registry cleanup needs.
- **Derive the migration log test tail from the live array**: Hardcoding the expected migration names in the test meant every new migration would silently break the assertion or require a manual update. Deriving from the live migrations array makes the test self-maintaining and catches real divergence rather than stale expectations.

**✅ What Was Implemented**

- Added `REPOS_DELETE_ALLOWED_DDL` to `SotSchema.ts`: a new migration that runs `DROP TRIGGER IF EXISTS repos_no_delete`, removing the blanket delete prohibition installed by the baseline schema. The baseline DDL was left untouched — it still creates the trigger, and the new migration drops it on every database that applies it. The `IF EXISTS` clause makes the migration safe on any install where the trigger was already absent.
- Registered the new migration in `DashboardDb.ts` and bumped `DASHBOARD_SCHEMA_VERSION` from 6 to 7. The JSDoc on the migration documents the safety argument: child tables reference `repos(id)` with `NO ACTION` foreign keys, and both read and write connection pragmas enable foreign key enforcement, so deleting a repo that owns any row still fails with a constraint error.
- Added an upgrade-path test that constructs a version-5 pre-migration database, asserts the trigger is present, opens it with the current build, and asserts the trigger is gone. Updated `DashboardDb.test.ts` with two new assertions: one confirming a repo with child rows still cannot be deleted (now via foreign key rather than trigger), and one confirming an empty repo row can be deleted. Made the migration log assertion derive its expected tail from the `MIGRATIONS` array rather than hardcoding names.
- Updated a doc comment in `DashboardQuery.ts` that referenced the now-retired trigger by name, replacing it with a description of the underlying behavior.

**📋 Future Enhancements**

The migration runner temporarily disables foreign keys, so a deletion performed inside that window would now succeed and orphan child rows. This is recorded in the migration comment for future authors to be aware of.

**📁 FILES**
- `cli/src/dashboard/SotSchema.ts`
- `cli/src/dashboard/DashboardDb.ts`
- `cli/src/dashboard/DashboardQuery.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · Case-insensitive path comparison when registering repository checkouts</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

On Windows and macOS, different tools such as terminals, IDE plugins, and git hooks can report the same folder path with different capitalisation. The registry was treating these as separate checkouts, causing duplicate entries on the Repositories page and redundant background work on every save.

**💡 Decisions Behind the Code**

- **Stored spelling is never normalised**: The value written to disk keeps whatever capitalisation the caller supplied, matching what git tooling would print. Only the comparison is normalised. This avoids a class of subtle mismatches where a stored path would no longer agree with what the filesystem or git tooling reports at read time.
- **Platform passed as a parameter, not read from the environment**: Case folding applies on Windows and macOS but not Linux. Reading the current platform inside the predicate would make it impossible to write a test that asserts Windows behaviour on a Linux CI machine. Making it an explicit argument keeps the logic deterministic and the tests self-contained.
- **New predicate not shared with the existing socket-path helper**: There is an identically-shaped expression elsewhere in the codebase used for MCP socket addressing. Reusing it would couple registry semantics to socket-addressing semantics, meaning a future change to either concern could break the other. A one-line expression repeated in two places is a cheaper trade-off than that coupling.

**✅ What Was Implemented**

- Added `sameRecordedRoot` to `RepoRegistry.ts`, a small predicate that wraps the existing case-normalisation helper and accepts an explicit platform argument so tests can assert Windows behaviour on Linux CI without depending on the host machine's case sensitivity.
- Updated `registerRepo` in `RepoRegistry.ts` to filter existing worktree paths through `sameRecordedRoot` before appending a new spelling, so a re-registration with a differently-cased path replaces the old entry rather than adding a second one. The freshest spelling always wins.
- Updated `ensureWorktreeListed` in `RepoRegistry.ts` to use the same predicate when checking whether a checkout is already recorded, preserving the function's "add only, never rewrite" contract while correctly recognising already-listed paths regardless of capitalisation.

**📋 Future Enhancements**

The read path for existing worktree lists does not de-duplicate entries already stored on disk. Machines that accumulated duplicates before this fix will continue to process them redundantly until the next write collapses them. Adding de-duplication on read was noted as a three-line change but was deferred to avoid altering a carefully-documented read contract consumed by multiple callers.

**📁 FILES**
- `cli/src/dashboard/RepoRegistry.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · Remove parser-capability caveats from Skills and MCPs cards</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Explanatory notes on the Skills and MCPs cards described which agent types cannot record tool calls at all, appearing in both populated footers and empty states. The user asked for these to be removed from every location on both cards.

**💡 Decisions Behind the Code**

- **Remove from empty states too, not just footers**: The caveat described a parser capability — which agent transcript formats can record tool calls at all — not a data fact about the current window. Placing it where a reader expects data about their activity created a mismatch in reader expectations, and keeping it only in some branches would have required readers to know which branch they were in to interpret the absence correctly.
- **Delete the helper rather than leave it unused**: Removing all three call sites made the shared helper dead code. Deleting it rather than leaving it in place prevents future callers from reintroducing the pattern and keeps the codebase honest about what the UI actually communicates. The server-side computation is preserved, leaving the door open for a future surface that presents the information in a more appropriate context.

**✅ What Was Implemented**

- Deleted the `uncoveredNote()` helper function from `stats.js` entirely, removing the caveat from three call sites: the Skills card populated footer, the Skills card empty state, and the MCPs card empty state. The server still computes `uncoveredSources` but nothing in the UI now prints it.
- Updated `FeedCardAsset.test.ts` to replace the old assertions (which expected the caveat to appear in some branches and not others) with a parameterized test covering both Skills and MCPs cards in both populated and empty states, asserting the caveat text is absent in all of them.

**📁 FILES**
- `cli/src/dashboard/assets/js/stats.js`
- `cli/src/dashboard/FeedCardAsset.test.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · Spend card footer disclaimer chips removed; Tokens card footer stripped entirely</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Tokens and Spend cards carried footer chips and notes explaining how figures were sourced — methodology caveats rather than facts about the current window. After an initial pass removed several chips, the user decided the final remaining chip on the Spend card should also go.

**💡 Decisions Behind the Code**

- **Strip footnotes that duplicate what the chart already shows**: The "cache is one combined figure" chip was redundant with the chart legend, which already presents Input, Output, and Cache as three separate series. Stating it again below the chart implied the chart was insufficient, when in fact it was the more natural place to communicate the point.
- **Caveat in the subtitle rather than the footer**: Keeping the qualification in the subtitle means readers encounter it before the numbers, not after. A footer chip that walks back a figure the reader has already processed is less effective than a subtitle that sets the expectation upfront. Spend and Tokens now both have no footer, while Skills, MCPs, and Decisions retain theirs because those footers state data coverage — how many sessions contributed — which is additive information rather than a qualification.

**✅ What Was Implemented**

- Removed the entire footer strip from the Tokens card in `stats.js`, eliminating all three chips. The surrounding comment explains that the chart legend and card header already answer each of those points at the place a reader is looking.
- Removed the "model splits are apportioned by token share" measure note from the Spend card footer in an earlier pass, then removed the final "estimated, not a bill" chip in a subsequent pass. The Spend card function now returns the chart HTML followed by a bare closing section tag. A code comment notes that the "estimated" qualification is already stated in the card's subtitle, which appears before the figures rather than after them. The "prices as of date" clause was also removed from the Spend card subtitle, with a comment noting that price-table metadata is constant across windows and reads as noise on the orientation line.

**📁 FILES**
- `cli/src/dashboard/assets/js/stats.js`

</blockquote>
</details>
<details>
<summary><strong>12 · Memory Activity subtitle correctly describes capped vs. full window feeds</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Memory Activity card subtitle had two successive bugs: first it printed the page size as though it were the total number of memories in the window, then the fix for that claimed a truncation had occurred even when the full window fit on the page — and always read "showing the 1 most recent" in the singular case.

**💡 Decisions Behind the Code**

The subtitle wording is driven by a server-supplied flag rather than by comparing the list length to a client-side constant. The client receives an already-truncated list, so a count of 20 is indistinguishable from "20 in the window" and "the 20 most recent of 300" without external information. A "N of M" framing was also considered and rejected: the coverage line above counts commits that carry a memory, while this list counts memory rows, so the two numbers are not directly comparable and presenting them as a fraction would introduce a third inaccuracy.

**✅ What Was Implemented**

- Added `memoryCardsCapped?: boolean` to `StatsModel` in `DashboardModel.ts`, set to `true` (and absent otherwise) when the returned feed length equals the internal cap. The value is emitted in `buildStats` alongside the existing memory card array.
- A `memoryActivitySub` helper in `stats.js` now selects the subtitle text based on the `memoryCardsCapped` flag supplied by the server. When the list is not capped it reads "N memories in this window" (with correct singular/plural); when the server did cap it, it reads "showing the N most recent."

**📁 FILES**
- `cli/src/dashboard/assets/js/stats.js`
- `cli/src/dashboard/DashboardModel.ts`
- `cli/src/dashboard/DashboardQuery.ts`

</blockquote>
</details>
<details>
<summary><strong>13 · Fix unpaired bold tag in singular session count footer</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When exactly one session fell within the selected time window, the Skills card footer rendered an extra closing bold tag with no matching opening tag. Browsers silently swallowed it, so it had gone unnoticed.

**💡 Decisions Behind the Code**

The test asserts tag balance rather than exact prose, making it resilient to future wording changes while still catching the structural defect. Asserting the raw count of opening versus closing tags is a lightweight way to catch this class of HTML structure bug without requiring a full DOM parser in the test environment.

**✅ What Was Implemented**

Removed the stray closing bold tag from the singular branch of the session-count footer in `stats.js`. Added a test in `FeedCardAsset.test.ts` that counts opening and closing bold tags in the footer and asserts they balance, covering the singular case that previously had no test coverage.

**📁 FILES**
- `cli/src/dashboard/assets/js/stats.js`
- `cli/src/dashboard/FeedCardAsset.test.ts`

</blockquote>
</details>
<details>
<summary><strong>14 · New asset-layer tests verify Spend card internal consistency</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Spend card bugs — headline vs. bars disagreement and busiest-day inflation — were not caught by any existing test. Existing tests used a server-computed summary field as a proxy for correctness, which meant they passed even when the rendered card was self-contradictory.

**💡 Decisions Behind the Code**

- **Positive assertion on busiest-day footer over negative assertion**: An earlier draft asserted that the footer must not name a day worth more than the headline. That test passed trivially when the footer rendered nothing at all — a silent failure. The final test asserts positively that the footer is present and names a specific date and amount, so a missing footer is a test failure rather than a pass.
- **Mutation-check each new test before committing**: Each behavioral property was verified by temporarily introducing the regression it guards against and confirming the test turned red. This step is what caught the weak busiest-day assertion, confirming that mutation-checking is necessary rather than optional for this class of rendering test.

**✅ What Was Implemented**

- Added a new test block in `FeedCardAsset.test.ts` with five focused tests for the Spend card: headline matches drawn bars not raw cost sum; legend per-key totals add up to the headline; busiest-day footer names a day that exists in the drawn series; clock-source label reflects the effective dimension; no stray undefined or NaN values in rendered output. A separate test verifies the Memory Activity subtitle wording.
- Each test was mutation-checked by temporarily introducing the regression it claims to catch and confirming the test turned red. This step caught a weak busiest-day assertion (a negative check that passed trivially when the footer rendered nothing at all) before it shipped; the final test asserts positively that the footer is present and names a specific date and amount.

**📁 FILES**
- `cli/src/dashboard/FeedCardAsset.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 14, 2026 at 3:48 PM · via Anthropic*
<!-- jollimemory-summary-end -->