### PR TITLE
Keep an expanded Skills / MCPs list across the dashboard's 30 s poll

### DIFF
--- a/cli/src/dashboard/DashboardModel.ts
+++ b/cli/src/dashboard/DashboardModel.ts
@@ -1286,8 +1286,11 @@ export interface McpServerRow {
  * number of rows visible without scrolling.
  *
  * The client has a copy of this number (`TOOL_PAGE_SIZE` in `assets/js/stats.js`)
- * for the scroll cap alone; the paging itself is driven by the server's
- * `*Total` counts below, never by the client re-deriving the page size.
+ * and it must stay equal to this one. The paging itself is still driven by the
+ * `*Total` counts below rather than by the client re-deriving the page size — but
+ * the copy is no longer cosmetic: past its scroll cap, the 30 s poll's
+ * carry-forward slices a list it decided to COLLAPSE back to that width, claiming
+ * it is what a freshly opened card shows. A freshly opened card shows this many.
  */
 export const TOOL_ROWS_LIMIT = 8;
 
@@ -1463,9 +1466,17 @@ export interface ToolUsage {
 	 * deriving this client-side would under-report every agent whose skills all
 	 * rank outside the loaded pages, and would have to re-sum session counts (see
 	 * {@link ToolUsageAgentShare}).
+	 *
+	 * NO READER TODAY. It fed the Skills card's `by agent · 12 claude` header line,
+	 * which was removed for restating at card level what every row already names
+	 * through its own `agents` — so the whole-window per-agent split with volume is
+	 * currently computed and shipped and stated nowhere. Kept because that makes
+	 * restoring the line a render change and nothing else (see the note where
+	 * `agentLine` was, in `assets/js/stats.js`); recorded here because a payload
+	 * field with no reader is otherwise a contract that drifts unnoticed.
 	 */
 	readonly skillAgents: ReadonlyArray<ToolUsageAgentTotal>;
-	/** Agents that called an MCP tool in the window, most calls first — same rule as {@link skillAgents}. */
+	/** Agents that called an MCP tool in the window, most calls first — same rule as {@link skillAgents}, and unread for the same reason. */
 	readonly mcpAgents: ReadonlyArray<ToolUsageAgentTotal>;
 	/** Sessions with at least one recorded tool call. */
 	readonly sessionsWithTools: number;

--- a/cli/src/dashboard/DashboardQuery.test.ts
+++ b/cli/src/dashboard/DashboardQuery.test.ts
@@ -1503,6 +1503,39 @@ describe("buildDashboardModel — tool usage", () => {
 		expect(page.rows).toHaveLength(1);
 	});
 
+	it("floors a fractional or negative limit onto a whole page of at least one row", async () => {
+		await applySummaryEvents(manySkillEvents(), { producerKind: "cli", dbPath });
+		const width = async (limit: number) =>
+			(
+				await withDashboardDb(
+					(db) =>
+						buildToolUsagePage(db, {
+							scope: { kind: "all" },
+							list: "skill",
+							offset: 0,
+							limit,
+							timeZone: "UTC",
+							nowMs,
+						}),
+					{ dbPath },
+				)
+			).rows.length;
+		// Same rule as `offset` one test up, and for the same reason: a width is a row
+		// count, so a bad one has a nearest sane answer. The route already truncates
+		// and clamps every HTTP-borne limit, so this is about the OTHER caller of an
+		// exported function — nothing today, which is exactly when the guard is free.
+		expect(await width(2.7)).toBe(2);
+		expect(await width(-5)).toBe(1);
+		// The two values a falsy `|| TOOL_ROWS_LIMIT` cannot tell from NaN, and so the
+		// two this test has to name: both floor below one row, and one row is the answer
+		// the route already gives them. Getting the default 8 here instead is the shape
+		// of the bug, because 8 is a plausible page rather than a visible mistake.
+		expect(await width(0)).toBe(1);
+		expect(await width(0.5)).toBe(1);
+		// Absent — and only absent — means one page, the size a Show more click asks for.
+		expect(await width(Number.NaN)).toBe(TOOL_ROWS_LIMIT);
+	});
+
 	it("honours the page's repo scope and window, so an appended page matches the card", async () => {
 		await applySummaryEvents(
 			[

--- a/cli/src/dashboard/DashboardQuery.ts
+++ b/cli/src/dashboard/DashboardQuery.ts
@@ -1794,7 +1794,15 @@ export interface ToolUsagePageOptions {
 	readonly list: ToolUsageList;
 	/** Row index to start at. Negative or fractional input is floored to a valid one. */
 	readonly offset: number;
-	/** Rows per page. Defaults to {@link TOOL_ROWS_LIMIT}, the size the first page rode in at. */
+	/**
+	 * Rows per page. Defaults to {@link TOOL_ROWS_LIMIT}, the size the first page
+	 * rode in at — which is also what a "Show more" click asks for.
+	 *
+	 * A bigger one is the poll path: re-reading a list the reader has already
+	 * expanded takes as many rows as are on screen, so it can be compared against
+	 * them. That number comes from the client, so the route caps it before this
+	 * ever sees it (`TOOL_USAGE_MAX_LIMIT` in DashboardServer).
+	 */
 	readonly limit?: number;
 	readonly range?: DashboardRange;
 	readonly customFrom?: string;
@@ -1825,11 +1833,29 @@ export function buildToolUsagePage(db: DashboardDbHandle, opts: ToolUsagePageOpt
 	const timeZone = opts.timeZone ?? machineTimeZone();
 	const window = resolveWindow(opts.range, opts.customFrom, opts.customTo, opts.nowMs ?? Date.now(), timeZone);
 	const where = toolUsageWhere(db, opts.scope, window);
-	// Floored, not rejected: an offset is a position in a list, and a bad one has
-	// a nearest sane answer (the first page). The LIMIT is ours, never the
-	// caller's — see DashboardServer's route.
+	// Floored, not rejected — for both, and for the same reason: an offset is a
+	// position in a list and a width is a row count, so a bad one has a nearest sane
+	// answer rather than an error. The floor is all this does to the limit; its
+	// MAGNITUDE is bounded one layer out, where the route clamps a caller-supplied
+	// one to TOOL_USAGE_MAX_LIMIT, so nothing here has to defend the SQL against an
+	// unbounded read. Kept symmetric with `offset` anyway because this is the only
+	// exported entry point: a second caller would otherwise be the first thing
+	// standing between a fractional or negative width and the SQL.
 	const offset = Math.max(0, Math.trunc(opts.offset) || 0);
-	const limit = opts.limit ?? TOOL_ROWS_LIMIT;
+	// `Number.isFinite` rather than `|| TOOL_ROWS_LIMIT`, which cannot tell NaN from
+	// a zero: the falsy test sent `0` and `0.5` to the DEFAULT page of 8, so the one
+	// caller this guard exists for would have received 8 rows where both this comment
+	// and the route's own clamp say 1. Absent still means one page; a number that
+	// floors below one row means one row.
+	//
+	// `Infinity` lands on the default page too, and that is the honest answer rather
+	// than an oversight: clamping needs a width to clamp TO, and this layer
+	// deliberately has no upper bound (the route holds it, see TOOL_USAGE_MAX_LIMIT).
+	// So an unbounded request has no nearest sane width the way a fractional one has
+	// a nearest sane row count, and one page is the only answer left that is not a
+	// whole-table read.
+	const requestedLimit = Math.trunc(opts.limit ?? TOOL_ROWS_LIMIT);
+	const limit = Number.isFinite(requestedLimit) ? Math.max(1, requestedLimit) : TOOL_ROWS_LIMIT;
 	const { totalCount } = toolListTotals(db, where, opts.list);
 	if (opts.list === "server") {
 		return { list: "server", offset, rows: serverRowsPage(db, where, offset, limit), totalCount };

--- a/cli/src/dashboard/DashboardServer.test.ts
+++ b/cli/src/dashboard/DashboardServer.test.ts
@@ -48,7 +48,7 @@ import { initTelemetry, shutdownTelemetry } from "../core/Telemetry.js";
 import { readTelemetryEvents } from "../core/TelemetryBuffer.js";
 import * as installer from "../install/Installer.js";
 import { withDashboardDb } from "./DashboardDb.js";
-import type { DashboardModel, DashboardScope, DashboardView } from "./DashboardModel.js";
+import { type DashboardModel, type DashboardScope, type DashboardView, TOOL_ROWS_LIMIT } from "./DashboardModel.js";
 import {
 	assembleDashboardHtml,
 	clearDashboardState,
@@ -1454,6 +1454,70 @@ describe("defaultModelBuilder (no injected buildModel)", () => {
 		expect((await get(port, "/api/tool-usage?list=server&offset=abc")).status).toBe(400);
 		// Absent means the first page, which is the one case a default is right.
 		expect((await get(port, "/api/tool-usage?list=skill")).status).toBe(200);
+	});
+
+	// The poll path's shape: re-reading a list the reader has already expanded takes
+	// as many rows as are on screen, which is a number only the client knows.
+	it("serves a caller-supplied tool-usage limit, clamped, and rejects one it cannot read", async () => {
+		const dbPath = join(dir, "tool-usage-limit.db");
+		const configDir = join(dir, "config-tool-limit");
+		await applyStatsEvents(
+			[
+				{
+					producerKind: "cli",
+					event: {
+						type: "repo.enabled",
+						repoIdentity: "repo-1",
+						repoName: "jolli",
+						worktreeRoot: "/w/jolli",
+						enabledAt: "t",
+					},
+				},
+				{
+					producerKind: "cli",
+					event: {
+						type: "session.upserted",
+						repoIdentity: "repo-1",
+						source: "claude",
+						sessionId: "s1",
+						updatedAtMs: Date.now() - 3_600_000,
+						tools: Array.from({ length: 12 }, (_, i) => ({
+							name: `srv${String(i).padStart(2, "0")}.run`,
+							kind: "mcp" as const,
+							server: `srv${String(i).padStart(2, "0")}`,
+							calls: 12 - i,
+						})),
+					},
+				},
+			],
+			{ producerKind: "cli", dbPath },
+		);
+
+		const port = await listen(createDashboardServer({ port: 0, assetsDir, dbPath, configDir }));
+
+		// Absent is still one page — the shape a Show more click asks for.
+		const onePage = await get(port, "/api/tool-usage?list=server");
+		expect(((await onePage.json()) as { rows: unknown[] }).rows).toHaveLength(TOOL_ROWS_LIMIT);
+
+		// A wider one answers the poll's question: all 12 rows in one read, so the
+		// client can compare them against the 12 it is displaying.
+		const wide = await get(port, "/api/tool-usage?list=server&limit=12");
+		expect(((await wide.json()) as { rows: unknown[] }).rows).toHaveLength(12);
+
+		// Clamped, not rejected: past the cap the client receives fewer rows than it
+		// asked for, reads that as "the card changed", and collapses to the first page.
+		// Turning an unbounded read into a 400 instead would break that degradation.
+		const past = await get(port, "/api/tool-usage?list=server&limit=1000000");
+		expect(past.status).toBe(200);
+		expect(((await past.json()) as { rows: unknown[] }).rows).toHaveLength(12);
+
+		// Floored to at least one row rather than answering an empty page.
+		const zero = await get(port, "/api/tool-usage?list=server&limit=0");
+		expect(((await zero.json()) as { rows: unknown[] }).rows).toHaveLength(1);
+
+		// Same rule as `offset`: a value this route cannot read is the caller's bug,
+		// and silently answering a different question is what hides it.
+		expect((await get(port, "/api/tool-usage?list=server&limit=abc")).status).toBe(400);
 	});
 
 	// The Context dialog's fetch. A read like every other GET here — no token —

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -118,6 +118,7 @@ import {
 	type DashboardScope,
 	type DashboardView,
 	type SeriesDimension,
+	TOOL_ROWS_LIMIT,
 	type ToolUsageList,
 } from "./DashboardModel.js";
 import { buildDashboardModel, buildToolUsagePage, type QueryOptions } from "./DashboardQuery.js";
@@ -992,6 +993,29 @@ const VIEW_TOKENS: ReadonlySet<string> = new Set<DashboardView>([
 const TOOL_USAGE_LISTS: ReadonlyArray<ToolUsageList> = ["skill", "server", "tool"];
 
 /**
+ * Widest `?limit=` this route will serve — 25 pages of {@link TOOL_ROWS_LIMIT}.
+ *
+ * The limit used to be ours alone, because the only caller was a "Show more"
+ * click and one click means one page. The 30 s poll needs the other shape: to
+ * decide whether a list the reader has already expanded still looks the same, it
+ * has to re-read exactly as many rows as are on screen, which is a number only
+ * the client knows (see `carryForwardToolLists` in `assets/js/stats.js`).
+ *
+ * Clamped rather than rejected, so a caller asking past the cap still gets a
+ * readable page. On the poll path that degrades in the safe direction: a client
+ * holding more rows than the cap receives fewer than it asked for, reads that as
+ * "the card changed", and collapses back to the first page — the pre-existing
+ * behaviour — rather than trusting rows it could not verify. It takes 25 clicks
+ * on one list to get there.
+ *
+ * A cap at all because this is an unauthenticated-shaped GET on a local server:
+ * without one, `?limit=1e9` turns a card's paging endpoint into an unbounded
+ * whole-table read, and the SQL behind it groups and folds per-agent shares for
+ * every row it returns.
+ */
+const TOOL_USAGE_MAX_LIMIT = TOOL_ROWS_LIMIT * 25;
+
+/**
  * Creates (but does not start) the server. Exported separately from
  * {@link startDashboardServer} so tests can drive it on port 0 with an
  * injected model builder and no real database.
@@ -1309,9 +1333,12 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 		// rendered under would append rows counted from a different set. The client
 		// sends them from the same `JD.query` builder every other fetch uses.
 		//
-		// `limit` is deliberately NOT a parameter. The page size is the height the
-		// card is laid out for, so it is ours to pick; accepting one would let a
-		// browser-reachable route ask for an unbounded scan.
+		// `limit` IS a parameter, and used to deliberately not be — the page size was
+		// the height the card is laid out for, so it was ours to pick. The 30 s poll
+		// added the other caller: re-reading an already-expanded list to compare it
+		// against what is on screen needs a width only the client knows. The reason
+		// it was refused survives as the CLAMP rather than as the absence of the
+		// parameter — see TOOL_USAGE_MAX_LIMIT for why clamped and not rejected.
 		if (url.pathname === "/api/tool-usage") {
 			const requested = url.searchParams.get("list") ?? "";
 			const list = TOOL_USAGE_LISTS.find((known) => known === requested);
@@ -1330,6 +1357,21 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 				sendJson(res, 400, { error: "offset must be a number" });
 				return;
 			}
+			// Absent means "one page", the shape a Show more click asks for. A
+			// non-numeric one is a 400 for the same reason `offset` is: the caller
+			// asked a question this route cannot answer, and silently answering a
+			// different one is what makes a client-side bug invisible. In range it is
+			// clamped, never rejected — see TOOL_USAGE_MAX_LIMIT.
+			const rawLimit = url.searchParams.get("limit");
+			let limit: number | undefined;
+			if (rawLimit !== null) {
+				const parsed = Number(rawLimit);
+				if (!Number.isFinite(parsed)) {
+					sendJson(res, 400, { error: "limit must be a number" });
+					return;
+				}
+				limit = Math.min(Math.max(1, Math.trunc(parsed)), TOOL_USAGE_MAX_LIMIT);
+			}
 			// Spelled out rather than spread from `parseWindow`: that helper also
 			// carries the series axis and the Memories view's `hash`/`detailRepo`,
 			// none of which this route has any business receiving.
@@ -1341,6 +1383,7 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 							scope: parseScope(url),
 							list,
 							offset,
+							...(limit !== undefined ? { limit } : {}),
 							...(requestedWindow.range ? { range: requestedWindow.range } : {}),
 							...(requestedWindow.customFrom ? { customFrom: requestedWindow.customFrom } : {}),
 							...(requestedWindow.customTo ? { customTo: requestedWindow.customTo } : {}),

--- a/cli/src/dashboard/FeedCardAsset.test.ts
+++ b/cli/src/dashboard/FeedCardAsset.test.ts
@@ -49,6 +49,13 @@ function loadJD(): { JD: JDNamespace; app: FakeElement } {
 			return elements.get(id);
 		},
 		querySelectorAll: () => [],
+		// Answered because `renderStats` snapshots and restores each ranked list's
+		// scroll offset by looking its <ul> up on the DOCUMENT (see
+		// `snapshotToolScroll` in stats.js), and unlike `revealToolRows` it does so
+		// unconditionally — there is no paging state to short-circuit on. `null` is
+		// the honest answer: this harness renders to a string and has no lists to
+		// scroll, so every offset is absent and every restore a no-op.
+		querySelector: () => null,
 		addEventListener: () => undefined,
 		createElement: element,
 		body: element(),

--- a/cli/src/dashboard/ToolUsagePagingAsset.test.ts
+++ b/cli/src/dashboard/ToolUsagePagingAsset.test.ts
@@ -55,6 +55,16 @@ interface Harness {
 	readonly fetched: string[];
 	/** Replaces the browser's current model, as `JD.refreshNow` does after a poll. */
 	setCurrentModel: (model: unknown) => void;
+	/**
+	 * Drives the REAL `JD.refreshNow` with `fresh` as the polled payload, so the
+	 * carry-forward seam is exercised through shell.js's own ordering rather than
+	 * through a copy of it in this file. `fetch` is injected into the asset scripts'
+	 * scope, which is what makes that possible without touching a global.
+	 */
+	poll: (fresh: unknown) => Promise<void>;
+	/** The model the page is currently rendered from — the poll replaces it. */
+	// biome-ignore lint/suspicious/noExplicitAny: as JD above.
+	current: () => any;
 }
 
 /**
@@ -85,17 +95,31 @@ function loadHarness(rowCounts: Record<string, number> = {}): Harness {
 	}
 	let buttons = new Map<string, FakeButton>();
 
-	const element = () => ({
-		innerHTML: "",
-		style: {} as Record<string, string>,
-		querySelectorAll: () => [] as ReadonlyArray<never>,
-		querySelector: () => null,
-		addEventListener: () => undefined,
-	});
+	const element = (id?: string) => {
+		let html = "";
+		return {
+			get innerHTML() {
+				return html;
+			},
+			set innerHTML(next: string) {
+				html = next;
+				// In the browser, rewriting #app destroys every ranked <ul>, and each
+				// replacement starts at row 1. These stubs are reused across renders, so
+				// that has to be modelled at the ASSIGNMENT — the renderer snapshots the
+				// offsets just before it, and resetting any earlier would make the
+				// snapshot read zeroes and hide a broken restore.
+				if (id === "app") for (const stub of lists.values()) stub.scrollTop = 0;
+			},
+			style: {} as Record<string, string>,
+			querySelectorAll: () => [] as ReadonlyArray<never>,
+			querySelector: () => null,
+			addEventListener: () => undefined,
+		};
+	};
 	const elements = new Map<string, ReturnType<typeof element>>();
 	const doc = {
 		getElementById: (id: string) => {
-			if (!elements.has(id)) elements.set(id, element());
+			if (!elements.has(id)) elements.set(id, element(id));
 			return elements.get(id);
 		},
 		// Only the two selectors this test is about are answered; every other
@@ -127,9 +151,14 @@ function loadHarness(rowCounts: Record<string, number> = {}): Harness {
 		string,
 		unknown
 	>;
+	/** The payload the next `JD.refreshNow` will receive from `/api/model`. */
+	let polled: unknown = null;
+	const fakeFetch = () => Promise.resolve({ ok: true, json: () => Promise.resolve(polled) });
 	for (const file of ["format.js", "shell.js", "charts.js", "stats.js"]) {
 		const src = readFileSync(new URL(`./assets/js/${file}`, import.meta.url), "utf8");
-		new Function("window", "document", src)(win, doc);
+		// `fetch` is a free variable in shell.js, so passing it here shadows the real
+		// global for these modules alone — no process-wide stub to undo.
+		new Function("window", "document", "fetch", src)(win, doc, fakeFetch);
 	}
 	// biome-ignore lint/suspicious/noExplicitAny: see the Harness comment.
 	const JD = win.JD as any;
@@ -141,8 +170,10 @@ function loadHarness(rowCounts: Record<string, number> = {}): Harness {
 		// `main.js` seeds this once at boot. Local re-renders keep the same object;
 		// only refreshNow replaces it, which the paging code detects by identity.
 		if (!("__JOLLI_DASHBOARD__" in win)) win.__JOLLI_DASHBOARD__ = model;
-		const app = doc.getElementById("app");
-		if (app) app.innerHTML = "";
+		// Deliberately NOT clearing #app first: `renderStats` assigns it on every
+		// path, and that assignment is what resets the list stubs' scroll (see the
+		// innerHTML setter). Clearing here would fire the reset BEFORE the renderer
+		// reads the offsets it is meant to restore.
 		JD.renderStats(model);
 		// `renderPage` is main.js's job in the browser; here it is the real
 		// re-render, which is what every paging handler ends in.
@@ -163,6 +194,12 @@ function loadHarness(rowCounts: Record<string, number> = {}): Harness {
 		setCurrentModel: (model: unknown) => {
 			win.__JOLLI_DASHBOARD__ = model;
 		},
+		poll: async (fresh: unknown) => {
+			polled = fresh;
+			JD.refreshNow(render);
+			await settle();
+		},
+		current: () => win.__JOLLI_DASHBOARD__,
 	};
 }
 
@@ -239,6 +276,78 @@ function model(toolUsageOver: Record<string, unknown> = {}): unknown {
 
 /** One microtask hop past the stubbed fetch, plus the render it ends in. */
 const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("ranked rows — the per-agent tag", () => {
+	const FIVE_AGENTS = ["claude", "codex", "cursor-agent", "opencode", "kimi"].map((source) => ({ source, calls: 5 }));
+
+	it("folds past two agents into a +N, with the full list behind a tooltip", () => {
+		const h = loadHarness();
+		h.render(
+			model({
+				servers: [{ ...serverRow(0), agents: FIVE_AGENTS }],
+				serversTotal: 1,
+				serverCallsTotal: 20,
+			}),
+		);
+		// `.rl-kind` is `flex: none` — it never shrinks and never ellipsises, so an
+		// unbounded name list does not truncate, it PUSHES. Measured in a real browser
+		// at 1200px with eight agents: the slot wanted 402px of a 261px row, which left
+		// the tool name -203px, i.e. rendered at 0 wide with no ellipsis to show for it,
+		// and armed a horizontal scrollbar on the list and the page. Folded: 131px.
+		expect(h.html()).toContain("1 tool · claude · codex +3");
+		// `+3` is only honest if the three are reachable.
+		expect(h.html()).toContain('title="1 tool · claude · codex · cursor-agent · opencode · kimi"');
+	});
+
+	it("leaves two or fewer agents whole, and gives them no tooltip", () => {
+		const h = loadHarness();
+		h.render(
+			model({
+				servers: [
+					{
+						...serverRow(0),
+						agents: [
+							{ source: "claude", calls: 5 },
+							{ source: "codex", calls: 3 },
+						],
+					},
+				],
+				serversTotal: 1,
+				serverCallsTotal: 8,
+			}),
+		);
+		// No `title` at all: a tooltip repeating the text under the pointer is noise,
+		// and it would claim there is more to see when there is not.
+		expect(h.html()).toContain('<span class="rl-kind">1 tool · claude · codex</span>');
+		expect(h.html()).not.toContain("+0");
+	});
+
+	it("emits no meta slot at all for a row with nothing to put in it", () => {
+		const h = loadHarness();
+		// `agents: []` is the shape `DashboardQuery`'s defensive `?? []` can hand a
+		// Skills row, and Skills is the one list whose meta slot is the agent tag
+		// ALONE — the MCP lists always spend it on a tool/session count first.
+		h.render(model({ skills: [{ ...skillRow(0), agents: [] }], skillsTotal: 1, skillCallsTotal: 20 }));
+		// An empty `.rl-kind` is not free: it is still a flex item, so it spends one of
+		// `.rl-top`'s 8px gaps and takes those pixels off the name, which is the only
+		// thing in the row that truncates. `withAgents` returns its object
+		// unconditionally, so the emptiness has to be tested on `.text`.
+		//
+		// Asserted as name-then-value with nothing between, rather than as "no
+		// `rl-kind` anywhere": `html()` is the whole page, and the MCPs card below
+		// carries a populated slot on every one of its rows.
+		expect(h.html()).toContain('title="/skill00">/skill00</span><span class="rl-val num">20 runs</span>');
+	});
+
+	it("folds a Skills row too, where the tag is the whole meta slot", () => {
+		const h = loadHarness();
+		h.render(model({ skills: [{ ...skillRow(0), agents: FIVE_AGENTS }], skillsTotal: 1, skillCallsTotal: 20 }));
+		// Skills rows carry no tool/session count, so there is no leading `N tools ·`
+		// for the names to hang off — the join has to hold with an empty meta.
+		expect(h.html()).toContain('<span class="rl-kind" title="claude · codex · cursor-agent · opencode · kimi">');
+		expect(h.html()).toContain("claude · codex +3</span>");
+	});
+});
 
 describe("tool-usage lists — header totals", () => {
 	it("prints the window's totals, not a sum of the page on screen", () => {
@@ -493,9 +602,333 @@ describe("tool-usage lists — the scroll cap", () => {
 		expect(h.list("skill").scrollTop).toBe(TOOL_ROWS_LIMIT * ROW_PITCH);
 
 		// And not again on the next repaint — a sticky reveal would yank the reader
-		// back to that row on every 30 s model poll.
+		// back to that row on every 30 s model poll. The repaint replaces the <ul>, so
+		// what puts the list back at 120 is `restoreToolScroll`, whose whole job is "do
+		// not move". A second reveal would land on TOOL_ROWS_LIMIT * ROW_PITCH instead,
+		// which is a different number precisely so the two cannot be confused: 0 is not
+		// available as the assertion here, because every repaint now restores.
 		h.list("skill").scrollTop = 120;
 		h.render(model({ skills: Array.from({ length: TOOL_ROWS_LIMIT + 1 }, (_, i) => skillRow(i)) }));
 		expect(h.list("skill").scrollTop).toBe(120);
+	});
+});
+
+/** Skills in the window — the model's own `skillsTotal`, so a poll can reuse it. */
+const SKILLS_TOTAL = TOOL_ROWS_LIMIT + 4;
+/** Rows on screen after the one Show more click these tests make. */
+const GROWN = TOOL_ROWS_LIMIT + 2;
+
+/**
+ * One Show more click on the Skills list, leaving it displaying {@link GROWN} of
+ * {@link SKILLS_TOTAL}. Returns the rows a verification read hands back for
+ * "nothing changed" — the first page plus what the click appended.
+ */
+async function expandSkills(h: Harness): Promise<Array<Record<string, unknown>>> {
+	const appended = [skillRow(TOOL_ROWS_LIMIT), skillRow(TOOL_ROWS_LIMIT + 1)];
+	h.JD.getJson = (path: string) => {
+		h.fetched.push(path);
+		return Promise.resolve({ list: "skill", offset: TOOL_ROWS_LIMIT, rows: appended, totalCount: SKILLS_TOTAL });
+	};
+	const buttons = h.render(model());
+	buttons.get("skill")?.onclick?.();
+	await settle();
+	return [...Array.from({ length: TOOL_ROWS_LIMIT }, (_, i) => skillRow(i)), ...appended];
+}
+
+/** Answers the poll's verification read, and records the URL it asked for. */
+function verifyWith(h: Harness, answer: unknown): void {
+	h.JD.getJson = (path: string) => {
+		h.fetched.push(path);
+		return Promise.resolve(answer);
+	};
+}
+
+describe("tool-usage lists — carrying an expansion across the 30 s poll", () => {
+	it("keeps the rows, re-reading the list at the width on screen", async () => {
+		const h = loadHarness({ skill: GROWN });
+		const onScreen = await expandSkills(h);
+		expect(h.html()).toContain(`Showing ${GROWN} of ${SKILLS_TOTAL} skills`);
+
+		h.fetched.length = 0;
+		verifyWith(h, { list: "skill", offset: 0, rows: onScreen, totalCount: SKILLS_TOTAL });
+		await h.poll(model());
+
+		// From the top, as wide as the list is displayed. The width is the rows on
+		// screen and never a click count: a page that came back holding a row already
+		// loaded is deduped, and from then on a counter asks for more rows than are
+		// displayed, which reads as "changed" forever.
+		expect(h.fetched).toEqual([`/api/tool-usage?range=month&dimension=model&list=skill&offset=0&limit=${GROWN}`]);
+		// Nothing moved, so the poll left the card exactly as the reader had it. Before
+		// this, `/api/model`'s first page silently replaced it every 30 s.
+		expect(h.html()).toContain(`Showing ${GROWN} of ${SKILLS_TOTAL} skills`);
+		expect(h.html()).toContain("skill09");
+	});
+
+	it("collapses to the first page when a re-read row disagrees with the one on screen", async () => {
+		const h = loadHarness({ skill: GROWN });
+		const onScreen = await expandSkills(h);
+		// One row busier than the copy on screen: its run count and every bar width
+		// beside it move, so the card is out of date.
+		const changed = onScreen.map((row, i) => (i === 0 ? { ...row, calls: 999 } : row));
+		verifyWith(h, { list: "skill", offset: 0, rows: changed, totalCount: SKILLS_TOTAL });
+		await h.poll(model());
+
+		expect(h.html()).toContain(`Showing ${TOOL_ROWS_LIMIT} of ${SKILLS_TOTAL} skills`);
+		expect(h.html()).toContain("999 runs");
+		// Back to eight rows: a reader watching row 10 has no way to tell a re-fetched
+		// page from the one they were already reading, whereas a card that visibly
+		// returns to its first page says "this changed, start again".
+		expect(h.html()).not.toContain("skill09");
+	});
+
+	it("collapses without a re-read when anything else on the card moved", async () => {
+		const h = loadHarness({ skill: GROWN });
+		await expandSkills(h);
+		h.fetched.length = 0;
+		verifyWith(h, { list: "skill", offset: 0, rows: [], totalCount: 0 });
+		// One more skill run landed in the window. The card repaints whatever the rows
+		// turn out to be, so confirming them would only delay it.
+		await h.poll(model({ skillCallsTotal: 201 }));
+
+		expect(h.fetched).toEqual([]);
+		expect(h.html()).toContain(`201 runs · ${SKILLS_TOTAL} skills`);
+		expect(h.html()).toContain(`Showing ${TOOL_ROWS_LIMIT} of ${SKILLS_TOTAL} skills`);
+	});
+
+	it("asks nothing about a list still on its first page", async () => {
+		const h = loadHarness();
+		h.render(model());
+		h.fetched.length = 0;
+		await h.poll(model());
+		// The polled payload already carries the whole first page of all three lists,
+		// so there is nothing to keep and nothing to ask about.
+		expect(h.fetched).toEqual([]);
+	});
+
+	it("leaves the other cards' rows and scroll alone when one card pages", async () => {
+		const SERVERS_TOTAL = TOOL_ROWS_LIMIT + 7;
+		const h = loadHarness({ skill: GROWN, server: GROWN });
+		const moreServers = [serverRow(TOOL_ROWS_LIMIT), serverRow(TOOL_ROWS_LIMIT + 1)];
+		h.JD.getJson = (path: string) => {
+			h.fetched.push(path);
+			return Promise.resolve(
+				path.includes("list=server")
+					? { list: "server", offset: TOOL_ROWS_LIMIT, rows: moreServers, totalCount: SERVERS_TOTAL }
+					: {
+							list: "skill",
+							offset: TOOL_ROWS_LIMIT,
+							rows: [skillRow(8), skillRow(9)],
+							totalCount: SKILLS_TOTAL,
+						},
+			);
+		};
+		h.render(model()).get("server")?.onclick?.();
+		await settle();
+		// The reader is part-way down the MCPs list and then pages the SKILLS card.
+		h.list("server").scrollTop = 300;
+		h.fetched.length = 0;
+		h.render(h.current()).get("skill")?.onclick?.();
+		await settle();
+
+		// One request, for the clicked list only. The three lists are independent in
+		// the payload, so paging one must not re-read — or reset — another.
+		expect(h.fetched).toEqual([`/api/tool-usage?range=month&dimension=model&list=skill&offset=${TOOL_ROWS_LIMIT}`]);
+		expect(h.html()).toContain(`Showing ${GROWN} of ${SKILLS_TOTAL} skills`);
+		expect(h.html()).toContain(`Showing ${GROWN} of ${SERVERS_TOTAL} servers`);
+		// And the untouched card does not move. A Show more ends in a whole-page
+		// repaint, so before the offsets were snapshotted this reset the reader's
+		// position in the other two cards — and because the cap shows exactly one page
+		// of rows, row 1 at the top made an expanded list look collapsed.
+		expect(h.list("server").scrollTop).toBe(300);
+	});
+
+	it("puts a carried list back where the reader had scrolled it", async () => {
+		const h = loadHarness({ skill: GROWN });
+		const onScreen = await expandSkills(h);
+		h.list("skill").scrollTop = 260;
+		verifyWith(h, { list: "skill", offset: 0, rows: onScreen, totalCount: SKILLS_TOTAL });
+		await h.poll(model());
+		// Without this the card is unchanged and still interrupts the reader: the
+		// repaint replaces the <ul>, so a list scrolled to row 10 restarts at row 1.
+		expect(h.list("skill").scrollTop).toBe(260);
+	});
+
+	it("keeps a sibling list's scroll when another list collapses", async () => {
+		const h = loadHarness({ skill: GROWN, server: GROWN });
+		const moreSkills = [skillRow(TOOL_ROWS_LIMIT), skillRow(TOOL_ROWS_LIMIT + 1)];
+		const moreServers = [serverRow(TOOL_ROWS_LIMIT), serverRow(TOOL_ROWS_LIMIT + 1)];
+		const SERVERS_TOTAL = TOOL_ROWS_LIMIT + 7;
+		// Both cards grown, so the poll has one list to collapse and one to keep.
+		h.JD.getJson = (path: string) =>
+			Promise.resolve(
+				path.includes("list=skill")
+					? { list: "skill", offset: TOOL_ROWS_LIMIT, rows: moreSkills, totalCount: SKILLS_TOTAL }
+					: { list: "server", offset: TOOL_ROWS_LIMIT, rows: moreServers, totalCount: SERVERS_TOTAL },
+			);
+		h.render(model()).get("skill")?.onclick?.();
+		await settle();
+		h.render(h.current()).get("server")?.onclick?.();
+		await settle();
+
+		const skillsShown = [...Array.from({ length: TOOL_ROWS_LIMIT }, (_, i) => skillRow(i)), ...moreSkills];
+		const serversShown = [...Array.from({ length: TOOL_ROWS_LIMIT }, (_, i) => serverRow(i)), ...moreServers];
+		// The reader is part-way down the MCPs list when the poll fires.
+		h.list("server").scrollTop = 300;
+		h.JD.getJson = (path: string) =>
+			Promise.resolve(
+				path.includes("list=skill")
+					? {
+							list: "skill",
+							offset: 0,
+							rows: skillsShown.map((row, i) => (i === 0 ? { ...row, calls: 999 } : row)),
+							totalCount: SKILLS_TOTAL,
+						}
+					: { list: "server", offset: 0, rows: serversShown, totalCount: SERVERS_TOTAL },
+			);
+		await h.poll(model());
+
+		// Skills moved and collapsed; MCP servers passed and kept the reader's rows.
+		expect(h.html()).toContain(`Showing ${TOOL_ROWS_LIMIT} of ${SKILLS_TOTAL} skills`);
+		expect(h.html()).toContain(`Showing ${GROWN} of ${SERVERS_TOTAL} servers`);
+		// One list collapsing repaints the whole page, which replaces the MCPs <ul> too.
+		// The untouched card keeps the reader's position because every repaint snapshots
+		// and restores each list's offset — otherwise it snaps back to row 1 on a repaint
+		// it had no part in: the same interruption this carry-over exists to prevent, one
+		// repaint later.
+		expect(h.list("server").scrollTop).toBe(300);
+	});
+
+	it("verifies the MCPs split the reader has switched away from", async () => {
+		const h = loadHarness({ tool: GROWN });
+		const appended = [
+			{ ...skillRow(TOOL_ROWS_LIMIT), kind: "mcp" },
+			{ ...skillRow(TOOL_ROWS_LIMIT + 1), kind: "mcp" },
+		];
+		h.JD.mcpSplitView = "tool";
+		h.JD.getJson = () => Promise.resolve({ list: "tool", offset: TOOL_ROWS_LIMIT, rows: appended, totalCount: 42 });
+		const buttons = h.render(model());
+		buttons.get("tool")?.onclick?.();
+		await settle();
+		expect(h.html()).toContain(`Showing ${GROWN} of 42 tools`);
+
+		// The reader switches to By server, so the expanded `tool` list is off screen.
+		h.JD.mcpSplitView = "server";
+		h.render(h.current());
+
+		const onScreen = [
+			...Array.from({ length: TOOL_ROWS_LIMIT }, (_, i) => ({ ...skillRow(i), kind: "mcp" })),
+			...appended,
+		];
+		verifyWith(h, {
+			list: "tool",
+			offset: 0,
+			rows: onScreen.map((row, i) => (i === 0 ? { ...row, calls: 999 } : row)),
+			totalCount: 42,
+		});
+		await h.poll(model());
+
+		// It collapsed even though nothing about it was painted. The comparison forces
+		// the split to the list it is asking about — without that, a change to the list
+		// the reader switched away from is invisible for as long as the tab stays open.
+		h.JD.mcpSplitView = "tool";
+		h.render(h.current());
+		expect(h.html()).toContain(`Showing ${TOOL_ROWS_LIMIT} of 42 tools`);
+	});
+
+	it("keeps the expanded rows when the re-read fails, and says nothing about it", async () => {
+		const h = loadHarness({ skill: GROWN });
+		await expandSkills(h);
+		h.JD.getJson = () => Promise.reject(new Error("offline"));
+		await h.poll(model());
+		// The aggregates beside them were already checked and matched, and the next
+		// poll asks again in 30 s — a card that empties itself over a transient failure
+		// is the worse answer.
+		expect(h.html()).toContain(`Showing ${GROWN} of ${SKILLS_TOTAL} skills`);
+		// Not the Show more failure state: the reader never asked for this read.
+		expect(h.html()).not.toContain("could not load more");
+	});
+
+	it("treats a body carrying no total as unverifiable rather than as a change", async () => {
+		const h = loadHarness({ skill: GROWN });
+		const onScreen = await expandSkills(h);
+		verifyWith(h, { list: "skill", offset: 0, rows: onScreen });
+		await h.poll(model());
+		// An absent total renders "of 0", which would make even a field-for-field
+		// identical list look changed — the same collapse for a reason that is not the
+		// reader's.
+		expect(h.html()).toContain(`Showing ${GROWN} of ${SKILLS_TOTAL} skills`);
+	});
+
+	it("leaves every other view alone", () => {
+		const h = loadHarness({ skill: GROWN });
+		h.render(model());
+		// Every view loads stats.js, so the hook itself is what has to know its scope.
+		expect(h.JD.carryForwardHooks).toHaveLength(1);
+		expect(h.JD.carryForwardHooks[0]({ view: "memories" }, h.current())).toBeNull();
+		expect(h.JD.carryForwardHooks[0]({ view: "stats" }, {})).toBeNull();
+	});
+
+	it("does not collapse a list a Show more click is still growing", async () => {
+		const h = loadHarness({ skill: GROWN });
+		const onScreen = await expandSkills(h);
+		let resolveVerify: ((page: unknown) => void) | undefined;
+		h.JD.getJson = (path: string) =>
+			path.includes("offset=0")
+				? new Promise((resolve) => {
+						resolveVerify = resolve;
+					})
+				: new Promise(() => undefined);
+		await h.poll(model());
+
+		// The reader clicks Show more while the verification read is in flight. That
+		// click's response rewrites these rows from the array it captured a moment ago,
+		// so a collapse now would be silently undone by it.
+		h.render(h.current()).get("skill")?.onclick?.();
+		resolveVerify?.({
+			list: "skill",
+			offset: 0,
+			rows: onScreen.map((row, i) => (i === 0 ? { ...row, calls: 999 } : row)),
+			totalCount: SKILLS_TOTAL,
+		});
+		await settle();
+
+		expect(h.html()).toContain(`Showing ${GROWN} of ${SKILLS_TOTAL} skills`);
+		expect(h.html()).not.toContain("999 runs");
+	});
+
+	it("does not collapse over a read narrower than the list it is comparing", async () => {
+		const h = loadHarness({ skill: GROWN });
+		const onScreen = await expandSkills(h);
+		let resolveVerify: ((page: unknown) => void) | undefined;
+		h.JD.getJson = (path: string) => {
+			if (path.includes("offset=0")) {
+				return new Promise((resolve) => {
+					resolveVerify = resolve;
+				});
+			}
+			return Promise.resolve({
+				list: "skill",
+				offset: GROWN,
+				rows: [skillRow(GROWN), skillRow(GROWN + 1)],
+				totalCount: SKILLS_TOTAL + 2,
+			});
+		};
+		await h.poll(model());
+
+		// This time the click LANDS first, so the list is wider than the read in flight.
+		h.render(h.current()).get("skill")?.onclick?.();
+		await settle();
+		expect(h.html()).toContain(`Showing ${GROWN + 2} of ${SKILLS_TOTAL + 2} skills`);
+
+		resolveVerify?.({
+			list: "skill",
+			offset: 0,
+			rows: onScreen.map((row, i) => (i === 0 ? { ...row, calls: 999 } : row)),
+			totalCount: SKILLS_TOTAL,
+		});
+		await settle();
+		// Comparing a 10-row read against 12 rendered rows can only ever say
+		// "changed", and collapsing would throw away the click that just succeeded.
+		expect(h.html()).toContain(`Showing ${GROWN + 2} of ${SKILLS_TOTAL + 2} skills`);
 	});
 });

--- a/cli/src/dashboard/assets/js/shell.js
+++ b/cli/src/dashboard/assets/js/shell.js
@@ -930,6 +930,31 @@ window.JD = window.JD || {};
 			},
 		);
 
+	/**
+	 * Seam for state a view holds ON the model rather than beside it, so a refresh
+	 * does not silently throw it away.
+	 *
+	 * Pushed to by a page module (Stats, for its expanded Skills / MCPs lists) and
+	 * empty everywhere else. Each hook is called with the incoming payload and the
+	 * outgoing one, BEFORE the swap and the repaint — carrying something forward has
+	 * to happen while both models are in hand and before the reader sees the new one,
+	 * or the card visibly resets and then un-resets. Every page module loads on every
+	 * view, so a hook's own `fresh.view` test is what scopes it.
+	 *
+	 * A hook may return a function, which runs AFTER the fresh model is adopted and
+	 * rendered. That is where asynchronous follow-up belongs: anything checking
+	 * whether the carried-over state is still correct has to run against a model
+	 * that is already `window.__JOLLI_DASHBOARD__`, because that identity is how
+	 * every in-flight response on this page recognises it has been superseded.
+	 *
+	 * A LIST rather than one slot, even though Stats is the only registrant today: a
+	 * second module assigning a single slot would silently displace the first, and
+	 * each hook's `view` guard makes both look correctly inert. Defensive `||` for
+	 * the same reason `window.JD` has one — it removes the load-order dependency
+	 * rather than relying on shell.js being evaluated first.
+	 */
+	JD.carryForwardHooks = JD.carryForwardHooks || [];
+
 	/* One model re-fetch (same params the page was rendered with).
 
 	   Carries the token like JD.getJson does, even though /api/model answers
@@ -956,8 +981,37 @@ window.JD = window.JD || {};
 					window.location.reload();
 					return;
 				}
+				/* Guarded per hook because this runs BEFORE the swap, and the catch below
+				   repaints the CURRENT model: an unguarded throw would leave
+				   `window.__JOLLI_DASHBOARD__` on the outgoing payload and repaint it, so
+				   the page would sit one poll behind for good — every later tick failing
+				   the same way. Carrying state forward is an optimisation over "repaint
+				   from the fresh model", so dropping it is the pre-existing behaviour and
+				   the right thing to degrade to.
+
+				   And REPORTED, or that degradation is indistinguishable from the feature
+				   never having been built: it would fail every 30 s, forever, with the page
+				   looking exactly as it did before any of this existed. This is a
+				   localhost developer dashboard, so the console is where a maintainer with
+				   devtools open will actually see it. */
+				var afterAdopt = [];
+				JD.carryForwardHooks.forEach((hook) => {
+					try {
+						var after = hook(fresh, model);
+						if (after) afterAdopt.push(after);
+					} catch (e) {
+						console.warn("jolli dashboard: a carry-forward hook threw; refreshing without it", e);
+					}
+				});
 				window.__JOLLI_DASHBOARD__ = fresh;
 				render(fresh);
+				afterAdopt.forEach((run) => {
+					try {
+						run();
+					} catch (e) {
+						console.warn("jolli dashboard: a carry-forward follow-up threw", e);
+					}
+				});
 			})
 			.catch(() => {
 				/* Transient — keep the last data, but still REPAINT it. Callers clear

--- a/cli/src/dashboard/assets/js/stats.js
+++ b/cli/src/dashboard/assets/js/stats.js
@@ -482,10 +482,16 @@ window.JD = window.JD || {};
 	}
 
 	/* Page size for every ranked tool list — mirrors TOOL_ROWS_LIMIT in
-	   DashboardModel.ts. Used for the SCROLL CAP only: how many rows exist and
-	   whether another page can be fetched are the server's `*Total` counts, never
-	   this number, so the two going out of step costs a slightly wrong cap height
-	   and nothing else. */
+	   DashboardModel.ts. How many rows exist and whether another page can be fetched
+	   are still the server's `*Total` counts, never this number.
+
+	   It has TWO readers now, and only the first is cosmetic. The scroll cap measures
+	   this many rendered rows, so a drift there costs a slightly wrong cap height and
+	   nothing else. But `verifyToolList` also slices a collapsed list back to it —
+	   the width it claims is "exactly what a freshly opened card shows" — and that
+	   card's rows came from the server at TOOL_ROWS_LIMIT. Drift makes the two
+	   disagree: the collapse says "start again from the first page" while showing a
+	   different first page. Keep them equal. */
 	var TOOL_PAGE_SIZE = 8;
 
 	/* The three pageable ranked lists, and everything that differs between them:
@@ -495,18 +501,22 @@ window.JD = window.JD || {};
 	   otherwise each spell the same four decisions out, and only one of them would
 	   get fixed. */
 	var TOOL_LISTS = {
-		skill: { rows: "skills", total: "skillsTotal", key: (r) => r.name, noun: "skills" },
-		server: { rows: "servers", total: "serversTotal", key: (r) => r.server, noun: "servers" },
-		tool: { rows: "mcpTools", total: "mcpToolsTotal", key: (r) => r.name, noun: "tools" },
+		skill: { rows: "skills", total: "skillsTotal", key: (r) => r.name, noun: "skills", card: "skills" },
+		server: { rows: "servers", total: "serversTotal", key: (r) => r.server, noun: "servers", card: "mcps" },
+		tool: { rows: "mcpTools", total: "mcpToolsTotal", key: (r) => r.name, noun: "tools", card: "mcps" },
 	};
 
-	/* Per-list paging state — in flight, failed, and which row index a click just
-	   grew the list from.
+	/* Per-list paging state — in flight, failed, which row index a click just grew
+	   the list from, and where a carried-over list was scrolled to.
 
 	   Kept ON `toolUsage`, never on JD: the 30 s `/api/model` poll replaces that
-	   object with a fresh FIRST page, and the paging state has to reset with it. A
-	   module-level flag would survive the swap and either strand the new payload
-	   at page 1 or scroll it to a row index the new list does not have. */
+	   object, and every one of those facts is about the payload beside it. A
+	   module-level flag would survive the swap and either strand the new payload at
+	   page 1 or scroll it to a row index the new list does not have.
+
+	   What DOES survive a poll is decided per list, once, by
+	   `carryForwardToolLists` — which writes a deliberately minimal entry rather
+	   than moving this object across. */
 	function toolPaging(usage, list) {
 		usage.paging = usage.paging || {};
 		usage.paging[list] = usage.paging[list] || {};
@@ -582,13 +592,29 @@ window.JD = window.JD || {};
 			// The name truncates with an ellipsis (see .rl-name), so the full text
 			// has to survive somewhere the reader can get at it.
 			var label = labelOf(row);
+			/* `{ text, title }`, not a bare string: the meta slot folds a long agent
+			   list into `+N` and has to carry the full one somewhere reachable.
+
+			   Tested on `.text`, not on the object: `withAgents` returns one
+			   unconditionally, so a row with nothing to put in the slot would otherwise
+			   get an EMPTY `.rl-kind` — and an empty flex item is not free, it spends
+			   one of `.rl-top`'s 8px gaps and takes those pixels off the only thing
+			   that gives (the name, which truncates). A bare string was falsy here and
+			   so emitted no slot at all; this keeps that. */
+			var kind = kindOf ? kindOf(row) : null;
 			html +=
 				'<li><div class="rl-top"><span class="rl-name mono" title="' +
 				JD.esc(label) +
 				'">' +
 				JD.esc(label) +
 				"</span>" +
-				(kindOf ? '<span class="rl-kind">' + JD.esc(kindOf(row)) + "</span>" : "") +
+				(kind && kind.text
+					? '<span class="rl-kind"' +
+						(kind.title ? ' title="' + JD.esc(kind.title) + '"' : "") +
+						">" +
+						JD.esc(kind.text) +
+						"</span>"
+					: "") +
 				'<span class="rl-val num">' +
 				value +
 				" " +
@@ -611,31 +637,73 @@ window.JD = window.JD || {};
 
 	   Counts are deliberately left OFF the per-row tag: the row already prints
 	   its own total beside the name, and a second set of numbers at that size
-	   reads as noise. The split WITH volume lives on the card's header line. */
+	   reads as noise. This is now the ONLY per-agent signal on either card — the
+	   `by agent · 12 claude` header line that carried the same split with volume
+	   was removed, so nothing states a whole-window per-agent total any more. */
+	/**
+	 * How many agent names ride on a row before the rest fold into `+N`.
+	 *
+	 * `.rl-kind` is `flex: none` — it neither shrinks nor truncates, and only
+	 * `.rl-name` gives. So an unbounded list of names does not ellipsis, it pushes:
+	 * measured in a real browser with eight agents on one row, the tool NAME was
+	 * squeezed to 0px wide (gone, with no ellipsis to show for it) and the row still
+	 * overflowed its card, arming a horizontal scrollbar on both the list and the
+	 * page. Two names plus a count is a bounded width that leaves the name room.
+	 *
+	 * Not solved with `min-width: 0` + ellipsis on `.rl-kind` instead: that makes
+	 * the name and the agents compete for the same pixels, so a busy row loses both
+	 * halves at once — every truncating label on this page keeps exactly one thing
+	 * that gives, and here that is the name.
+	 */
+	var ROW_AGENT_LIMIT = 2;
+
 	function agentTag(agents) {
+		if (!agents || agents.length === 0) return "";
+		var names = agents.map((a) => a.source);
+		if (names.length <= ROW_AGENT_LIMIT) return names.join(" · ");
+		return names.slice(0, ROW_AGENT_LIMIT).join(" · ") + " +" + (names.length - ROW_AGENT_LIMIT);
+	}
+
+	/** Every agent on the row, for the `title` the folded tag hides them behind. */
+	function agentTagFull(agents) {
 		if (!agents || agents.length === 0) return "";
 		return agents.map((a) => a.source).join(" · ");
 	}
 
-	/* Append the agent tag to a row's existing meta slot without losing it —
-	   the MCP lists already spend that slot on tool/session counts. */
+	/* Append the agent tag to a row's existing meta slot without losing it — the MCP
+	   lists already spend that slot on tool/session counts.
+
+	   Returns the visible text AND the untruncated one, because `+3` is only honest
+	   if the three are reachable. `title` is left empty when nothing was folded, so
+	   a row with one agent does not carry a tooltip repeating what it already says.
+	   A native `title`, like `.rl-name`'s: same kind of information (the label you
+	   are already looking at, in full) and so the same affordance. */
 	function withAgents(metaOf) {
 		return (row) => {
-			var tag = agentTag(row.agents);
 			var meta = metaOf ? metaOf(row) : "";
-			return meta && tag ? meta + " · " + tag : meta || tag;
+			var join = (tag) => (meta && tag ? meta + " · " + tag : meta || tag);
+			var text = join(agentTag(row.agents));
+			var full = join(agentTagFull(row.agents));
+			return { text: text, title: full === text ? "" : full };
 		};
 	}
 
-	/* The card's per-agent header line: who produced everything below, with
-	   volume. Built from the server's own untruncated grouping (`skillAgents` /
-	   `mcpAgents`), never from the visible rows — those are cut to 8, so summing
-	   them would quietly under-report an agent whose tools all rank lower. */
-	function agentLine(agents) {
-		if (!agents || agents.length === 0) return "";
-		var parts = agents.map((a) => '<b class="num">' + a.calls + "</b> " + JD.esc(a.source));
-		return '<div class="sub" style="margin-top:2px">by agent · ' + parts.join(" · ") + "</div>";
-	}
+	/*
+	 * `agentLine` used to render the per-agent header line on both cards —
+	 * `by agent · 12 claude`, one `<b>calls</b> source` part per agent, from the
+	 * server's own untruncated `skillAgents` / `mcpAgents` grouping rather than
+	 * from the visible rows (those are cut to a page, so summing them
+	 * under-reports an agent whose tools all rank lower).
+	 *
+	 * Removed: it restated at card level what every row beneath it already names
+	 * through `agentTag`, and on a single-agent machine — the common case — it was
+	 * one line saying the same word as every row below it.
+	 *
+	 * `skillAgents` / `mcpAgents` are still in the payload and still computed by
+	 * `agentTotals` in DashboardQuery, so restoring the line is a render change
+	 * only. They now have NO reader on this page; the whole-window per-agent split
+	 * with volume is not stated anywhere.
+	 */
 
 	/* The "…so this list is not everything" caveat, shared by both cards.
 	   `uncoveredSources` is a PARSER capability the server computed, not "these
@@ -703,7 +771,6 @@ window.JD = window.JD || {};
 			(totalRuns === 1 ? " run · " : " runs · ") +
 			totalSkills +
 			(totalSkills === 1 ? " skill</div>" : " skills</div>");
-		html += agentLine(usage.skillAgents);
 
 		html += rankedList(
 			usage.skills,
@@ -828,7 +895,6 @@ window.JD = window.JD || {};
 			(totalServers === 1 ? " server · " : " servers · ") +
 			totalCalls +
 			(totalCalls === 1 ? " call</div>" : " calls</div>");
-		html += agentLine(usage.mcpAgents);
 
 		if (usage.recallCalls) {
 			html +=
@@ -928,6 +994,49 @@ window.JD = window.JD || {};
 	}
 
 	/**
+	 * Where each ranked list is scrolled to, read BEFORE a repaint replaces them.
+	 *
+	 * Every repaint on this page rewrites the whole of `#app`, so a grown list's
+	 * `<ul>` is destroyed and its replacement starts at row 1. That makes an
+	 * expanded list look collapsed rather than scrolled — the cap shows exactly one
+	 * page of rows, so row 1 at the top is indistinguishable from never having
+	 * clicked. And because a repaint is what EVERY control on the page ends in, one
+	 * card's Show more reset the reader's position in the other two: measured on a
+	 * real page, expanding MCPs to 11 rows, scrolling to 120, then clicking Skills'
+	 * Show more left MCPs' rows, cap and footer untouched with `scrollTop` back at 0.
+	 *
+	 * Snapshotting here, in the renderer, rather than at each control: the paging
+	 * state used to carry a per-list `restoreScroll` (since removed) that the 30 s
+	 * poll set on the one list it carried, and extending THAT would mean every
+	 * future caller of `renderPage` remembering to fill it in for the lists it is
+	 * NOT touching — forget one and the position is silently lost again. The poll
+	 * needs no special case now: `carryForwardHooks` run before the swap, so by the
+	 * time the repaint reads these offsets the old rows are still on screen.
+	 */
+	function snapshotToolScroll() {
+		var offsets = {};
+		Object.keys(TOOL_LISTS).forEach((list) => {
+			var el = document.querySelector('[data-toollist="' + list + '"]');
+			if (el && el.scrollTop) offsets[list] = el.scrollTop;
+		});
+		return offsets;
+	}
+
+	/* Puts every list back where the reader had it. Runs after `capToolLists`, which
+	   is what arms the scroll container: assigning `scrollTop` to a list with no
+	   `max-height` yet is silently a no-op — and so is assigning it to a list this
+	   repaint collapsed, which is what makes a collapse still land at row 1.
+
+	   Before `revealToolRows`, so the one list a click just grew wins: its reveal is
+	   a deliberate jump to the new rows, where this is only "do not move". */
+	function restoreToolScroll(offsets) {
+		Object.keys(offsets).forEach((list) => {
+			var el = document.querySelector('[data-toollist="' + list + '"]');
+			if (el) el.scrollTop = offsets[list];
+		});
+	}
+
+	/**
 	 * Fetches ONE more page of a ranked tool list and appends it.
 	 *
 	 * The paging is SQL-side (`/api/tool-usage` → `buildToolUsagePage`), so this
@@ -1005,6 +1114,249 @@ window.JD = window.JD || {};
 				state.error = true;
 				JD.renderPage(model);
 			});
+	}
+
+	/* Which renderer paints each pageable list. Both cards read
+	   `model.stats.toolUsage` and nothing else, which is what lets a comparison
+	   below run them against a stub model. */
+	var TOOL_CARDS = { skills: (usage) => skillsCard({ stats: { toolUsage: usage } }), mcps: mcpCardFor };
+
+	/* The MCPs card renders ONE of its two lists — whichever chip is pressed — so a
+	   comparison about `tool` while the reader is looking at `server` would compare
+	   HTML that does not contain the rows in question, and call every change
+	   invisible forever. The view is forced to the list being asked about and put
+	   straight back; nothing on screen is re-rendered in between. */
+	function mcpCardFor(usage, list) {
+		var previous = JD.mcpSplitView;
+		JD.mcpSplitView = list;
+		try {
+			return mcpCard({ stats: { toolUsage: usage } });
+		} finally {
+			JD.mcpSplitView = previous;
+		}
+	}
+
+	/**
+	 * One card's HTML, as the card that owns `list` would paint it.
+	 *
+	 * Rendering is the comparison: "has this card changed" is answered by the real
+	 * renderer rather than by a hand-kept list of the fields it prints, so a stat
+	 * line added to either card joins the check by existing. A field list would
+	 * have gone stale the first time someone added one, and it would have gone
+	 * stale SILENTLY — the failure is a card that stops noticing it is out of date.
+	 */
+	function toolCardHtml(usage, list) {
+		return TOOL_CARDS[TOOL_LISTS[list].card](usage, list);
+	}
+
+	/**
+	 * A `toolUsage` reduced to what a comparison should see: one payload's
+	 * aggregates, another's rows, and a paging state that is identical on both
+	 * sides.
+	 *
+	 * Normalising the paging is what keeps the check about DATA. `loading` and
+	 * `error` describe one request, not the card's contents, and `grown` is kept
+	 * because it is not decoration either: it is what holds the footer row in place
+	 * once a list has reached its end, and so part of the card's height.
+	 */
+	function comparableUsage(aggregatesFrom, rowsFrom) {
+		var merged = Object.assign({}, aggregatesFrom);
+		var paging = {};
+		Object.keys(TOOL_LISTS).forEach((list) => {
+			merged[TOOL_LISTS[list].rows] = rowsFrom[TOOL_LISTS[list].rows] || [];
+			paging[list] = { grown: !!((rowsFrom.paging || {})[list] || {}).grown };
+		});
+		merged.paging = paging;
+		return merged;
+	}
+
+	/**
+	 * Re-reads ONE expanded list at the width it is displayed at, and collapses it
+	 * back to the first page if anything about its card would now paint differently.
+	 *
+	 * Resolves `true` when it changed something (so the caller repaints once for all
+	 * three lists rather than up to three times).
+	 *
+	 * A failed read keeps the expanded rows and says nothing: the aggregates beside
+	 * them were already checked and matched, the next poll asks again 30 s later, and
+	 * a card that empties itself over a transient fetch failure is a worse answer
+	 * than one that is briefly a poll behind.
+	 */
+	function verifyToolList(model, list, width) {
+		var spec = TOOL_LISTS[list];
+		var usage = model.stats.toolUsage;
+		return JD.getJson(
+			JD.withParams("/api/tool-usage" + JD.query(model, {}), { list: list, offset: "0", limit: String(width) }),
+		)
+			.then((page) => {
+				/* Superseded — a later poll already replaced the model this answer was
+				   about. Same identity test, same reason, as `loadMoreToolRows`. */
+				if (window.__JOLLI_DASHBOARD__ !== model) return false;
+				/* A body that parsed but carries no total cannot be compared: the footer
+				   would read "of 0", so every field-for-field identical list would look
+				   changed. Unverifiable is the failed-read case, not the changed one. */
+				if (!page || typeof page.totalCount !== "number") return false;
+				var state = (usage.paging || {})[list] || {};
+				/* A Show more click overlapped this read, in either order, and both orders
+				   are only resolvable by waiting: its response rewrites these rows from the
+				   array it captured BEFORE the collapse (so collapsing now is undone a
+				   moment later), and if it has already landed, this read is narrower than
+				   what is on screen — which can only ever say "changed" and would throw
+				   away a click that just succeeded. The next poll asks again. */
+				if (state.loading) return false;
+				if ((usage[spec.rows] || []).length !== width) return false;
+				var rows = page.rows || [];
+				var candidate = Object.assign({}, usage);
+				candidate[spec.rows] = rows;
+				candidate[spec.total] = page.totalCount;
+				candidate.paging = usage.paging;
+				/* Wrapped separately from the read below, because the two failures are not
+				   the same answer wearing different clothes. A failed READ is expected and
+				   documented (keep the rows, say nothing); a renderer that THROWS is a bug,
+				   and letting it fall into that same silent `.catch` would spend this
+				   feature's whole lifetime looking like an offline blip. */
+				var cardChanged;
+				try {
+					var before = toolCardHtml(comparableUsage(usage, usage), list);
+					cardChanged = toolCardHtml(comparableUsage(candidate, candidate), list) !== before;
+				} catch (e) {
+					console.warn("jolli dashboard: could not compare the re-read " + list + " list", e);
+					return false;
+				}
+				if (!cardChanged) return false;
+				/* Changed — back to exactly the state a freshly opened card is in: the
+				   first page, no scroll cap, no sticky footer. The rows come from THIS
+				   response rather than from the poll's own first page, so the count in the
+				   footer and the rows above it are answers to the same question at the
+				   same moment.
+
+				   Collapsing is the asked-for behaviour, not a shortcut around
+				   re-expanding: a reader watching row 30 has no way to tell a re-fetched
+				   page 4 from the one they were already reading, whereas a card that
+				   visibly returns to 8 rows says "this changed, start again". */
+				usage[spec.rows] = rows.slice(0, TOOL_PAGE_SIZE);
+				usage[spec.total] = page.totalCount;
+				/* Reset rather than deleted, which is the same thing to `toolPaging` and
+				   one fewer shape for the rest of this module to consider. */
+				if (usage.paging) usage.paging[list] = {};
+				return true;
+			})
+			.catch(() => false);
+	}
+
+	/**
+	 * Keeps the Skills / MCPs lists a reader has expanded across the 30 s poll,
+	 * instead of silently dropping them back to 8 rows.
+	 *
+	 * The poll re-reads `/api/model`, whose tool lists are always the FIRST page —
+	 * so before this, three clicks' worth of rows lasted at most 30 s, and the card
+	 * shrank under whoever was reading it for no reason they could see.
+	 *
+	 * Two checks, in cost order, and a list has to pass both to stay expanded:
+	 *
+	 *   1. Everything on the card OTHER than its rows, compared synchronously. Both
+	 *      sides are handed the outgoing rows, which leaves the aggregates as the
+	 *      only thing that can differ. A change here needs no round trip to act on —
+	 *      the card is repainting whatever the rows say.
+	 *   2. The rows themselves, re-read at the width they are displayed at
+	 *      (`/api/tool-usage?limit=<rows on screen>`) and compared against them.
+	 *      This is the only asynchronous part, and it runs AFTER the fresh model is
+	 *      adopted, because that identity is how its response knows whether it is
+	 *      still relevant.
+	 *
+	 * The width is taken from `rows.length`, never from a click counter. They agree
+	 * until a page comes back holding a row already on screen (which the append
+	 * dedupes, see `loadMoreToolRows`), and from then on a counter asks for more
+	 * rows than are displayed — so every later comparison would be N fresh rows
+	 * against N-1 rendered ones, i.e. "changed" forever.
+	 *
+	 * Nothing is persisted: this is one browser tab's reading position. A reload or
+	 * a range/repo click is a full navigation, which is exactly the point where an
+	 * expansion should not follow the reader.
+	 *
+	 * COST, since only correctness is argued above: an expansion is a standing charge
+	 * for as long as the tab stays open, not a one-off. Every 30 s each expanded list
+	 * costs one `/api/tool-usage` read — up to three concurrent, each up to
+	 * `TOOL_USAGE_MAX_LIMIT` (200) rows, and that SQL folds per-agent shares for every
+	 * row it returns. Unmeasurable against a local database today, which is why the
+	 * cap is the thing holding it down rather than a fetch budget here; a reader who
+	 * clicks Show more is asking for it, and the collapse on any change is what stops
+	 * a stale expansion from being paid for indefinitely.
+	 */
+	function carryForwardToolLists(fresh, previous) {
+		/* Every page loads this module, so the hook has to be what knows it only
+		   applies to Stats. */
+		if (!fresh || fresh.view !== "stats") return null;
+		var freshUsage = fresh.stats && fresh.stats.toolUsage;
+		var prevUsage = previous && previous.stats && previous.stats.toolUsage;
+		if (!freshUsage || !prevUsage) return null;
+		var pending = [];
+		Object.keys(TOOL_LISTS).forEach((list) => {
+			var spec = TOOL_LISTS[list];
+			var prevRows = prevUsage[spec.rows] || [];
+			/* Never expanded: the fresh payload already carries this list's whole first
+			   page, so there is nothing to keep and nothing to ask about. */
+			if (prevRows.length <= TOOL_PAGE_SIZE) return;
+			/* Check 1: the card apart from its rows. Both sides are handed the outgoing
+			   rows, so the aggregates are the only thing left that can differ.
+
+			   Wrapped per list, and BEFORE the first write below, so a renderer that
+			   throws on one card costs that card its expansion and nothing else. The
+			   alternative is a half-carried payload: rows moved across with no entry in
+			   `pending`, so check 2 never runs and the list keeps rows nothing verified
+			   for as long as the tab stays open. Skipping is the pre-existing behaviour;
+			   the seam's own guard in shell.js is what stops a throw from stranding the
+			   whole poll on the outgoing model. */
+			var matches;
+			try {
+				var onScreen = toolCardHtml(comparableUsage(prevUsage, prevUsage), list);
+				matches = toolCardHtml(comparableUsage(freshUsage, prevUsage), list) === onScreen;
+			} catch (e) {
+				/* Reported, not just swallowed: a renderer that throws here degrades to the
+				   pre-existing collapse, which looks exactly like this feature not existing
+				   — so it would fail every 30 s forever with no signal anywhere. */
+				console.warn("jolli dashboard: could not compare the " + list + " card; not carrying it over", e);
+				return;
+			}
+			if (!matches) return;
+			var prevState = (prevUsage.paging || {})[list] || {};
+			freshUsage[spec.rows] = prevRows;
+			freshUsage.paging = freshUsage.paging || {};
+			/* Rebuilt, not moved: `loading` and `error` belong to a request that this
+			   swap has just orphaned (its own identity guard will drop the response), so
+			   carrying `loading` would leave the button disabled with nothing left to
+			   finish it, and carrying `error` would keep reporting a failure whose
+			   subject is gone. `revealFrom` is dropped for the same kind of reason — it
+			   describes one click's scroll, and re-applying it here would yank the reader
+			   to a row boundary on a repaint that changed nothing.
+
+			   No scroll offset either: `snapshotToolScroll` reads it off the live DOM at
+			   the top of every repaint, and this runs before the swap, so the rows the
+			   reader is looking at are still on screen when it does. */
+			freshUsage.paging[list] = { grown: !!prevState.grown };
+			pending.push(list);
+		});
+		if (pending.length === 0) return null;
+		/* Check 2, once the fresh model is the current one — see JD.carryForwardHooks. */
+		return () => {
+			var model = window.__JOLLI_DASHBOARD__;
+			if (model !== fresh) return;
+			var usage = model.stats.toolUsage;
+			var reads = pending.map((list) => verifyToolList(model, list, usage[TOOL_LISTS[list].rows].length));
+			Promise.all(reads).then((changed) => {
+				if (window.__JOLLI_DASHBOARD__ !== model) return;
+				/* One repaint for all three, and only if something actually moved.
+
+				   That repaint replaces every <ul>, including the lists that PASSED and are
+				   still showing the reader's rows — they keep their position because
+				   `renderStats` snapshots and restores every list's offset, not because
+				   anything is re-armed here. A list that DID collapse lands at row 1 out of
+				   the same mechanism: its <ul> is no longer scrollable, so the restore is a
+				   no-op on it. */
+				if (!changed.some(Boolean)) return;
+				JD.renderPage(model);
+			});
+		};
 	}
 
 	/* Tokens (span4) — input/output/cache, day-bucketed. Reuses
@@ -1288,6 +1640,10 @@ window.JD = window.JD || {};
 
 	JD.renderStats = (model) => {
 		var stats = model.stats;
+		/* Read before anything writes to #app — see `snapshotToolScroll`. Taken even
+		   on the no-repos path below, which is cheap and keeps the one rule ("read
+		   first, always") rather than a second thing to remember. */
+		var toolScroll = snapshotToolScroll();
 		if ((model.repos || []).length === 0) {
 			document.getElementById("app").innerHTML = noReposCard();
 			return;
@@ -1378,9 +1734,14 @@ window.JD = window.JD || {};
 		   height and its scrollbar), then the reveal, which needs the cap in place
 		   to have anything to scroll. */
 		capToolLists();
+		restoreToolScroll(toolScroll);
 		revealToolRows(stats.toolUsage);
 		document.querySelectorAll("[data-toolmore]").forEach((button) => {
 			button.onclick = () => loadMoreToolRows(model, button.getAttribute("data-toolmore"));
 		});
 	};
+
+	/* Registered unconditionally — every view loads this module, and the hook's own
+	   `view !== "stats"` guard is what scopes it. See `JD.carryForwardHooks`. */
+	JD.carryForwardHooks.push(carryForwardToolLists);
 })(window.JD);


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Context

- Skills used — 2 skills · 76.1k tokens

## Quick recap

The developer made expanded lists on the statistics dashboard stick. Readers who click "Show more" on the Skills or MCPs cards keep every row they revealed through the dashboard's automatic thirty-second refresh, and the list stays scrolled exactly where they left it. The behaviour also holds for the tools view of the MCPs card while the reader is looking at the servers view, so switching between the two chips never surfaces stale rows. Clicking "Show more" while a background check is running keeps the rows that click just added.

When the underlying numbers actually move, the card behaves differently: it returns to its first eight rows with the up-to-date figures, giving a visible signal that the data has been replaced and is worth reading from the top. Aggregate figures beside the list — total runs, total skill counts — are checked first, and a change to any of them collapses the card immediately. A failed background check leaves the reader's rows in place with no error message, and the next refresh tries again.

The refresh now survives a failure anywhere in that step. The dashboard redraws the fresh numbers, lets only the affected list fall back to its first page, and keeps the rest of the page updating normally on every subsequent refresh. A single failure there would previously have stranded the dashboard on stale figures indefinitely with no visible sign that anything had gone wrong. On the server side, the tool-usage endpoint accepts a requested page width, bounded to twenty-five pages, and answers with a readable page for anything beyond that.

---

## Topics (4)
<details>
<summary><strong>01 · Expanded Skills and MCPs lists now survive the dashboard's periodic refresh</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

On the statistics dashboard, a reader who clicked "Show more" on the Skills or MCPs lists lost their expanded rows every thirty seconds when the page refreshed itself. The card silently shrank back to eight rows for no reason the reader could see.

**💡 Decisions Behind the Code**

- **Collapse rather than silently re-fetch when the data changed**: if the underlying rows moved, the card returns to its first eight rows instead of quietly swapping in fresh deep pages. A reader looking at row thirty cannot tell a refreshed page from the one they were already reading, whereas a card that visibly resets communicates "this changed, start again".
- **Compare by re-rendering the card, not by checking a list of fields**: the change detection paints both the old and candidate versions of the card and compares the result. A hand-maintained list of which numbers matter would go stale the first time someone added a stat line, and it would go stale invisibly — the card would just quietly stop noticing it was out of date.
- **Degrade to the pre-existing behaviour instead of failing loudly**: keeping an expanded list across a refresh is an optimisation over simply redrawing from fresh data, so dropping it on error returns the page to exactly how it behaved before. This avoids the far worse outcome where the dashboard silently sits one refresh behind indefinitely with nothing on screen saying so.
- **Place the per-card guard before any write to the fresh data**: an error partway through the carry-over could otherwise move rows across without registering them for verification, leaving unverified rows on screen for as long as the tab stays open. Guarding earlier makes the only possible failure mode "this one card collapses".
- **Cap the requested page width instead of rejecting it**: an oversized request returns the maximum rather than an error. That degrades in the safe direction — a client that gets fewer rows than it asked for reads that as "the list changed" and falls back to the first page. A hard cap also stops this local, unauthenticated read from being turned into an unbounded whole-table scan.

**✅ What Was Implemented**

- Added a `JD.carryForwardState` seam in `shell.js` that `refreshNow` calls with the incoming and outgoing models before the swap, returning a callback that runs once the fresh model is adopted and rendered. Stats registers `carryForwardToolLists` from `stats.js` unconditionally; the hook itself guards on `view !== "stats"`. The call is wrapped in a try/catch so a throwing page-module hook never prevents `window.__JOLLI_DASHBOARD__` from adopting the fresh payload.
- Implemented the two-stage carry-over in `stats.js`: a synchronous comparison renders each card's HTML through the real renderers (`skillsCard` / `mcpCard`, via `TOOL_CARDS` and `comparableUsage`) with rows held constant so only aggregates can differ, then `verifyToolList` re-reads the list at the on-screen width and collapses to the first page if the re-rendered card differs. `restoreToolScroll` puts a carried list back at its previous scroll offset after `capToolLists` arms the container.
- Added a per-list try/catch inside `verifyToolList` around the two `toolCardHtml` comparison renders, placed before the first mutation of the fresh payload, so a failure costs only that card its expanded state and never leaves rows carried across without a matching `pending` entry.
- Handled overlapping activity so clicking "Show more" while a background check is in flight never discards the rows that click just added, and kept the behaviour working for the MCP card's tools view while the reader is on the servers view.
- Taught the `/api/tool-usage` route in `DashboardServer.ts` to accept a caller-supplied `limit`, clamped to a new `TOOL_USAGE_MAX_LIMIT` (25 pages) and rejected with a 400 only when non-numeric.

**📁 FILES**
- `cli/src/dashboard/assets/js/stats.js`
- `cli/src/dashboard/assets/js/shell.js`
- `cli/src/dashboard/DashboardServer.ts`
- `cli/src/dashboard/DashboardQuery.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Clamp fractional and negative page widths in tool usage list queries</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The list of tool usage rows defended itself against a bad starting position but passed the requested row count straight through to the database, leaving that responsibility to the web address handler alone.

**💡 Decisions Behind the Code**

- **Floor rather than reject, matching the neighbouring position guard**: a row count has a nearest sensible answer, so returning one row beats throwing an error and keeps the two adjacent parameters behaving consistently. This is verifiably identical for every input reachable today because the web route already truncates and bounds the value.
- **Left the empty-parameter quirk alone**: an empty width in the address bar resolves to a single row rather than an error or the default. The existing starting-position parameter behaves the exact same way, and changing only one would break the symmetry the code documents about itself, while no browser path can reach it.

**✅ What Was Implemented**

- `buildToolUsagePage` in `DashboardQuery.ts` now floors the limit with `Math.max(1, Math.trunc(...) || TOOL_ROWS_LIMIT)`, mirroring the existing offset guard; magnitude clamping stays at the route via `TOOL_USAGE_MAX_LIMIT`.
- Added a test in `DashboardQuery.test.ts` covering fractional (2.7 → 2), negative (-5 → 1) and absent (NaN → default page size) widths so the new branch does not drag coverage thresholds down.

**📁 FILES**
- `cli/src/dashboard/DashboardQuery.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Correct stale contract comments that contradicted the new refresh behaviour</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Three explanatory notes in the code described decisions that had since been reversed, including one claiming a request size setting was deliberately refused when the new code accepts it, and two claiming a duplicated page-size value was purely cosmetic.

**💡 Decisions Behind the Code**

This codebase treats comments as the only record of a decision, so a comment that contradicts the code is worse than no comment: a later reader either strips the setting to "restore" an invariant that no longer exists, or trusts a stale cosmetic claim and lets two values drift until a collapsed list shows one page while announcing another. Recording the shipped-but-unread data alongside its own contract keeps a future restore a display-only change.

**✅ What Was Implemented**

- Rewrote the route comment in `DashboardServer.ts` to record that the width parameter is now accepted, that the refresh added the second caller needing it, and that the original security concern survives as the clamp rather than as the parameter's absence.
- Updated both copies of the page-size contract (`TOOL_ROWS_LIMIT` in `DashboardModel.ts` and `TOOL_PAGE_SIZE` in `stats.js`) to state they must stay equal, since the collapse path now slices a list back to that width and claims it matches a freshly opened card.
- Documented in `DashboardModel.ts` that the per-agent skill and MCP breakdown fields currently have no reader, naming the removed header line they fed and why they are kept.

**📁 FILES**
- `cli/src/dashboard/DashboardServer.ts`
- `cli/src/dashboard/DashboardModel.ts`
- `cli/src/dashboard/assets/js/stats.js`

</blockquote>
</details>
<details>
<summary><strong>04 · Removed redundant per-agent summary line from Skills and MCP usage cards</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Skills and MCP usage cards each carried a summary line naming which assistant produced the activity below, but every row underneath already named its own source. On machines with only one assistant configured — the usual case — that line simply repeated the same word as every row beneath it.

**💡 Decisions Behind the Code**

- **Drop the line rather than keep it for multi-agent setups**: The card-level line restated at summary level what each row already named individually, and on a single-assistant machine it was pure duplication. The trade-off accepted is that call volume broken down by assistant across the whole time window is no longer displayed anywhere on the page.
- **Keep the underlying data in the payload**: The grouped per-assistant totals continue to be computed and sent even though nothing on the page reads them now. This leaves a small amount of unused data flowing through, in exchange for making a future reinstatement of the line a display-only change with no server work.

**✅ What Was Implemented**

- Deleted the `agentLine` helper in `cli/src/dashboard/assets/js/stats.js` and both of its call sites (the Skills card render and the MCP card render), replacing the function body with a comment recording what it rendered, where its data came from, and why it was dropped.
- Left the server-side `skillAgents` / `mcpAgents` payload fields and their `agentTotals` computation in DashboardQuery untouched, so both cards' data contracts are unchanged and restoring the line would be a render-only edit.
- Updated the comment above `agentTag` to note that the per-row source tag is now the only per-agent signal on either card, and that no place states a whole-window per-agent total with call volume.

**📁 FILES**
- `cli/src/dashboard/assets/js/stats.js`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 14, 2026 at 3:57 PM · via Local agent - Claude Code*
<!-- jollimemory-summary-end -->