### PR TITLE
Add dismissible wiki banner with nonce-based re-show logic

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -1772,6 +1772,20 @@ export interface JolliMemoryConfig {
 	/** Optional explicit path to the local agent binary, overriding PATH discovery. */
 	readonly localAgentPath?: string;
 	/**
+	 * When the wiki/graph (topic KB) is rebuilt from newly-summarized commits.
+	 *  - "manual" (DEFAULT — an absent value means manual): no git operation
+	 *    (commit / rebase / amend / squash / merge) auto-triggers a wiki/graph
+	 *    rebuild. The user rebuilds on demand from the dashboard or the VS Code
+	 *    sidebar. recall and commit-search stay fresh regardless (they read the
+	 *    per-commit summaries, not the topic KB).
+	 *  - "auto": the legacy behaviour — every commit / merge / backfill enqueues an
+	 *    ingest pass that folds new summaries into the wiki and rebuilds the graph.
+	 *
+	 * Read via `wikiRebuildIsAuto(config)`; the polarity is deliberately
+	 * `=== "auto"` so an absent key (every existing install) means manual.
+	 */
+	readonly wikiRebuild?: "manual" | "auto";
+	/**
 	 * Whether the post-commit hook prints live memory-capture progress to stdout
 	 * (so a `git commit` driven from a terminal or AI-agent session shows the
 	 * capture lifecycle inline, and blocks until it drains).

--- a/cli/src/backfill/BackfillEngine.test.ts
+++ b/cli/src/backfill/BackfillEngine.test.ts
@@ -94,7 +94,10 @@ const summaryResult = {
 beforeEach(() => {
 	vi.clearAllMocks();
 	vi.mocked(getIndexEntryMap).mockResolvedValue(new Map());
-	vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-ant-test" } as never);
+	// the post-backfill wiki/graph ingest is now gated on
+	// wikiRebuild === "auto"; these legacy tests assert that ingest, so default
+	// the config to auto here. A dedicated manual-mode test overrides it below.
+	vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-ant-test", wikiRebuild: "auto" } as never);
 	vi.mocked(generateSummary).mockResolvedValue(summaryResult as never);
 	vi.mocked(getCurrentBranch).mockResolvedValue("main");
 });
@@ -296,6 +299,20 @@ describe("runBackfill", () => {
 		expect(vi.mocked(storeSummary).mock.calls[0][3]).toBeUndefined();
 		// Diff-only summaries still count as generated → ingest fires once.
 		expect(vi.mocked(enqueueIngestOperation)).toHaveBeenCalledTimes(1);
+	});
+
+	it("does NOT enqueue the wiki ingest in the default MANUAL mode, even when a summary was generated", async () => {
+		// wikiRebuild absent → manual: back-fill still generates the summary (the
+		// expensive work the user asked for) but leaves folding it into the wiki to
+		// an explicit rebuild.
+		vi.mocked(loadConfig).mockResolvedValue({ apiKey: "sk-ant-test" } as never);
+		vi.mocked(attributeCommits).mockReturnValue({ attributed: new Map([["c1", attrFor("c1")]]), skipped: [] });
+
+		const report = await runBackfill({ cwd: CWD, hashes: ["c1"] });
+
+		expect(report.generated).toBe(1);
+		expect(vi.mocked(enqueueIngestOperation)).not.toHaveBeenCalled();
+		expect(vi.mocked(launchWorker)).not.toHaveBeenCalled();
 	});
 
 	it("errors (not throws) when no LLM credentials are configured", async () => {

--- a/cli/src/backfill/BackfillEngine.ts
+++ b/cli/src/backfill/BackfillEngine.ts
@@ -25,6 +25,7 @@ import { generateSummary } from "../core/Summarizer.js";
 import { getIndexEntryMap, setActiveStorage, storeSummary } from "../core/SummaryStore.js";
 import { generateTranscriptId } from "../core/TranscriptId.js";
 import { buildMultiSessionContext } from "../core/TranscriptReader.js";
+import { wikiRebuildIsAuto } from "../core/WikiRebuildMode.js";
 import { launchWorker } from "../hooks/QueueWorker.js";
 import { createLogger } from "../Logger.js";
 import { type CommitSummary, CURRENT_SCHEMA_VERSION, type LlmConfig, type StoredTranscript } from "../Types.js";
@@ -403,7 +404,12 @@ export async function runBackfill(opts: BackfillOptions): Promise<BackfillReport
 	// the debounce cooldown so a deliberate back-fill always refreshes the
 	// knowledge wiki/graph; `launchWorker` drains the enqueued ingest op in a
 	// detached worker. Skipped on dry-run and when nothing was generated.
-	if (!dryRun && outcomes.some((o) => o.status === "generated")) {
+	//
+	// also gated on wikiRebuild === "auto". In the default MANUAL mode
+	// back-fill still generates every summary (the expensive part users asked for)
+	// but leaves folding them into the wiki/graph to an explicit user rebuild; the
+	// freshness indicator then shows the newly-generated summaries as pending.
+	if (!dryRun && wikiRebuildIsAuto(config) && outcomes.some((o) => o.status === "generated")) {
 		log.info("Back-fill batch done — triggering one repo-wide wiki/graph ingest");
 		await enqueueIngestOperation(cwd, "manual", { force: true });
 		launchWorker(cwd);

--- a/cli/src/commands/ConfigureCommand.test.ts
+++ b/cli/src/commands/ConfigureCommand.test.ts
@@ -192,6 +192,26 @@ describe("ConfigureCommand — settable keys", () => {
 		expect(mockSaveConfig).toHaveBeenCalledWith(expect.objectContaining({ aiProvider: "local-agent" }));
 	});
 
+	it("accepts wikiRebuild as the manual|auto enum and rejects other values", async () => {
+		await runConfigure(["--set", "wikiRebuild=manual"]);
+		expect(mockSaveConfig).toHaveBeenCalledWith(expect.objectContaining({ wikiRebuild: "manual" }));
+
+		await runConfigure(["--set", "wikiRebuild=auto"]);
+		expect(mockSaveConfig).toHaveBeenCalledWith(expect.objectContaining({ wikiRebuild: "auto" }));
+
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const prevExitCode = process.exitCode;
+		mockSaveConfig.mockClear();
+		try {
+			await runConfigure(["--set", "wikiRebuild=maual"]);
+			expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("manual"));
+			expect(mockSaveConfig).not.toHaveBeenCalled();
+		} finally {
+			errorSpy.mockRestore();
+			process.exitCode = prevExitCode;
+		}
+	});
+
 	it("accepts localAgentTool and localAgentPath for the Local Agent provider", async () => {
 		await runConfigure(["--set", "localAgentTool=claude-code"]);
 		expect(mockSaveConfig).toHaveBeenCalledWith(expect.objectContaining({ localAgentTool: "claude-code" }));

--- a/cli/src/commands/ConfigureCommand.ts
+++ b/cli/src/commands/ConfigureCommand.ts
@@ -39,6 +39,9 @@ const VALID_GLOBAL_INSTRUCTIONS: ReadonlyArray<NonNullable<JolliMemoryConfig["gl
 	"disabled",
 ];
 
+/** Valid values for the `wikiRebuild` config key. */
+const VALID_WIKI_REBUILD: ReadonlyArray<NonNullable<JolliMemoryConfig["wikiRebuild"]>> = ["manual", "auto"];
+
 /**
  * Valid config keys exposed via `jolli configure --set/--remove`.
  * Must stay in sync with {@link JolliMemoryConfig} in Types.ts.
@@ -78,6 +81,7 @@ const VALID_CONFIG_KEYS = [
 	"localAgentPath",
 	"backupFolder",
 	"backupRetentionDays",
+	"wikiRebuild",
 	"slack.workspaceUrl",
 ] as const satisfies ReadonlyArray<keyof JolliMemoryConfig | "slack.workspaceUrl">;
 
@@ -183,6 +187,12 @@ function coerceConfigValue(key: ConfigKey, raw: string): string | number | boole
 	if (key === "globalInstructions") {
 		if (!(VALID_GLOBAL_INSTRUCTIONS as ReadonlyArray<string>).includes(raw)) {
 			throw new Error(`${key} must be one of: ${VALID_GLOBAL_INSTRUCTIONS.join(", ")} (got: ${raw})`);
+		}
+		return raw;
+	}
+	if (key === "wikiRebuild") {
+		if (!(VALID_WIKI_REBUILD as ReadonlyArray<string>).includes(raw)) {
+			throw new Error(`${key} must be one of: ${VALID_WIKI_REBUILD.join(", ")} (got: ${raw})`);
 		}
 		return raw;
 	}
@@ -307,6 +317,12 @@ const CONFIG_KEY_INFO: ReadonlyArray<{ key: ConfigKey; type: string; description
 		key: "syncPollIntervalSec",
 		type: "number",
 		description: "Sync poll interval in seconds (5400-86400; default + floor = 90 min, ceiling = 24h; plugin only)",
+	},
+	{
+		key: "wikiRebuild",
+		type: "enum",
+		description:
+			"When the wiki/graph rebuilds: manual (default — rebuild on demand from dashboard/sidebar) | auto (every commit/merge/backfill)",
 	},
 	{
 		key: "slack.workspaceUrl",

--- a/cli/src/core/ProcessedSourceStore.test.ts
+++ b/cli/src/core/ProcessedSourceStore.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { FileWrite } from "../Types.js";
 import {
 	addProcessed,
+	carryProcessedSummaryHash,
 	emptyProcessedSet,
 	hasProcessed,
 	readProcessedSet,
@@ -73,5 +74,46 @@ describe("ProcessedSourceStore", () => {
 		const storage = makeFakeStorage({ "topics/processed.json": JSON.stringify({ schemaVersion: 1 }) });
 		const set = await readProcessedSet("/tmp/x", storage);
 		expect(set).toEqual(emptyProcessedSet());
+	});
+
+	describe("carryProcessedSummaryHash (rebase 1:1 migration)", () => {
+		it("carries the old hash's mark onto the new hash AND prunes the dead old hash", async () => {
+			const storage = makeFakeStorage();
+			await saveProcessedSet(addProcessed(emptyProcessedSet(), [ref("summary", "OLD")]), "/tmp/x", storage);
+			await carryProcessedSummaryHash("/tmp/x", "OLD", "NEW", storage);
+			const set = await readProcessedSet("/tmp/x", storage);
+			expect(hasProcessed(set, ref("summary", "NEW"))).toBe(true);
+			// The old commit no longer exists after a 1:1 rebase migration — its entry is
+			// pruned so the set doesn't grow by one dead row per rebased commit.
+			expect(hasProcessed(set, ref("summary", "OLD"))).toBe(false);
+			expect(set.processed.summary).toEqual(["NEW"]);
+		});
+
+		it("does nothing when old and new hash are identical", async () => {
+			const storage = makeFakeStorage();
+			await saveProcessedSet(addProcessed(emptyProcessedSet(), [ref("summary", "SAME")]), "/tmp/x", storage);
+			await carryProcessedSummaryHash("/tmp/x", "SAME", "SAME", storage);
+			const set = await readProcessedSet("/tmp/x", storage);
+			expect(set.processed.summary).toEqual(["SAME"]);
+		});
+
+		it("is a no-op when the old hash was never processed", async () => {
+			const storage = makeFakeStorage();
+			await carryProcessedSummaryHash("/tmp/x", "OLD", "NEW", storage);
+			const set = await readProcessedSet("/tmp/x", storage);
+			expect(hasProcessed(set, ref("summary", "NEW"))).toBe(false);
+		});
+
+		it("is idempotent when the new hash is already processed", async () => {
+			const storage = makeFakeStorage();
+			await saveProcessedSet(
+				addProcessed(emptyProcessedSet(), [ref("summary", "OLD"), ref("summary", "NEW")]),
+				"/tmp/x",
+				storage,
+			);
+			await carryProcessedSummaryHash("/tmp/x", "OLD", "NEW", storage);
+			const set = await readProcessedSet("/tmp/x", storage);
+			expect(set.processed.summary).toEqual(["OLD", "NEW"]);
+		});
 	});
 });

--- a/cli/src/core/ProcessedSourceStore.ts
+++ b/cli/src/core/ProcessedSourceStore.ts
@@ -84,6 +84,52 @@ export function addProcessed(set: ProcessedSet, refs: ReadonlyArray<SourceRef>):
 	return { schemaVersion: 1, processed: next };
 }
 
+/**
+ * After a 1:1 rebase migration (`migrateOneToOne`), carries the OLD summary
+ * hash's processed status onto the NEW hash.
+ *
+ * A rebase-pick rewrites a summary under a new commit hash without changing its
+ * content, but the topic-KB pipeline keys "already ingested" on `{summary, hash}`
+ * (see `SourceTimeline`). Without this, the migrated summary looks like a
+ * brand-new pending source and the next ingest re-reconciles every topic page it
+ * touched — full-page LLM rewrites for zero content change. No-op when the old
+ * hash was never processed (nothing folded yet) or the new hash is already marked
+ * (idempotent re-run).
+ */
+export async function carryProcessedSummaryHash(
+	cwd: string | undefined,
+	oldHash: string,
+	newHash: string,
+	storage?: StorageProvider,
+): Promise<void> {
+	// Read-modify-write MUST happen inside the orphan-write lock, mirroring the
+	// ingest pipeline's guarded read (the only other writer of this file). The
+	// summary phase (which runs this carry) and the ingest phase run in separate
+	// workers on separate locks, so an unlocked read here would let a concurrent
+	// ingest write land between our read and our write and be clobbered — dropping
+	// a batch of already-folded sources and forcing their full-page re-reconcile.
+	// The lock is re-entrant, so the nested saveProcessedSet is safe.
+	if (oldHash === newHash) return;
+	await withRequiredOrphanWriteLock(cwd, "carryProcessedSummaryHash", async () => {
+		const set = await readProcessedSet(cwd, storage);
+		const oldRef: SourceRef = { type: "summary", id: oldHash, timestamp: "" };
+		if (!hasProcessed(set, oldRef)) return;
+		const newRef: SourceRef = { type: "summary", id: newHash, timestamp: "" };
+		if (hasProcessed(set, newRef)) return;
+		// Carry the mark AND prune the now-dead old hash: a 1:1 rebase migration
+		// re-points the summary onto `newHash`, so the old commit no longer exists and
+		// its processed entry is a dead row. Leaving it (the old behaviour) let the set
+		// grow by one per rebased commit forever — every save re-serialises the whole
+		// file and every `hasProcessed` is a linear scan.
+		const next = addProcessed(set, [newRef]);
+		const pruned: ProcessedSet = {
+			schemaVersion: 1,
+			processed: { ...next.processed, summary: next.processed.summary.filter((h) => h !== oldHash) },
+		};
+		await saveProcessedSet(pruned, cwd, storage);
+	});
+}
+
 /** Persists the set via the active StorageProvider. */
 export async function saveProcessedSet(set: ProcessedSet, cwd?: string, storage?: StorageProvider): Promise<void> {
 	const resolved = await resolveStorage(storage, cwd);

--- a/cli/src/core/WikiFreshness.test.ts
+++ b/cli/src/core/WikiFreshness.test.ts
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { INGEST_CODES } from "./IngestErrors.js";
+import type { IngestRunRecord } from "./IngestRunStore.js";
+import type { StorageProvider } from "./StorageProvider.js";
+import type { SourceRef, SourceType } from "./TopicKBTypes.js";
+
+vi.mock("node:fs", () => ({ existsSync: vi.fn() }));
+vi.mock("../graph/GraphArtifactStore.js", () => ({
+	graphJsonPath: (root: string) => `${root}/.jolli/graph/graph.json`,
+}));
+vi.mock("./ProcessedSourceStore.js", () => ({
+	readProcessedSet: vi.fn().mockResolvedValue({ schemaVersion: 1, processed: {} }),
+}));
+vi.mock("./SourceTimeline.js", () => ({ listPendingSources: vi.fn() }));
+vi.mock("./IngestRunStore.js", () => ({ readIngestRuns: vi.fn() }));
+vi.mock("./ReadStorageResolver.js", () => ({ createReadStorage: vi.fn() }));
+vi.mock("./MemoryBankRepoDiscovery.js", () => ({ discoverRepos: vi.fn() }));
+vi.mock("./StorageFactory.js", () => ({ createFolderStorageAtRoot: (root: string) => ({ kbRoot: root }) }));
+
+import { existsSync } from "node:fs";
+import type { JolliMemoryConfig } from "../Types.js";
+import { readIngestRuns } from "./IngestRunStore.js";
+import { discoverRepos } from "./MemoryBankRepoDiscovery.js";
+import { createReadStorage } from "./ReadStorageResolver.js";
+import { listPendingSources } from "./SourceTimeline.js";
+import { getAggregateWikiFreshness, getWikiFreshness, WIKI_BEHIND_WARN_MS } from "./WikiFreshness.js";
+
+const mockExists = vi.mocked(existsSync);
+const mockPending = vi.mocked(listPendingSources);
+const mockRuns = vi.mocked(readIngestRuns);
+const mockCreateReadStorage = vi.mocked(createReadStorage);
+const mockDiscover = vi.mocked(discoverRepos);
+
+const STORAGE = { kbRoot: "/kb" } as unknown as StorageProvider;
+
+function ref(type: SourceType, id: string): SourceRef {
+	return { type, id, timestamp: "2026-08-01T00:00:00.000Z" };
+}
+
+function okRun(startedAt: string): IngestRunRecord {
+	return {
+		startedAt,
+		durationMs: 1,
+		triggeredBy: "manual",
+		outcome: INGEST_CODES.OK,
+		batches: 1,
+		ingested: 1,
+		touchedSlugs: 1,
+		routeCalls: 1,
+		reconcileCalls: 1,
+		topicFailures: [],
+	};
+}
+
+describe("getWikiFreshness", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockExists.mockReturnValue(true); // graph exists → everBuilt
+		mockPending.mockResolvedValue([]);
+		mockRuns.mockResolvedValue([]);
+	});
+
+	it("counts pending sources by type", async () => {
+		mockPending.mockResolvedValue([ref("summary", "a"), ref("summary", "b"), ref("plan", "p"), ref("note", "n")]);
+		const f = await getWikiFreshness("/cwd", STORAGE);
+		expect(f.pending).toEqual({ summary: 2, plan: 1, note: 1, userfile: 0, total: 4 });
+	});
+
+	it("severity 'never' when nothing was ever built (no graph, no OK run)", async () => {
+		mockExists.mockReturnValue(false);
+		mockRuns.mockResolvedValue([]);
+		mockPending.mockResolvedValue([ref("summary", "a")]);
+		const f = await getWikiFreshness("/cwd", STORAGE);
+		expect(f.everBuilt).toBe(false);
+		expect(f.severity).toBe("never");
+	});
+
+	it("severity 'fresh' when built and nothing pending", async () => {
+		mockPending.mockResolvedValue([]);
+		const f = await getWikiFreshness("/cwd", STORAGE);
+		expect(f.severity).toBe("fresh");
+	});
+
+	it("severity 'info' when a few summaries are pending and last rebuild is recent", async () => {
+		const now = Date.parse("2026-08-10T00:00:00.000Z");
+		mockRuns.mockResolvedValue([okRun("2026-08-09T23:00:00.000Z")]);
+		mockPending.mockResolvedValue([ref("summary", "a"), ref("summary", "b")]);
+		const f = await getWikiFreshness("/cwd", STORAGE, now);
+		expect(f.severity).toBe("info");
+		expect(f.lastRebuiltAt).toBe("2026-08-09T23:00:00.000Z");
+	});
+
+	it("severity 'warn' when more than the count threshold of summaries are pending", async () => {
+		mockPending.mockResolvedValue(Array.from({ length: 11 }, (_, i) => ref("summary", `s${i}`)));
+		const f = await getWikiFreshness("/cwd", STORAGE);
+		expect(f.severity).toBe("warn");
+	});
+
+	it("severity 'warn' by time when the last rebuild is older than the window and something is pending", async () => {
+		const last = "2026-08-01T00:00:00.000Z";
+		const now = Date.parse(last) + WIKI_BEHIND_WARN_MS + 1;
+		mockRuns.mockResolvedValue([okRun(last)]);
+		mockPending.mockResolvedValue([ref("plan", "p")]); // only a plan; summary=0
+		const f = await getWikiFreshness("/cwd", STORAGE, now);
+		expect(f.severity).toBe("warn");
+	});
+
+	it("does not warn by time when nothing is pending, however old the last rebuild", async () => {
+		const now = Date.parse("2030-01-01T00:00:00.000Z");
+		mockRuns.mockResolvedValue([okRun("2026-01-01T00:00:00.000Z")]);
+		mockPending.mockResolvedValue([]);
+		const f = await getWikiFreshness("/cwd", STORAGE, now);
+		expect(f.severity).toBe("fresh");
+	});
+
+	it("picks the most recent OK run and ignores non-OK outcomes", async () => {
+		mockRuns.mockResolvedValue([
+			okRun("2026-08-01T00:00:00.000Z"),
+			{ ...okRun("2026-08-05T00:00:00.000Z"), outcome: INGEST_CODES.ROUTE_FAILED },
+			okRun("2026-08-03T00:00:00.000Z"),
+		]);
+		mockPending.mockResolvedValue([ref("summary", "a")]);
+		const f = await getWikiFreshness("/cwd", STORAGE, Date.parse("2026-08-03T01:00:00.000Z"));
+		expect(f.lastRebuiltAt).toBe("2026-08-03T00:00:00.000Z");
+	});
+
+	it("everBuilt=false + severity 'never' when graph.json is absent and no run is OK (only a NO_PENDING run)", async () => {
+		mockExists.mockReturnValue(false);
+		// A run exists but is NOT OK → lastRebuiltAt stays null, everBuilt stays false.
+		mockRuns.mockResolvedValue([{ ...okRun("2026-08-01T00:00:00.000Z"), outcome: INGEST_CODES.NO_PENDING }]);
+		mockPending.mockResolvedValue([ref("summary", "a")]);
+		const f = await getWikiFreshness("/cwd", STORAGE, Date.now());
+		expect(f.everBuilt).toBe(false);
+		expect(f.lastRebuiltAt).toBeNull();
+		expect(f.severity).toBe("never");
+	});
+
+	it("everBuilt=true via an OK run even when graph.json is absent (the lastRebuiltAt disjunct)", async () => {
+		mockExists.mockReturnValue(false); // no graph.json
+		mockRuns.mockResolvedValue([okRun("2026-08-09T00:00:00.000Z")]); // but a clean drain ran
+		mockPending.mockResolvedValue([ref("summary", "a")]);
+		const f = await getWikiFreshness("/cwd", STORAGE, Date.parse("2026-08-09T01:00:00.000Z"));
+		expect(f.everBuilt).toBe(true);
+		expect(f.lastRebuiltAt).toBe("2026-08-09T00:00:00.000Z");
+		expect(f.severity).toBe("info");
+	});
+
+	it("falls back to cwd for the graph path when the storage has no kbRoot (orphan-only)", async () => {
+		mockExists.mockReturnValue(true);
+		mockPending.mockResolvedValue([]);
+		const f = await getWikiFreshness("/cwd", {} as unknown as StorageProvider);
+		// existsSync is mocked true, so everBuilt holds via the cwd-rooted graph path.
+		expect(f.everBuilt).toBe(true);
+		expect(f.severity).toBe("fresh");
+	});
+
+	it("resolves its own read storage when none is passed", async () => {
+		mockCreateReadStorage.mockResolvedValue(STORAGE);
+		mockPending.mockResolvedValue([]);
+		await getWikiFreshness("/cwd");
+		expect(mockCreateReadStorage).toHaveBeenCalledWith("/cwd");
+	});
+});
+
+describe("getAggregateWikiFreshness", () => {
+	const CONFIG = { localFolder: "/mb" } as unknown as JolliMemoryConfig;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockExists.mockReturnValue(true); // graph exists → everBuilt for every repo
+		mockRuns.mockResolvedValue([]);
+		mockPending.mockResolvedValue([]);
+	});
+
+	it("aggregates behind repos only, summing pending and listing their names", async () => {
+		mockDiscover.mockResolvedValue([
+			{ folder: "acme", kbRoot: "/mb/acme" },
+			{ folder: "beta", kbRoot: "/mb/beta" },
+		]);
+		// acme behind by 3 summaries; beta fresh.
+		mockPending.mockImplementation(async (cwd) =>
+			cwd === "/mb/acme" ? [ref("summary", "a1"), ref("summary", "a2"), ref("summary", "a3")] : [],
+		);
+		const f = await getAggregateWikiFreshness("/mb", CONFIG);
+		expect(f.behindRepoNames).toEqual(["acme"]);
+		expect(f.pending).toEqual({ summary: 3, total: 3 });
+		expect(f.severity).toBe("info");
+		expect(f.repos).toHaveLength(2);
+	});
+
+	it("severity 'fresh' and no behind repos when every repo is up to date", async () => {
+		mockDiscover.mockResolvedValue([
+			{ folder: "acme", kbRoot: "/mb/acme" },
+			{ folder: "beta", kbRoot: "/mb/beta" },
+		]);
+		mockPending.mockResolvedValue([]);
+		const f = await getAggregateWikiFreshness("/mb", CONFIG);
+		expect(f.behindRepoNames).toEqual([]);
+		expect(f.severity).toBe("fresh");
+		expect(f.pending).toEqual({ summary: 0, total: 0 });
+	});
+
+	it("severity 'warn' when the folder-wide summary count crosses the threshold (each repo only 'info')", async () => {
+		mockDiscover.mockResolvedValue([
+			{ folder: "acme", kbRoot: "/mb/acme" },
+			{ folder: "beta", kbRoot: "/mb/beta" },
+		]);
+		// 6 + 6 = 12 > 10, though neither repo alone is warn.
+		mockPending.mockImplementation(async () => Array.from({ length: 6 }, (_, i) => ref("summary", `s${i}`)));
+		const f = await getAggregateWikiFreshness("/mb", CONFIG);
+		expect(f.severity).toBe("warn");
+		expect(f.pending.summary).toBe(12);
+		expect(f.behindRepoNames).toEqual(["acme", "beta"]);
+	});
+
+	it("severity 'warn' when a single repo is itself warn (>10 pending summaries)", async () => {
+		mockDiscover.mockResolvedValue([{ folder: "acme", kbRoot: "/mb/acme" }]);
+		mockPending.mockResolvedValue(Array.from({ length: 11 }, (_, i) => ref("summary", `s${i}`)));
+		const f = await getAggregateWikiFreshness("/mb", CONFIG);
+		expect(f.severity).toBe("warn");
+		expect(f.behindRepoNames).toEqual(["acme"]);
+	});
+
+	it("lastRebuiltAt is the most recent OK run across repos", async () => {
+		mockDiscover.mockResolvedValue([
+			{ folder: "acme", kbRoot: "/mb/acme" },
+			{ folder: "beta", kbRoot: "/mb/beta" },
+		]);
+		mockRuns.mockImplementation(async (cwd) =>
+			cwd === "/mb/acme" ? [okRun("2026-08-01T00:00:00.000Z")] : [okRun("2026-08-05T00:00:00.000Z")],
+		);
+		const f = await getAggregateWikiFreshness("/mb", CONFIG);
+		expect(f.lastRebuiltAt).toBe("2026-08-05T00:00:00.000Z");
+		expect(f.everBuilt).toBe(true);
+	});
+
+	it("excludes a never-built repo that has nothing pending (not 'behind' — Rebuild could never clear it)", async () => {
+		mockDiscover.mockResolvedValue([
+			{ folder: "acme", kbRoot: "/mb/acme" },
+			{ folder: "empty", kbRoot: "/mb/empty" },
+		]);
+		// acme: behind by 2. empty: never built AND nothing pending → not behind.
+		mockExists.mockImplementation((p) => String(p).startsWith("/mb/acme")); // graph only for acme
+		mockPending.mockImplementation(async (cwd) =>
+			cwd === "/mb/acme" ? [ref("summary", "a1"), ref("summary", "a2")] : [],
+		);
+		const f = await getAggregateWikiFreshness("/mb", CONFIG);
+		expect(f.behindRepoNames).toEqual(["acme"]);
+		expect(f.pending).toEqual({ summary: 2, total: 2 });
+		expect(f.severity).toBe("info");
+	});
+
+	it("empty folder (no repos) yields an all-fresh, empty snapshot", async () => {
+		mockDiscover.mockResolvedValue([]);
+		const f = await getAggregateWikiFreshness("/mb", CONFIG);
+		expect(f).toMatchObject({ repos: [], behindRepoNames: [], severity: "fresh", lastRebuiltAt: null });
+	});
+});

--- a/cli/src/core/WikiFreshness.ts
+++ b/cli/src/core/WikiFreshness.ts
@@ -1,0 +1,186 @@
+/**
+ * WikiFreshness — how far the wiki/graph (topic KB) lags behind the summaries
+ * already generated for this repo, plus how long since it was last rebuilt.
+ *
+ * The single source of truth for the "N updates behind · rebuilt X ago"
+ * indicator both the local dashboard and the VS Code sidebar render. Product
+ * rule → lives in `cli/src/core` (AGENTS.md: hosts are adapters).
+ *
+ * Cheap-ish but not free: it scans every source ref (summaries index + plan/note
+ * + user files) to count what is pending, so callers treat it as a slow probe
+ * (its own endpoint on the dashboard, off the first-paint path), never a hot loop.
+ */
+
+import { existsSync } from "node:fs";
+import { graphJsonPath } from "../graph/GraphArtifactStore.js";
+import type { JolliMemoryConfig } from "../Types.js";
+import { INGEST_CODES } from "./IngestErrors.js";
+import { readIngestRuns } from "./IngestRunStore.js";
+import { discoverRepos } from "./MemoryBankRepoDiscovery.js";
+import { readProcessedSet } from "./ProcessedSourceStore.js";
+import { createReadStorage } from "./ReadStorageResolver.js";
+import { listPendingSources } from "./SourceTimeline.js";
+import { createFolderStorageAtRoot } from "./StorageFactory.js";
+import type { StorageProvider } from "./StorageProvider.js";
+
+/** Pending-source count is warn-worthy above this many un-ingested summaries. */
+export const WIKI_BEHIND_WARN_COUNT = 10;
+/** Pending changes older than this since the last rebuild are warn-worthy (3 days). */
+export const WIKI_BEHIND_WARN_MS = 3 * 24 * 60 * 60 * 1000;
+
+export type WikiFreshnessSeverity = "never" | "fresh" | "info" | "warn";
+
+export interface WikiFreshness {
+	/** Un-ingested sources by type. `summary` is the headline "N updates behind". */
+	readonly pending: {
+		readonly summary: number;
+		readonly plan: number;
+		readonly note: number;
+		readonly userfile: number;
+		readonly total: number;
+	};
+	/** ISO timestamp of the last successful rebuild, or null if never built. */
+	readonly lastRebuiltAt: string | null;
+	/** True once a wiki/graph has ever been produced (graph.json exists, or a clean ingest ran). */
+	readonly everBuilt: boolean;
+	readonly severity: WikiFreshnessSeverity;
+}
+
+/**
+ * Computes the freshness snapshot for the repo rooted at `cwd`.
+ *
+ * `storage` scopes the source reads (defaults to the repo's read view). `nowMs`
+ * is injectable for deterministic tests — production passes the wall clock.
+ */
+export async function getWikiFreshness(
+	cwd: string,
+	storage?: StorageProvider,
+	nowMs: number = Date.now(),
+): Promise<WikiFreshness> {
+	const readStorage = storage ?? (await createReadStorage(cwd));
+
+	const processed = await readProcessedSet(cwd, readStorage);
+	const pendingRefs = await listPendingSources(cwd, processed, readStorage);
+	const pending = {
+		summary: pendingRefs.filter((r) => r.type === "summary").length,
+		plan: pendingRefs.filter((r) => r.type === "plan").length,
+		note: pendingRefs.filter((r) => r.type === "note").length,
+		userfile: pendingRefs.filter((r) => r.type === "userfile").length,
+		total: pendingRefs.length,
+	};
+
+	// Last successful rebuild = most recent OK drain (ring buffer is oldest→newest,
+	// so scan from the end). An OK outcome means the drain completed and folded its
+	// pending sources; benign/idle/error outcomes are not "rebuilt".
+	const runs = await readIngestRuns(cwd);
+	let lastRebuiltAt: string | null = null;
+	for (let i = runs.length - 1; i >= 0; i--) {
+		if (runs[i].outcome === INGEST_CODES.OK) {
+			lastRebuiltAt = runs[i].startedAt;
+			break;
+		}
+	}
+
+	// The graph.json lives in the folder layer at kbRoot; orphan-only storage has
+	// no folder (kbRoot falls back to cwd, where the file simply won't exist).
+	const kbRoot = readStorage.kbRoot ?? cwd;
+	const graphExists = existsSync(graphJsonPath(kbRoot));
+	const everBuilt = graphExists || lastRebuiltAt !== null;
+
+	const severity = deriveSeverity(everBuilt, pending.summary, pending.total, lastRebuiltAt, nowMs);
+	return { pending, lastRebuiltAt, everBuilt, severity };
+}
+
+/**
+ * Severity ladder. Time-staleness only escalates when something is actually
+ * pending: an old-but-empty wiki is up to date, not "behind". `lastRebuiltAt`
+ * null (never built, or ring buffer aged out) skips the time clause rather than
+ * feeding NaN into the comparison.
+ */
+function deriveSeverity(
+	everBuilt: boolean,
+	summaryBehind: number,
+	total: number,
+	lastRebuiltAt: string | null,
+	nowMs: number,
+): WikiFreshnessSeverity {
+	if (!everBuilt) return "never";
+	if (total === 0) return "fresh";
+	const lastMs = lastRebuiltAt !== null ? Date.parse(lastRebuiltAt) : Number.NaN;
+	const staleByTime = Number.isFinite(lastMs) && nowMs - lastMs > WIKI_BEHIND_WARN_MS;
+	if (summaryBehind > WIKI_BEHIND_WARN_COUNT || staleByTime) return "warn";
+	return "info";
+}
+
+/** Per-repo freshness plus the repo's Memory Bank folder name (the label). */
+export interface RepoWikiFreshness extends WikiFreshness {
+	readonly repoName: string;
+}
+
+/**
+ * Freshness aggregated across EVERY repo in the Memory Bank folder — the single
+ * shape both the dashboard banner and the VS Code sidebar banner render. The
+ * rebuild both surfaces trigger is the whole-folder sweep (`compileAllRepos`),
+ * so the indicator matches it: it reports how far the *folder* lags, not one repo.
+ *
+ * Each repo is scored with folder-only storage (no git worktree needed —
+ * `compileAllRepos` sweeps the same way), so repos with no local checkout are
+ * still counted and still rebuilt by the same button.
+ */
+export interface AggregateWikiFreshness {
+	readonly repos: ReadonlyArray<RepoWikiFreshness>;
+	/** Names of the repos that are not `fresh` (drives the banner's repo label). */
+	readonly behindRepoNames: ReadonlyArray<string>;
+	/** Pending sources summed over the behind repos. `summary` is the headline. */
+	readonly pending: { readonly summary: number; readonly total: number };
+	/** Most recent successful rebuild across all repos, or null. */
+	readonly lastRebuiltAt: string | null;
+	/** True if any repo has ever produced a wiki/graph. */
+	readonly everBuilt: boolean;
+	/** Worst state across repos: `fresh` when nothing is behind. */
+	readonly severity: WikiFreshnessSeverity;
+}
+
+/**
+ * Computes the folder-wide freshness snapshot. `nowMs` is injectable for tests.
+ * A `localFolder` with no discovered repos yields an all-`fresh` (empty) result.
+ */
+export async function getAggregateWikiFreshness(
+	localFolder: string,
+	config: JolliMemoryConfig,
+	nowMs: number = Date.now(),
+): Promise<AggregateWikiFreshness> {
+	const targets = await discoverRepos(localFolder, config.compileExcludeFolders ?? []);
+	const repos: RepoWikiFreshness[] = [];
+	for (const t of targets) {
+		const storage = createFolderStorageAtRoot(t.kbRoot);
+		const f = await getWikiFreshness(t.kbRoot, storage, nowMs);
+		repos.push({ ...f, repoName: t.folder });
+	}
+
+	// "Behind" = has un-ingested sources to fold in. A repo with nothing pending is
+	// NOT behind even if it never built a wiki (an empty/just-migrated repo scores
+	// `never` with `total===0`): calling it behind would show "0 items pending" and
+	// a Rebuild that can never clear it (an empty ingest leaves it `never` forever).
+	const behind = repos.filter((r) => r.severity !== "fresh" && r.pending.total > 0);
+	const pending = {
+		summary: behind.reduce((n, r) => n + r.pending.summary, 0),
+		total: behind.reduce((n, r) => n + r.pending.total, 0),
+	};
+	const lastRebuiltAt = repos.reduce<string | null>((acc, r) => {
+		if (!r.lastRebuiltAt) return acc;
+		if (!acc) return r.lastRebuiltAt;
+		return Date.parse(r.lastRebuiltAt) > Date.parse(acc) ? r.lastRebuiltAt : acc;
+	}, null);
+	const everBuilt = repos.some((r) => r.everBuilt);
+
+	// Worst-state ladder: warn if any repo is warn OR the folder-wide headline
+	// crosses the same count threshold; otherwise info while anything is behind.
+	let severity: WikiFreshnessSeverity = "fresh";
+	if (behind.length > 0) {
+		severity =
+			repos.some((r) => r.severity === "warn") || pending.summary > WIKI_BEHIND_WARN_COUNT ? "warn" : "info";
+	}
+
+	return { repos, behindRepoNames: behind.map((r) => r.repoName), pending, lastRebuiltAt, everBuilt, severity };
+}

--- a/cli/src/core/WikiRebuildMode.test.ts
+++ b/cli/src/core/WikiRebuildMode.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { wikiRebuildIsAuto } from "./WikiRebuildMode.js";
+
+describe("wikiRebuildIsAuto", () => {
+	it("is false when the key is absent (default = manual)", () => {
+		expect(wikiRebuildIsAuto({})).toBe(false);
+		expect(wikiRebuildIsAuto({ wikiRebuild: undefined })).toBe(false);
+	});
+
+	it("is false when explicitly manual", () => {
+		expect(wikiRebuildIsAuto({ wikiRebuild: "manual" })).toBe(false);
+	});
+
+	it("is true only when explicitly auto", () => {
+		expect(wikiRebuildIsAuto({ wikiRebuild: "auto" })).toBe(true);
+	});
+});

--- a/cli/src/core/WikiRebuildMode.ts
+++ b/cli/src/core/WikiRebuildMode.ts
@@ -1,0 +1,20 @@
+/**
+ * WikiRebuildMode — the single polarity check for whether a git operation should
+ * auto-trigger a wiki/graph (topic KB) rebuild.
+ *
+ * Kept as a dependency-free leaf module (only a type import) so the git-hook
+ * bundles that gate their `enqueueIngestOperation` calls on it — PostCommit,
+ * PostMerge, Backfill — don't drag storage / source-timeline code in.
+ *
+ * The polarity is deliberately `=== "auto"`: an ABSENT `wikiRebuild` key (every
+ * install that predates this change) means MANUAL. Never spell this `!== "manual"`
+ * — that would flip undefined to auto and re-enable the very auto-ingest this
+ * feature removes.
+ */
+
+import type { JolliMemoryConfig } from "../Types.js";
+
+/** True iff wiki/graph rebuild should auto-trigger on git operations. Default (absent key) = manual. */
+export function wikiRebuildIsAuto(config: Pick<JolliMemoryConfig, "wikiRebuild">): boolean {
+	return config.wikiRebuild === "auto";
+}

--- a/cli/src/dashboard/DashboardServer.test.ts
+++ b/cli/src/dashboard/DashboardServer.test.ts
@@ -1748,6 +1748,10 @@ describe("wiki freshness + rebuild endpoints", () => {
 			behindRepoNames: ["acme-api"],
 			pending: { summary: 3, total: 3 },
 		});
+		// A per-process nonce the page keys its banner-dismiss on (restart → new
+		// nonce → dismissed banner reappears). Just needs to be a non-empty string.
+		expect(typeof body.nonce).toBe("string");
+		expect((body.nonce as string).length).toBeGreaterThan(0);
 	});
 
 	it("GET /api/wiki/freshness reports available:false when no Memory Bank folder is configured", async () => {

--- a/cli/src/dashboard/DashboardServer.test.ts
+++ b/cli/src/dashboard/DashboardServer.test.ts
@@ -34,11 +34,34 @@ vi.mock("./RepoRegistry.js", async (importOriginal) => ({
 	deregisterRepo: vi.fn().mockResolvedValue("r1"),
 	readRepoRegistry: vi.fn().mockResolvedValue({ version: 1, repos: [] }),
 }));
+// unlink is wrapped (not replaced) so every other state-file test keeps its
+// real filesystem behavior — only the non-ENOENT-unlink-error test below ever
+// overrides it, and only for its own call.
+vi.mock("node:fs/promises", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:fs/promises")>();
+	return { ...actual, unlink: vi.fn(actual.unlink) };
+});
+// wiki endpoints reach these directly (same no-injectable-seam pattern
+// as the other write handlers) — mocked so the server-layer tests stay hermetic.
+// Freshness is folder-wide aggregate; rebuild is the whole-folder compile sweep.
+vi.mock("../core/WikiFreshness.js", () => ({ getAggregateWikiFreshness: vi.fn() }));
+vi.mock("../core/MultiRepoCompile.js", () => ({
+	compileAllRepos: vi.fn(async () => ({ repos: [], totalIngested: 0, failed: 0 })),
+}));
+// Partial mock so the rebuild endpoint's up-front provider gate is controllable;
+// default = a usable provider so the happy-path rebuild tests proceed.
+vi.mock("../core/LlmClient.js", async (orig) => ({
+	...(await orig<typeof import("../core/LlmClient.js")>()),
+	resolveLlmCredentialSource: vi.fn(() => "local-agent"),
+}));
 
 import * as gitOps from "../core/GitOps.js";
+import { resolveLlmCredentialSource } from "../core/LlmClient.js";
+import { compileAllRepos } from "../core/MultiRepoCompile.js";
 import { initTelemetry, shutdownTelemetry } from "../core/Telemetry.js";
 import { readTelemetryEvents } from "../core/TelemetryBuffer.js";
 import { TRANSCRIPT_SOURCE_LABELS } from "../core/TranscriptSourceLabel.js";
+import { getAggregateWikiFreshness } from "../core/WikiFreshness.js";
 import * as installer from "../install/Installer.js";
 import { withDashboardDb } from "./DashboardDb.js";
 import { type DashboardModel, type DashboardScope, type DashboardView, TOOL_ROWS_LIMIT } from "./DashboardModel.js";
@@ -1679,5 +1702,153 @@ describe("telemetry beacon", () => {
 		const res = await post(port, { event: "range_changed", properties: { range: "7d" } });
 		expect(res.status).toBe(204);
 		expect(await readTelemetryEvents(dir)).toEqual([]);
+	});
+});
+
+describe("wiki freshness + rebuild endpoints", () => {
+	const TOKEN = "wiki-token-0123456789abcdef";
+	const HEADERS = { "X-Jolli-Dashboard-Token": TOKEN, "content-type": "application/json" };
+
+	const AGG = {
+		repos: [],
+		behindRepoNames: ["acme-api"],
+		pending: { summary: 3, total: 3 },
+		lastRebuiltAt: "2026-08-10T00:00:00.000Z",
+		everBuilt: true,
+		severity: "info" as const,
+	};
+
+	// A configDir whose config.json points `localFolder` at a real Memory Bank
+	// dir, so `loadConfigFromDir` returns a localFolder and the endpoints proceed.
+	// The aggregate freshness and the compile sweep are BOTH mocked, so the folder
+	// contents are irrelevant — only that `localFolder` is set.
+	function wikiServer(): Server {
+		const configDir = writeMemoryBank(dir, [{ dir: "acme-api" }]);
+		return testServer({ token: TOKEN, configDir });
+	}
+
+	// A configDir with a config.json that has NO localFolder (Memory Bank not set).
+	function noFolderServer(): Server {
+		const configDir = join(dir, "cfg-empty");
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(join(configDir, "config.json"), "{}");
+		return testServer({ token: TOKEN, configDir });
+	}
+
+	it("GET /api/wiki/freshness returns the aggregate freshness + inFlight", async () => {
+		vi.mocked(getAggregateWikiFreshness).mockResolvedValue(AGG);
+		const port = await listen(wikiServer());
+		const res = await get(port, "/api/wiki/freshness");
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(body).toMatchObject({
+			available: true,
+			inFlight: false,
+			severity: "info",
+			behindRepoNames: ["acme-api"],
+			pending: { summary: 3, total: 3 },
+		});
+	});
+
+	it("GET /api/wiki/freshness reports available:false when no Memory Bank folder is configured", async () => {
+		const port = await listen(noFolderServer());
+		const res = await get(port, "/api/wiki/freshness");
+		expect(res.status).toBe(200);
+		expect((await res.json()) as { available: boolean }).toEqual({ available: false });
+	});
+
+	it("GET /api/wiki/freshness 500s when freshness computation throws", async () => {
+		vi.mocked(getAggregateWikiFreshness).mockRejectedValueOnce(new Error("boom"));
+		const port = await listen(wikiServer());
+		const res = await get(port, "/api/wiki/freshness");
+		expect(res.status).toBe(500);
+	});
+
+	it("POST /api/wiki/rebuild launches the folder-wide compile and returns 202", async () => {
+		vi.mocked(compileAllRepos).mockResolvedValue({ repos: [], totalIngested: 0, failed: 0 });
+		const port = await listen(wikiServer());
+		const res = await fetch(`http://127.0.0.1:${port}/api/wiki/rebuild`, {
+			method: "POST",
+			headers: HEADERS,
+			body: "{}",
+		});
+		expect(res.status).toBe(202);
+		// Fire-and-forget: the sweep is kicked off after the 202 is sent.
+		await vi.waitFor(() => expect(compileAllRepos).toHaveBeenCalled());
+		expect(vi.mocked(compileAllRepos).mock.calls[0][0]).toMatch(/[\\/]mb$/);
+	});
+
+	it("POST /api/wiki/rebuild 409s when a rebuild is already in flight (no second sweep)", async () => {
+		// Hold the first sweep pending so the in-flight flag stays set for POST #2.
+		let release: (() => void) | undefined;
+		vi.mocked(compileAllRepos).mockImplementationOnce(
+			() =>
+				new Promise((r) => {
+					release = () => r({ repos: [], totalIngested: 0, failed: 0 });
+				}),
+		);
+		const port = await listen(wikiServer());
+		const first = await fetch(`http://127.0.0.1:${port}/api/wiki/rebuild`, {
+			method: "POST",
+			headers: HEADERS,
+			body: "{}",
+		});
+		expect(first.status).toBe(202);
+		await vi.waitFor(() => expect(compileAllRepos).toHaveBeenCalledTimes(1));
+		const second = await fetch(`http://127.0.0.1:${port}/api/wiki/rebuild`, {
+			method: "POST",
+			headers: HEADERS,
+			body: "{}",
+		});
+		expect(second.status).toBe(409);
+		expect(compileAllRepos).toHaveBeenCalledTimes(1);
+		release?.(); // let the first sweep finish so no promise dangles
+	});
+
+	it("POST /api/wiki/rebuild clears the in-flight flag when the sweep throws (a later rebuild still starts)", async () => {
+		// The fire-and-forget sweep rejects; the handler's catch + finally must
+		// still clear the flag, so a subsequent rebuild is accepted (202, not 409).
+		vi.mocked(compileAllRepos).mockRejectedValueOnce(new Error("boom"));
+		const port = await listen(wikiServer());
+		const first = await fetch(`http://127.0.0.1:${port}/api/wiki/rebuild`, {
+			method: "POST",
+			headers: HEADERS,
+			body: "{}",
+		});
+		expect(first.status).toBe(202);
+		await vi.waitFor(() => expect(compileAllRepos).toHaveBeenCalledTimes(1));
+		// Flag cleared by the finally → a fresh rebuild starts again.
+		await vi.waitFor(async () => {
+			const again = await fetch(`http://127.0.0.1:${port}/api/wiki/rebuild`, {
+				method: "POST",
+				headers: HEADERS,
+				body: "{}",
+			});
+			expect(again.status).toBe(202);
+		});
+	});
+
+	it("POST /api/wiki/rebuild 400s when no Memory Bank folder is configured", async () => {
+		const port = await listen(noFolderServer());
+		const res = await fetch(`http://127.0.0.1:${port}/api/wiki/rebuild`, {
+			method: "POST",
+			headers: HEADERS,
+			body: "{}",
+		});
+		expect(res.status).toBe(400);
+		expect(compileAllRepos).not.toHaveBeenCalled();
+	});
+
+	it("POST /api/wiki/rebuild 400s (no silent no-op) when no usable LLM provider is configured", async () => {
+		vi.mocked(resolveLlmCredentialSource).mockReturnValueOnce(null);
+		const port = await listen(wikiServer());
+		const res = await fetch(`http://127.0.0.1:${port}/api/wiki/rebuild`, {
+			method: "POST",
+			headers: HEADERS,
+			body: "{}",
+		});
+		expect(res.status).toBe(400);
+		expect(((await res.json()) as { error: string }).error).toMatch(/AI provider/);
+		expect(compileAllRepos).not.toHaveBeenCalled();
 	});
 });

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -1000,6 +1000,13 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 	// polls it to completion. (The old per-repo detached-worker rebuild needed the
 	// real lock/queue state; a folder sweep in-process does not.)
 	let wikiRebuildInFlight = false;
+	// A per-server-process identity handed to the browser with every freshness
+	// response. The page stores a banner "dismiss" in localStorage keyed by this
+	// value, so restarting the dashboard (a new process → a new nonce) makes a
+	// dismissed banner reappear — the web analog of "restart the server to see it
+	// again". It only needs to differ across restarts, so process start time is
+	// enough; it is captured once here (server-creation) and never changes.
+	const wikiBannerNonce = String(Date.now());
 	const buildModel =
 		options.buildModel ??
 		((request: ModelRequest) =>
@@ -1455,7 +1462,12 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 					return;
 				}
 				const freshness = await getAggregateWikiFreshness(config.localFolder, config);
-				sendJson(res, 200, { available: true, inFlight: wikiRebuildInFlight, ...freshness });
+				sendJson(res, 200, {
+					available: true,
+					inFlight: wikiRebuildInFlight,
+					nonce: wikiBannerNonce,
+					...freshness,
+				});
 			} catch (err) {
 				log.warn("wiki freshness failed: %s", errMsg(err));
 				sendJson(res, 500, { error: "could not compute wiki freshness" });

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -100,6 +100,7 @@ import { getGlobalConfigDir, loadConfigFromDir } from "../core/SessionTracker.js
 import { trackAs } from "../core/Telemetry.js";
 import { isTelemetryEventName, type TelemetryEventName } from "../core/TelemetryEvents.js";
 import { TRANSCRIPT_SOURCE_LABELS } from "../core/TranscriptSourceLabel.js";
+import { getAggregateWikiFreshness } from "../core/WikiFreshness.js";
 import { resolveAssetsDir as resolveGraphAssetsDir } from "../graph/GraphExport.js";
 import { install } from "../install/Installer.js";
 import { createLogger, errMsg } from "../Logger.js";
@@ -992,6 +993,13 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 	// paying for every summary twice. Process-scoped: it guards this server, not
 	// a separate CLI `jolli backfill` (those still serialise on the orphan lock).
 	let generateMissingInFlight = false;
+	// Same one-at-a-time guard as `generateMissingInFlight`, for the folder-wide
+	// wiki rebuild. The rebuild (`compileAllRepos`) runs IN this long-lived server
+	// process (fire-and-forget), so a plain process-scoped boolean observes its
+	// start and end — the freshness endpoint reports it as `inFlight` and the page
+	// polls it to completion. (The old per-repo detached-worker rebuild needed the
+	// real lock/queue state; a folder sweep in-process does not.)
+	let wikiRebuildInFlight = false;
 	const buildModel =
 		options.buildModel ??
 		((request: ModelRequest) =>
@@ -1434,6 +1442,27 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 			return;
 		}
 
+		// Folder-wide wiki/graph freshness, aggregated across EVERY Memory Bank repo
+		// (matches the whole-folder rebuild below). Slow (scans source refs per
+		// repo), so it is its own endpoint off first paint (like missing-summaries).
+		// `inFlight` reflects the in-process rebuild flag. `available:false` when no
+		// `localFolder` (Memory Bank) is configured.
+		if (url.pathname === "/api/wiki/freshness") {
+			try {
+				const config = await loadConfigFromDir(configDir ?? getGlobalConfigDir());
+				if (!config.localFolder) {
+					sendJson(res, 200, { available: false });
+					return;
+				}
+				const freshness = await getAggregateWikiFreshness(config.localFolder, config);
+				sendJson(res, 200, { available: true, inFlight: wikiRebuildInFlight, ...freshness });
+			} catch (err) {
+				log.warn("wiki freshness failed: %s", errMsg(err));
+				sendJson(res, 500, { error: "could not compute wiki freshness" });
+			}
+			return;
+		}
+
 		sendText(res, 404, "Not found");
 	}
 
@@ -1496,6 +1525,10 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 		}
 		if (url.pathname === "/api/settings/generate-missing") {
 			await handleGenerateMissing(res);
+			return;
+		}
+		if (url.pathname === "/api/wiki/rebuild") {
+			await handleWikiRebuild(res);
 			return;
 		}
 		if (url.pathname === "/api/settings/probe-local-agent") {
@@ -1645,6 +1678,59 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 		} finally {
 			generateMissingInFlight = false;
 		}
+	}
+
+	/**
+	 * Knowledge/Graph page: rebuild the WHOLE Memory Bank folder's wiki/graph on
+	 * demand — the same folder-wide sweep as `jolli compile` / VS Code's "Build
+	 * Knowledge Wiki" (`compileAllRepos`). Runs IN this long-lived server process,
+	 * fire-and-forget: returns 202 immediately while the sweep proceeds, and the
+	 * page polls `/api/wiki/freshness` (whose `inFlight` reflects the flag below)
+	 * to completion. 409 when one is already running so the page shows one
+	 * "Rebuilding…", not two.
+	 *
+	 * In-process (not a detached worker) is what lets a plain server-local boolean
+	 * observe start and end — `compileAllRepos` uses folder-only storage per repo
+	 * (no git worktree), so it needs no per-repo queue/worker.
+	 */
+	async function handleWikiRebuild(res: ServerResponse): Promise<void> {
+		const config = await loadConfigFromDir(configDir ?? getGlobalConfigDir());
+		if (!config.localFolder) {
+			sendJson(res, 400, { error: "no Memory Bank folder is configured" });
+			return;
+		}
+		// Gate on a usable LLM provider up front — the same check VS Code's
+		// "Build Knowledge Wiki" does. Without it, `compileAllRepos` would fail every
+		// batch silently (its per-repo errors are caught, not thrown), the flag would
+		// flip back, and the banner would return to the identical "behind" state with
+		// no signal to the user beyond a server log line. Surfacing it as an error the
+		// page renders (shell.js's non-409 catch → callout + Retry) keeps parity.
+		const { resolveLlmCredentialSource } = await import("../core/LlmClient.js");
+		if (resolveLlmCredentialSource(config) === null) {
+			sendJson(res, 400, {
+				error: "Building the knowledge wiki needs an AI provider — open Settings to sign in, add a key, or select the Local Agent, then try again.",
+			});
+			return;
+		}
+		if (wikiRebuildInFlight) {
+			sendJson(res, 409, { error: "a wiki rebuild is already running — wait for it to finish" });
+			return;
+		}
+		wikiRebuildInFlight = true;
+		const localFolder = config.localFolder;
+		// Fire-and-forget: the sweep is multi-minute and LLM-bearing, so it must not
+		// block this handler. The flag is cleared in the tail regardless of outcome.
+		void (async () => {
+			try {
+				const { compileAllRepos } = await import("../core/MultiRepoCompile.js");
+				await compileAllRepos(localFolder, config);
+			} catch (err) {
+				log.warn("wiki rebuild (compile all repos) failed: %s", errMsg(err));
+			} finally {
+				wikiRebuildInFlight = false;
+			}
+		})();
+		sendJson(res, 202, { ok: true });
 	}
 
 	/** Settings → AI Summary: probe whether a local-agent CLI is usable (spawns `--version`). */

--- a/cli/src/dashboard/assets/js/graph.js
+++ b/cli/src/dashboard/assets/js/graph.js
@@ -56,7 +56,14 @@ window.JD = window.JD || {};
 			src +
 			'"></iframe></section>';
 		syncUrlWithFrame(available);
+		// wiki/graph freshness + on-demand Rebuild (folder-wide aggregate).
+		if (JD.mountWikiFreshness) JD.mountWikiFreshness();
 	}
+
+	// Note: the "No graphs yet" empty state above returns before this, so the
+	// banner shows only when at least one graph exists — matching where a rebuild
+	// makes sense. The banner is folder-wide: it reports how far behind ALL Memory
+	// Bank repos are (aggregate), and its `never`/`fresh`/`behind` states cover that.
 
 	// Mirror the frame's in-iframe repo switch into this page's /graph?kb= URL.
 	// Re-registered per render with the current repo list; the previous handler

--- a/cli/src/dashboard/assets/js/knowledge.js
+++ b/cli/src/dashboard/assets/js/knowledge.js
@@ -173,6 +173,8 @@ window.JD = window.JD || {};
 		};
 		wireList(model);
 		wireWikiNav(model);
+		// wiki/graph freshness + on-demand Rebuild (folder-wide aggregate).
+		if (JD.mountWikiFreshness) JD.mountWikiFreshness();
 	}
 
 	// A source-commit link clicked inside the wiki iframe posts up its commit hash

--- a/cli/src/dashboard/assets/js/shell.js
+++ b/cli/src/dashboard/assets/js/shell.js
@@ -1200,22 +1200,96 @@ window.JD = window.JD || {};
 	// re-render) the new chain replaces the old rather than stacking a second one.
 	var wikiPollTimer = null;
 
+	/* Banner "dismiss" (×) persistence. The user can collapse the reminder; it comes
+	   back only when there is genuinely something new to say. State lives in
+	   localStorage as {nonce, total, severity}:
+	   - `nonce` is the server's per-process id (see DashboardServer `wikiBannerNonce`).
+	     A restart mints a new one, so a dismissed banner reappears after a restart —
+	     the web analog of VSCode's host-process memory.
+	   - re-show when the backlog GREW (`total` up) or got more urgent (severity up),
+	     so a dismiss can never permanently mute a growing debt.
+	   - clearing on `fresh` (nothing behind) scopes a dismiss to ONE behind episode:
+	     once caught up, the next time it falls behind it shows again. */
+	var WIKI_DISMISS_KEY = "jolli.wikiBannerDismiss";
+	// `never` folds to info's rank (it never reaches the aggregate severity, which is
+	// only fresh/info/warn) — kept identical to the VS Code side (WIKI_SEVERITY_RANK
+	// in SidebarWebviewProvider.ts) so both surfaces order urgency the same way.
+	var WIKI_SEVERITY_RANK = { fresh: 0, never: 1, info: 1, warn: 2 };
+	// Cache of the freshness last rendered, so the × click handler (which has no `f`
+	// in scope) can snapshot the state at dismiss time.
+	var lastWikiFreshness = null;
+	function wikiSeverityRank(s) { return WIKI_SEVERITY_RANK[s] || 0; }
+	function wikiDismissRead() {
+		try {
+			var raw = window.localStorage.getItem(WIKI_DISMISS_KEY);
+			return raw ? JSON.parse(raw) : null;
+		} catch (_e) { return null; }
+	}
+	function wikiDismissWrite(f) {
+		try {
+			window.localStorage.setItem(WIKI_DISMISS_KEY, JSON.stringify({
+				nonce: f && f.nonce,
+				total: (f && f.pending && f.pending.total) || 0,
+				summary: (f && f.pending && f.pending.summary) || 0,
+				severity: f && f.severity,
+				repos: (f && f.behindRepoNames) || []
+			}));
+		} catch (_e) { /* storage blocked — dismiss simply won't persist */ }
+	}
+	function wikiDismissClear() {
+		try { window.localStorage.removeItem(WIKI_DISMISS_KEY); } catch (_e) { /* ignore */ }
+	}
+	// True when a currently-behind `f` should stay HIDDEN because the user dismissed
+	// it and nothing new has happened since. If anything HAS (backlog grew — by total
+	// OR by the headline `summary` count — got more urgent, or a repo the dismissal
+	// never saw is now behind), the dismissal is spent: clear it and return false so
+	// the banner shows again and stays shown. This clear-on-re-show mirrors the VS
+	// Code host gate (SidebarWebviewProvider.gateWikiFreshnessByDismiss) so both
+	// surfaces behave identically — without it a later drop below the frozen baseline
+	// would silently re-hide a banner the user had already seen re-appear.
+	function wikiDismissBlocks(f) {
+		var d = wikiDismissRead();
+		if (!d || d.nonce !== (f && f.nonce)) return false; // no record, or server restarted
+		var total = (f && f.pending && f.pending.total) || 0;
+		var summary = (f && f.pending && f.pending.summary) || 0;
+		var names = (f && f.behindRepoNames) || [];
+		var grew = total > (d.total || 0) || summary > (d.summary || 0);
+		var moreUrgent = wikiSeverityRank(f && f.severity) > wikiSeverityRank(d.severity);
+		var newRepo = names.some(function (n) { return (d.repos || []).indexOf(n) === -1; });
+		if (grew || moreUrgent || newRepo) {
+			wikiDismissClear();
+			return false;
+		}
+		return true;
+	}
+
 	function wikiBannerHtml(f) {
 		var esc = JD.esc;
+		lastWikiFreshness = f || null;
 		if (!f || f.available === false) return "";
 		if (f.inFlight) {
 			// Keep the warn tint while rebuilding if the wiki was warn-behind — the
-			// banner shouldn't lose its severity color mid-rebuild.
+			// banner shouldn't lose its severity color mid-rebuild. No × while a
+			// rebuild is running (nothing to dismiss; it clears itself when fresh).
 			var inCls = f.severity === "warn" ? "warning-banner" : "callout";
 			return (
 				'<div class="' + inCls + '"><span class="spin" aria-hidden="true"></span>' +
-				"<span>Rebuilding the wiki/graph…</span></div>"
+				"<span>Updating the wiki/graph…</span></div>"
 			);
 		}
 		// Aggregate across the whole Memory Bank folder. Up to date (nothing behind):
 		// show nothing — the empty container collapses via `.wiki-freshness:empty`.
 		var names = (f.behindRepoNames || []).slice();
-		if (!names.length) return "";
+		if (!names.length) {
+			// Caught up: forget any prior dismiss so the next behind episode shows.
+			// Opportunistic — these pages have no idle poll, so the clear happens the
+			// next time a render observes `fresh` (page mount, or the end of a rebuild
+			// poll), not the instant the folder catches up. Acceptable: the freshness
+			// is a deliberately slow probe, and every page mount re-evaluates it.
+			wikiDismissClear();
+			return "";
+		}
+		if (wikiDismissBlocks(f)) return "";
 		var repo =
 			names.length === 1
 				? "for <strong>" + esc(names[0]) + "</strong>"
@@ -1228,9 +1302,10 @@ window.JD = window.JD || {};
 				: extra + " " + (extra === 1 ? "item" : "items") + " pending";
 		var cls = f.severity === "warn" ? "warning-banner" : "callout";
 		return (
-			'<div class="' + cls + '"><span>Wiki is behind ' + repo + " — " + esc(String(label)) +
-			". Rebuilding uses your LLM.</span> " +
-			'<button type="button" class="cta sm" data-wiki-rebuild="1">Rebuild wiki</button></div>'
+			'<div class="' + cls + '"><span>Wiki &amp; graph are behind ' + repo + " — " + esc(String(label)) +
+			".</span> " +
+			'<button type="button" class="cta sm" data-wiki-rebuild="1">Update</button>' +
+			'<button type="button" class="wiki-dismiss" data-wiki-dismiss="1" aria-label="Dismiss" title="Dismiss">×</button></div>'
 		);
 	}
 
@@ -1263,11 +1338,20 @@ window.JD = window.JD || {};
 	}
 
 	function wireWikiRebuild(container) {
+		// The × (present only on a behind banner, never on the in-flight/error state).
+		// Snapshot the freshness shown at dismiss time so re-show can compare against it.
+		var dismissBtn = container.querySelector("[data-wiki-dismiss]");
+		if (dismissBtn) {
+			dismissBtn.onclick = function () {
+				wikiDismissWrite(lastWikiFreshness);
+				container.innerHTML = ""; // collapses via `.wiki-freshness:empty`
+			};
+		}
 		var btn = container.querySelector("[data-wiki-rebuild]");
 		if (!btn) return;
 		btn.onclick = function () {
 			btn.disabled = true;
-			btn.textContent = "Rebuilding…";
+			btn.textContent = "Updating…";
 			JD.post("/api/wiki/rebuild", {})
 				.then(function () {
 					pollWikiUntilDone(container, WIKI_POLL_MAX);
@@ -1281,7 +1365,7 @@ window.JD = window.JD || {};
 					// Any other failure: surface it BUT keep a wired retry button — these
 					// pages have no auto-refresh poll, so a buttonless error callout would
 					// leave the feature dead until a full reload.
-					container.innerHTML = '<div class="callout err"><span>Could not start the rebuild: ' +
+					container.innerHTML = '<div class="callout err"><span>Could not start the update: ' +
 						JD.esc(String((e && e.message) || "error")) + "</span> " +
 						'<button type="button" class="cta sm" data-wiki-rebuild="1">Retry</button></div>';
 					wireWikiRebuild(container);

--- a/cli/src/dashboard/assets/js/shell.js
+++ b/cli/src/dashboard/assets/js/shell.js
@@ -1051,7 +1051,11 @@ window.JD = window.JD || {};
 			body: JSON.stringify(body || {}),
 		}).then(async (res) => {
 			var data = await res.json().catch(() => ({}));
-			if (!res.ok) throw new Error(data.error || "request failed (" + res.status + ")");
+			if (!res.ok) {
+				var err = new Error(data.error || "request failed (" + res.status + ")");
+				err.status = res.status;
+				throw err;
+			}
 			return data;
 		});
 
@@ -1170,5 +1174,147 @@ window.JD = window.JD || {};
 	JD.startRefresh = (render) => {
 		if ((window.__JOLLI_DASHBOARD__ || {}).view !== "stats") return;
 		setInterval(() => JD.refreshNow(render), PAGE_REFRESH_MS);
+	};
+
+	/* the folder-wide wiki/graph freshness banner shared by the Knowledge and
+	   Graph pages. Fetches /api/wiki/freshness (slow, off first paint) into the
+	   container, and offers a Rebuild button that POSTs /api/wiki/rebuild (a whole-
+	   folder `compileAllRepos` sweep) and polls freshness to completion. The freshness
+	   is aggregated across every Memory Bank repo, so the banner describes the whole
+	   folder, not one repo. */
+	// 5s, not a tight loop: each tick re-runs the whole-folder freshness scan (every
+	// repo's index / processed-set / plans / notes / user files) in the same process
+	// as the LLM sweep, so a shorter interval would turn a documented "slow probe"
+	// into a hot loop. Completion latency of a few seconds is invisible next to a
+	// multi-minute rebuild.
+	var WIKI_POLL_MS = 5000;
+	// Poll budget per attempt (~16 min). `inFlight` is the server's in-process
+	// `wikiRebuildInFlight` flag (the sweep runs inside the dashboard process, fire-
+	// and-forget), so it drops to false when the sweep ends and the poll terminates.
+	// This bound only governs a still-running sweep: on exhaustion we re-probe once
+	// and, if still inFlight, resume polling (showing continued progress is preferable
+	// to abandoning a long-but-live rebuild).
+	var WIKI_POLL_MAX = 200;
+	// The single live poll timer. Every scheduled tick clears the previous one before
+	// arming, so if the banner is ever re-mounted mid-rebuild (a future in-page
+	// re-render) the new chain replaces the old rather than stacking a second one.
+	var wikiPollTimer = null;
+
+	function wikiBannerHtml(f) {
+		var esc = JD.esc;
+		if (!f || f.available === false) return "";
+		if (f.inFlight) {
+			// Keep the warn tint while rebuilding if the wiki was warn-behind — the
+			// banner shouldn't lose its severity color mid-rebuild.
+			var inCls = f.severity === "warn" ? "warning-banner" : "callout";
+			return (
+				'<div class="' + inCls + '"><span class="spin" aria-hidden="true"></span>' +
+				"<span>Rebuilding the wiki/graph…</span></div>"
+			);
+		}
+		// Aggregate across the whole Memory Bank folder. Up to date (nothing behind):
+		// show nothing — the empty container collapses via `.wiki-freshness:empty`.
+		var names = (f.behindRepoNames || []).slice();
+		if (!names.length) return "";
+		var repo =
+			names.length === 1
+				? "for <strong>" + esc(names[0]) + "</strong>"
+				: "for <strong>" + names.length + " repos</strong> (" + esc(names.join(", ")) + ")";
+		var n = f.pending ? f.pending.summary : 0;
+		var extra = f.pending && f.pending.total > n ? f.pending.total - n : 0;
+		var label =
+			n > 0
+				? n + " new " + (n === 1 ? "memory" : "memories") + " to fold in"
+				: extra + " " + (extra === 1 ? "item" : "items") + " pending";
+		var cls = f.severity === "warn" ? "warning-banner" : "callout";
+		return (
+			'<div class="' + cls + '"><span>Wiki is behind ' + repo + " — " + esc(String(label)) +
+			". Rebuilding uses your LLM.</span> " +
+			'<button type="button" class="cta sm" data-wiki-rebuild="1">Rebuild wiki</button></div>'
+		);
+	}
+
+	function pollWikiUntilDone(container, tries) {
+		if (tries <= 0) {
+			refreshWikiBanner(container);
+			return;
+		}
+		// One timer only: clear any pending tick so a re-mounted chain replaces this
+		// one instead of running in parallel.
+		clearTimeout(wikiPollTimer);
+		wikiPollTimer = setTimeout(function () {
+			JD.getJson("/api/wiki/freshness")
+				.then(function (f) {
+					if (f && f.inFlight) {
+						container.innerHTML = wikiBannerHtml(f);
+						pollWikiUntilDone(container, tries - 1);
+					} else {
+						// Worker no longer running — read the final state once. A drop to
+						// fresh is success; still-behind means the run failed or held some
+						// sources, so we surface the (behind) banner again for a retry.
+						container.innerHTML = wikiBannerHtml(f);
+						wireWikiRebuild(container);
+					}
+				})
+				.catch(function () {
+					refreshWikiBanner(container);
+				});
+		}, WIKI_POLL_MS);
+	}
+
+	function wireWikiRebuild(container) {
+		var btn = container.querySelector("[data-wiki-rebuild]");
+		if (!btn) return;
+		btn.onclick = function () {
+			btn.disabled = true;
+			btn.textContent = "Rebuilding…";
+			JD.post("/api/wiki/rebuild", {})
+				.then(function () {
+					pollWikiUntilDone(container, WIKI_POLL_MAX);
+				})
+				.catch(function (e) {
+					// 409 (already running) is not an error for the user — just start polling.
+					if (e && e.status === 409) {
+						pollWikiUntilDone(container, WIKI_POLL_MAX);
+						return;
+					}
+					// Any other failure: surface it BUT keep a wired retry button — these
+					// pages have no auto-refresh poll, so a buttonless error callout would
+					// leave the feature dead until a full reload.
+					container.innerHTML = '<div class="callout err"><span>Could not start the rebuild: ' +
+						JD.esc(String((e && e.message) || "error")) + "</span> " +
+						'<button type="button" class="cta sm" data-wiki-rebuild="1">Retry</button></div>';
+					wireWikiRebuild(container);
+				});
+		};
+	}
+
+	function refreshWikiBanner(container) {
+		JD.getJson("/api/wiki/freshness")
+			.then(function (f) {
+				container.innerHTML = wikiBannerHtml(f);
+				if (f && f.inFlight) pollWikiUntilDone(container, WIKI_POLL_MAX);
+				else wireWikiRebuild(container);
+			})
+			.catch(function () {
+				container.innerHTML = ""; // slow probe failed — show nothing rather than a scary error
+			});
+	}
+
+	/* Mount the folder-wide freshness banner as the FIRST child of the right
+	   content column (`.main`) — the same top-of-column spot on both Knowledge and
+	   Graph, above the page header. Idempotent: `.main` outlives per-page `#app`
+	   re-renders, so reuse an existing banner instead of stacking a second one.
+	   Safe no-op when the column is missing. */
+	JD.mountWikiFreshness = function () {
+		var host = document.querySelector(".main");
+		if (!host) return;
+		var banner = host.querySelector(".wiki-freshness");
+		if (!banner) {
+			banner = document.createElement("div");
+			banner.className = "wiki-freshness";
+			host.insertBefore(banner, host.firstChild);
+		}
+		refreshWikiBanner(banner);
 	};
 })(window.JD);

--- a/cli/src/dashboard/assets/styles/main.css
+++ b/cli/src/dashboard/assets/styles/main.css
@@ -1689,3 +1689,11 @@ body {
 	display: flex; gap: 10px; align-items: center; border-radius: 0; border-width: 0 0 1px;
 }
 .jd .wiki-freshness .cta.sm { margin-left: auto; white-space: nowrap; }
+/* Close (×): sits just right of the Update button (which carries margin-left:auto,
+   so both are pushed to the far end). Subtle by default, full-opacity on hover. */
+.jd .wiki-freshness .wiki-dismiss {
+	flex: none; border: 0; background: transparent; color: inherit; cursor: pointer;
+	opacity: .55; font-size: 18px; line-height: 1; padding: 0 2px; margin-left: 2px;
+}
+.jd .wiki-freshness .wiki-dismiss:hover { opacity: 1; }
+.jd .wiki-freshness .wiki-dismiss:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }

--- a/cli/src/dashboard/assets/styles/main.css
+++ b/cli/src/dashboard/assets/styles/main.css
@@ -1553,22 +1553,51 @@ body {
      min-height:100vh, which grows past the viewport under `.main`'s 48px
      padding-bottom + the footer note) and drop both for these views. */
   .jd:has(.knowledge-page), .jd:has(.graph-page) { height: 100vh; overflow: hidden; }
-  .main:has(.knowledge-page), .main:has(.graph-page) { padding-bottom: 0; }
+  /* Column layout so the freshness banner (first child, auto height) + the header
+     + the content stack, and the content fills the REMAINING space rather than a
+     hardcoded calc that ignores the banner (which pushed the list bottom past the
+     viewport and clipped it). Heights below are parent-relative (100%), not
+     viewport calc, so the banner's height is subtracted automatically. */
+  .main:has(.knowledge-page), .main:has(.graph-page) {
+    padding-bottom: 0; display: flex; flex-direction: column; height: 100vh; min-height: 0;
+  }
   .main:has(.knowledge-page) .footer-note, .main:has(.graph-page) .footer-note { display: none; }
   /* Graph carries its own header (repo name + search) inside the framed viz, so
      the dashboard topbar ("Graph · knowledge graph · per-repo") is redundant — hide
      it and let the graph fill the full viewport; the repo picker below is the only
      dashboard chrome the page needs. Knowledge keeps its topbar. */
   .main:has(.graph-page) .topbar { display: none; }
-  .wrap:has(.knowledge-page) { max-width: none; padding: 0 56px 0 0; }
-  .wrap:has(.graph-page) { max-width: none; padding: 0; }
-  .grid:has(.knowledge-page), .grid:has(.graph-page) { display: block; }
+  /* margin:0 overrides the base `.wrap { margin: 0 auto }`: inside `.main`'s flex
+     column those horizontal auto margins would shrink-to-content + center the item
+     (collapsing the list/graph to a narrow centered strip) instead of stretching. */
+  /* Pure flex chain (each level flex:1 + min-height:0), NOT percentage heights:
+     a height:100% chain breaks at the grid (its implicit row is auto, so
+     `.kn-side { height:100% }` can't resolve and the list stops scrolling). margin:0
+     overrides the base `.wrap { margin: 0 auto }` — horizontal auto margins in a
+     flex column shrink-to-content + center instead of stretching. */
+  .wrap:has(.knowledge-page) {
+    max-width: none; margin: 0; padding: 0 56px 0 0;
+    flex: 1; min-height: 0; display: flex; flex-direction: column;
+  }
+  .wrap:has(.graph-page) {
+    max-width: none; margin: 0; padding: 0;
+    flex: 1; min-height: 0; display: flex; flex-direction: column;
+  }
+  /* Target #app by id, NOT `.grid`: main.js sets `#app.className = view.grid ? "grid" : ""`,
+     so on the Knowledge/Graph views (grid:false) #app has NO class and a `.grid:has(...)`
+     rule never matches — the flex chain would break here and the content collapse. */
+  #app:has(.knowledge-page), #app:has(.graph-page) {
+    display: flex; flex-direction: column; flex: 1; min-height: 0;
+  }
   .knowledge-page {
     display: grid; grid-template-columns: 344px minmax(0, 1fr);
-    gap: 6px; height: calc(100vh - 58px);
+    /* Row fills the flex-definite height so the grid items (kn-side/kn-detail) get
+       a definite height to resolve their own 100% / internal scroll against. */
+    grid-template-rows: minmax(0, 1fr);
+    gap: 6px; flex: 1; min-height: 0;
   }
   .kn-side {
-    min-width: 0; height: calc(100vh - 58px); align-self: start; overflow: hidden;
+    min-width: 0; height: 100%; align-self: start; overflow: hidden;
     border: 1px solid var(--border); border-radius: 12px; background: var(--surface);
     box-shadow: 0 2px 5px rgba(20, 30, 50, .05); display: flex; flex-direction: column;
   }
@@ -1620,7 +1649,7 @@ body {
      The whole page IS the framed `/graph-viewer` viz (its own header carries the
      repo switcher + search). Dashboard topbar hidden (above); iframe fills the
      viewport. It needs an explicit height — an iframe with none collapses to ~150px. */
-  .graph-page { display: flex; flex-direction: column; height: 100vh; padding: 0; }
+  .graph-page { display: flex; flex-direction: column; flex: 1; min-height: 0; padding: 0; }
   .graph-frame { flex: 1; min-height: 0; width: 100%; border: 0; background: var(--surface); }
   .graph-page .empty { margin: 24px; }
 
@@ -1632,13 +1661,31 @@ body {
     /* Stacked layout is taller than the viewport, so let the OUTER page scroll
        again (undo the viewport cap) rather than clipping the reading pane. */
     .jd:has(.knowledge-page), .jd:has(.graph-page) { height: auto; overflow: visible; }
-    .main:has(.knowledge-page), .main:has(.graph-page) { padding-bottom: 48px; }
-    .wrap:has(.knowledge-page) { padding: 0 16px; }
-    .wrap:has(.graph-page) { padding: 0 16px; }
-    .knowledge-page { grid-template-columns: 1fr; gap: 0; height: auto; }
+    .main:has(.knowledge-page), .main:has(.graph-page) { padding-bottom: 48px; display: block; height: auto; }
+    /* Undo the flex chain from the wide layout so the stacked page scrolls normally. */
+    .wrap:has(.knowledge-page) { padding: 0 16px; display: block; flex: none; }
+    .wrap:has(.graph-page) { padding: 0 16px; display: block; flex: none; }
+    #app:has(.knowledge-page), #app:has(.graph-page) { display: block; flex: none; }
+    .knowledge-page { grid-template-columns: 1fr; grid-template-rows: auto; gap: 0; flex: none; }
     .kn-side { height: auto; }
     .kn-list { height: min(42vh, 360px); }
     .kn-detail { height: min(60vh, 520px); }
-    .graph-page { height: auto; }
+    .graph-page { flex: none; }
     .graph-frame { height: min(70vh, 560px); }
   }
+
+/* wiki/graph freshness banner (shared by Knowledge + Graph pages). */
+/* Folder-wide freshness banner: a full-width strip flush at the very top of the
+   content column (`.main`), above the page header — identical placement on the
+   Knowledge and Graph pages. In normal flow (a banner, not a floating tag), so it
+   reads as a page-level notice. Empty (up-to-date) collapses to nothing. */
+.jd .wiki-freshness { margin: 0; }
+.jd .wiki-freshness:empty { display: none; }
+.jd .wiki-freshness .callout,
+.jd .wiki-freshness .warning-banner {
+	/* Both flex so the Rebuild button's `margin-left:auto` pushes it to the far
+	   right consistently. `.callout` is already flex; `.warning-banner` is block by
+	   default, which is why warn used to sit the button right next to the text. */
+	display: flex; gap: 10px; align-items: center; border-radius: 0; border-width: 0 0 1px;
+}
+.jd .wiki-freshness .cta.sm { margin-left: auto; white-space: nowrap; }

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -592,12 +592,22 @@ describe("PostCommitHook", () => {
 		expect(spawn).not.toHaveBeenCalled();
 	});
 
-	it("debounce-enqueues a post-commit ingest after processing a commit", async () => {
+	it("debounce-enqueues a post-commit ingest after processing a commit when wikiRebuild is auto", async () => {
 		setupFullPipeline();
+		// the post-commit ingest enqueue is gated on wikiRebuild==="auto".
+		vi.mocked(loadConfig).mockResolvedValue({ wikiRebuild: "auto" });
 
 		await runWorker("/test/project");
 
 		expect(enqueueIngestOperation).toHaveBeenCalledWith("/test/project", "post-commit");
+	});
+
+	it("does NOT enqueue a post-commit ingest in the default manual mode", async () => {
+		setupFullPipeline(); // loadConfig defaults to {} → wikiRebuild absent → manual
+
+		await runWorker("/test/project");
+
+		expect(enqueueIngestOperation).not.toHaveBeenCalled();
 	});
 
 	it("should run the full pipeline successfully", async () => {

--- a/cli/src/hooks/PostMergeHook.test.ts
+++ b/cli/src/hooks/PostMergeHook.test.ts
@@ -127,7 +127,7 @@ describe("handlePostMerge", () => {
 			stderr: "",
 			exitCode: 0,
 		});
-		mockLoadConfig.mockResolvedValue({ aiProvider: "local-agent" });
+		mockLoadConfig.mockResolvedValue({ aiProvider: "local-agent", wikiRebuild: "auto" });
 		const origKey = process.env.ANTHROPIC_API_KEY;
 		delete process.env.ANTHROPIC_API_KEY;
 
@@ -144,7 +144,7 @@ describe("handlePostMerge", () => {
 			stderr: "",
 			exitCode: 0,
 		});
-		mockLoadConfig.mockResolvedValue({ apiKey: "sk-test" });
+		mockLoadConfig.mockResolvedValue({ apiKey: "sk-test", wikiRebuild: "auto" });
 
 		await handlePostMerge("/test");
 
@@ -161,7 +161,7 @@ describe("handlePostMerge", () => {
 			stderr: "",
 			exitCode: 0,
 		});
-		mockLoadConfig.mockResolvedValue({ apiKey: "sk-test" });
+		mockLoadConfig.mockResolvedValue({ apiKey: "sk-test", wikiRebuild: "auto" });
 
 		await handlePostMerge("/test");
 
@@ -179,7 +179,7 @@ describe("handlePostMerge", () => {
 			stderr: "",
 			exitCode: 0,
 		});
-		mockLoadConfig.mockResolvedValue({ apiKey: "sk-test" });
+		mockLoadConfig.mockResolvedValue({ apiKey: "sk-test", wikiRebuild: "auto" });
 
 		await handlePostMerge("/test");
 
@@ -203,7 +203,7 @@ describe("handlePostMerge", () => {
 			}
 			return { stdout: "", stderr: "", exitCode: 0 };
 		});
-		mockLoadConfig.mockResolvedValue({ apiKey: "sk-test" });
+		mockLoadConfig.mockResolvedValue({ apiKey: "sk-test", wikiRebuild: "auto" });
 
 		await handlePostMerge("/test");
 
@@ -251,12 +251,42 @@ describe("handlePostMerge", () => {
 			stderr: "",
 			exitCode: 0,
 		});
-		mockLoadConfig.mockResolvedValue({ apiKey: "sk-test" });
+		mockLoadConfig.mockResolvedValue({ apiKey: "sk-test", wikiRebuild: "auto" });
 		mockEnqueueIngest.mockResolvedValue(false);
 
 		await handlePostMerge("/test");
 
 		expect(mockEnqueueIngest).toHaveBeenCalledOnce();
+		expect(mockLaunchWorker).not.toHaveBeenCalled();
+	});
+
+	it("does NOT enqueue in the default MANUAL mode — absent wikiRebuild means manual", async () => {
+		mockExecGit.mockResolvedValue({
+			stdout: "Merge branch 'feature/x' into main",
+			stderr: "",
+			exitCode: 0,
+		});
+		// wikiRebuild absent → manual: the merged commits are summarized by the
+		// per-commit path, but folding them into the wiki waits for a user rebuild.
+		mockLoadConfig.mockResolvedValue({ apiKey: "sk-test" });
+
+		await handlePostMerge("/test");
+
+		expect(mockEnqueueIngest).not.toHaveBeenCalled();
+		expect(mockLaunchWorker).not.toHaveBeenCalled();
+	});
+
+	it("does NOT enqueue when wikiRebuild is explicitly manual", async () => {
+		mockExecGit.mockResolvedValue({
+			stdout: "Merge branch 'feature/x' into main",
+			stderr: "",
+			exitCode: 0,
+		});
+		mockLoadConfig.mockResolvedValue({ apiKey: "sk-test", wikiRebuild: "manual" });
+
+		await handlePostMerge("/test");
+
+		expect(mockEnqueueIngest).not.toHaveBeenCalled();
 		expect(mockLaunchWorker).not.toHaveBeenCalled();
 	});
 });

--- a/cli/src/hooks/PostMergeHook.ts
+++ b/cli/src/hooks/PostMergeHook.ts
@@ -21,6 +21,7 @@ import { resolveLlmCredentialSource } from "../core/LlmClient.js";
 import { readManualDisableFlag } from "../core/RepoProfile.js";
 import { loadConfig } from "../core/SessionTracker.js";
 import { runWithTrace, traceIdFromEnv } from "../core/TraceContext.js";
+import { wikiRebuildIsAuto } from "../core/WikiRebuildMode.js";
 import { createLogger, setLogDir } from "../Logger.js";
 import { launchWorker } from "./QueueWorker.js";
 
@@ -120,6 +121,14 @@ export async function handlePostMerge(cwd: string): Promise<void> {
 	const config = await loadConfig();
 	if (resolveLlmCredentialSource(config) === null) {
 		log.info("No API key configured -- skipping compile enqueue");
+		return;
+	}
+
+	// In the default MANUAL mode a `git pull`'s merged commits are NOT
+	// auto-folded into the wiki/graph — the per-commit summaries already exist, and
+	// the user rebuilds the wiki on demand from the dashboard / VS Code sidebar.
+	if (!wikiRebuildIsAuto(config)) {
+		log.info("wikiRebuild=manual -- skipping post-merge ingest enqueue (rebuild on demand)");
 		return;
 	}
 

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -532,6 +532,13 @@ vi.mock("../core/IngestPipeline.js", () => ({
 	drainIngest: vi.fn(async () => ({ batches: 0, ingested: 0, outcome: "NO_PENDING", topicFailures: [] })),
 }));
 
+// the only ProcessedSourceStore symbol QueueWorker imports is the
+// rebase-pick processed-carry. Mock it so the rebase-pick wiring test can assert
+// the call without a real orphan-branch write.
+vi.mock("../core/ProcessedSourceStore.js", () => ({
+	carryProcessedSummaryHash: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("../core/TopicWikiRenderer.js", () => ({
 	renderTopicKBWiki: vi.fn(async () => {}),
 }));
@@ -4250,6 +4257,48 @@ describe("QueueWorker", () => {
 			// type; setupPipelineMocks() at the top of every other test rebuilds the
 			// full mock pack, but here we only need the branch reader.
 			vi.mocked(getCurrentBranch).mockResolvedValue("feature/test");
+		});
+
+		// a real rebase-pick (with sourceHashes) migrates
+		// the summary 1:1 and MUST carry the old hash's "already ingested" mark onto
+		// the new hash, or the next wiki rebuild re-reconciles a byte-identical
+		// summary. The other rebase-pick tests early-return (no sourceHashes), so
+		// this is the only one that exercises the carry wiring.
+		it("carries the processed mark old→new on a real rebase-pick migration", async () => {
+			const { getSummary } = await import("../core/SummaryStore.js");
+			const { carryProcessedSummaryHash } = await import("../core/ProcessedSourceStore.js");
+			vi.mocked(carryProcessedSummaryHash).mockClear();
+			vi.mocked(getSummary).mockResolvedValue({
+				version: 5,
+				commitHash: "oldhash",
+				commitMessage: "Old",
+				commitAuthor: "Jane",
+				commitDate: "2026-04-01T10:00:00.000Z",
+				branch: "feature/test",
+				generatedAt: "2026-04-01T10:00:00.000Z",
+				topics: [],
+			} as Awaited<ReturnType<typeof getSummary>>);
+			vi.mocked(getCommitInfo).mockResolvedValue({
+				hash: "newhash123",
+				message: "New",
+				author: "Jane",
+				date: "2026-04-02T10:00:00.000Z",
+			} as never);
+
+			await __test__.processQueueEntry(
+				{
+					type: "rebase-pick",
+					commitHash: "newhash123",
+					branch: "feature/test",
+					sourceHashes: ["oldhash"],
+					createdAt: new Date().toISOString(),
+				} as never,
+				"/test/cwd",
+				mockStorage as never,
+				false,
+			);
+
+			expect(carryProcessedSummaryHash).toHaveBeenCalledWith("/test/cwd", "oldhash", "newhash123");
 		});
 
 		// Use op.type === "rebase-pick" with no sourceHashes: the handler early-

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -82,6 +82,7 @@ import { readOpenCodeTranscript } from "../core/OpenCodeTranscriptReader.js";
 import { evaluatePlanProgress } from "../core/PlanProgressEvaluator.js";
 import { formatPlansBlock } from "../core/PlanPromptFormatter.js";
 import { estimateCostUsd, PRICES_AS_OF } from "../core/Pricing.js";
+import { carryProcessedSummaryHash } from "../core/ProcessedSourceStore.js";
 import { triggerPushForNewSummaries } from "../core/PushExecutor.js";
 import { createPlanSourceClassifier, partitionForeignPlans } from "../core/plans/PlanContainment.js";
 import { baseKeyOf, mergeRefsNewWins } from "../core/RefMerge.js";
@@ -152,6 +153,7 @@ import { generateTranscriptId } from "../core/TranscriptId.js";
 import { getParserForSource } from "../core/TranscriptParser.js";
 import type { SessionTranscript } from "../core/TranscriptReader.js";
 import { buildMultiSessionContext, readTranscript } from "../core/TranscriptReader.js";
+import { wikiRebuildIsAuto } from "../core/WikiRebuildMode.js";
 import { maybeAutoCutover } from "../dashboard/AutoCutover.js";
 import { opportunisticSnapshot } from "../dashboard/Backup.js";
 import { recordCommitsFromWorker } from "../dashboard/ProducerHooks.js";
@@ -809,7 +811,12 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 			// IngestTrigger's per-cwd cooldown collapses rapid commit bursts to one
 			// drain. Without this, the topic KB only updated on `git pull` merges or
 			// a manual `jolli compile`, so commit-heavy workflows went stale.
-			if (committedThisRun) {
+			//
+			// gated on wikiRebuild === "auto". In the default MANUAL mode
+			// the wiki/graph never auto-rebuilds — summaries are still generated above
+			// (recall/commit-search stay fresh), and the user folds them into the wiki
+			// on demand from the dashboard / VS Code sidebar.
+			if (committedThisRun && wikiRebuildIsAuto(await loadConfig())) {
 				await enqueueIngestOperation(cwd, "post-commit");
 			}
 
@@ -2853,6 +2860,24 @@ async function handleRebasePickFromQueue(op: CommitGitOperation, cwd: string): P
 
 	// Re-associate plans and notes with the new hash
 	await reassociateMetadata([oldSummary], op.commitHash, cwd);
+
+	// carry the old hash's "already ingested" mark onto
+	// the new hash so the byte-identical migrated summary is not re-reconciled as a
+	// brand-new source on the next wiki rebuild. This is a pure optimization — its
+	// own try/catch (like the stale-child cleanup tail) so an orphan-write throw
+	// (contention / IO) can NEVER turn a successful, already-durable migration into
+	// a reported failure; worst case we skip the mark and the next rebuild
+	// re-reconciles this one summary, i.e. the pre-2164 behaviour.
+	try {
+		await carryProcessedSummaryHash(cwd, oldHash, op.commitHash);
+	} catch (err) {
+		log.warn(
+			"Rebase-pick: could not carry processed mark %s → %s (next rebuild will re-reconcile it): %s",
+			oldHash.substring(0, 8),
+			op.commitHash.substring(0, 8),
+			errMsg(err),
+		);
+	}
 
 	log.info("Rebase-pick: migrated %s → %s", oldHash.substring(0, 8), op.commitHash.substring(0, 8));
 	// The 1:1 migration produced a summary at the new hash, so report the capture

--- a/vscode/src/CompileCommand.test.ts
+++ b/vscode/src/CompileCommand.test.ts
@@ -56,7 +56,13 @@ vi.mock("../../cli/src/core/MultiRepoCompile.js", () => ({
 import { registerCompileCommand } from "./CompileCommand.js";
 
 function makeOpts() {
-	return { sidebarProvider: { refreshKnowledgeBaseFolders: vi.fn() } };
+	return {
+		sidebarProvider: {
+			refreshKnowledgeBaseFolders: vi.fn(),
+			pushWikiFreshness: vi.fn(),
+			setWikiRebuilding: vi.fn(),
+		},
+	};
 }
 
 beforeEach(() => {
@@ -83,12 +89,30 @@ describe("registerCompileCommand", () => {
 
 	it("shows info and skips compile when no usable provider", async () => {
 		mockLoadConfig.mockResolvedValue({ localFolder: "/mb" });
-		registerCompileCommand(makeOpts());
+		const opts = makeOpts();
+		registerCompileCommand(opts);
 
 		await registeredHandlers.get("jollimemory.compileNow")?.();
 
 		expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("AI provider"));
 		expect(mockCompileAllRepos).not.toHaveBeenCalled();
+		// Resets the kb-tab banner's optimistic "Rebuilding…" button — nothing ran.
+		expect(opts.sidebarProvider.pushWikiFreshness).toHaveBeenCalled();
+	});
+
+	it("re-pushes wiki freshness after a completed sweep (resets the banner button)", async () => {
+		mockLoadConfig.mockResolvedValue({ apiKey: "sk-test", localFolder: "/mb" });
+		const opts = makeOpts();
+		registerCompileCommand(opts);
+
+		await registeredHandlers.get("jollimemory.compileNow")?.();
+
+		expect(mockCompileAllRepos).toHaveBeenCalled();
+		expect(opts.sidebarProvider.refreshKnowledgeBaseFolders).toHaveBeenCalled();
+		expect(opts.sidebarProvider.pushWikiFreshness).toHaveBeenCalled();
+		// Banner "Rebuilding…" state driven across the whole sweep: on at start, off at end.
+		expect(opts.sidebarProvider.setWikiRebuilding).toHaveBeenCalledWith(true);
+		expect(opts.sidebarProvider.setWikiRebuilding).toHaveBeenCalledWith(false);
 	});
 
 	it("compiles when the Local Agent provider is selected without any API key", async () => {
@@ -105,12 +129,15 @@ describe("registerCompileCommand", () => {
 
 	it("shows info and skips compile when no localFolder", async () => {
 		mockLoadConfig.mockResolvedValue({ apiKey: "sk-test" });
-		registerCompileCommand(makeOpts());
+		const opts = makeOpts();
+		registerCompileCommand(opts);
 
 		await registeredHandlers.get("jollimemory.compileNow")?.();
 
 		expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("Memory Bank folder"));
 		expect(mockCompileAllRepos).not.toHaveBeenCalled();
+		// Resets the banner's optimistic "Rebuilding…" button — nothing ran.
+		expect(opts.sidebarProvider.pushWikiFreshness).toHaveBeenCalled();
 	});
 
 	it("sweeps all repos and refreshes panel when API key + localFolder present", async () => {

--- a/vscode/src/CompileCommand.test.ts
+++ b/vscode/src/CompileCommand.test.ts
@@ -96,7 +96,7 @@ describe("registerCompileCommand", () => {
 
 		expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("AI provider"));
 		expect(mockCompileAllRepos).not.toHaveBeenCalled();
-		// Resets the kb-tab banner's optimistic "Rebuilding…" button — nothing ran.
+		// Resets the kb-tab banner's optimistic "Updating…" button — nothing ran.
 		expect(opts.sidebarProvider.pushWikiFreshness).toHaveBeenCalled();
 	});
 
@@ -110,7 +110,7 @@ describe("registerCompileCommand", () => {
 		expect(mockCompileAllRepos).toHaveBeenCalled();
 		expect(opts.sidebarProvider.refreshKnowledgeBaseFolders).toHaveBeenCalled();
 		expect(opts.sidebarProvider.pushWikiFreshness).toHaveBeenCalled();
-		// Banner "Rebuilding…" state driven across the whole sweep: on at start, off at end.
+		// Banner "Updating…" state driven across the whole sweep: on at start, off at end.
 		expect(opts.sidebarProvider.setWikiRebuilding).toHaveBeenCalledWith(true);
 		expect(opts.sidebarProvider.setWikiRebuilding).toHaveBeenCalledWith(false);
 	});
@@ -136,7 +136,7 @@ describe("registerCompileCommand", () => {
 
 		expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("Memory Bank folder"));
 		expect(mockCompileAllRepos).not.toHaveBeenCalled();
-		// Resets the banner's optimistic "Rebuilding…" button — nothing ran.
+		// Resets the banner's optimistic "Updating…" button — nothing ran.
 		expect(opts.sidebarProvider.pushWikiFreshness).toHaveBeenCalled();
 	});
 

--- a/vscode/src/CompileCommand.ts
+++ b/vscode/src/CompileCommand.ts
@@ -11,7 +11,21 @@ import * as vscode from "vscode";
 import { log } from "./util/Logger.js";
 
 export interface CompileCommandOpts {
-	readonly sidebarProvider: { refreshKnowledgeBaseFolders(): void };
+	readonly sidebarProvider: {
+		refreshKnowledgeBaseFolders(): void;
+		// Re-push the folder-wide freshness so the kb-tab banner re-renders. Its
+		// Rebuild button optimistically shows "Rebuilding…" on click and relies on
+		// the next push to reset; without this, an immediate-return compile (no
+		// provider) or a no-op sweep (nothing folded, so no ingest-phase event
+		// fires) would leave the button stuck until the user switches tabs. Optional
+		// so tests that stub a bare sidebarProvider keep compiling.
+		pushWikiFreshness?(): void;
+		// Drive the kb-tab banner's "Rebuilding the wiki/graph…" state across the
+		// WHOLE sweep (true at start, false at end), mirroring the dashboard's
+		// in-flight banner. Without this the banner would only change its button
+		// text, not the message. Optional for the same test-stub reason.
+		setWikiRebuilding?(active: boolean): void;
+	};
 }
 
 /**
@@ -39,12 +53,17 @@ export function registerCompileCommand(opts: CompileCommandOpts): vscode.Disposa
 			await vscode.window.showInformationMessage(
 				"Building the knowledge wiki needs an AI provider. Open Settings → Memory Bank to sign in, configure a key, or select the Local Agent, then try again.",
 			);
+			// Reset the banner's optimistic "Rebuilding…" button — nothing ran.
+			sidebarProvider.pushWikiFreshness?.();
 			return;
 		}
 		if (!config.localFolder) {
 			await vscode.window.showInformationMessage(
 				"No Memory Bank folder configured. Open Settings → Memory Bank to set one, then try again.",
 			);
+			// Reset the banner's optimistic "Rebuilding…" button — nothing ran (matches
+			// the no-provider gate; this path never reaches the try/finally that clears it).
+			sidebarProvider.pushWikiFreshness?.();
 			return;
 		}
 
@@ -56,6 +75,9 @@ export function registerCompileCommand(opts: CompileCommandOpts): vscode.Disposa
 			return;
 		}
 		compileInFlight = true;
+		// Mirror the dashboard: the banner shows "Rebuilding the wiki/graph…" for the
+		// whole sweep. Set at start (past the gates), cleared in the finally.
+		sidebarProvider.setWikiRebuilding?.(true);
 
 		const { compileAllRepos } = await import("../../cli/src/core/MultiRepoCompile.js");
 
@@ -91,8 +113,14 @@ export function registerCompileCommand(opts: CompileCommandOpts): vscode.Disposa
 			);
 		} finally {
 			compileInFlight = false;
+			// Clear the banner's "Rebuilding…" state; the freshness push below then
+			// re-renders it to the final state (fresh → hidden, or reduced backlog).
+			sidebarProvider.setWikiRebuilding?.(false);
 		}
 
 		sidebarProvider.refreshKnowledgeBaseFolders();
+		// Re-render the kb-tab freshness banner (fresh → hidden, or the reduced
+		// backlog) and reset its "Rebuilding…" button, regardless of sweep outcome.
+		sidebarProvider.pushWikiFreshness?.();
 	});
 }

--- a/vscode/src/Extension.test.ts
+++ b/vscode/src/Extension.test.ts
@@ -360,6 +360,16 @@ const {
 		openReferenceMarkdown: vi.fn().mockResolvedValue(undefined),
 		previewReferenceMarkdown: vi.fn().mockResolvedValue(undefined),
 		removeReference: vi.fn().mockResolvedValue(undefined),
+		// Folder-wide wiki/graph freshness. Full AggregateWikiFreshness by default;
+		// the Extension.ts dep maps it to the compact webview shape.
+		getWikiFreshness: vi.fn().mockResolvedValue({
+			repos: [],
+			behindRepoNames: ["acme", "beta"],
+			pending: { summary: 2, total: 3 },
+			lastRebuiltAt: "2026-08-10T00:00:00.000Z",
+			everBuilt: true,
+			severity: "info",
+		}),
 	};
 
 	const mockCommitCommand_ = { execute: vi.fn().mockResolvedValue(undefined) };
@@ -1036,6 +1046,7 @@ vi.mock("./views/SidebarWebviewProvider.js", () => ({
 		}
 		resolveWebviewView() {}
 		dispose() {}
+		pushWikiFreshness = vi.fn().mockResolvedValue(undefined);
 		refreshKnowledgeBaseFolders = mockRefreshKnowledgeBaseFolders;
 		clearKnowledgeBaseFolderDivergence = mockClearKnowledgeBaseFolderDivergence;
 		refreshConversationsPanel = mockRefreshConversationsPanel;
@@ -1614,6 +1625,31 @@ describe("Extension", () => {
 			};
 			expect(typeof deps.getSummaryAnyRepoWithSource).toBe("function");
 			expect(typeof deps.readTranscriptForRepo).toBe("function");
+		});
+
+		it("maps the bridge's full AggregateWikiFreshness to the compact getWikiFreshness dep", async () => {
+			const ctx = makeContext();
+
+			activate(ctx);
+
+			const deps = sidebarDepsCaptured as {
+				getWikiFreshness: () => Promise<{
+					severity: string;
+					behindRepoNames: ReadonlyArray<string>;
+					summary: number;
+					total: number;
+					lastRebuiltAt: string | null;
+				}>;
+			};
+			expect(typeof deps.getWikiFreshness).toBe("function");
+			await expect(deps.getWikiFreshness()).resolves.toEqual({
+				severity: "info",
+				behindRepoNames: ["acme", "beta"],
+				summary: 2,
+				total: 3,
+				lastRebuiltAt: "2026-08-10T00:00:00.000Z",
+			});
+			expect(mockBridge.getWikiFreshness).toHaveBeenCalled();
 		});
 
 		it("registers all expected commands", () => {

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -1391,6 +1391,18 @@ export function activate(context: vscode.ExtensionContext): void {
 			getMode: historyProvider.getMode.bind(historyProvider),
 		},
 		kbFolders: kbFoldersService,
+		// Folder-wide wiki/graph freshness for the kb-tab banner. Maps the bridge's
+		// full AggregateWikiFreshness to the compact shape the webview renders.
+		getWikiFreshness: async () => {
+			const f = await bridge.getWikiFreshness();
+			return {
+				severity: f.severity,
+				behindRepoNames: f.behindRepoNames,
+				summary: f.pending.summary,
+				total: f.pending.total,
+				lastRebuiltAt: f.lastRebuiltAt,
+			};
+		},
 		// Breadcrumb dropdowns. The discoverRepos output carries `kbRoot` /
 		// `dirName` fields that the webview doesn't need (selector key is
 		// the configured repoName, with remoteUrl forwarded for cross-repo
@@ -2332,13 +2344,23 @@ export function activate(context: vscode.ExtensionContext): void {
 		statusStore.setIngest(busy, phase);
 	};
 	ingestPhaseWatcher.onDidCreate(() => void refreshIngestState());
+	// Only refresh the (cheap) ingest pill here. Deliberately NOT pushing wiki
+	// freshness: the worker rewrites this file on a 60s heartbeat (not just on real
+	// phase transitions), so a push here would re-run the whole-folder freshness
+	// scan every minute for the entire ingest. The backlog refresh rides the
+	// authoritative end-of-ingest signal (onDidDelete) instead, and a manual rebuild
+	// already shows "Rebuilding…" via setWikiRebuilding.
 	ingestPhaseWatcher.onDidChange(() => void refreshIngestState());
 	// An explicit delete of the phase file is authoritative teardown: the worker
 	// removes it when the ingest ends. Clear the pill directly rather than going
 	// through readIngestPhase — otherwise the `ingest.lock` liveness backstop
 	// (the lock is released just AFTER the phase file) could momentarily resurrect
 	// a stale (and possibly mislabeled) pill until the 60s timer catches it.
-	ingestPhaseWatcher.onDidDelete(() => statusStore.setIngest(false, null));
+	ingestPhaseWatcher.onDidDelete(() => {
+		statusStore.setIngest(false, null);
+		// Ingest ended — the backlog just dropped, so refresh the freshness chip.
+		void sidebarProvider?.pushWikiFreshness();
+	});
 	context.subscriptions.push(ingestPhaseWatcher);
 	// The watcher fires on file writes but NOT when the phase file / `ingest.lock`
 	// simply age out (a crashed ingest leaves them behind). Re-check on a 60s timer

--- a/vscode/src/JolliMemoryBridge.test.ts
+++ b/vscode/src/JolliMemoryBridge.test.ts
@@ -309,6 +309,10 @@ vi.mock("../../cli/src/core/SummaryStore.js", () => ({
 	storeSummary,
 }));
 
+vi.mock("../../cli/src/core/WikiFreshness.js", () => ({
+	getAggregateWikiFreshness: vi.fn(),
+}));
+
 vi.mock("../../cli/src/core/RegenerateContext.js", () => ({
 	loadRegenerateContext,
 }));
@@ -427,6 +431,7 @@ vi.mock("node:fs/promises", () => ({
 
 // ── Import under test (after mocks) ─────────────────────────────────────────
 
+import { getAggregateWikiFreshness } from "../../cli/src/core/WikiFreshness.js";
 import { JolliMemoryBridge } from "./JolliMemoryBridge.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -6520,5 +6525,41 @@ describe("JolliMemoryBridge", () => {
 				{ path: "README.md", dir: "", status: "A" },
 			]);
 		});
+	});
+});
+
+describe("JolliMemoryBridge.getWikiFreshness", () => {
+	it("delegates to the shared aggregate rule with the configured localFolder", async () => {
+		const bridge = makeBridge();
+		loadConfig.mockResolvedValue({ localFolder: "/mb" });
+		const freshness = {
+			repos: [],
+			behindRepoNames: ["acme"],
+			pending: { summary: 4, total: 5 },
+			lastRebuiltAt: "2026-08-12T00:00:00.000Z",
+			everBuilt: true,
+			severity: "warn" as const,
+		};
+		vi.mocked(getAggregateWikiFreshness).mockResolvedValue(freshness);
+		const result = await bridge.getWikiFreshness();
+		expect(result).toEqual(freshness);
+		// Folder-wide: called with the configured localFolder (not a single repo).
+		expect(vi.mocked(getAggregateWikiFreshness).mock.calls[0][0]).toBe("/mb");
+	});
+
+	it("returns an all-fresh empty snapshot when no localFolder is configured", async () => {
+		const bridge = makeBridge();
+		loadConfig.mockResolvedValue({});
+		vi.mocked(getAggregateWikiFreshness).mockClear();
+		const result = await bridge.getWikiFreshness();
+		expect(result).toEqual({
+			repos: [],
+			behindRepoNames: [],
+			pending: { summary: 0, total: 0 },
+			lastRebuiltAt: null,
+			everBuilt: false,
+			severity: "fresh",
+		});
+		expect(getAggregateWikiFreshness).not.toHaveBeenCalled();
 	});
 });

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -49,6 +49,7 @@ import {
 	generateSquashMessage,
 } from "../../cli/src/core/Summarizer.js";
 import { getDisplayDate } from "../../cli/src/core/SummaryFormat.js";
+import { type AggregateWikiFreshness, getAggregateWikiFreshness } from "../../cli/src/core/WikiFreshness.js";
 import {
 	deleteNoteVisibleArtifact,
 	deletePlanVisibleArtifact,
@@ -536,6 +537,23 @@ export class JolliMemoryBridge {
 	// ── Status ────────────────────────────────────────────────────────────
 
 	/** Returns the current JolliMemory status by calling Installer.getStatus() directly. */
+	/**
+	 * How far the wiki/graph lags across the WHOLE Memory Bank folder, for the
+	 * kb-tab freshness banner. Aggregate (all repos) so the banner matches its
+	 * rebuild action — the "Build Knowledge Wiki" command runs the same folder-wide
+	 * sweep (`compileAllRepos`). Delegates entirely to the shared core rule
+	 * (`cli/src/core/WikiFreshness.ts`); the host only reads it. A missing
+	 * `localFolder` yields an all-`fresh` (empty) snapshot.
+	 */
+	async getWikiFreshness(): Promise<AggregateWikiFreshness> {
+		const config = (await loadConfig()) as Record<string, unknown>;
+		const localFolder = config.localFolder as string | undefined;
+		if (!localFolder) {
+			return { repos: [], behindRepoNames: [], pending: { summary: 0, total: 0 }, lastRebuiltAt: null, everBuilt: false, severity: "fresh" };
+		}
+		return getAggregateWikiFreshness(localFolder, config as never);
+	}
+
 	async getStatus(): Promise<StatusInfo> {
 		try {
 			const storage = await this.getStorage();

--- a/vscode/src/views/SidebarCssBuilder.ts
+++ b/vscode/src/views/SidebarCssBuilder.ts
@@ -376,6 +376,23 @@ export function buildSidebarCss(): string {
     opacity: 0.6;
     cursor: default;
   }
+  .kb-wiki-banner-dismiss {
+    flex: none;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    opacity: 0.6;
+    font-size: 16px;
+    line-height: 1;
+    padding: 0 2px;
+  }
+  .kb-wiki-banner-dismiss:hover { opacity: 1; }
+  .kb-wiki-banner-dismiss:focus-visible {
+    opacity: 1;
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: 1px;
+  }
   .iconbtn {
     width: 24px;
     height: 22px;

--- a/vscode/src/views/SidebarCssBuilder.ts
+++ b/vscode/src/views/SidebarCssBuilder.ts
@@ -331,6 +331,51 @@ export function buildSidebarCss(): string {
   .toolbar-worker-icon-error {
     color: var(--vscode-errorForeground, var(--vscode-editorError-foreground, #f48771));
   }
+  /* Folder-wide wiki/graph freshness banner — a full-width strip below the kb
+     toolbar, above the tree (mirrors the dashboard). Message + a Rebuild button
+     that triggers the same folder-wide "Build Knowledge Wiki" sweep. The .warn
+     variant tints it when the wiki is well behind. */
+  .kb-wiki-banner {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    font-size: var(--vscode-font-size, 13px);
+    line-height: 1.45;
+    border-bottom: 1px solid var(--vscode-inputValidation-infoBorder, var(--vscode-panel-border));
+    background: var(--vscode-inputValidation-infoBackground, var(--vscode-editorWidget-background));
+    color: var(--vscode-foreground);
+  }
+  .kb-wiki-banner.warn {
+    /* Match the dashboard's warn tint (main.css .warning-banner): a low-% mix of
+       the warning color over the editor background — same 9%/28% formula, using
+       VSCode's theme warning color so it still respects light/dark. Avoids the
+       heavier, theme-varying inputValidation-warningBackground. */
+    border-bottom-color: color-mix(in srgb, var(--vscode-editorWarning-foreground, #cca700) 28%, var(--vscode-panel-border));
+    background: color-mix(in srgb, var(--vscode-editorWarning-foreground, #cca700) 9%, var(--vscode-editor-background));
+  }
+  .kb-wiki-banner-text {
+    flex: 1;
+    min-width: 0;
+  }
+  .kb-wiki-banner-btn {
+    flex: none;
+    white-space: nowrap;
+    border: 0;
+    border-radius: 2px;
+    padding: 5px 12px;
+    font-size: var(--vscode-font-size, 13px);
+    cursor: pointer;
+    color: var(--vscode-button-foreground);
+    background: var(--vscode-button-background);
+  }
+  .kb-wiki-banner-btn:hover {
+    background: var(--vscode-button-hoverBackground, var(--vscode-button-background));
+  }
+  .kb-wiki-banner-btn:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
   .iconbtn {
     width: 24px;
     height: 22px;

--- a/vscode/src/views/SidebarHtmlBuilder.ts
+++ b/vscode/src/views/SidebarHtmlBuilder.ts
@@ -199,6 +199,7 @@ export function buildSidebarHtml(
     </div>
     <div class="dropdown-menu hidden" id="breadcrumb-menu" role="menu"></div>
     <div class="tab-toolbar hidden" id="tab-toolbar"></div>
+    <div class="kb-wiki-banner hidden" id="kb-wiki-banner"></div>
     <div class="tab-content hidden" id="tab-content-kb"><p class="placeholder">Loading...</p></div>
     <div class="tab-content hidden" id="tab-content-branch"><p class="placeholder">Loading...</p></div>
     <div class="tab-content hidden" id="tab-content-status">

--- a/vscode/src/views/SidebarMessages.ts
+++ b/vscode/src/views/SidebarMessages.ts
@@ -1165,6 +1165,34 @@ export type SidebarInboundMsg =
 	  }
 	| {
 			/**
+			 * Folder-wide wiki/graph freshness, shown as a banner at the top of the
+			 * kb tab ("Wiki is behind for N repos — M new memories to fold in" with a
+			 * Rebuild button). Aggregated across every Memory Bank repo so it matches
+			 * its rebuild action — the "Build Knowledge Wiki" command runs the same
+			 * folder-wide sweep. `null` clears it. A compact shape, not the full core
+			 * `AggregateWikiFreshness`, so the webview client stays dumb.
+			 */
+			readonly type: "wiki:freshness";
+			readonly freshness: {
+				readonly severity: "never" | "fresh" | "info" | "warn";
+				readonly behindRepoNames: ReadonlyArray<string>;
+				readonly summary: number;
+				readonly total: number;
+				readonly lastRebuiltAt: string | null;
+			} | null;
+	  }
+	| {
+			/**
+			 * Drive the kb-tab banner's "Rebuilding the wiki/graph…" state for the
+			 * whole compile sweep — `true` at start, `false` at end (CompileCommand).
+			 * Mirrors the dashboard's in-flight banner (which stays up for the whole
+			 * folder sweep) instead of only flipping the button label.
+			 */
+			readonly type: "wiki:rebuilding";
+			readonly active: boolean;
+	  }
+	| {
+			/**
 			 * Push the list of repos discoverable under the Memory Bank parent.
 			 * Drives the breadcrumb repo dropdown. When `repos.length <= 1`, the
 			 * webview hides the dropdown affordance entirely (no point offering

--- a/vscode/src/views/SidebarMessages.ts
+++ b/vscode/src/views/SidebarMessages.ts
@@ -1023,6 +1023,29 @@ export type SidebarOutboundMsg =
 			 * "Generate Missing Summaries" control lives under its Memory Bank area.
 			 */
 			readonly type: "backfill:openSettings";
+	  }
+	| {
+			/**
+			 * User clicked the wiki banner's × (close). The host remembers this
+			 * dismissal in PROCESS memory (no persistence) and gates the next
+			 * `pushWikiFreshness` on it: the banner stays hidden until the backlog
+			 * GROWS (`total` up) or gets more urgent (severity up), or the host
+			 * process restarts (Reload Window). Once the wiki is caught up (fresh)
+			 * the host forgets the dismissal, so the next behind episode shows again.
+			 *
+			 * The host is the web dashboard's `wikiBannerNonce` analog: its lifetime
+			 * IS the reset boundary, so unlike the dashboard we need neither a nonce
+			 * nor localStorage. The webview snapshots the visible `{total, severity}`
+			 * so the host can compare a later freshness against exactly what the user
+			 * was looking at when they dismissed it.
+			 */
+			readonly type: "wiki:dismiss";
+			readonly total: number;
+			/** Headline "N new memories" count at dismiss time — re-show if it grows even when `total` is flat. */
+			readonly summary: number;
+			readonly severity: "never" | "fresh" | "info" | "warn";
+			/** Repos behind at dismiss time — re-show if a repo NOT in this set later falls behind. */
+			readonly repos: ReadonlyArray<string>;
 	  };
 
 export type SidebarInboundMsg =

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -172,6 +172,14 @@ export function buildSidebarScript(): string {
     // in a sticky terminal failure. Shape: { label, severity } | null. Not
     // persisted — host re-pushes on reload.
     syncPhase: null,
+    // wiki/graph freshness for the workspace repo, pushed read-only
+    // for the kb-tab toolbar. Shape: { severity, summary, total, lastRebuiltAt }
+    // | null. Not persisted — host re-pushes on reload / kb activation / refresh.
+    wikiFreshness: null,
+    // True while a folder-wide rebuild sweep is running (host drives it via the
+    // 'wiki:rebuilding' message across the whole compile). Makes the banner show
+    // "Rebuilding the wiki/graph…" for the duration, mirroring the dashboard.
+    wikiRebuilding: false,
     // Aggregated token usage for the current branch, pushed alongside
     // branch:commitsData. Shape: { input, output, total } | null. Not
     // persisted -- host re-pushes on reload.
@@ -204,6 +212,8 @@ export function buildSidebarScript(): string {
   state.ingestPhase = null;
   state.summarizingHash = null;
   state.syncPhase = null;
+  state.wikiFreshness = null;
+  state.wikiRebuilding = false;
   state.tokenStats = null;
   // Cold-start signals + card runtime are host-driven / transient — never
   // resurrected from persisted state (would flash a stale card on reload).
@@ -311,6 +321,11 @@ export function buildSidebarScript(): string {
     branch: document.getElementById('tab-content-branch'),
     status: document.getElementById('tab-content-status')
   };
+  // Folder-wide wiki freshness banner. A persistent sibling BETWEEN the toolbar
+  // and the kb panel (not inside it): renderFolders/renderMemories replaceChildren
+  // the panel on every render, so a banner mounted inside would be wiped — this
+  // outside slot survives, and renderWikiBanner gates its visibility on the kb tab.
+  const wikiBannerEl = document.getElementById('kb-wiki-banner');
   // Status panel has two stacked children: the disabled-banner (intro + Enable
   // button shown when state.enabled === false) and the status-entries list
   // (rendered by renderStatus when state.enabled === true). They are siblings
@@ -408,6 +423,9 @@ export function buildSidebarScript(): string {
     Object.keys(tabContents).forEach(function(t) { tabContents[t].classList.toggle('hidden', t !== tab); });
     renderToolbar();
     applyRepoFilterVisibility();
+    // Show/hide the folder-wide wiki banner with the kb tab (it lives in a
+    // persistent slot outside the tab panels, so it isn't toggled by the loop above).
+    renderWikiBanner();
     const incoming = tabContents[tab];
     if (incoming) incoming.scrollTop = state.scrollTops[tab] || 0;
     // Tab content can be stale if data arrived while a different tab was active
@@ -567,6 +585,8 @@ export function buildSidebarScript(): string {
       // header explains why.)
       items.push(iconButton('sync-now', 'Sync to Personal Space', 'cloud-upload'));
       items.push(iconButton('compile-now', 'Build Knowledge Wiki', 'database'));
+      // Folder-wide "N behind" now renders as a banner at the top of the kb tab
+      // body (renderWikiBanner), mirroring the dashboard — not a toolbar chip.
       items.push(iconButton('refresh', 'Refresh', 'refresh'));
       mountIn(tabToolbar, items);
     } else if (state.activeTab === 'status') {
@@ -614,6 +634,63 @@ export function buildSidebarScript(): string {
       }));
     }
     return busyEl;
+  }
+
+  // Folder-wide wiki/graph freshness banner — the same message and Rebuild action
+  // as the dashboard. Lives in the persistent wikiBannerEl slot above the kb
+  // panel; shown only on the kb tab, and only when something is behind.
+  function renderWikiBanner() {
+    if (!wikiBannerEl) return;
+    const f = state.wikiFreshness;
+    const names = (f && f.behindRepoNames) || [];
+    const wasWarn = !!f && f.severity === 'warn';
+    // Rebuilding takes precedence over the freshness snapshot: while the sweep
+    // runs the banner shows "Rebuilding the wiki/graph…" for its whole duration
+    // (mirrors the dashboard), keeping the warn tint if it was warn.
+    if (state.activeTab === 'kb' && state.wikiRebuilding) {
+      wikiBannerEl.classList.remove('hidden');
+      wikiBannerEl.classList.toggle('warn', wasWarn);
+      clear(wikiBannerEl);
+      wikiBannerEl.appendChild(el('i', { className: 'codicon codicon-loading codicon-modifier-spin', 'aria-hidden': 'true' }));
+      wikiBannerEl.appendChild(el('span', { className: 'kb-wiki-banner-text', text: 'Rebuilding the wiki/graph…' }));
+      return;
+    }
+    const show = state.activeTab === 'kb' && !!f && f.severity !== 'fresh' && names.length > 0;
+    wikiBannerEl.classList.toggle('hidden', !show);
+    if (!show) {
+      clear(wikiBannerEl);
+      return;
+    }
+    clear(wikiBannerEl);
+    wikiBannerEl.classList.toggle('warn', f.severity === 'warn');
+
+    const repoLabel = names.length === 1
+      ? ('for ' + names[0])
+      : ('for ' + names.length + ' repos (' + names.join(', ') + ')');
+    const n = f.summary || 0;
+    const extra = (f.total || 0) > n ? (f.total || 0) - n : 0;
+    const countLabel = n > 0
+      ? (n + ' new ' + (n === 1 ? 'memory' : 'memories') + ' to fold in')
+      : (extra + ' ' + (extra === 1 ? 'item' : 'items') + ' pending');
+
+    wikiBannerEl.appendChild(el('span', {
+      className: 'kb-wiki-banner-text',
+      text: 'Wiki is behind ' + repoLabel + ' — ' + countLabel + '. Rebuilding uses your LLM.'
+    }));
+    const btn = el('button', {
+      className: 'kb-wiki-banner-btn',
+      type: 'button',
+      text: 'Rebuild wiki',
+      title: 'Rebuild the wiki/graph for every Memory Bank repo'
+    });
+    btn.addEventListener('click', function() {
+      // Immediate feedback; the compile shows its own progress notification, and
+      // the next freshness push re-renders this banner (fresh → hidden).
+      btn.disabled = true;
+      btn.textContent = 'Rebuilding…';
+      vscode.postMessage({ type: 'command', command: 'jollimemory.compileNow' });
+    });
+    wikiBannerEl.appendChild(btn);
   }
 
   tabToolbar.addEventListener('click', function(e) {
@@ -959,6 +1036,26 @@ export function buildSidebarScript(): string {
         state.syncPhase = msg.phase || null;
         if (state.activeTab === 'kb') {
           renderToolbar();
+        }
+        break;
+      }
+      case 'wiki:freshness': {
+        // Folder-wide wiki/graph freshness, rendered as a banner at the top of
+        // the kb tab body (mirrors the dashboard). A push also arrives while/after
+        // a rebuild, so re-rendering here is what clears the "Rebuilding…" button.
+        state.wikiFreshness = msg.freshness || null;
+        if (state.activeTab === 'kb') {
+          renderWikiBanner();
+        }
+        break;
+      }
+      case 'wiki:rebuilding': {
+        // Host-driven in-flight flag for the whole sweep (CompileCommand: true at
+        // start, false at end). renderWikiBanner shows "Rebuilding the wiki/graph…"
+        // while true, then the trailing wiki:freshness push renders the final state.
+        state.wikiRebuilding = !!msg.active;
+        if (state.activeTab === 'kb') {
+          renderWikiBanner();
         }
         break;
       }

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -178,7 +178,7 @@ export function buildSidebarScript(): string {
     wikiFreshness: null,
     // True while a folder-wide rebuild sweep is running (host drives it via the
     // 'wiki:rebuilding' message across the whole compile). Makes the banner show
-    // "Rebuilding the wiki/graph…" for the duration, mirroring the dashboard.
+    // "Updating the wiki/graph…" for the duration, mirroring the dashboard.
     wikiRebuilding: false,
     // Aggregated token usage for the current branch, pushed alongside
     // branch:commitsData. Shape: { input, output, total } | null. Not
@@ -645,14 +645,14 @@ export function buildSidebarScript(): string {
     const names = (f && f.behindRepoNames) || [];
     const wasWarn = !!f && f.severity === 'warn';
     // Rebuilding takes precedence over the freshness snapshot: while the sweep
-    // runs the banner shows "Rebuilding the wiki/graph…" for its whole duration
+    // runs the banner shows "Updating the wiki/graph…" for its whole duration
     // (mirrors the dashboard), keeping the warn tint if it was warn.
     if (state.activeTab === 'kb' && state.wikiRebuilding) {
       wikiBannerEl.classList.remove('hidden');
       wikiBannerEl.classList.toggle('warn', wasWarn);
       clear(wikiBannerEl);
       wikiBannerEl.appendChild(el('i', { className: 'codicon codicon-loading codicon-modifier-spin', 'aria-hidden': 'true' }));
-      wikiBannerEl.appendChild(el('span', { className: 'kb-wiki-banner-text', text: 'Rebuilding the wiki/graph…' }));
+      wikiBannerEl.appendChild(el('span', { className: 'kb-wiki-banner-text', text: 'Updating the wiki/graph…' }));
       return;
     }
     const show = state.activeTab === 'kb' && !!f && f.severity !== 'fresh' && names.length > 0;
@@ -675,22 +675,49 @@ export function buildSidebarScript(): string {
 
     wikiBannerEl.appendChild(el('span', {
       className: 'kb-wiki-banner-text',
-      text: 'Wiki is behind ' + repoLabel + ' — ' + countLabel + '. Rebuilding uses your LLM.'
+      text: 'Wiki & graph are behind ' + repoLabel + ' — ' + countLabel + '.'
     }));
     const btn = el('button', {
       className: 'kb-wiki-banner-btn',
       type: 'button',
-      text: 'Rebuild wiki',
-      title: 'Rebuild the wiki/graph for every Memory Bank repo'
+      text: 'Update',
+      title: 'Update the wiki/graph for every Memory Bank repo'
     });
     btn.addEventListener('click', function() {
       // Immediate feedback; the compile shows its own progress notification, and
       // the next freshness push re-renders this banner (fresh → hidden).
       btn.disabled = true;
-      btn.textContent = 'Rebuilding…';
+      btn.textContent = 'Updating…';
       vscode.postMessage({ type: 'command', command: 'jollimemory.compileNow' });
     });
     wikiBannerEl.appendChild(btn);
+    // Close (×): hide now, and tell the host to remember the dismissal so the next
+    // freshness push keeps it hidden until the backlog grows / gets more urgent, or
+    // the host restarts (see SidebarWebviewProvider.wikiDismissed). Only on a behind
+    // banner — never while rebuilding (that branch returns above).
+    // A freshness push already in flight when × is clicked can momentarily re-show
+    // the banner (the host sets wikiDismissed only when it PROCESSES this message);
+    // it self-corrects on the next push, which the host then gates. Not worth a
+    // client-side dismissed flag, which would duplicate the host's rule here.
+    const dismiss = el('button', {
+      className: 'kb-wiki-banner-dismiss',
+      type: 'button',
+      text: '×',
+      title: 'Dismiss',
+      'aria-label': 'Dismiss'
+    });
+    dismiss.addEventListener('click', function() {
+      vscode.postMessage({
+        type: 'wiki:dismiss',
+        total: f.total || 0,
+        summary: f.summary || 0,
+        severity: f.severity,
+        repos: names.slice()
+      });
+      wikiBannerEl.classList.add('hidden');
+      clear(wikiBannerEl);
+    });
+    wikiBannerEl.appendChild(dismiss);
   }
 
   tabToolbar.addEventListener('click', function(e) {
@@ -1042,7 +1069,7 @@ export function buildSidebarScript(): string {
       case 'wiki:freshness': {
         // Folder-wide wiki/graph freshness, rendered as a banner at the top of
         // the kb tab body (mirrors the dashboard). A push also arrives while/after
-        // a rebuild, so re-rendering here is what clears the "Rebuilding…" button.
+        // a rebuild, so re-rendering here is what clears the "Updating…" button.
         state.wikiFreshness = msg.freshness || null;
         if (state.activeTab === 'kb') {
           renderWikiBanner();
@@ -1051,7 +1078,7 @@ export function buildSidebarScript(): string {
       }
       case 'wiki:rebuilding': {
         // Host-driven in-flight flag for the whole sweep (CompileCommand: true at
-        // start, false at end). renderWikiBanner shows "Rebuilding the wiki/graph…"
+        // start, false at end). renderWikiBanner shows "Updating the wiki/graph…"
         // while true, then the trailing wiki:freshness push renders the final state.
         state.wikiRebuilding = !!msg.active;
         if (state.activeTab === 'kb') {

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -6844,4 +6844,118 @@ describe("SidebarWebviewProvider.pushWikiFreshness", () => {
 		await p.pushWikiFreshness();
 		expect(freshnessMessages(view)).toEqual([]);
 	});
+
+	describe("banner dismiss (× → wiki:dismiss) gating", () => {
+		type F = {
+			severity: "never" | "fresh" | "info" | "warn";
+			behindRepoNames: ReadonlyArray<string>;
+			summary: number;
+			total: number;
+			lastRebuiltAt: string | null;
+		} | null;
+		const behind = (over: Partial<NonNullable<F>> = {}): NonNullable<F> => ({
+			severity: "info",
+			behindRepoNames: ["acme"],
+			summary: 2,
+			total: 3,
+			lastRebuiltAt: null,
+			...over,
+		});
+		function setup(): { view: MockWebviewView; p: SidebarWebviewProvider; setFreshness: (f: F) => void } {
+			const view = makeMockView();
+			let current: F = behind();
+			const gwf = vi.fn(() => Promise.resolve(current));
+			const p = providerWith(gwf);
+			p.resolveWebviewView(view as unknown as never);
+			return { view, p, setFreshness: (f) => { current = f; } };
+		}
+		function lastFreshness(view: MockWebviewView): F | undefined {
+			const msgs = freshnessMessages(view);
+			const last = msgs[msgs.length - 1];
+			return last ? (last as { freshness: F }).freshness : undefined;
+		}
+
+		// The full snapshot the × click sends, matching `behind()`'s defaults.
+		const dismiss = { type: "wiki:dismiss" as const, total: 3, summary: 2, severity: "info" as const, repos: ["acme"] };
+
+		it("hides the banner while dismissed and nothing has escalated", async () => {
+			const { view, p } = setup();
+			p.handleOutbound(dismiss);
+			view.webview.postMessage.mockClear();
+			await p.pushWikiFreshness();
+			expect(lastFreshness(view)).toBeNull();
+		});
+
+		it("re-shows when the backlog grows (total up)", async () => {
+			const { view, p, setFreshness } = setup();
+			p.handleOutbound(dismiss);
+			setFreshness(behind({ total: 5 }));
+			view.webview.postMessage.mockClear();
+			await p.pushWikiFreshness();
+			expect(lastFreshness(view)).toEqual(behind({ total: 5 }));
+			// dismissal was cleared, so the same state keeps showing afterwards
+			setFreshness(behind({ total: 5 }));
+			view.webview.postMessage.mockClear();
+			await p.pushWikiFreshness();
+			expect(lastFreshness(view)).toEqual(behind({ total: 5 }));
+		});
+
+		it("re-shows when the headline summary count grows even if total is flat", async () => {
+			const { view, p, setFreshness } = setup();
+			// Dismiss at total=10, summary=3 (7 non-summary pending).
+			p.handleOutbound({ type: "wiki:dismiss", total: 10, summary: 3, severity: "info", repos: ["acme"] });
+			// Non-summary items drain, new memories arrive: total flat at 10, summary 3→8.
+			setFreshness(behind({ total: 10, summary: 8 }));
+			view.webview.postMessage.mockClear();
+			await p.pushWikiFreshness();
+			expect(lastFreshness(view)).toEqual(behind({ total: 10, summary: 8 }));
+		});
+
+		it("re-shows when a repo the dismissal never saw falls behind", async () => {
+			const { view, p, setFreshness } = setup();
+			p.handleOutbound(dismiss); // repos: ["acme"]
+			// A partial hand-off: totals/severity unchanged, but a new repo is behind.
+			setFreshness(behind({ behindRepoNames: ["acme", "beta"] }));
+			view.webview.postMessage.mockClear();
+			await p.pushWikiFreshness();
+			expect(lastFreshness(view)).toEqual(behind({ behindRepoNames: ["acme", "beta"] }));
+		});
+
+		it("re-shows when severity escalates even if the count did not grow", async () => {
+			const { view, p, setFreshness } = setup();
+			p.handleOutbound(dismiss);
+			setFreshness(behind({ severity: "warn", total: 3 }));
+			view.webview.postMessage.mockClear();
+			await p.pushWikiFreshness();
+			expect(lastFreshness(view)).toEqual(behind({ severity: "warn", total: 3 }));
+		});
+
+		it("forgets the dismissal once caught up (fresh), so the next behind episode shows", async () => {
+			const { view, p, setFreshness } = setup();
+			p.handleOutbound(dismiss);
+			setFreshness({ severity: "fresh", behindRepoNames: [], summary: 0, total: 0, lastRebuiltAt: null });
+			view.webview.postMessage.mockClear();
+			await p.pushWikiFreshness();
+			expect(lastFreshness(view)).toEqual({ severity: "fresh", behindRepoNames: [], summary: 0, total: 0, lastRebuiltAt: null });
+			// A brand-new behind episode (smaller than the old dismiss total) still shows.
+			setFreshness(behind({ total: 1, summary: 1 }));
+			view.webview.postMessage.mockClear();
+			await p.pushWikiFreshness();
+			expect(lastFreshness(view)).toEqual(behind({ total: 1, summary: 1 }));
+		});
+
+		it("keeps hidden but does NOT forget the dismissal on a probe failure (null)", async () => {
+			const { view, p, setFreshness } = setup();
+			p.handleOutbound(dismiss);
+			setFreshness(null);
+			view.webview.postMessage.mockClear();
+			await p.pushWikiFreshness();
+			expect(lastFreshness(view)).toBeNull();
+			// A later non-escalated behind is still suppressed — the null didn't clear it.
+			setFreshness(behind({ total: 2, summary: 1 }));
+			view.webview.postMessage.mockClear();
+			await p.pushWikiFreshness();
+			expect(lastFreshness(view)).toBeNull();
+		});
+	});
 });

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -6779,3 +6779,69 @@ describe("broadcast targets", () => {
 		expect(applyPlanCheckbox).toHaveBeenCalledWith("p1", false);
 	});
 });
+
+describe("SidebarWebviewProvider.pushWikiFreshness", () => {
+	function providerWith(
+		getWikiFreshness?: () => Promise<{
+			severity: "never" | "fresh" | "info" | "warn";
+			behindRepoNames: ReadonlyArray<string>;
+			summary: number;
+			total: number;
+			lastRebuiltAt: string | null;
+		} | null>,
+	): SidebarWebviewProvider {
+		return new SidebarWebviewProvider({
+			executeCommand: vi.fn().mockResolvedValue(undefined) as never,
+			getInitialState: () => ({
+				enabled: true,
+				authenticated: false,
+				activeTab: "kb",
+				kbMode: "folders",
+				branchName: "main",
+				detached: false,
+			}),
+			extensionUri: mockExtensionUri as unknown as never,
+			...(getWikiFreshness ? { getWikiFreshness } : {}),
+		});
+	}
+
+	function freshnessMessages(view: MockWebviewView): SidebarInboundMsg[] {
+		return (view.webview.postMessage.mock.calls.map((c) => c[0]) as SidebarInboundMsg[]).filter(
+			(m) => m.type === "wiki:freshness",
+		);
+	}
+
+	it("posts the freshness snapshot on success", async () => {
+		const view = makeMockView();
+		const p = providerWith(
+			vi.fn().mockResolvedValue({ severity: "info", behindRepoNames: ["acme"], summary: 2, total: 3, lastRebuiltAt: null }),
+		);
+		p.resolveWebviewView(view as unknown as never);
+		view.webview.postMessage.mockClear();
+		await p.pushWikiFreshness();
+		expect(freshnessMessages(view)).toEqual([
+			{
+				type: "wiki:freshness",
+				freshness: { severity: "info", behindRepoNames: ["acme"], summary: 2, total: 3, lastRebuiltAt: null },
+			},
+		]);
+	});
+
+	it("posts null on failure and never throws", async () => {
+		const view = makeMockView();
+		const p = providerWith(vi.fn().mockRejectedValue(new Error("boom")));
+		p.resolveWebviewView(view as unknown as never);
+		view.webview.postMessage.mockClear();
+		await expect(p.pushWikiFreshness()).resolves.toBeUndefined();
+		expect(freshnessMessages(view)).toEqual([{ type: "wiki:freshness", freshness: null }]);
+	});
+
+	it("no-ops when the host did not wire getWikiFreshness", async () => {
+		const view = makeMockView();
+		const p = providerWith(undefined);
+		p.resolveWebviewView(view as unknown as never);
+		view.webview.postMessage.mockClear();
+		await p.pushWikiFreshness();
+		expect(freshnessMessages(view)).toEqual([]);
+	});
+});

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -171,6 +171,19 @@ export interface SidebarWebviewDeps {
 		...args: ReadonlyArray<unknown>
 	) => Thenable<unknown>;
 	getInitialState: () => SidebarState;
+	/**
+	 * wiki/graph freshness for the workspace repo, pushed read-only
+	 * to the kb-tab toolbar. Delegates to the shared core rule via the bridge.
+	 * Optional so tests that don't exercise the indicator keep compiling; when
+	 * absent the indicator simply never appears.
+	 */
+	getWikiFreshness?: () => Promise<{
+		readonly severity: "never" | "fresh" | "info" | "warn";
+		readonly behindRepoNames: ReadonlyArray<string>;
+		readonly summary: number;
+		readonly total: number;
+		readonly lastRebuiltAt: string | null;
+	} | null>;
 	/** Extension installation root — used to compute webview-resolvable URIs for bundled assets (codicons). */
 	extensionUri: vscode.Uri;
 	/** Optional in scaffold; required once Phase 2 lands. */
@@ -824,6 +837,7 @@ export class SidebarWebviewProvider
 		void this.pushCommits();
 		void this.pushConversations();
 		void this.pushPins();
+		void this.pushWikiFreshness();
 		if (this.deps.branchWatcher) {
 			const cur = this.deps.branchWatcher.current();
 			this.postMessage({
@@ -860,6 +874,10 @@ export class SidebarWebviewProvider
 					const view = msg.tab === "branch" ? "current" : msg.tab === "kb" ? "bank" : undefined;
 					if (view) track("view_switched", { view });
 				}
+				// refresh the freshness indicator when the user lands on the
+				// kb tab (its toolbar is the only place it shows), so it reflects any
+				// summaries generated since the sidebar opened without a full refresh.
+				if (msg.tab === "kb") void this.pushWikiFreshness();
 				return;
 			}
 			case "kb:memoryToggled":
@@ -2153,6 +2171,41 @@ export class SidebarWebviewProvider
 		// dropdown frozen on the pre-sync set until the user manually switched
 		// repos.
 		this.pushBreadcrumbSelection();
+		// a refresh (external write, migration, or a just-finished
+		// compile) may have moved the wiki/graph forward or left new summaries
+		// pending — re-push the freshness indicator so the kb toolbar reflects it.
+		void this.pushWikiFreshness();
+	}
+
+	/**
+	 * compute the workspace repo's wiki/graph freshness (via the
+	 * bridge → shared core rule) and push it to the kb-tab toolbar as a read-only
+	 * indicator. No-op when the host didn't wire `getWikiFreshness`. Never throws:
+	 * a freshness probe failure must never disturb the sidebar, so it posts `null`
+	 * (clears the chip) on error.
+	 */
+	async pushWikiFreshness(): Promise<void> {
+		if (!this.deps.getWikiFreshness) return;
+		try {
+			const freshness = await this.deps.getWikiFreshness();
+			this.postMessage({ type: "wiki:freshness", freshness });
+		} catch (err) {
+			log.warn(
+				"SidebarWebviewProvider",
+				`getWikiFreshness failed: ${err instanceof Error ? err.message : String(err)}`,
+			);
+			this.postMessage({ type: "wiki:freshness", freshness: null });
+		}
+	}
+
+	/**
+	 * Drive the kb-tab banner's "Rebuilding the wiki/graph…" state for the whole
+	 * compile sweep (called by CompileCommand: true at start, false at end), so the
+	 * banner mirrors the dashboard's in-flight message rather than only changing its
+	 * button text. The subsequent `pushWikiFreshness()` re-renders the final state.
+	 */
+	setWikiRebuilding(active: boolean): void {
+		this.postMessage({ type: "wiki:rebuilding", active });
 	}
 
 	/**

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -107,6 +107,15 @@ const ALLOWED_BUILTIN_WEBVIEW_COMMANDS = new Set<string>(["vscode.open", "vscode
  */
 const MAX_COPY_TEXT_LENGTH = 256;
 
+/**
+ * Ordering for the wiki banner's severity, so a dismiss can be re-shown when the
+ * state escalates (info → warn) even if the backlog count didn't grow — e.g. a
+ * repo crossing the 3-day staleness threshold. `never` folds to `info`'s rank
+ * (it never reaches the aggregate severity, which is only fresh/info/warn).
+ */
+type WikiSeverity = "never" | "fresh" | "info" | "warn";
+const WIKI_SEVERITY_RANK: Readonly<Record<WikiSeverity, number>> = { fresh: 0, never: 1, info: 1, warn: 2 };
+
 /** True when the webview may ask the host to run `command` (see the set above). */
 function isAllowedWebviewCommand(command: string): boolean {
 	return command.startsWith("jollimemory.") || ALLOWED_BUILTIN_WEBVIEW_COMMANDS.has(command);
@@ -618,6 +627,22 @@ export class SidebarWebviewProvider
 	// the repoDir-prefixed relPath all paths use, so signals for one row never
 	// suppress another's.
 	private readonly divergenceCheckSeq = new Map<string, number>();
+	/**
+	 * The wiki banner's "dismiss" (× click), held in PROCESS memory only — the
+	 * host process's lifetime is the reset boundary (Reload Window forgets it),
+	 * which is this surface's analog of the dashboard restarting. `null` = not
+	 * dismissed. `pushWikiFreshness` gates on it: a later freshness whose backlog
+	 * grew (`total`) or got more urgent (`severity`) clears it and shows the
+	 * banner again, and catching up (fresh) clears it so the next behind episode
+	 * shows. Snapshots exactly what the user saw at dismiss time so the compare is
+	 * against that, not against a stale recompute.
+	 */
+	private wikiDismissed: {
+		readonly total: number;
+		readonly summary: number;
+		readonly severity: WikiSeverity;
+		readonly repos: ReadonlyArray<string>;
+	} | null = null;
 
 	constructor(private readonly deps: SidebarWebviewDeps) {}
 
@@ -1363,6 +1388,16 @@ export class SidebarWebviewProvider
 			}
 			case "backfill:dismiss":
 				this.deps.backfill?.dismiss();
+				return;
+			case "wiki:dismiss":
+				// Snapshot what the user was looking at; pushWikiFreshness compares a
+				// later freshness against it. Process-memory only (see the field doc).
+				this.wikiDismissed = {
+					total: msg.total,
+					summary: msg.summary,
+					severity: msg.severity,
+					repos: msg.repos,
+				};
 				return;
 			case "backfill:openSettings":
 				void this.deps.executeCommand("jollimemory.openSettings");
@@ -2188,7 +2223,7 @@ export class SidebarWebviewProvider
 		if (!this.deps.getWikiFreshness) return;
 		try {
 			const freshness = await this.deps.getWikiFreshness();
-			this.postMessage({ type: "wiki:freshness", freshness });
+			this.postMessage({ type: "wiki:freshness", freshness: this.gateWikiFreshnessByDismiss(freshness) });
 		} catch (err) {
 			log.warn(
 				"SidebarWebviewProvider",
@@ -2196,6 +2231,49 @@ export class SidebarWebviewProvider
 			);
 			this.postMessage({ type: "wiki:freshness", freshness: null });
 		}
+	}
+
+	/**
+	 * Apply the user's banner dismissal (× click) to a freshness before it is
+	 * pushed. Returns `null` (banner hidden) while a live dismissal holds and the
+	 * state has not escalated; otherwise returns the freshness unchanged and, when
+	 * appropriate, clears the dismissal. See the {@link wikiDismissed} field doc
+	 * for the full rule. Kept separate from `pushWikiFreshness` so it can be unit
+	 * tested without a live webview.
+	 */
+	private gateWikiFreshnessByDismiss(
+		freshness: {
+			readonly severity: "never" | "fresh" | "info" | "warn";
+			readonly behindRepoNames: ReadonlyArray<string>;
+			readonly summary: number;
+			readonly total: number;
+			readonly lastRebuiltAt: string | null;
+		} | null,
+	): typeof freshness {
+		const d = this.wikiDismissed;
+		if (!d) return freshness;
+		// Probe failed (null): keep the banner hidden but DON'T forget the dismissal
+		// — a transient failure must not silently un-dismiss.
+		if (!freshness) return null;
+		const behind = freshness.severity !== "fresh" && freshness.behindRepoNames.length > 0;
+		if (!behind) {
+			// Caught up — scope the dismissal to this one behind episode.
+			this.wikiDismissed = null;
+			return freshness;
+		}
+		// Re-show if the backlog grew — by `total` OR by the headline `summary` count
+		// (summary can rise while total stays flat when other pending types drain) —
+		// got more urgent, or a repo the dismissal never saw is now behind (a partial
+		// multi-repo hand-off never reaches `fresh`, so this is the only signal a
+		// brand-new repo's backlog produces).
+		const grew = freshness.total > d.total || freshness.summary > d.summary;
+		const moreUrgent = WIKI_SEVERITY_RANK[freshness.severity] > WIKI_SEVERITY_RANK[d.severity];
+		const newRepo = freshness.behindRepoNames.some((r) => !d.repos.includes(r));
+		if (grew || moreUrgent || newRepo) {
+			this.wikiDismissed = null;
+			return freshness;
+		}
+		return null; // still behind, nothing new to say → stay dismissed
 	}
 
 	/**


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Commits in this PR (2)

1. Add manual wiki rebuild mode gated by wikiRebuild config key (`2e3b2d2`)
2. Add dismissible wiki banner with nonce-based re-show logic (`4e62da2`)


## Quick recap (2)

### Commit 1 of 2: Add manual wiki rebuild mode gated by wikiRebuild config key (`2e3b2d2`)

Wiki and graph rebuilds are now manual by default. Previously, every git operation — commits, rebases, merges, and backfills — triggered a full wiki rebuild whose cost grew with the total size of the accumulated memory corpus. A new configuration key lets users opt into the old automatic behavior, but every existing and new installation defaults to manual mode with no migration required. Per-commit summarization is unaffected, so search and recall stay current; only the expensive wiki-folding pass is deferred until the user asks for it.

Both the local dashboard and the VS Code sidebar gained a full-width freshness banner showing how many new memories are waiting to be folded into the wiki, which repositories are behind, and a Rebuild button that triggers a folder-wide sweep. The dashboard banner appears at the top of the Knowledge and Graph pages; the VS Code banner appears at the top of the Memory Bank tab. Both surfaces show a "Rebuilding…" state for the duration of the sweep and return to a clean state when it completes. A shared staleness computation in the core layer — covering pending source counts by type, time since last successful rebuild, and a four-level severity ladder — ensures both surfaces always agree on what "behind" means. The dashboard's Rebuild endpoint also gained an up-front check for a configured AI provider: clicking Rebuild with no provider now immediately surfaces an actionable prompt to open Settings, matching the behavior the VS Code equivalent already had.

A long-standing source of unnecessary cost was also addressed: when a rebase rewrites commit hashes without changing summary content, the pipeline previously treated every migrated hash as a new pending source and re-ran full-page reconciliation for zero content change. The fix carries the "already processed" mark from the old hash to the new one during migration — and removes the now-dead old entry from the processed set — so the next rebuild skips those summaries entirely and the set stays bounded to live commits.

### Commit 2 of 2: Add dismissible wiki banner with nonce-based re-show logic (`4e62da2`)

The wiki freshness banner on both the local dashboard and the VS Code sidebar gained a close button, giving users a way to temporarily dismiss the reminder. The banner reappears automatically when the backlog genuinely grows — measured by either the total pending count or the headline new-memory count independently — when urgency escalates from informational to warning level, or when a repository that was not behind at dismiss time falls behind. Catching up completely clears the dismissal record, so the next time the wiki falls behind the reminder shows fresh.

The two surfaces use different storage mechanisms that produce identical user-visible behavior. On the dashboard, a process-level identifier generated at server startup is stored alongside the dismissal in the browser; restarting the local server produces a new identifier and causes any dismissed banner to reappear. In VS Code, the dismissal lives in the extension host's process memory and is cleared automatically when the window reloads. Banner copy was also updated on both surfaces: the action button now reads "Update" and the body text explicitly names both the wiki and the graph as the things being refreshed.

## Topics (11)
<details>
<summary><strong>01 · [2e3b2d2] Manual wiki rebuild mode gated by configuration key</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Wiki and graph rebuilds fired automatically after every git operation — commits, rebases, merges, and backfills — with cost scaling with total corpus size rather than the amount of new work. The team needed a way to make manual-only the default while preserving an opt-in escape hatch for users who want the old automatic behavior.

**💡 Decisions Behind the Code**

- **Fail-safe polarity over explicit default constant**: The gate uses strict `=== "auto"` rather than `!== "manual"`, meaning every existing installation with no config key automatically gets manual behavior on upgrade. Writing a default constant of `"manual"` would have been equivalent in new installs but would not protect against a future code path accidentally reading the raw value before coercion; the strict-equality approach makes the safe path the zero-configuration path.
- **Leaf module for the polarity check**: The helper was extracted into a dependency-free file so the three git-hook bundles that import it do not pull in storage or source-timeline code. Hook bundles run on every git operation and must stay lean; a heavier import would increase startup latency for every commit.
- **CLI-only escape hatch, no UI toggle**: The `auto` mode is intentionally reachable only via a command-line configure command, not through the dashboard or VS Code settings panel. This keeps the power-user escape hatch discoverable by those who need it while preventing casual users from accidentally enabling a mode that can generate large LLM costs on every git operation.
- **Summarization left untouched**: Only the wiki/graph ingest enqueue is gated, not per-commit summary generation. This preserves the product's core value — recall and commit search stay current — while eliminating the corpus-scaling cost. The wiki simply shows a "behind" count until the user explicitly rebuilds.

**✅ What Was Implemented**

- Added a `wikiRebuild` configuration key accepting `"manual"` or `"auto"` values, wired through the full configuration pipeline in `ConfigureCommand.ts`: valid keys list, enum validation that rejects typos at set-time, and the help/list display. A new leaf module `WikiRebuildMode.ts` exposes a single `wikiRebuildIsAuto()` helper using strict `=== "auto"` polarity so that absent, undefined, or unrecognized values resolve to manual — the fail-safe direction — without any migration step for existing installations.
- Gated all three production auto-trigger call sites — the post-commit path in `QueueWorker.ts`, the post-merge hook in `PostMergeHook.ts`, and the end-of-batch trigger in `BackfillEngine.ts` — behind the new config check. No commit, rebase, merge, or backfill triggers a wiki/graph rebuild unless the user has explicitly opted into `auto` mode. Summarization is untouched, so recall and commit search remain current in manual mode; only the wiki/graph fold is deferred.
- Updated existing tests that asserted auto-enqueue behavior to explicitly set `wikiRebuild: "auto"`, and added paired manual-mode tests for each gate site confirming no enqueue occurs when the key is absent.

**📁 FILES**
- `cli/src/Types.ts`
- `cli/src/core/WikiRebuildMode.ts`
- `cli/src/commands/ConfigureCommand.ts`
- `cli/src/hooks/QueueWorker.ts`
- `cli/src/hooks/PostMergeHook.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · [2e3b2d2] Shared wiki freshness signal and aggregate staleness computation across all repos</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Both the dashboard and the VS Code sidebar needed a way to show how far behind the wiki and graph were, but there was no shared source of truth for how many summaries were pending or when the last successful rebuild had occurred. Each surface would have had to reimplement the same staleness logic independently.

**💡 Decisions Behind the Code**

- **Aggregate over single-repo for both surfaces**: Both the dashboard and VS Code sidebar rebuild actions run the same folder-wide sweep, so the indicator was aligned to match — reporting how far the whole folder lags rather than one repo. This eliminates the confusing mismatch where the indicator could show "up to date" for the current repo while other repos were behind, and means the Rebuild button always clears what the indicator describes.
- **Folder-only storage for the aggregate scan**: Each repo is scored using its on-disk folder storage rather than requiring a git worktree. This lets the indicator and rebuild cover repos that exist in the Memory Bank but have no local checkout, which is a real scenario when a team member's repos are synced but not cloned.
- **`total > 0` precondition on time-based warn escalation**: A wiki that was last rebuilt years ago but has nothing pending is still "fresh," not "warn." Without this guard, any long-running installation with an empty backlog would permanently show a warning, making the indicator meaningless.

**✅ What Was Implemented**

- Created `WikiFreshness.ts` in the core layer with `getWikiFreshness()` for a single repo and `getAggregateWikiFreshness()` for the entire Memory Bank folder. The single-repo function reads the processed-source set, counts pending refs by type (summary, plan, note, userfile), finds the most recent successful ingest run, checks whether the graph artifact exists, and derives a four-level severity (`never` / `fresh` / `info` / `warn`) with NaN-guarded time comparison and a `total > 0` precondition on the time clause.
- The aggregate function iterates every discovered repo using folder-only storage (no git worktree required), sums pending counts across repos that have actual work to fold in, and applies a folder-wide warn threshold so a spread of small per-repo backlogs can still escalate to warn collectively. Repos that are never-built with nothing pending are excluded from the "behind" list so the Rebuild button can always clear the indicator.
- The VS Code bridge delegates to the aggregate function and maps the result to a compact shape for the webview; the Extension wires this as a dependency so the sidebar provider can push freshness on tab activation, ingest-phase transitions, and compile completion.

**📁 FILES**
- `cli/src/core/WikiFreshness.ts`
- `vscode/src/JolliMemoryBridge.ts`
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · [2e3b2d2] Dashboard wiki freshness banner and on-demand rebuild endpoint</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The Knowledge and Graph pages in the local dashboard had no way to show that the wiki was behind or to trigger a rebuild without running a CLI command. The team wanted a visible indicator and a one-click rebuild on both pages.

**💡 Decisions Behind the Code**

- **In-process fire-and-forget over a detached worker**: The rebuild runs inside the long-lived dashboard server process rather than spawning a separate worker. This lets a plain process-scoped boolean reliably observe start and end — a detached worker would require reading lock files or queue state to know when it finished, and the boolean approach is what makes the 409 guard and the `inFlight` poll signal work without additional infrastructure.
- **Full-width flow banner over a floating overlay**: An earlier iteration used a floating positioned element to avoid pushing content down. After testing, the floating approach felt visually wrong for a persistent, actionable state, and the layout fix to make the banner occupy flow without clipping content was achievable with a flex chain. The industry convention for "N behind, click to sync" is an inline strip, not a tooltip or overlay.
- **409 detected by HTTP status rather than message substring**: An earlier version of the client distinguished "already running" from real errors by matching a substring of the error message. This was fragile — any rewording of the server message would turn a benign concurrent rebuild into a scary error callout. Attaching the HTTP status to the thrown error object and branching on it makes the distinction robust to message changes.
- **Provider check parity with VS Code**: The dashboard endpoint now matches the behavior the VS Code "Build Knowledge Wiki" command already had — an explicit provider check with a user-visible message before any work begins. The alternative of letting the sweep run and surface errors through server logs was rejected: in a fire-and-forget in-process sweep, per-repo errors are caught and not re-thrown, so the flag clears and the banner resets with zero user-visible signal.

**✅ What Was Implemented**

- Added `GET /api/wiki/freshness` and `POST /api/wiki/rebuild` endpoints to the dashboard server. The GET endpoint computes the folder-wide aggregate and returns it with an `inFlight` flag; the POST runs `compileAllRepos` as a fire-and-forget task inside the server process, guarded by a process-scoped boolean that returns 409 on concurrent requests and is cleared in a `finally` block so a failed sweep never permanently blocks future rebuilds.
- Added a full-width banner strip (`wikiBannerHtml` in `shell.js`, mounted idempotently as the first child of the right content column via `mountWikiFreshness`) that appears on both the Knowledge and Graph pages. The banner shows repo names, pending count, and a Rebuild button; it polls the freshness endpoint while a rebuild is in flight and surfaces a wired Retry button on non-409 failures so the feature remains usable without a page reload.
- Added an up-front provider check in the rebuild handler: if no usable AI provider is configured, the endpoint returns a 400 with a human-readable error message before starting any work. The existing error-callout path in the frontend renders the message with a Retry button and a prompt to open Settings, so no frontend changes were needed for this fix.
- Fixed the layout so the banner occupies normal flow at the top of the content column without pushing the knowledge list or graph frame out of the viewport: the content column uses a flex chain with `min-height: 0` at each level, the knowledge page grid uses `minmax(0, 1fr)` row sizing, and the graph iframe fills the remaining flex space.

**📋 Future Enhancements**

Cross-surface "Rebuilding…" state sharing — so a rebuild started from the dashboard also shows as in-progress in VS Code and vice versa — was explicitly deferred. The agreed approach is a folder-level heartbeat lock that all three surfaces read, with a timeout to handle crashed rebuilds.

**📁 FILES**
- `cli/src/dashboard/DashboardServer.ts`
- `cli/src/dashboard/assets/js/shell.js`
- `cli/src/dashboard/assets/js/knowledge.js`
- `cli/src/dashboard/assets/js/graph.js`
- `cli/src/dashboard/assets/styles/main.css`

</blockquote>
</details>
<details>
<summary><strong>04 · [2e3b2d2] VS Code sidebar wiki freshness banner matching the dashboard</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The VS Code sidebar had a small unreadable chip showing a bare number like "18 behind" with no context and no rebuild button nearby. The team wanted the sidebar to show the same full-width banner as the dashboard, with matching text and a working Rebuild button.

**💡 Decisions Behind the Code**

- **Banner outside the tab panel, not inside it**: The tree panel's content is replaced on every render, so a banner mounted inside it would be wiped on each refresh. Placing the banner in a persistent sibling slot between the toolbar and the panel means it survives re-renders and only needs to toggle visibility based on the active tab.
- **Reuse the existing folder-wide rebuild command**: The Rebuild button posts a message that triggers the same "Build Knowledge Wiki" command already in the toolbar, rather than adding a new single-repo rebuild action. This keeps the rebuild scope consistent with what the indicator describes (the whole folder) and avoids adding a new bridge action and endpoint.

**✅ What Was Implemented**

- Replaced the toolbar chip with a persistent banner slot (`#kb-wiki-banner`) inserted between the toolbar and the tree in the sidebar HTML. The banner renders the same message format as the dashboard ("Wiki is behind for N repos — M new memories to fold in") and a Rebuild button that triggers the existing folder-wide "Build Knowledge Wiki" command. The banner is shown only on the Memory Bank tab and hidden when the wiki is up to date.
- Added `setWikiRebuilding(active: boolean)` to the sidebar provider and wired it into the compile command so the banner shows "Rebuilding the wiki/graph…" for the entire sweep duration — matching the dashboard's in-flight state — rather than only changing the button label. A `pushWikiFreshness()` call at compile completion and on early-return paths resets the banner to its final state reliably.
- Wired freshness pushes to ingest-phase file-system watcher events so the backlog count updates as summaries are folded in, without requiring a tab switch or manual refresh.

**📁 FILES**
- `vscode/src/views/SidebarScriptBuilder.ts`
- `vscode/src/views/SidebarHtmlBuilder.ts`
- `vscode/src/views/SidebarWebviewProvider.ts`
- `vscode/src/CompileCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · [2e3b2d2] Skip redundant wiki re-reconciliation after rebase hash migration</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a rebase rewrites commit hashes without changing summary content, the wiki pipeline treated every migrated hash as a brand-new pending source and re-ran full-page LLM reconciliation for zero content change. This was identified as one of the root causes of the corpus-scaling cost problem.

**💡 Decisions Behind the Code**

- **Read inside the lock, not before it**: The summary phase (which runs the carry) and the ingest phase (which writes the processed set) are explicitly allowed to run concurrently in separate workers. An unlocked read followed by a locked write creates a real race where a concurrent ingest write lands between the read and the write, dropping a batch of already-folded sources. Performing the entire read-modify-write inside the lock eliminates this window, matching the ingest pipeline's own guarded pattern.
- **Isolated try/catch rather than inline**: The carry is a pure optimization with no user-visible artifact of its own. Wrapping it in its own error handler means a transient failure degrades gracefully to the pre-existing behavior rather than surfacing as a migration failure to the user.
- **Prune old hash at carry time**: The old hash refers to a commit that no longer exists after a rebase, so retaining it provides no correctness benefit — it only grows the processed set. Pruning at carry time keeps the set bounded to live commits rather than accumulating historical rebase artifacts indefinitely, reducing both serialization cost and lookup time on every subsequent save.

**✅ What Was Implemented**

- Added `carryProcessedSummaryHash()` to `ProcessedSourceStore.ts`, which copies the "already ingested" mark from an old commit hash to its rebase-migrated replacement and removes the old (now nonexistent) hash from the summary bucket in the same operation. An early return handles the case where old and new hash are identical. The read-modify-write runs inside the orphan-write lock to prevent a concurrent ingest drain from clobbering the update.
- Wired the carry into the rebase-pick handler in `QueueWorker.ts` inside a separate try/catch so that a lock contention or IO failure on this optimization path can never turn a successful, already-durable migration into a reported failure. The worst case is that the carry is skipped and the next rebuild re-reconciles that one summary, which is the pre-existing behavior.
- Updated the existing carry test to assert the old hash is absent after migration (reversing the previous assertion that it was harmlessly left in place), and added a new test for the identical-hash no-op path.

**📁 FILES**
- `cli/src/core/ProcessedSourceStore.ts`
- `cli/src/hooks/QueueWorker.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · [2e3b2d2] Dashboard rebuild endpoint silent-failure fix when no AI provider is configured</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When no AI provider was configured, clicking the Rebuild button in the dashboard returned a success response and showed a "Rebuilding…" spinner, but every batch failed silently inside the sweep. The banner then returned to the identical "behind" state with no explanation, leaving the user with no signal that anything went wrong.

**💡 Decisions Behind the Code**

The dashboard endpoint now matches the behavior the VS Code "Build Knowledge Wiki" command already had — an explicit provider check with a user-visible message before any work begins. Letting the sweep run and surface errors through server logs was rejected: in a fire-and-forget in-process sweep, per-repo errors are caught and not re-thrown, so the flag clears and the banner resets with zero user-visible signal.

**✅ What Was Implemented**

Added an up-front provider check in `DashboardServer.ts`'s rebuild handler: if no usable AI provider is configured, the endpoint returns a 400 with a human-readable error message before starting any work. The existing error-callout path in the frontend already handles non-409 errors by rendering the message with a Retry button and a prompt to open Settings, so no frontend changes were needed. Added a corresponding test in `DashboardServer.test.ts` that mocks the provider resolver to return null and asserts the 400 response, the error message content, and that the compile function is never called.

**📁 FILES**
- `cli/src/dashboard/DashboardServer.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · [2e3b2d2] Dashboard freshness poll interval increased and duplicate poll chain prevented</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The dashboard polled the freshness endpoint every 3 seconds during a rebuild, but each poll triggers a full scan of every repository's index, processed set, plans, notes, and user files — all running in the same process as the active LLM sweep. The endpoint's own documentation described it as a slow probe never intended for a hot loop.

**💡 Decisions Behind the Code**

- **5 seconds over a tighter interval**: The completion latency difference between 3s and 5s is imperceptible relative to a multi-minute rebuild, but the reduction in concurrent filesystem pressure during an active LLM sweep is real. The "slow probe" label in the existing code was the clearest signal that the original interval was already too aggressive.
- **Single shared timer variable over per-invocation closure**: Storing the timer in a module-level variable rather than a closure means any future re-mount of the banner replaces the running chain rather than adding to it. This was identified as a latent resource-leak pattern even though no current code path triggers it; the fix is one variable and one additional call.

**✅ What Was Implemented**

- Increased the in-flight poll interval from 3 seconds to 5 seconds in `shell.js`, with an updated comment explaining that each tick is a whole-folder filesystem scan running in the same process as the LLM compile sweep.
- Introduced a module-level `wikiPollTimer` variable in `shell.js`; every scheduled tick calls `clearTimeout` on the previous timer before arming a new one, so if the banner is ever re-mounted during an active rebuild the new poll chain replaces the old one rather than stacking alongside it.

**📁 FILES**
- `cli/src/dashboard/assets/js/shell.js`

</blockquote>
</details>
<details>
<summary><strong>08 · [2e3b2d2] VS Code freshness scan decoupled from worker heartbeat writes</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The background ingest worker rewrites a phase file on a 60-second heartbeat throughout the entire ingest run, not only on real phase transitions. A freshness push was wired to every file-change event on that file, causing a full folder-wide freshness scan to run once per minute for the entire duration of every ingest — with no debounce and regardless of which tab was visible.

**💡 Decisions Behind the Code**

A file being rewritten is not the same signal as a phase changing. Treating every heartbeat write as a phase transition degraded the file-changed event from an edge trigger into a periodic trigger, making the freshness scan run on a fixed schedule rather than on meaningful state changes. Moving the push to the delete event restores edge-trigger semantics at no cost, since a manual rebuild already shows "Rebuilding…" through a separate mechanism.

**✅ What Was Implemented**

Removed the `pushWikiFreshness` call from the file-change handler in `Extension.ts`, leaving only the cheap ingest-pill refresh there. The authoritative freshness refresh now rides exclusively on the file-delete event, which the worker emits only when the ingest genuinely ends. A comment explains the heartbeat behavior so the next maintainer understands why the change handler is intentionally left without a freshness push.

**📁 FILES**
- `vscode/src/Extension.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · [2e3b2d2] VS Code banner reset fixed when Memory Bank folder is not configured</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a user clicked the Rebuild button in the VS Code sidebar but the Memory Bank folder setting had been cleared between the freshness fetch and the click, the command returned early without resetting the banner. The button stayed disabled and showed "Rebuilding…" until the user switched tabs or triggered a refresh.

**💡 Decisions Behind the Code**

The fix mirrors the no-provider path that already handled this correctly, making the two early-return branches symmetric. Letting the button stay stuck until a tab switch was rejected because the dashboard's equivalent path already renders an error callout with a Retry button, and the VS Code path should behave consistently with it.

**✅ What Was Implemented**

Added a `pushWikiFreshness` call to the no-folder early-return path in `CompileCommand.ts`, matching the existing call on the no-provider early-return path. Updated the corresponding test in `CompileCommand.test.ts` to capture the options object and assert that the freshness push is called on this path.

**📁 FILES**
- `vscode/src/CompileCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · [2e3b2d2] Rebase migration now removes the old commit entry from the processed set</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Every time a commit was rebased, the hash migration added the new commit hash to the processed set but left the old (now nonexistent) hash in place. Over time this caused the processed set to grow by one dead entry per rebased commit, making every save re-serialize a larger file and making the "already processed" lookup scan a longer list.

**💡 Decisions Behind the Code**

The carry function is the only place in the codebase where a 1-to-1 rebase migration is recorded, making it the natural and lowest-risk location to prune the dead entry. The old hash refers to a commit that no longer exists after a rebase, so retaining it provides no correctness benefit — it only grows the set. Pruning at carry time keeps the set bounded to live commits rather than accumulating historical rebase artifacts indefinitely.

**✅ What Was Implemented**

Modified `carryProcessedSummaryHash` in `ProcessedSourceStore.ts` to remove the old hash from the summary bucket at the same time it adds the new one, and added an early return for the case where old and new hash are identical. Updated the existing carry test to assert the old hash is absent after migration (reversing the previous assertion that it was harmlessly left in place), and added a new test for the identical-hash no-op path.

**📁 FILES**
- `cli/src/core/ProcessedSourceStore.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · [4e62da2] Dismissible wiki freshness banner with restart-aware re-show logic</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users wanted a way to temporarily hide the "wiki is behind" reminder banner without it being permanently silenced — the banner should reappear when the backlog genuinely grows, urgency escalates, or the tool restarts.

**💡 Decisions Behind the Code**

- **Process memory vs. persistent storage for VS Code**: The VS Code sidebar webview is destroyed and recreated whenever the user switches away from it, so storing dismissal state inside the webview would make the × button ineffective across tab switches. Persisting it with VS Code's `setState` API would make it survive a full window reload, which is the intended reset boundary. Holding it in the extension host process memory threads the needle: it survives normal tab switching but clears on Reload Window, exactly matching the behavior the dashboard gets from a server restart.
- **Snapshot the visible state at dismiss time, not a recomputed value**: The re-show predicate compares a later freshness probe against what the user actually saw when they clicked ×, not against a freshness value recomputed at some later point. This prevents a scenario where a partial rebuild drains some pending items below the dismiss threshold and silently re-hides a banner the user had already seen reappear — once a dismissal is spent (re-show triggered), it is cleared immediately so the banner stays visible.
- **Two-surface consistency over implementation simplicity**: Both surfaces implement identical re-show rules (total grew, summary grew, severity escalated, new repo appeared, caught up clears the record) even though their storage mechanisms differ. An earlier design considered only `total` for re-show, but review identified that the headline memory count (`summary`) can rise while `total` stays flat when other pending types drain simultaneously — omitting it would silently mute a genuinely growing backlog.

**✅ What Was Implemented**

- Added a close (×) button to the wiki freshness banner on both the local dashboard and the VS Code sidebar. On the dashboard, the dismissal state is stored in the browser's local storage alongside a server-generated process identifier (`wikiBannerNonce` in `DashboardServer.ts`), so restarting the dashboard server mints a new identifier and causes a dismissed banner to reappear. The re-show predicate in `shell.js` checks whether the total backlog grew, the headline memory count grew independently, severity escalated, or a previously-unseen repository fell behind — any of these clears the stored dismissal and shows the banner again.
- On the VS Code side, dismissal state is held in the extension host's process memory (`wikiDismissed` field in `SidebarWebviewProvider.ts`) with an equivalent gate (`gateWikiFreshnessByDismiss`). The webview sends a `wiki:dismiss` message carrying a snapshot of the visible counts, severity, and repository list at dismiss time; the host compares each subsequent freshness probe against that snapshot using the same four re-show conditions. Reloading the VS Code window clears host memory, which is the natural restart boundary for this surface.
- Updated banner copy on both surfaces: button label changed from "Rebuild wiki" to "Update", body text changed from "Wiki is behind…" to "Wiki & graph are behind…", and the phrase "Rebuilding uses your LLM." was removed. Eight new unit tests in `SidebarWebviewProvider.test.ts` cover the dismiss gate, including the summary-grew-while-total-flat and new-repo-appeared edge cases.

**📋 Future Enhancements**

Cross-surface "rebuilding in progress" state is not shared: a rebuild triggered from VS Code is invisible to the dashboard's in-flight indicator, and vice versa. A folder-level heartbeat lock was discussed as the eventual solution but deferred.

**📁 FILES**
- `cli/src/dashboard/DashboardServer.ts`
- `cli/src/dashboard/assets/js/shell.js`
- `cli/src/dashboard/assets/styles/main.css`
- `vscode/src/views/SidebarWebviewProvider.ts`
- `vscode/src/views/SidebarScriptBuilder.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 14, 2026 at 7:55 PM · via Anthropic*
<!-- jollimemory-summary-end -->