### PR TITLE
Run the dashboard button's command in a terminal, not the extension host

### DIFF
--- a/claude-plugin/scripts/_publish-lib.sh
+++ b/claude-plugin/scripts/_publish-lib.sh
@@ -416,6 +416,24 @@ publish_git_repo() {
 		last_version="${last_msg#"$release_subject"}"
 		if [ -z "$last_msg" ]; then
 			echo "==> No previous release commit on the target — version guard has no baseline."
+		elif [ "${JOLLI_PUBLISH_FORCE:-0}" != "1" ] && [ "$last_version" = "$last_msg" ]; then
+			# `--grep` matches the whole MESSAGE and its `^` anchors per LINE, so a commit
+			# whose BODY carries a release-looking line is selected while its SUBJECT is
+			# something else — the prefix then does not strip and `last_version` is not a
+			# version at all. Fail CLOSED rather than treating it as "no baseline": the
+			# real last release may be further back in history, so an unparseable
+			# candidate is not evidence that this version is higher than it. (Reaching
+			# `publish_version_gt` with the garbage also stops the publish, since a
+			# non-semver answers "not greater" — but it does so while printing that
+			# subject as though it were the last published version.)
+			echo "error: a commit matching the release pattern has a non-release subject:" >&2
+			echo "         ${last_msg}" >&2
+			echo "       Cannot establish a version baseline, so the downgrade guard cannot run." >&2
+			echo "       Re-run with JOLLI_PUBLISH_FORCE=1 if this is intentional." >&2
+			git reset -q --hard HEAD
+			git -c core.excludesFile=/dev/null clean -fdq
+			echo "       (The synced changes were reverted — the checkout is back at HEAD.)" >&2
+			return 1
 		elif [ "${JOLLI_PUBLISH_FORCE:-0}" != "1" ] &&
 			! publish_version_gt "$version" "$last_version"; then
 			# `publish_sync` already ran `rsync --delete` + `git add -A`, so the checkout is

--- a/cli/src/Cli.test.ts
+++ b/cli/src/Cli.test.ts
@@ -73,6 +73,9 @@ describe("serveMcpInProcess (the fast path's fallback)", () => {
 			bootstrapTelemetry: vi.fn(async () => void order.push("bootstrap")),
 			flushTelemetryNow: vi.fn(async () => {}),
 			maybeShowCliTelemetryNotice: vi.fn(async () => {}),
+			// The exit flush reads this off the module handle, so the mock has to
+			// carry it: an ESM namespace throws on an export the factory omitted.
+			BOUNDED_FLUSH_BUDGET_MS: 2_000,
 		}));
 		vi.doMock("./mcp/McpServer.js", () => ({
 			startMcpServer: vi.fn(async () => void order.push("serve")),
@@ -95,6 +98,7 @@ describe("serveMcpInProcess (the fast path's fallback)", () => {
 			}),
 			flushTelemetryNow: vi.fn(async () => {}),
 			maybeShowCliTelemetryNotice: vi.fn(async () => {}),
+			BOUNDED_FLUSH_BUDGET_MS: 2_000,
 		}));
 		const startMcpServer = vi.fn(async () => {});
 		vi.doMock("./mcp/McpServer.js", () => ({ startMcpServer }));

--- a/cli/src/Cli.ts
+++ b/cli/src/Cli.ts
@@ -114,12 +114,20 @@ export function isDetachedDaemonInvocation(argv: ReadonlyArray<string>): boolean
  * reads while marking itself shown forever. It stays owed to the next ordinary
  * `jolli` invocation.
  *
- * Priming is best-effort: telemetry must never cost a session its MCP server.
+ * Priming is best-effort: telemetry must never cost a session its MCP server. That
+ * is why the module IMPORT is inside the guard too, and why the flush is reached
+ * through a nullable module handle: an import that fails outside it would reject
+ * before `startMcpServer` is ever called, which is the one outcome this whole
+ * function is not allowed to produce. With the handle null, the session simply
+ * runs untelemetered — the pre-existing behaviour this priming replaced.
  */
 export async function serveMcpInProcess(dir: string): Promise<void> {
-	const { bootstrapTelemetry, flushTelemetryNow } = await import("./core/TelemetryStartup.js");
+	// Held across the try so the `finally` can still flush what the session
+	// buffered; null only when the module itself could not be loaded.
+	let telemetry: typeof import("./core/TelemetryStartup.js") | null = null;
 	try {
-		await bootstrapTelemetry({ cwd: dir });
+		telemetry = await import("./core/TelemetryStartup.js");
+		await telemetry.bootstrapTelemetry({ cwd: dir });
 	} catch (error: unknown) {
 		// stderr, never stdout — stdout is this session's JSON-RPC stream.
 		console.error("telemetry unavailable for this MCP session:", error);
@@ -129,8 +137,25 @@ export async function serveMcpInProcess(dir: string): Promise<void> {
 		await startMcpServer(dir);
 	} finally {
 		// The session is over, so this is the only chance to upload what it buffered.
-		// Bounded and best-effort, like the command path's exit flush.
-		await flushTelemetryNow(dir, { timeoutMs: 2_000 });
+		// Both bounds come from the shared budget, not a local literal: `timeoutMs`
+		// caps one POST, and a session that filled its buffer flushes as SEVERAL
+		// sequential POSTs — so without `deadlineMs` this `finally` could hold up
+		// process exit for a multiple of the budget.
+		//
+		// Wrapped because a `finally` that throws REPLACES the exception the server
+		// was reporting. `flushTelemetryNow` swallows its own failures, so what is
+		// left is the namespace read above it — which would throw if that export were
+		// ever renamed, turning a real MCP fault into a telemetry stack trace.
+		try {
+			if (telemetry !== null) {
+				await telemetry.flushTelemetryNow(dir, {
+					timeoutMs: telemetry.BOUNDED_FLUSH_BUDGET_MS,
+					deadlineMs: telemetry.BOUNDED_FLUSH_BUDGET_MS,
+				});
+			}
+		} catch (error: unknown) {
+			console.error("telemetry flush failed for this MCP session:", error);
+		}
 	}
 }
 

--- a/codex-plugin/scripts/_publish-lib.sh
+++ b/codex-plugin/scripts/_publish-lib.sh
@@ -426,6 +426,29 @@ publish_git_repo() {
 				# No release commit on the target: a first publish has no baseline to be
 				# higher than. Said out loud, because "guard skipped" must never be silent.
 				echo "==> No previous release commit on the target — version guard has no baseline."
+			elif [ "${JOLLI_PUBLISH_FORCE:-0}" != "1" ] && [ "$last_version" = "$last_msg" ]; then
+				# `--grep` matches the whole MESSAGE and its `^` anchors per LINE, so a
+				# commit whose BODY carries a release-looking line is selected while its
+				# SUBJECT is something else — the prefix then does not strip and
+				# `last_version` is not a version at all. Fail CLOSED rather than treating
+				# it as "no baseline": the real last release may be further back in
+				# history, so an unparseable candidate is not evidence that this version is
+				# higher than it. (Reaching `publish_version_gt` with the garbage also
+				# stops the publish, since a non-semver answers "not greater" — but it does
+				# so while printing that subject as though it were the last version.)
+				echo "error: a commit matching the release pattern has a non-release subject:" >&2
+				echo "         ${last_msg}" >&2
+				echo "       Cannot establish a version baseline, so the guard cannot run." >&2
+				echo "       Re-run with JOLLI_PUBLISH_FORCE=1 if this is intentional." >&2
+				# Same state the version-guard branch below leaves behind, so say the same
+				# thing: the mirror ran BEFORE this guard, so the destination now holds this
+				# build uncommitted. Left in place rather than auto-reverted (it may hold
+				# deliberate local edits, and the safe-dest guard cannot tell those from
+				# mirror output) — but silence here makes the next run's diff read as a real
+				# change.
+				echo "note: '${dest}' already holds this build, uncommitted. Discard it with:" >&2
+				echo "        git -C '${dest}' checkout . && git -C '${dest}' clean -fd" >&2
+				exit 1
 			elif [ "${JOLLI_PUBLISH_FORCE:-0}" != "1" ] &&
 				! publish_version_gt "$version" "$last_version"; then
 				echo "error: content changed but plugin version ${version} is not higher than" >&2

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -277,11 +277,6 @@
 				"command": "jollimemory.openDashboard",
 				"title": "Open Dashboard",
 				"category": "Jolli Memory"
-			},
-			{
-				"command": "jollimemory.stopDashboard",
-				"title": "Stop Dashboard",
-				"category": "Jolli Memory"
 			}
 		],
 		"menus": {

--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -125,7 +125,7 @@ import { StatusTreeProvider } from "./providers/StatusTreeProvider.js";
 import { ActiveSessionsProvider } from "./services/ActiveSessionsProvider.js";
 import { AuthService } from "./services/AuthService.js";
 import { readBackfillDismissFlag, writeBackfillDismissFlag } from "./services/BackfillDismissFlag.js";
-import { launchDashboard, stopDashboard } from "./services/DashboardLauncher.js";
+import { launchDashboard } from "./services/DashboardLauncher.js";
 import { KbFoldersService } from "./services/KbFoldersService.js";
 import {
 	readManualDisableFlag,
@@ -4250,27 +4250,24 @@ export function activate(context: vscode.ExtensionContext): void {
 			},
 		),
 
-		// Dashboard — the branch footer button. Everything about starting the
-		// server lives in the CLI's `jolli dashboard`, which DashboardLauncher runs
-		// as a child process — it is a foreground command now, so it cannot be
-		// called in-process here without never returning. The launcher supplies the
-		// editor-shaped plugs (output channel, Electron-as-node spawn, host URL
-		// opener), the remote-window gate, and the child's lifetime.
+		// Dashboard — the branch footer button. Runs `jolli dashboard` in an
+		// integrated terminal rather than in this process, so the command's own
+		// output (including the history import, which runs after the page is up and
+		// can take minutes) is in front of the user. DashboardLauncher decides only
+		// which CLI entry to invoke, and keeps the remote-window gate.
+		//
+		// No stop command rides beside this one: the command is a FOREGROUND server
+		// and the terminal is what owns it, so Ctrl+C is the stop — the thing an
+		// extension-owned child process had to reinvent.
 		vscode.commands.registerCommand("jollimemory.openDashboard", () => {
 			log.info("cmd", "openDashboard invoked");
-			// Not awaited: launchDashboard resolves when the startup phase settles
-			// and reports its own failures, so there is nothing here to wait for.
+			// Not awaited: launchDashboard resolves once the line has been sent to
+			// the terminal and reports its own failures, so there is nothing to wait
+			// for here.
 			void launchDashboard({
 				cwd: workspaceRoot,
 				distDir: join(context.extensionPath, "dist"),
 			});
-		}),
-
-		// The Ctrl+C a button has no way to offer. `deactivate` calls the same
-		// function, so closing the window is the other way to stop it.
-		vscode.commands.registerCommand("jollimemory.stopDashboard", () => {
-			log.info("cmd", "stopDashboard invoked");
-			stopDashboard();
 		}),
 
 		// Settings — accessible via the gear icon in the STATUS panel title bar.
@@ -4805,12 +4802,11 @@ export function activate(context: vscode.ExtensionContext): void {
 
 export function deactivate(): void {
 	log.info("deactivate", "Jolli Memory extension deactivating");
-	// `jolli dashboard` is a foreground server running as OUR child, so this
-	// window owns its lifetime the way a terminal would. Skipping this would
-	// leave a listener nobody can see, reach or stop — the background process the
-	// command was rewritten to stop being. Before `log.dispose()`, so the stop is
-	// still recorded in the channel.
-	stopDashboard();
+	// Nothing to stop here: `jolli dashboard` runs in an integrated terminal, not
+	// as a child of this process, so the window closing takes its terminals — and
+	// therefore the server — with it. That is also what makes the running server
+	// reachable while the window is open, which is the whole reason it is not ours
+	// to own.
 	log.dispose();
 	// VSCode disposes context.subscriptions automatically
 }

--- a/vscode/src/services/DashboardLauncher.test.ts
+++ b/vscode/src/services/DashboardLauncher.test.ts
@@ -1,49 +1,44 @@
 /**
  * DashboardLauncher tests.
  *
- * The subject is the wiring, not the dashboard: the child process is injected by
- * every case except the one that exists to prove the default spawner is wired
- * (and that one mocks `spawnHidden`), so nothing here binds a port, starts a
- * process or opens a browser.
+ * The subject is the command line and the terminal, not the dashboard: nothing
+ * here starts a process, and `executeDashboard` is not involved at all any more —
+ * the launcher's job ends when a line has been sent to a terminal.
  *
- * What is worth pinning is what this module decides on its own now that
- * `jolli dashboard` is a foreground command it runs as a CHILD: the remote gate,
- * the argv that runs the CLI entry as node with `--no-open`, that the URL is
- * recovered from the child's own output (nothing on disk records the port any
- * more), that the progress notification ends at the BROWSER rather than at the
- * child's exit, that a child which dies before serving is reported, that a
- * repeat click reuses the running dashboard, that a refused browser is reported
- * at all, and that the child can be stopped — the Ctrl+C a button cannot offer.
+ * What is worth pinning is what this module decides on its own: the remote gate,
+ * that tier 0 is a version-gated global `jolli`, tier 1 is `run-cli` and tier 2 is
+ * the bundled entry run by the host's Node, that tier 1 is skipped on a shell that
+ * cannot execute a bash script, that each shell's quoting and the PowerShell call
+ * operator are right (a wrong quote does not fail loudly — it passes a mangled path
+ * to the CLI), that the repo directory reaches the CLI ONLY as the terminal's own
+ * cwd and never as a command argument, and that every click opens a NEW terminal
+ * rather than reusing or revealing an earlier one.
  */
 
-import { EventEmitter } from "node:events";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { PassThrough } from "node:stream";
+import { delimiter, join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// `withProgress` runs its task here (rather than being an inert `vi.fn()`)
-// because the default-seam case below goes through `defaultUi()`, whose progress
-// adapter is the only thing that awaits the startup barrier. An inert stub would
-// let that test pass without the barrier ever being released.
-vi.mock("vscode", () => ({
-	env: { remoteName: undefined, openExternal: vi.fn() },
-	window: {
-		withProgress: vi.fn((_options: unknown, task: () => Promise<void>) => task()),
-		showErrorMessage: vi.fn(),
-		showInformationMessage: vi.fn(),
-	},
-	Uri: { parse: (s: string) => s },
-	ProgressLocation: { Notification: 15 },
+// `createTerminal` returns a usable stub rather than `undefined` because one case
+// below omits the `host` seam entirely, so that it exercises the `?? defaultHost()`
+// fallback — the only line in this module that touches `vscode.window` directly.
+const { createTerminalMock } = vi.hoisted(() => ({
+	createTerminalMock: vi.fn((options: { name: string }) => ({
+		name: options.name,
+		show: vi.fn(),
+		sendText: vi.fn(),
+	})),
 }));
 
-const { spawnHiddenMock } = vi.hoisted(() => ({ spawnHiddenMock: vi.fn() }));
-
-// No real process is ever started: the default spawner's whole job here is the
-// argv + env it hands to `spawnHidden`, which is what makes Electron run the
-// CLI entry as a plain node process.
-vi.mock("../../../cli/src/util/Subprocess.js", () => ({ spawnHidden: spawnHiddenMock }));
+vi.mock("vscode", () => ({
+	env: { remoteName: undefined, shell: "/bin/zsh" },
+	window: {
+		createTerminal: createTerminalMock,
+		showInformationMessage: vi.fn(),
+		showErrorMessage: vi.fn(),
+	},
+}));
 
 const logCalls: Array<{ level: string; message: string }> = [];
 vi.mock("../util/Logger.js", () => ({
@@ -57,429 +52,711 @@ vi.mock("../util/Logger.js", () => ({
 }));
 
 import {
-	__resetDashboardLaunchForTests,
-	BROWSER_FAILURE_MESSAGE,
+	BUNDLED_CLI_VERSION,
 	CLI_ENTRY_FILE,
-	type DashboardLauncherUi,
-	type DashboardSpawner,
-	FAILURE_MESSAGE,
-	isDashboardRunning,
+	type DashboardLauncherHost,
+	detectShellFlavor,
+	findExecutableOnPath,
+	GLOBAL_BIN_NAME,
 	isRemoteWorkspace,
 	launchDashboard,
-	PROGRESS_TITLE,
+	quoteArg,
+	readWinningGlobalCliVersion,
 	REMOTE_HINT,
-	stopDashboard,
-	URL_PATTERN,
+	resolveDashboardCommand,
+	resolveRunCliPath,
+	type ShellFlavor,
+	TERMINAL_NAME,
+	type TerminalLike,
+	UNAVAILABLE_MESSAGE,
 } from "./DashboardLauncher.js";
 
-interface FakeUiCalls {
-	progressEnded: boolean;
-	errors: Array<string>;
-	infos: Array<string>;
-	opened: Array<string>;
-	logRevealed: boolean;
-}
+const REPO = "/repo/root";
+const EXEC = "/Applications/Code.app/Contents/MacOS/Electron";
+const RUN_CLI = "/home/u/.jolli/jollimemory/run-cli";
 
-/**
- * A UI seam that records what it was asked to do.
- *
- * `errorChoice` is what the user is taken to have clicked on the failure
- * notification — a constructor argument rather than an override so a case can
- * exercise the "Show Log" branch without having to restate the recording.
- */
-function fakeUi(
-	opts: { readonly errorChoice?: string; readonly overrides?: Partial<DashboardLauncherUi> } = {},
-): { ui: DashboardLauncherUi; calls: FakeUiCalls } {
-	const calls: FakeUiCalls = {
-		progressEnded: false,
-		errors: [],
-		infos: [],
-		opened: [],
-		logRevealed: false,
-	};
-	const ui: DashboardLauncherUi = {
-		withProgress: async (_title, task) => {
-			await task();
-			calls.progressEnded = true;
-		},
-		showError: async (message) => {
-			calls.errors.push(message);
-			return opts.errorChoice;
-		},
-		showInfo: async (message) => {
-			calls.infos.push(message);
-		},
-		openExternal: async (url) => {
-			calls.opened.push(url);
-		},
-		revealLog: () => {
-			calls.logRevealed = true;
-		},
-		...(opts.overrides ?? {}),
-	};
-	return { ui, calls };
-}
-
-/**
- * A stand-in for the spawned `jolli dashboard`.
- *
- * Real streams rather than stubs, because the module reads them through
- * `readline` — the line buffering is part of what is under test (a chunk
- * boundary inside the URL line must not lose it).
- */
-function fakeChild(): {
-	child: EventEmitter & { stdout: PassThrough; stderr: PassThrough; kill: ReturnType<typeof vi.fn>; exitCode: null };
-	say: (line: string) => Promise<void>;
-	gone: (code: number) => Promise<void>;
-	closed: (code: number) => Promise<void>;
-	exit: (code: number) => Promise<void>;
-} {
-	const stdout = new PassThrough();
-	const stderr = new PassThrough();
-	const child = Object.assign(new EventEmitter(), {
-		stdout,
-		stderr,
-		kill: vi.fn(),
-		exitCode: null as null,
-	});
-	// The two halves of a child ending, exposed separately because the GAP between
-	// them is what this module has to survive: `exit` fires the moment the process
-	// is gone, while lines it printed a moment earlier are still travelling through
-	// the pipes, and `close` is the event that waits for those pipes.
-	//
-	// They are separate here rather than sequenced inside one helper because a
-	// `PassThrough` written from a test delivers synchronously — the gap a real
-	// pipe has does not exist unless a case opens it deliberately.
-	const gone = async (code: number) => {
-		child.emit("exit", code);
-		await flushMicrotasks();
-	};
-	const closed = async (code: number) => {
-		stdout.end();
-		stderr.end();
-		await flushMicrotasks();
-		child.emit("close", code);
-		await flushMicrotasks();
-	};
-	return {
-		child,
-		say: async (line: string) => {
-			stdout.write(`${line}\n`);
-			await flushMicrotasks();
-		},
-		gone,
-		closed,
-		/** The ordinary case: nothing was left in flight, so both fire back to back. */
-		exit: async (code: number) => {
-			await gone(code);
-			await closed(code);
-		},
-	};
-}
-
-/** The spawner seam, wired to a fake child. */
-function spawnerFor(child: unknown, record?: { args: string[]; cwd: string }[]): DashboardSpawner {
-	return (args, cwd) => {
-		record?.push({ args: [...args], cwd });
-		return child as ReturnType<DashboardSpawner>;
-	};
-}
-
-/** A real dist directory holding a real CLI entry, so `existsSync` passes. */
-function distWithEntry(): string {
+/** A dist directory that really holds a real `Cli.js`, so `existsSync` passes. */
+function distWithCli(): string {
 	const dir = mkdtempSync(join(tmpdir(), "jolli-dashboard-launcher-"));
 	writeFileSync(join(dir, CLI_ENTRY_FILE), "");
 	return dir;
 }
 
-/** A macrotask: guarantees every pending microtask has drained first. */
-function flushMicrotasks(): Promise<void> {
-	return new Promise<void>((resolve) => setTimeout(resolve, 0));
+interface FakeTerminal extends TerminalLike {
+	readonly sent: Array<string>;
+	readonly shown: Array<boolean | undefined>;
 }
 
-const URL_LINE = "  Jolli dashboard → http://127.0.0.1:1818/dashboard";
-const URL = "http://127.0.0.1:1818/dashboard";
+function fakeTerminal(name: string = TERMINAL_NAME): FakeTerminal {
+	const terminal: FakeTerminal = {
+		name,
+		sent: [],
+		shown: [],
+		show: (preserveFocus) => {
+			terminal.shown.push(preserveFocus);
+		},
+		sendText: (text) => {
+			terminal.sent.push(text);
+		},
+	};
+	return terminal;
+}
+
+interface FakeHostCalls {
+	readonly created: Array<{ name: string; cwd: string; env: Readonly<Record<string, string>> }>;
+	readonly infos: Array<string>;
+	readonly errors: Array<string>;
+	/** Every terminal handed out, in creation order. */
+	readonly terminals: Array<FakeTerminal>;
+}
+
+/** A host that records what it was asked to do and hands back fake terminals. */
+function fakeHost(): { host: DashboardLauncherHost; calls: FakeHostCalls } {
+	const calls: FakeHostCalls = { created: [], infos: [], errors: [], terminals: [] };
+	const host: DashboardLauncherHost = {
+		createTerminal: (options) => {
+			calls.created.push({ ...options });
+			const created = fakeTerminal(options.name);
+			calls.terminals.push(created);
+			return created;
+		},
+		showInfo: async (message) => {
+			calls.infos.push(message);
+		},
+		showError: async (message) => {
+			calls.errors.push(message);
+		},
+	};
+	return { host, calls };
+}
+
+/**
+ * Options that resolve to tier 1 on a POSIX shell, with nothing left to the machine.
+ *
+ * `globalCliVersion: null` is the load-bearing part: without it the launcher reads
+ * the REAL dist-paths registry, and a developer machine with a global CLI installed
+ * would silently push every one of these cases up to tier 0.
+ */
+function tierOneOptions(overrides: Partial<Parameters<typeof launchDashboard>[0]> = {}) {
+	return {
+		cwd: REPO,
+		distDir: "/ext/dist",
+		platform: "darwin" as NodeJS.Platform,
+		shell: "/bin/zsh",
+		execPath: EXEC,
+		runCliPath: RUN_CLI,
+		canExecute: (path: string) => path === RUN_CLI,
+		fileExists: () => true,
+		globalCliVersion: null,
+		...overrides,
+	};
+}
 
 beforeEach(() => {
 	logCalls.length = 0;
-	spawnHiddenMock.mockReset();
-	// The live-dashboard guard is module state, and several cases below leave a
-	// child running — without this the next case would be treated as a repeat
-	// click on the previous one's dashboard.
-	__resetDashboardLaunchForTests();
+	createTerminalMock.mockClear();
 });
 
 describe("isRemoteWorkspace", () => {
-	it("is true for any remote name and false only for undefined", () => {
-		expect(isRemoteWorkspace("ssh-remote")).toBe(true);
-		expect(isRemoteWorkspace("wsl")).toBe(true);
+	it("is false for a local window", () => {
 		expect(isRemoteWorkspace(undefined)).toBe(false);
+	});
+
+	it("is true for every remote flavour, WSL included", () => {
+		for (const name of ["ssh-remote", "wsl", "dev-container", "attached-container", "codespaces"]) {
+			expect(isRemoteWorkspace(name)).toBe(true);
+		}
 	});
 });
 
-describe("URL_PATTERN", () => {
-	it("finds the loopback URL in the command's own line", () => {
-		expect(URL_PATTERN.exec(URL_LINE)?.[1]).toBe(URL);
+describe("detectShellFlavor", () => {
+	it("reads PowerShell off either of its two binary names, with or without .exe", () => {
+		for (const shell of [
+			"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+			"C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+			"/usr/local/bin/pwsh",
+		]) {
+			expect(detectShellFlavor(shell, "win32")).toBe("powershell");
+		}
 	});
 
-	it("matches the fallback port too — the port is not knowable in advance", () => {
-		expect(URL_PATTERN.exec("  Jolli dashboard → http://127.0.0.1:18118/dashboard")?.[1]).toBe(
-			"http://127.0.0.1:18118/dashboard",
+	it("recognises cmd only when the path actually names it", () => {
+		expect(detectShellFlavor("C:\\Windows\\System32\\cmd.exe", "win32")).toBe("cmd");
+	});
+
+	it("classifies every POSIX shell as posix, Git Bash on Windows included", () => {
+		for (const shell of ["/bin/bash", "/bin/sh", "/bin/zsh", "/usr/bin/fish", "/bin/dash", "/bin/ksh"]) {
+			expect(detectShellFlavor(shell, "darwin")).toBe("posix");
+		}
+		// The reason the classification keys off the shell rather than the platform:
+		// Git Bash as the Windows default can run tier 1, and gets to.
+		expect(detectShellFlavor("C:\\Program Files\\Git\\bin\\bash.exe", "win32")).toBe("posix");
+	});
+
+	it("falls back to the platform default when the shell is unknown or absent", () => {
+		expect(detectShellFlavor(undefined, "win32")).toBe("powershell");
+		expect(detectShellFlavor(undefined, "darwin")).toBe("posix");
+		expect(detectShellFlavor("C:\\tools\\nushell\\nu.exe", "win32")).toBe("powershell");
+		expect(detectShellFlavor("/opt/homebrew/bin/nu", "darwin")).toBe("posix");
+	});
+});
+
+describe("quoteArg", () => {
+	it("single-quotes for POSIX so $ and backticks in a path stay literal", () => {
+		expect(quoteArg("/a/b $HOME/`x`", "posix")).toBe(`'/a/b $HOME/\`x\`'`);
+	});
+
+	it("escapes a literal quote per shell, and the two shells disagree", () => {
+		expect(quoteArg("it's", "posix")).toBe(`'it'\\''s'`);
+		expect(quoteArg("it's", "powershell")).toBe("'it''s'");
+	});
+
+	it("double-quotes for cmd, which has no literal-quoting form", () => {
+		expect(quoteArg("C:\\Program Files\\x", "cmd")).toBe(`"C:\\Program Files\\x"`);
+	});
+});
+
+describe("resolveRunCliPath", () => {
+	it("points at the machine-global dispatcher under the given home", () => {
+		expect(resolveRunCliPath("/home/u")).toBe(join("/home/u", ".jolli", "jollimemory", "run-cli"));
+	});
+});
+
+describe("findExecutableOnPath", () => {
+	it("finds a bare name in the first PATH dir that has it", () => {
+		const seen: Array<string> = [];
+		const found = findExecutableOnPath("jolli", {
+			pathEnv: ["/nope", "/usr/local/bin"].join(delimiter),
+			platform: "darwin",
+			fileExists: (path) => {
+				seen.push(path);
+				return path === join("/usr/local/bin", "jolli");
+			},
+		});
+		expect(found).toBe(join("/usr/local/bin", "jolli"));
+		expect(seen[0]).toBe(join("/nope", "jolli"));
+	});
+
+	it("is null for an absent binary, an empty PATH, and no PATH at all", () => {
+		const common = { platform: "darwin" as NodeJS.Platform, fileExists: () => false };
+		expect(findExecutableOnPath("jolli", { pathEnv: "/a", ...common })).toBeNull();
+		expect(findExecutableOnPath("jolli", { pathEnv: "", ...common })).toBeNull();
+		expect(findExecutableOnPath("jolli", { platform: "darwin" })).toBeNull();
+	});
+
+	// These two assert WINDOWS behaviour from a POSIX host, which only works because
+	// the function takes its separator and its join from the `platform` argument. A
+	// `C:\npm` PATH split on the host's `:` would come back as `["C", "\\npm"]`.
+	it("tries PATHEXT suffixes on win32, which is how a .cmd shim is found", () => {
+		const found = findExecutableOnPath("jolli", {
+			pathEnv: "C:\\npm;C:\\other",
+			pathExt: ".COM;.EXE;.BAT;.CMD",
+			platform: "win32",
+			// npm installs a cmd-shim, so only the .CMD candidate exists.
+			fileExists: (path) => path === "C:\\npm\\jolli.CMD",
+		});
+		expect(found).toBe("C:\\npm\\jolli.CMD");
+	});
+
+	it("falls back to a default PATHEXT when the variable is absent", () => {
+		const found = findExecutableOnPath("jolli", {
+			pathEnv: "C:\\npm",
+			platform: "win32",
+			fileExists: (path) => path === "C:\\npm\\jolli.CMD",
+		});
+		expect(found).toBe("C:\\npm\\jolli.CMD");
+	});
+
+	it("never appends a suffix off win32, so it cannot match jolli.CMD there", () => {
+		expect(
+			findExecutableOnPath("jolli", {
+				pathEnv: "/usr/local/bin",
+				pathExt: ".CMD",
+				platform: "linux",
+				fileExists: (path) => path === "/usr/local/bin/jolli.CMD",
+			}),
+		).toBeNull();
+	});
+
+	it("uses a real exec-bit probe when none is injected", () => {
+		const dir = distWithCli();
+		chmodSync(join(dir, CLI_ENTRY_FILE), 0o755);
+		// The host's own platform, since this one touches a real path on it.
+		expect(findExecutableOnPath(CLI_ENTRY_FILE, { pathEnv: dir, platform: process.platform })).toBe(
+			join(dir, CLI_ENTRY_FILE),
 		);
 	});
 
-	it("ignores lines that carry no loopback URL", () => {
-		expect(URL_PATTERN.exec("  ✓ Migrated 3 memories.")).toBeNull();
-		expect(URL_PATTERN.exec("  Port 1818 was in use")).toBeNull();
+	// The reason that default is the exec bit and not `existsSync`: a present but
+	// unrunnable file would clear tier 0's gate and hand the shell a `command not
+	// found`, where a miss falls safely through to tier 1. Skipped on Windows,
+	// which has no exec bit for `chmod` to clear — there libuv folds X_OK down to
+	// an existence check, which is the intended behaviour on that platform.
+	it.skipIf(process.platform === "win32")("does not match a present file with no exec bit", () => {
+		const dir = distWithCli();
+		chmodSync(join(dir, CLI_ENTRY_FILE), 0o644);
+		expect(findExecutableOnPath(CLI_ENTRY_FILE, { pathEnv: dir, platform: process.platform })).toBeNull();
+	});
+
+	// The other false positive `existsSync` let through: a DIRECTORY named `jolli`
+	// early on PATH. It has the exec (search) bit, so the probe alone cannot reject
+	// it — but a directory is not a regular file, which is what `isExecutableFile`
+	// now also requires.
+	it("does not match a directory that happens to carry the binary's name", () => {
+		const dir = mkdtempSync(join(tmpdir(), "jolli-dashboard-launcher-"));
+		mkdirSync(join(dir, "jolli"));
+		expect(findExecutableOnPath("jolli", { pathEnv: dir, platform: process.platform })).toBeNull();
+	});
+});
+
+describe("readWinningGlobalCliVersion", () => {
+	/** A global config dir holding the given dist-paths entries, all pointing at real dirs. */
+	function registryWith(entries: Record<string, string>): string {
+		const globalDir = mkdtempSync(join(tmpdir(), "jolli-dashboard-registry-"));
+		const distPaths = join(globalDir, "dist-paths");
+		mkdirSync(distPaths, { recursive: true });
+		for (const [source, version] of Object.entries(entries)) {
+			// `available` is just existsSync(distDir), so any real directory will do.
+			const distDir = join(globalDir, `${source}-dist`);
+			mkdirSync(distDir, { recursive: true });
+			writeFileSync(join(distPaths, source), `${version}\n${distDir}\n`);
+		}
+		return globalDir;
+	}
+
+	it("reports the global CLI's version when it wins the competition", () => {
+		expect(readWinningGlobalCliVersion(registryWith({ cli: "1.2.3", vscode: "0.99.12" }))).toBe("1.2.3");
+	});
+
+	it("reports it on a tie too, since the preference order puts cli ahead of vscode", () => {
+		expect(readWinningGlobalCliVersion(registryWith({ cli: "0.99.12", vscode: "0.99.12" }))).toBe("0.99.12");
+	});
+
+	it("is null when another source outranks the global CLI", () => {
+		expect(readWinningGlobalCliVersion(registryWith({ cli: "0.97.0", vscode: "0.99.12" }))).toBeNull();
+	});
+
+	it("is null when no global CLI is registered at all", () => {
+		expect(readWinningGlobalCliVersion(registryWith({ vscode: "0.99.12" }))).toBeNull();
+	});
+
+	it("is null for a registry that does not exist", () => {
+		expect(readWinningGlobalCliVersion(join(tmpdir(), "jolli-dashboard-no-such-dir"))).toBeNull();
+	});
+});
+
+describe("resolveDashboardCommand", () => {
+	// `fileExists` is stubbed true because `/ext/dist` is a fictional path; the
+	// two cases that exercise the real probes build a real directory instead.
+	// `globalCliVersion: null` keeps tier 0 out of the way of the tier-1/2 cases.
+	const base = {
+		cwd: REPO,
+		distDir: "/ext/dist",
+		execPath: EXEC,
+		runCliPath: RUN_CLI,
+		fileExists: () => true,
+		globalCliVersion: null,
+	};
+
+	/** Tier-0-eligible: a winning global CLI at the bundle's own version, on PATH. */
+	const withGlobalCli = { ...base, globalCliVersion: BUNDLED_CLI_VERSION, globalBinOnPath: true };
+
+	it("prefers a global jolli over run-cli when it wins and is new enough", () => {
+		const resolved = resolveDashboardCommand({
+			...withGlobalCli,
+			flavor: "posix",
+			// run-cli is present and usable — tier 0 still wins.
+			canExecute: (path) => path === RUN_CLI,
+		});
+		expect(resolved).toEqual({
+			tier: "global-jolli",
+			commandLine: `${GLOBAL_BIN_NAME} dashboard`,
+		});
+	});
+
+	it("sends the bare name unquoted, with no call operator on any shell", () => {
+		for (const flavor of ["posix", "powershell", "cmd"] as Array<ShellFlavor>) {
+			const resolved = resolveDashboardCommand({ ...withGlobalCli, flavor });
+			// Tier 0 is the one tier that is not platform-gated: PowerShell and cmd
+			// resolve a bare name through PATHEXT themselves.
+			expect(resolved?.tier).toBe("global-jolli");
+			expect(resolved?.commandLine.startsWith(`${GLOBAL_BIN_NAME} dashboard`)).toBe(true);
+		}
+	});
+
+	it("never puts the repo directory in the command, on any tier or shell", () => {
+		// The directory reaches the CLI only as the terminal's own working directory
+		// (`createTerminal({ cwd })` → `process.cwd()`). Pinned because the opposite —
+		// an explicit `--cwd` — is the obvious thing to add back, and was dropped on
+		// purpose. Every tier is covered: tier 0 by the global CLI, tier 1 by run-cli,
+		// tier 2 by canExecute answering false.
+		const cwd = "/some/repo/root";
+		for (const flavor of ["posix", "powershell", "cmd"] as Array<ShellFlavor>) {
+			for (const tierDeps of [withGlobalCli, { ...base, canExecute: () => true }, base]) {
+				const resolved = resolveDashboardCommand({ ...tierDeps, cwd, flavor });
+				expect(resolved?.commandLine).not.toContain(cwd);
+				expect(resolved?.commandLine).not.toContain("--cwd");
+				expect(resolved?.commandLine.endsWith("dashboard")).toBe(true);
+			}
+		}
+	});
+
+	it("refuses a global CLI older than the core this bundle carries", () => {
+		const resolved = resolveDashboardCommand({
+			...withGlobalCli,
+			flavor: "posix",
+			globalCliVersion: "0.97.0",
+			minGlobalCliVersion: "0.99.12",
+			canExecute: (path) => path === RUN_CLI,
+		});
+		// The whole reason presence is not the gate: 0.97 has no `dashboard` command,
+		// so a bare `jolli` there answers `unknown command` where run-cli works.
+		expect(resolved?.tier).toBe("run-cli");
+	});
+
+	it("refuses a winning global CLI that is not on PATH", () => {
+		const resolved = resolveDashboardCommand({
+			...withGlobalCli,
+			flavor: "posix",
+			globalBinOnPath: false,
+			canExecute: (path) => path === RUN_CLI,
+		});
+		expect(resolved?.tier).toBe("run-cli");
+	});
+
+	it("prefers run-cli on a POSIX shell — never a bare `jolli`", () => {
+		const resolved = resolveDashboardCommand({
+			...base,
+			flavor: "posix",
+			canExecute: (path) => path === RUN_CLI,
+		});
+		expect(resolved).toEqual({
+			tier: "run-cli",
+			commandLine: `'${RUN_CLI}' dashboard`,
+		});
+		// The point of tier 1 existing at all: it is the version-selecting entry,
+		// and a bare CLI name would bypass that selection.
+		expect(resolved?.commandLine.startsWith("jolli ")).toBe(false);
+	});
+
+	it("falls to the bundled entry when run-cli is not executable", () => {
+		const resolved = resolveDashboardCommand({ ...base, flavor: "posix", canExecute: () => false });
+		expect(resolved).toEqual({
+			tier: "bundled-node",
+			commandLine: `'${EXEC}' '${join("/ext/dist", CLI_ENTRY_FILE)}' dashboard`,
+		});
+	});
+
+	it("never tries run-cli on a shell that cannot execute a bash script", () => {
+		for (const flavor of ["powershell", "cmd"] as Array<ShellFlavor>) {
+			const probed: Array<string> = [];
+			const resolved = resolveDashboardCommand({
+				...base,
+				flavor,
+				canExecute: (path) => {
+					probed.push(path);
+					return true;
+				},
+			});
+			// Not even probed: `run-cli` carries a #!/bin/bash shebang and has no
+			// .cmd / .ps1 sibling, so an executable bit would not make it runnable.
+			expect(probed).toEqual([]);
+			expect(resolved?.tier).toBe("bundled-node");
+		}
+	});
+
+	it("prefixes the PowerShell form with the call operator, and no other form", () => {
+		const ps = resolveDashboardCommand({ ...base, flavor: "powershell", canExecute: () => false });
+		expect(ps?.commandLine).toBe(
+			`& '${EXEC}' '${join("/ext/dist", CLI_ENTRY_FILE)}' dashboard`,
+		);
+		const cmd = resolveDashboardCommand({ ...base, flavor: "cmd", canExecute: () => false });
+		expect(cmd?.commandLine).toBe(
+			`"${EXEC}" "${join("/ext/dist", CLI_ENTRY_FILE)}" dashboard`,
+		);
+		expect(cmd?.commandLine.startsWith("&")).toBe(false);
+	});
+
+	it("is null when the bundled entry is missing, since tier 2 has no other precondition", () => {
+		expect(
+			resolveDashboardCommand({ ...base, flavor: "posix", canExecute: () => false, fileExists: () => false }),
+		).toBeNull();
+	});
+
+	it("uses real filesystem probes when none are injected", () => {
+		const dir = distWithCli();
+		// `runCliPath` names a file that does not exist, so the default X_OK probe
+		// must answer false and hand over to tier 2 — whose entry really is there,
+		// so the default `existsSync` must answer true.
+		const resolved = resolveDashboardCommand({
+			cwd: REPO,
+			distDir: dir,
+			execPath: EXEC,
+			flavor: "posix",
+			runCliPath: join(dir, "definitely-absent-run-cli"),
+		});
+		expect(resolved?.tier).toBe("bundled-node");
+		expect(resolved?.commandLine).toContain(join(dir, CLI_ENTRY_FILE));
+	});
+
+	it("treats a real executable as tier 1 through the default probe", () => {
+		// `process.execPath` is the one file every platform guarantees is
+		// executable, so it stands in for an installed `run-cli`.
+		const resolved = resolveDashboardCommand({
+			cwd: REPO,
+			distDir: "/ext/dist",
+			execPath: EXEC,
+			flavor: "posix",
+			runCliPath: process.execPath,
+		});
+		expect(resolved?.tier).toBe("run-cli");
+	});
+
+	it("resolves run-cli under the real home when no path is given", () => {
+		// Only the shape is asserted: whether this machine has run-cli installed
+		// decides the tier, and a test must not depend on that.
+		const resolved = resolveDashboardCommand({ ...base, runCliPath: undefined, flavor: "posix" });
+		expect(resolved === null || resolved.tier === "run-cli" || resolved.tier === "bundled-node").toBe(true);
 	});
 });
 
 describe("launchDashboard", () => {
-	it("refuses a remote window with a hint instead of a local server", async () => {
-		const { ui, calls } = fakeUi();
-		const spawned: { args: string[]; cwd: string }[] = [];
-		await launchDashboard({
-			cwd: "/repo",
-			distDir: "/dist",
-			remoteName: "ssh-remote",
-			ui,
-			spawn: spawnerFor(fakeChild().child, spawned),
-		});
-		expect(spawned).toEqual([]);
+	it("sends the line immediately, without waiting for the shell", async () => {
+		// The launcher's whole contract: open a terminal, put the command in it,
+		// return. The cosmetic double-echo this leaves is documented at the send
+		// site, along with the two measured fixes that were reverted for costing
+		// seconds per click.
+		const { host, calls } = fakeHost();
+		await launchDashboard(tierOneOptions({ host }));
+		expect(calls.terminals[0]?.shown).toEqual([true]);
+		expect(calls.terminals[0]?.sent).toEqual([`'${RUN_CLI}' dashboard`]);
+	});
+
+	it("refuses a remote window with the hint, touching no terminal", async () => {
+		const { host, calls } = fakeHost();
+		await launchDashboard(tierOneOptions({ host, remoteName: "ssh-remote" }));
 		expect(calls.infos).toEqual([REMOTE_HINT]);
+		expect(calls.created).toEqual([]);
 	});
 
-	it("runs `dashboard --no-open` in the repo, and opens the URL itself", async () => {
-		const { child, say } = fakeChild();
-		const spawned: { args: string[]; cwd: string }[] = [];
-		const { ui, calls } = fakeUi();
-		const done = launchDashboard({ cwd: "/repo", distDir: "/dist", ui, spawn: spawnerFor(child, spawned) });
-		await say(URL_LINE);
-		await done;
-
-		// `--no-open` is what stops the child launching a browser the editor did
-		// not choose; the host opens it instead.
-		expect(spawned).toEqual([{ args: ["dashboard", "--no-open", "--cwd", "/repo"], cwd: "/repo" }]);
-		expect(calls.opened).toEqual([URL]);
+	it("creates the dashboard terminal at the repo root and runs the tier-1 line in it", async () => {
+		const { host, calls } = fakeHost();
+		await launchDashboard(tierOneOptions({ host }));
+		expect(calls.created).toEqual([
+			{ name: TERMINAL_NAME, cwd: REPO, env: { ELECTRON_RUN_AS_NODE: "1" } },
+		]);
+		const terminal = calls.terminals[0];
+		expect(terminal?.sent).toEqual([`'${RUN_CLI}' dashboard`]);
 	});
 
-	it("ends the progress notification at the browser, not at the child's exit", async () => {
-		// The child serves until stopped and its history import runs for minutes
-		// behind the page, so a notification spanning it would read as a hang.
-		const { child, say } = fakeChild();
-		const { ui, calls } = fakeUi();
-		const done = launchDashboard({ cwd: "/repo", distDir: "/dist", ui, spawn: spawnerFor(child) });
-		expect(calls.progressEnded).toBe(false);
-		await say(URL_LINE);
-		await done;
-		expect(calls.progressEnded).toBe(true);
-		// Still running — the notification ended, the dashboard did not.
-		expect(isDashboardRunning()).toBe(true);
+	it("shows the terminal without stealing focus, before sending", async () => {
+		const { host, calls } = fakeHost();
+		await launchDashboard(tierOneOptions({ host }));
+		const terminal = calls.terminals[0];
+		// `true` is preserveFocus: the click came from the sidebar, not the panel.
+		expect(terminal?.shown).toEqual([true]);
+		expect(terminal?.sent).toHaveLength(1);
 	});
 
-	it("drains the child's output into the log", async () => {
-		const { child, say } = fakeChild();
-		const { ui } = fakeUi();
-		const done = launchDashboard({ cwd: "/repo", distDir: "/dist", ui, spawn: spawnerFor(child) });
-		await say("  ✓ Migrated 3 memories.");
-		await say(URL_LINE);
-		await done;
-		expect(logCalls.some((c) => c.message.includes("Migrated 3 memories"))).toBe(true);
+	it("carries the repo directory ONLY as the terminal's cwd, never in the command", async () => {
+		const { host, calls } = fakeHost();
+		await launchDashboard(tierOneOptions({ host, cwd: "/other/repo" }));
+		// The terminal is created there, and the command says nothing about it — so
+		// `executeDashboard` gets the directory from `process.cwd()`. That is the whole
+		// mechanism, and it is why no `cd` line is sent either.
+		expect(calls.created[0]?.cwd).toBe("/other/repo");
+		expect(calls.terminals[0]?.sent).toEqual([`'${RUN_CLI}' dashboard`]);
 	});
 
-	it("reports a child that dies before it ever served", async () => {
-		const { child, exit } = fakeChild();
-		const { ui, calls } = fakeUi({ errorChoice: "Show Log" });
-		const done = launchDashboard({ cwd: "/repo", distDir: "/dist", ui, spawn: spawnerFor(child) });
-		await exit(1);
-		await done;
-		expect(calls.errors).toEqual([FAILURE_MESSAGE]);
-		expect(calls.logRevealed).toBe(true);
-		expect(isDashboardRunning()).toBe(false);
+	it("opens a NEW terminal on every click, never reusing or revealing an old one", async () => {
+		const { host, calls } = fakeHost();
+		await launchDashboard(tierOneOptions({ host }));
+		await launchDashboard(tierOneOptions({ host }));
+		await launchDashboard(tierOneOptions({ host }));
+		expect(calls.created).toHaveLength(3);
+		// Each terminal carries exactly its own run — no earlier one is written to
+		// again, so no click can land a second command in a terminal already busy.
+		for (const terminal of calls.terminals) {
+			expect(terminal.sent).toEqual([`'${RUN_CLI}' dashboard`]);
+			expect(terminal.shown).toEqual([true]);
+		}
 	});
 
-	it("does not report a child that exits AFTER serving — that is a stop, not a failure", async () => {
-		const { child, say, exit } = fakeChild();
-		const { ui, calls } = fakeUi();
-		const done = launchDashboard({ cwd: "/repo", distDir: "/dist", ui, spawn: spawnerFor(child) });
-		await say(URL_LINE);
-		await done;
-		await exit(0);
-		expect(calls.errors).toEqual([]);
-		expect(isDashboardRunning()).toBe(false);
+	it("gives every terminal the same name, cwd and env", async () => {
+		const { host, calls } = fakeHost();
+		await launchDashboard(tierOneOptions({ host }));
+		await launchDashboard(tierOneOptions({ host }));
+		expect(calls.created).toEqual([
+			{ name: TERMINAL_NAME, cwd: REPO, env: { ELECTRON_RUN_AS_NODE: "1" } },
+			{ name: TERMINAL_NAME, cwd: REPO, env: { ELECTRON_RUN_AS_NODE: "1" } },
+		]);
 	});
 
-	it("does not report a stop whose URL was still in the pipe when the child ended", async () => {
-		// A dashboard stopped moments after it started serving: the process is gone
-		// while the URL it printed is still in flight. Listening on `exit` read
-		// `launch.url` at that instant, so a dashboard that HAD served was reported
-		// as one that could not be started — a modal error for a stop the user
-		// asked for. `close` is the event that waits for the pipe, and waiting is
-		// the only thing that separates this from a child that never served.
-		const { child, say, gone, closed } = fakeChild();
-		const { ui, calls } = fakeUi({ errorChoice: "Show Log" });
-		const done = launchDashboard({ cwd: "/repo", distDir: "/dist", ui, spawn: spawnerFor(child) });
-		await gone(0);
-		await say(URL_LINE);
-		await closed(0);
-		await done;
-		expect(calls.errors).toEqual([]);
-		expect(calls.opened).toEqual([URL]);
+	it("runs the bundled entry through the host's Node when run-cli is unusable", async () => {
+		const { host, calls } = fakeHost();
+		await launchDashboard(tierOneOptions({ host, canExecute: () => false }));
+		expect(calls.terminals[0]?.sent).toEqual([
+			`'${EXEC}' '${join("/ext/dist", CLI_ENTRY_FILE)}' dashboard`,
+		]);
+		// The env is what makes that Electron path behave as node.
+		expect(calls.created[0]?.env).toEqual({ ELECTRON_RUN_AS_NODE: "1" });
 	});
 
-	it("reports a failed spawn once, though both `error` and `close` fire for it", async () => {
-		// A spawn that fails emits `error` and then `close`, with no `exit` between
-		// them — so moving this listener to `close` put two modal errors on screen
-		// for one click unless the report is guarded.
-		const { child, exit } = fakeChild();
-		const { ui, calls } = fakeUi();
-		const done = launchDashboard({ cwd: "/repo", distDir: "/dist", ui, spawn: spawnerFor(child) });
-		child.emit("error", new Error("ENOENT"));
-		await flushMicrotasks();
-		await exit(1);
-		await done;
-		expect(calls.errors).toEqual([FAILURE_MESSAGE]);
+	it("reports an incomplete build instead of opening an empty terminal", async () => {
+		const { host, calls } = fakeHost();
+		await launchDashboard(tierOneOptions({ host, canExecute: () => false, fileExists: () => false }));
+		expect(calls.errors).toEqual([UNAVAILABLE_MESSAGE]);
+		expect(calls.created).toEqual([]);
+		expect(logCalls.some((c) => c.level === "error" && c.message.includes(CLI_ENTRY_FILE))).toBe(true);
 	});
 
-	it("reports a spawn that throws", async () => {
-		const { ui, calls } = fakeUi();
+	it("runs the readable `jolli dashboard` when a winning global CLI is on PATH", async () => {
+		const { host, calls } = fakeHost();
+		await launchDashboard(
+			tierOneOptions({
+				host,
+				globalCliVersion: BUNDLED_CLI_VERSION,
+				minGlobalCliVersion: BUNDLED_CLI_VERSION,
+				pathEnv: "/usr/local/bin",
+				// Stands in for both the PATH probe and the Cli.js check.
+				fileExists: () => true,
+			}),
+		);
+		expect(calls.terminals[0]?.sent).toEqual([`${GLOBAL_BIN_NAME} dashboard`]);
+	});
+
+	it("skips tier 0 without probing PATH when no global CLI wins", async () => {
+		const probed: Array<string> = [];
+		const { host, calls } = fakeHost();
+		await launchDashboard(
+			tierOneOptions({
+				host,
+				globalCliVersion: null,
+				pathEnv: "/usr/local/bin",
+				fileExists: (path) => {
+					probed.push(path);
+					return true;
+				},
+			}),
+		);
+		// A null version short-circuits the PATH walk entirely, so the only existence
+		// question asked is tier 2's — never `/usr/local/bin/jolli`.
+		expect(probed.some((path) => path.endsWith(GLOBAL_BIN_NAME))).toBe(false);
+		expect(calls.terminals[0]?.sent[0]).toContain(RUN_CLI);
+	});
+
+	it("falls back to run-cli when the winning global CLI is not on PATH", async () => {
+		const { host, calls } = fakeHost();
+		await launchDashboard(
+			tierOneOptions({
+				host,
+				globalCliVersion: BUNDLED_CLI_VERSION,
+				minGlobalCliVersion: BUNDLED_CLI_VERSION,
+				pathEnv: "/usr/local/bin",
+				// Nothing named `jolli` on PATH; run-cli is still executable.
+				fileExists: (path) => !path.endsWith(GLOBAL_BIN_NAME),
+			}),
+		);
+		expect(calls.terminals[0]?.sent[0]).toContain(RUN_CLI);
+	});
+
+	it("searches the ambient PATH when no pathEnv is injected", async () => {
+		const { host, calls } = fakeHost();
+		await launchDashboard(
+			tierOneOptions({
+				host,
+				globalCliVersion: BUNDLED_CLI_VERSION,
+				minGlobalCliVersion: BUNDLED_CLI_VERSION,
+				// pathEnv omitted on purpose: the walk must fall back to process.env.PATH.
+				// Nothing exists there as far as this probe is concerned, so tier 1 wins.
+				fileExists: (path) => !path.endsWith(GLOBAL_BIN_NAME),
+			}),
+		);
+		expect(calls.terminals[0]?.sent[0]).toContain(RUN_CLI);
+	});
+
+	it("reads the real registry and PATH when neither is injected", async () => {
+		const { host, calls } = fakeHost();
+		// `globalCliVersion` omitted, so `readWinningGlobalCliVersion` runs against
+		// the real machine. Only the shape is asserted — whether this machine has a
+		// global CLI decides the tier, and a test must not depend on that.
 		await launchDashboard({
-			cwd: "/repo",
-			distDir: "/dist",
-			ui,
-			spawn: () => {
-				throw new Error("entry not found");
-			},
+			cwd: REPO,
+			distDir: "/ext/dist",
+			host,
+			platform: "darwin",
+			shell: "/bin/zsh",
+			execPath: EXEC,
+			runCliPath: RUN_CLI,
+			canExecute: (path) => path === RUN_CLI,
+			fileExists: () => true,
 		});
-		expect(calls.errors).toEqual([FAILURE_MESSAGE]);
-		// No guard leaked, so the button still works next time.
-		expect(isDashboardRunning()).toBe(false);
+		expect(calls.terminals[0]?.sent).toHaveLength(1);
 	});
 
-	it("reports a process-level error", async () => {
-		const { child } = fakeChild();
-		const { ui, calls } = fakeUi();
-		const done = launchDashboard({ cwd: "/repo", distDir: "/dist", ui, spawn: spawnerFor(child) });
-		child.emit("error", new Error("ENOENT"));
-		await flushMicrotasks();
-		await done;
-		expect(calls.errors).toEqual([FAILURE_MESSAGE]);
-		expect(isDashboardRunning()).toBe(false);
+	it("records the tier and the shell it chose", async () => {
+		const { host } = fakeHost();
+		await launchDashboard(tierOneOptions({ host }));
+		expect(logCalls.some((c) => c.message.includes("run-cli") && c.message.includes("posix shell"))).toBe(
+			true,
+		);
 	});
 
-	it("a repeat click re-opens the URL instead of starting a second dashboard", async () => {
-		const { child, say } = fakeChild();
-		const spawned: { args: string[]; cwd: string }[] = [];
-		const { ui, calls } = fakeUi();
-		const done = launchDashboard({ cwd: "/repo", distDir: "/dist", ui, spawn: spawnerFor(child, spawned) });
-		await say(URL_LINE);
-		await done;
-
-		await launchDashboard({ cwd: "/repo", distDir: "/dist", ui, spawn: spawnerFor(fakeChild().child, spawned) });
-		// One spawn, two opens: a second child would bind a second port and run a
-		// second import against the same database.
-		expect(spawned).toHaveLength(1);
-		expect(calls.opened).toEqual([URL, URL]);
-	});
-
-	it("a click that arrives before the URL shares the wait rather than spawning", async () => {
-		const { child, say } = fakeChild();
-		const spawned: { args: string[]; cwd: string }[] = [];
-		const { ui, calls } = fakeUi();
-		const first = launchDashboard({ cwd: "/repo", distDir: "/dist", ui, spawn: spawnerFor(child, spawned) });
-		const second = launchDashboard({ cwd: "/repo", distDir: "/dist", ui, spawn: spawnerFor(fakeChild().child, spawned) });
-		await say(URL_LINE);
-		await Promise.all([first, second]);
-		expect(spawned).toHaveLength(1);
-		// The first launch's browser is what ends both notifications.
-		expect(calls.opened).toEqual([URL]);
-	});
-
-	it("reports a refused browser without calling the launch a failure", async () => {
-		const { child, say } = fakeChild();
-		const { ui, calls } = fakeUi({
-			overrides: {
-				openExternal: async () => {
-					throw new Error("no handler");
-				},
-			},
+	it("falls back to the ambient platform and shell when neither is injected", async () => {
+		const { host, calls } = fakeHost();
+		await launchDashboard({
+			cwd: REPO,
+			distDir: "/ext/dist",
+			host,
+			remoteName: undefined,
+			execPath: EXEC,
+			runCliPath: RUN_CLI,
+			canExecute: (path) => path === RUN_CLI,
+			fileExists: () => true,
+			// Pinned for the reason `tierOneOptions` states: without it this case
+			// reads the REAL dist-paths registry, so it asserted tier 1 only while
+			// this machine happened to have no available `cli` entry. Building
+			// `cli/dist` locally flipped it to tier 0 and the case went red with
+			// nothing about its subject — the ambient platform/shell — having changed.
+			globalCliVersion: null,
 		});
-		const done = launchDashboard({ cwd: "/repo", distDir: "/dist", ui, spawn: spawnerFor(child) });
-		await say(URL_LINE);
-		await done;
-		await flushMicrotasks();
-		// The dashboard IS up, so this is not FAILURE_MESSAGE...
-		expect(calls.errors).toEqual([BROWSER_FAILURE_MESSAGE]);
-		// ...and the spinner still ends, or a working dashboard would look hung.
-		expect(calls.progressEnded).toBe(true);
-		expect(isDashboardRunning()).toBe(true);
+		// The mocked `vscode.env.shell` is /bin/zsh, so tier 1 is reachable.
+		expect(calls.terminals[0]?.sent).toEqual([`'${RUN_CLI}' dashboard`]);
 	});
 
-	it("uses the default spawner when none is injected", async () => {
-		const { child, say } = fakeChild();
-		spawnHiddenMock.mockReturnValue(child);
-		const { ui } = fakeUi();
-		const dir = distWithEntry();
-		const done = launchDashboard({ cwd: "/repo", distDir: dir, ui });
-		await say(URL_LINE);
-		await done;
-
-		const [command, args, opts] = spawnHiddenMock.mock.calls[0] as [string, string[], Record<string, unknown>];
-		expect(command).toBe(process.execPath);
-		expect(args).toEqual([join(dir, CLI_ENTRY_FILE), "dashboard", "--no-open", "--cwd", "/repo"]);
-		// Electron only runs a script as node with this set.
-		expect((opts.env as Record<string, string>).ELECTRON_RUN_AS_NODE).toBe("1");
-		// Piped, so the URL line is readable — and NOT detached/unref'd, so the
-		// child cannot outlive the window that owns it.
-		expect(opts.stdio).toEqual(["ignore", "pipe", "pipe"]);
-		expect(opts.detached).toBeUndefined();
-	});
-
-	it("PROGRESS_TITLE is what the notification shows", async () => {
-		const { child, say } = fakeChild();
-		const titles: string[] = [];
-		const { ui } = fakeUi({
-			overrides: {
-				withProgress: async (title, task) => {
-					titles.push(title);
-					await task();
-				},
-			},
+	it("reaches vscode.window when no host is injected", async () => {
+		await launchDashboard({
+			cwd: REPO,
+			distDir: "/ext/dist",
+			platform: "darwin",
+			shell: "/bin/zsh",
+			execPath: EXEC,
+			runCliPath: RUN_CLI,
+			canExecute: (path) => path === RUN_CLI,
+			fileExists: () => true,
 		});
-		const done = launchDashboard({ cwd: "/repo", distDir: "/dist", ui, spawn: spawnerFor(child) });
-		await say(URL_LINE);
-		await done;
-		expect(titles).toEqual([PROGRESS_TITLE]);
-	});
-});
-
-describe("stopDashboard", () => {
-	it("kills the running child and forgets it", async () => {
-		const { child, say } = fakeChild();
-		const { ui } = fakeUi();
-		const done = launchDashboard({ cwd: "/repo", distDir: "/dist", ui, spawn: spawnerFor(child) });
-		await say(URL_LINE);
-		await done;
-
-		stopDashboard();
-		expect(child.kill).toHaveBeenCalledTimes(1);
-		expect(isDashboardRunning()).toBe(false);
+		expect(createTerminalMock).toHaveBeenCalledWith({
+			name: TERMINAL_NAME,
+			cwd: REPO,
+			env: { ELECTRON_RUN_AS_NODE: "1" },
+		});
 	});
 
-	it("is a no-op when nothing is running", () => {
-		expect(() => stopDashboard()).not.toThrow();
-		expect(isDashboardRunning()).toBe(false);
-	});
-
-	it("does not kill a child that already exited", async () => {
-		const { child, say, exit } = fakeChild();
-		const { ui } = fakeUi();
-		const done = launchDashboard({ cwd: "/repo", distDir: "/dist", ui, spawn: spawnerFor(child) });
-		await say(URL_LINE);
-		await done;
-		await exit(0);
-
-		stopDashboard();
-		expect(child.kill).not.toHaveBeenCalled();
+	it("uses the real execPath when none is injected", async () => {
+		const { host, calls } = fakeHost();
+		await launchDashboard({
+			cwd: REPO,
+			distDir: "/ext/dist",
+			host,
+			remoteName: undefined,
+			platform: "darwin",
+			shell: "/bin/zsh",
+			canExecute: () => false,
+			fileExists: () => true,
+			// Same machine-independence pin as above: the subject here is tier 2's
+			// execPath default, which tier 0 would short-circuit past entirely.
+			globalCliVersion: null,
+		});
+		expect(calls.terminals[0]?.sent[0]).toContain(process.execPath);
 	});
 });

--- a/vscode/src/services/DashboardLauncher.ts
+++ b/vscode/src/services/DashboardLauncher.ts
@@ -1,55 +1,65 @@
 /**
- * DashboardLauncher — the extension-host side of `jolli dashboard`.
+ * DashboardLauncher — opens the Jolli dashboard by running `jolli dashboard` in
+ * an integrated terminal.
  *
- * `jolli dashboard` is a FOREGROUND command: it binds the port in its own
- * process and serves until it is stopped. That is why this module runs it as a
- * child process rather than calling `executeDashboard` in-process the way it
- * used to. In the extension host there is no Ctrl+C, so an in-process call would
- * never return, and the HTTP listener would live inside the editor's own
- * process for the rest of the session.
+ * This used to run `executeDashboard` IN the extension host, with three
+ * editor-shaped plugs (the output channel, an Electron-as-node server spawner,
+ * `vscode.env.openExternal`). Running it in a terminal instead moves all three
+ * back to their command-line defaults and hands the user something the in-process
+ * version could not: the command's own output, in front of them, as it happens.
+ * The launcher's phases are untouched — the browser still opens (the CLI does it),
+ * and the history import still runs last, now visibly.
  *
- * So the split is: the CLI owns every decision (runtime floor, database
- * creation, repo registration, the history import, cutover, the backup
- * snapshot); this module owns the child's LIFECYCLE, which is the one thing a
- * terminal used to provide for free.
+ * What is left here is one decision: **which command line to send**. Three tiers,
+ * in order:
  *
- *   1. **What runs it.** `process.execPath` here is Electron, not node — see
- *      {@link RUN_AS_NODE_ENV}. The host's embedded Node is already guaranteed
- *      new enough by `engines.vscode`, so nothing here hunts for a system node
- *      the way `~/.jolli/jollimemory/run-cli` has to.
- *   2. **Where the lines go.** The child's stdout/stderr are drained into the
- *      "Jolli Memory" output channel. The CLI's `DashboardOutput` seam cannot
- *      help across a process boundary, so the pipes are the seam.
- *   3. **What opens the URL.** The child is run with `--no-open`: inside an
- *      editor the host owns URL handling (`vscode.env.openExternal`), and the
- *      CLI's `open` package would otherwise launch a browser from a process the
- *      editor did not choose. The URL is read off the child's own output — see
- *      {@link URL_PATTERN}.
- *   4. **When it stops.** {@link stopDashboard} kills it, and `deactivate` calls
- *      that. The child is deliberately NOT `unref`'d: an orphan whose stdout
- *      nobody drains blocks forever once the pipe fills (the history import
- *      prints for minutes), and a surviving invisible server is exactly the
- *      background process this command was rewritten to stop being.
+ *   0. **`jolli`** — the readable spelling, used only when a globally-installed CLI
+ *      both WINS the dist-paths version competition and is at least as new as the
+ *      core this bundle carries. Presence is not the gate: an ungated bare-`jolli`
+ *      tier would bypass that competition, so a stale global CLI would shadow a
+ *      newer bundled one and answer `unknown command 'dashboard'`. The competition
+ *      is not reimplemented here — see {@link readWinningGlobalCliVersion}, which
+ *      calls the same two functions `resolve-dist-path` mirrors. So tier 0 fires
+ *      exactly when tier 1 would have chosen the global CLI anyway: same code,
+ *      readable spelling.
+ *   1. **`~/.jolli/jollimemory/run-cli`** — the machine-global dispatcher, which
+ *      resolves the highest-versioned registered dist. This ONE tier covers both
+ *      "the user has a global CLI" and "only the VS Code bundle exists", which is
+ *      why it, and not tier 0, is the fallback that must always work.
+ *   2. **The extension's own `dist/Cli.js`, run by the host's Node** — reached when
+ *      tier 1 cannot be used. That is two situations: `run-cli` is absent or not
+ *      executable (no repo on this machine has been enabled), or the terminal's
+ *      shell cannot execute a `#!/bin/bash` script at all.
  *
- * Two things it owns for the same reason as before: only one dashboard at a time
- * (see {@link LiveDashboard}), and a browser that refuses to open is reported
- * (see {@link reportBrowserFailure}).
+ *      A third situation looks like it belongs beside those and is NOT covered:
+ *      tier 1 also needs a `node` on the shell's PATH (its only other source,
+ *      `~/.jolli/jollimemory/node-path`, is written by the IntelliJ plugin and
+ *      never by this extension), and nothing here probes for one. A machine with
+ *      an executable `run-cli` but no PATH node therefore stays on tier 1 and
+ *      gets run-cli's own `ERROR: node runtime not found` in the terminal rather
+ *      than falling through to tier 2. The integrated terminal is an interactive
+ *      shell, so it carries the user's version manager and this is rare — but it
+ *      is a known gap, not a handled case.
+ *
+ * Tier 2 is the one that needs no user Node: `ELECTRON_RUN_AS_NODE` makes the
+ * host's own Electron run as node, and `engines.vscode` (^1.101.0) already
+ * guarantees that Node clears the 22.13 `node:sqlite` floor. It is the only use
+ * of that variable left in the tree — every launcher that spawned a CLI from the
+ * extension host used it, and this is the one path that still has to.
+ *
+ * Nothing checks the Node version on either tier, and nothing should:
+ * `executeDashboard` gates on `canUseDashboardDb()` as the second thing it does
+ * and names both the required and the running version. In a terminal that message
+ * is finally visible — it used to go to an output channel nobody had open.
  */
 
-import { existsSync } from "node:fs";
-import { join } from "node:path";
-import { createInterface } from "node:readline";
+import { accessSync, constants, existsSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, posix as posixPath, win32 as win32Path } from "node:path";
 import * as vscode from "vscode";
-import { spawnHidden } from "../../../cli/src/util/Subprocess.js";
+import { pickBestDistPath, traverseDistPaths } from "../../../cli/src/install/DistPathResolver.js";
+import { compareSemver } from "../../../cli/src/install/SemverCompare.js";
 import { log } from "../util/Logger.js";
-
-/**
- * The child handle, derived from the wrapper rather than imported from
- * `node:child_process` — that module is lint-blocked here (every spawn must go
- * through `spawnHidden`, which injects `windowsHide`), and deriving it also
- * keeps this type honest if the wrapper's return ever narrows.
- */
-type ChildProcess = ReturnType<typeof spawnHidden>;
 
 const TAG = "dashboard";
 
@@ -57,46 +67,60 @@ const TAG = "dashboard";
 export const CLI_ENTRY_FILE = "Cli.js";
 
 /**
- * Makes Electron run the entry as a plain node process.
+ * The name given to each terminal this button opens.
  *
- * The extension host is an Electron helper, so `process.execPath` is that
- * binary rather than a node one. Handing it a script path without this variable
- * does not start a node process at all. The Node embedded in it is the host's
- * own, which `engines.vscode` (^1.101.0 — the first release whose bundled Node
- * crossed the 22.13 `node:sqlite` floor) already guarantees is new enough, so
- * nothing here needs to hunt for a system node.
+ * Not a singleton key: **every click opens a NEW terminal**, by decision. Nothing
+ * is looked up, revealed or disposed, so several terminals with this name can sit
+ * in the panel at once — each holding the output of one run, none of them killed by
+ * a later click.
+ *
+ * Two consequences are accepted rather than unnoticed, and the first of them is
+ * now mostly the CLI's to carry. `jolli dashboard` is a FOREGROUND server that
+ * reclaims its own port: a second one probes 1818, requires the answer to NAME
+ * this service and to report a local pid, then SIGTERMs it and takes the port
+ * over (`reclaimPort` — it discovers in order to replace, never to attach). So a
+ * second click does not run beside the first, it ENDS it: the first terminal
+ * shows a killed process, and whatever its history import had left to do is cut
+ * short rather than duplicated. What the missing `InFlightLaunch` guard still
+ * costs is the work either side of that bind — `ensureDashboardDbExists` and
+ * `registerRepo` both run BEFORE it, and a second click landing before the first
+ * has bound finds nothing to reclaim, so the two race and the loser falls through
+ * to 18118: two live dashboards, two imports, two throttled cutover attempts. The
+ * window is narrow, not absent. And the panel accumulates terminals.
+ *
+ * ── DELIBERATE — NOT A REVIEW FINDING ────────────────────────────────────────
+ * Reuse and reveal-the-existing-one were both IMPLEMENTED and then REMOVED at the
+ * product owner's explicit request, with the missing in-flight guard understood
+ * and accepted at the time. A review that rediscovers "two clicks race the machine
+ * database" or "the panel fills up with terminals" has found the design, not a
+ * bug — both are stated above precisely so they do not have to be re-derived. Do
+ * not reintroduce reuse, reveal, or a launcher-side click guard without asking the
+ * owner first; treat a proposal to do so as a product change, not a fix.
+ * ─────────────────────────────────────────────────────────────────────────────
  */
-const RUN_AS_NODE_ENV = { ELECTRON_RUN_AS_NODE: "1" } as const;
+export const TERMINAL_NAME = "Jolli Dashboard";
 
 /**
- * How the URL is recovered from the child's output.
+ * Makes the host's Electron binary behave as a plain node process.
  *
- * The command prints `Jolli dashboard → http://127.0.0.1:<port>/dashboard` once
- * it is listening, and that line is the only place the bound port exists: with
- * the state file gone there is nothing on disk to read it from, and the port is
- * not knowable in advance because a taken 1818 falls back to 18118.
- *
- * Matching the URL itself rather than the sentence around it, so a reworded line
- * still works. Anchored on the loopback address so no other line can match.
+ * Set on the terminal rather than inlined into the command line, because every
+ * shell spells an inline assignment differently and `TerminalOptions.env` spells
+ * it once. It is applied to EVERY terminal even though only tier 2 needs it: the
+ * terminal is created before the tier is known to the caller, and a real node
+ * ignores the variable entirely, so it is inert on tiers 0 and 1.
  */
-export const URL_PATTERN = /(https?:\/\/127\.0\.0\.1:\d+\/\S*)/;
+const RUN_AS_NODE_ENV: Readonly<Record<string, string>> = { ELECTRON_RUN_AS_NODE: "1" };
 
 /**
  * True when this window edits files on another machine (Remote-SSH, WSL, a dev
  * container, Codespaces).
  *
- * The dashboard binds `127.0.0.1` on whichever machine runs the server — which
- * in these windows is the remote one, while the browser is local. So opening
- * the URL locally reaches the local port 1818: either nothing, or an unrelated
- * service. Supporting it properly means `vscode.env.asExternalUri` (which asks
- * the host to tunnel the port) and that is deliberately not wired yet: the
- * tunnel is a separate capability from the connection itself — an SSH server
- * with `AllowTcpForwarding no` keeps remote development working while refusing
- * to forward — so it needs its own verification rather than an assumption.
- *
- * WSL would very likely work as-is (its localhost is shared with the host), but
- * it is not special-cased for the same reason: one unverified exception is
- * worse than a uniform, honest message.
+ * Kept exactly as it was when the launch ran in-process. A terminal is a genuine
+ * opportunity here — the integrated terminal runs ON the remote, which is where
+ * the server has to run, and the host offers to forward the port — but two things
+ * behind that are unverified: the remote needs a usable Node/dist of its own, and
+ * the CLI's `open` would be trying to launch a browser on a machine that has no
+ * display. Both deserve their own change, not a side effect of this one.
  */
 export function isRemoteWorkspace(remoteName: string | undefined = vscode.env.remoteName): boolean {
 	return remoteName !== undefined;
@@ -107,323 +131,465 @@ export const REMOTE_HINT =
 	"The Jolli dashboard runs on the machine that holds your code. " +
 	"Open a terminal on that machine and run `jolli dashboard` — VS Code will offer to forward the port.";
 
-/** The window interactions this module performs, as a seam. */
-export interface DashboardLauncherUi {
-	readonly withProgress: (title: string, task: () => Promise<void>) => Promise<void>;
-	readonly showError: (message: string, action: string) => Promise<string | undefined>;
-	readonly showInfo: (message: string) => Promise<void>;
-	readonly openExternal: (url: string) => Promise<void>;
-	readonly revealLog: () => void;
+/** Shown when neither tier yielded a runnable command. Details are in the log. */
+export const UNAVAILABLE_MESSAGE =
+	"Could not find a Jolli CLI to run the dashboard — this build may be incomplete.";
+
+/* ── Command resolution ──────────────────────────────────────────────────────── */
+
+/**
+ * How the terminal's shell parses a command line.
+ *
+ * Only quoting and one prefix depend on this, but both are load-bearing: a
+ * quoting style that is wrong for the shell does not fail loudly, it passes a
+ * mangled path to the CLI. `powershell` needs the call operator `&` before a
+ * quoted executable path, and `&` at the start of a POSIX line is a syntax error
+ * — so there is no one string that works everywhere.
+ */
+export type ShellFlavor = "posix" | "powershell" | "cmd";
+
+/**
+ * Classifies the terminal's default shell.
+ *
+ * Driven by the shell's own path rather than by `process.platform`, so Git Bash
+ * as the default on Windows is recognised as POSIX and gets tier 1 — which is
+ * both correct and free. Windows falls back to `powershell` when the shell is
+ * unknown because that is the host's default there; `cmd` is only ever chosen
+ * when the path actually names it.
+ */
+export function detectShellFlavor(shell: string | undefined, platform: NodeJS.Platform): ShellFlavor {
+	if (shell !== undefined) {
+		// Matched against the whole path, anchored to a separator, rather than by
+		// extracting a basename first: `path.basename` is platform-dependent about
+		// backslashes (on POSIX it returns a Windows path whole), and every
+		// hand-rolled alternative carries an unreachable "no last segment" branch.
+		const named = (names: string): RegExp => new RegExp(String.raw`(?:^|[\\/])(?:${names})(?:\.exe)?$`, "i");
+		if (named("pwsh|powershell").test(shell)) return "powershell";
+		if (named("cmd").test(shell)) return "cmd";
+		if (named("bash|sh|zsh|fish|dash|ksh").test(shell)) return "posix";
+	}
+	return platform === "win32" ? "powershell" : "posix";
 }
 
-/** Spawning the child, as a seam. Returns the process so the caller owns it. */
-export type DashboardSpawner = (args: readonly string[], cwd: string) => ChildProcess;
+/**
+ * Quotes one argument for `flavor`.
+ *
+ * POSIX and PowerShell both get single quotes — the only form in either that
+ * suppresses interpolation, which matters because a path may legitimately contain
+ * `$` (POSIX) or `$`/backtick (PowerShell). They differ only in how a literal
+ * quote is escaped. `cmd` has no such form and gets double quotes; a Windows path
+ * cannot contain `"` at all, so nothing is lost.
+ */
+export function quoteArg(value: string, flavor: ShellFlavor): string {
+	switch (flavor) {
+		case "posix":
+			return `'${value.replaceAll("'", `'\\''`)}'`;
+		case "powershell":
+			return `'${value.replaceAll("'", "''")}'`;
+		case "cmd":
+			return `"${value}"`;
+	}
+}
+
+/** Absolute path of the machine-global CLI dispatcher. */
+export function resolveRunCliPath(homeDir: string = homedir()): string {
+	return join(homeDir, ".jolli", "jollimemory", "run-cli");
+}
+
+/* ── Tier 0: a global `jolli` that is new enough ─────────────────────────────── */
+
+/** The name a global install puts on PATH, and the whole point of tier 0. */
+export const GLOBAL_BIN_NAME = "jolli";
+
+/** The dist-paths source tag a global `npm i -g @jolli.ai/cli` writes. */
+export const GLOBAL_CLI_SOURCE = "cli";
+
+/**
+ * The core version this bundle carries — the floor a global CLI must clear.
+ *
+ * `__CLI_PKG_VERSION__`, NOT `__PKG_VERSION__` (the extension's own release
+ * number): dist-paths entries record the `@jolli.ai/cli` core version, so that is
+ * what the comparison below is against.
+ */
+/* v8 ignore next -- compile-time ternary: "0.0.0" under vitest, the real define in bundled builds */
+export const BUNDLED_CLI_VERSION = typeof __CLI_PKG_VERSION__ !== "undefined" ? __CLI_PKG_VERSION__ : "0.0.0";
+
+/**
+ * The version of a globally-installed CLI that outranks every other registered
+ * dist, or null when there is no such install.
+ *
+ * This is the reuse: `traverseDistPaths` + `pickBestDistPath` ARE the "is a CLI
+ * installed, and which install wins on version" logic — the same two functions
+ * `resolve-dist-path` mirrors and `JolliMemoryBridge` already calls. So tier 0
+ * fires exactly when run-cli would have chosen the global CLI anyway, which is
+ * what makes it a readable spelling of tier 1 rather than a second opinion. Not
+ * reimplemented, and deliberately not probed with `jolli --version` either: a
+ * spawn (measured 0.35 s) would answer a question the registry already answers
+ * for free, and could disagree with it.
+ *
+ * The version is still compared against {@link BUNDLED_CLI_VERSION} rather than
+ * being taken on trust from `cli` having won. Winning implies "at least as new as
+ * this bundle" only while our OWN `dist-paths/vscode` entry is registered — and on
+ * a fresh install, or after a failed registration, it is not, so a stale `cli`
+ * could win a field of one.
+ *
+ * KNOWN RESIDUAL RISK, and the price of not spawning: this answers for the install
+ * that WROTE `dist-paths/cli`, while the terminal resolves the bare name against
+ * its OWN PATH. Those can be different binaries — two node versions under
+ * nvm/volta, or a shim earlier on PATH — and then tier 0 clears a gate the CLI
+ * that actually runs never faced, so an old one answers `unknown command
+ * 'dashboard'` in the terminal. Tier 1 has no such gap, because `run-cli` re-reads
+ * the registry itself at run time. Closing it needs the `jolli --version` spawn
+ * ruled out above, so the gap is accepted, not overlooked: it costs one visible
+ * error line on a misconfigured machine, and the user can still run the printed
+ * command by hand.
+ */
+export function readWinningGlobalCliVersion(globalDir?: string): string | null {
+	const winner = pickBestDistPath(traverseDistPaths(globalDir));
+	return winner?.source === GLOBAL_CLI_SOURCE ? winner.version : null;
+}
+
+/**
+ * Finds `binName` on the plain inherited PATH, or null.
+ *
+ * Deliberately NOT the local-agent resolver's `discover`: that widens PATH with
+ * well-known install dirs because it then spawns the absolute path it found. Tier
+ * 0 sends the bare NAME, so the only PATH that matters is the one the TERMINAL
+ * resolves it against — widening ours would let us emit a `jolli` the terminal
+ * cannot find. A GUI-launched editor's narrow PATH therefore produces false
+ * negatives here, which is the right way round: a miss falls through to tier 1,
+ * while a false positive is a `command not found` in the user's face.
+ *
+ * Also why this probes the filesystem and never spawns: the Windows install is a
+ * `.cmd` shim that `execFile` refuses outright (EINVAL since the CVE-2024-27980
+ * fix), but a bare name is resolved through `PATHEXT` by PowerShell and cmd
+ * themselves. We need to know the shim is THERE, not to run it — so Windows needs
+ * no shim expansion and tier 0 works there too.
+ *
+ * The probe is the EXEC BIT, not mere existence, and the default deliberately
+ * shares {@link isExecutableFile} with tier 1's `run-cli` check. A bare
+ * `existsSync` answers true for a directory named `jolli`, or for a file whose
+ * exec bit was never set — both of which the shell then refuses, which is the
+ * `command not found` in the user's face that this whole function exists to
+ * avoid, and which tier 1 would have handled fine. `accessSync(X_OK)` is also the
+ * right call on Windows for free: that platform has no exec bit, so libuv folds
+ * `X_OK` down to an existence check, which is exactly the PATHEXT-membership rule
+ * above.
+ *
+ * Every platform-dependent choice — the PATH separator, the path join, whether
+ * `PATHEXT` applies at all — comes from the `platform` ARGUMENT, never from the
+ * host. Same rule as the local-agent resolver's `discoveryPath`: a function
+ * parameterized by platform must not change shape when the host differs, or its
+ * tests assert the host's behaviour instead of the target's. This is not
+ * hypothetical here — `"C:\\npm"` split on the host delimiter yields `["C",
+ * "\\npm"]` on macOS, so the win32 path was silently unreachable.
+ */
+export function findExecutableOnPath(
+	binName: string,
+	deps: {
+		readonly pathEnv?: string | undefined;
+		readonly pathExt?: string | undefined;
+		readonly platform: NodeJS.Platform;
+		/** Defaults to {@link isExecutableFile} — the exec bit, not mere existence. */
+		readonly fileExists?: ((path: string) => boolean) | undefined;
+	},
+): string | null {
+	const exists = deps.fileExists ?? isExecutableFile;
+	const paths = deps.platform === "win32" ? win32Path : posixPath;
+	const dirs = (deps.pathEnv ?? "").split(paths.delimiter).filter((dir) => dir.length > 0);
+	// On win32 a bare name is only runnable via one of these extensions; elsewhere
+	// the file itself is the candidate.
+	const suffixes =
+		deps.platform === "win32"
+			? (deps.pathExt ?? ".COM;.EXE;.BAT;.CMD").split(";").filter((ext) => ext.length > 0)
+			: [""];
+	for (const dir of dirs) {
+		for (const suffix of suffixes) {
+			const candidate = paths.join(dir, `${binName}${suffix}`);
+			if (exists(candidate)) return candidate;
+		}
+	}
+	return null;
+}
+
+/** Which tier produced a command line. Reported in the log, and pinned by tests. */
+export type DashboardCommandTier = "global-jolli" | "run-cli" | "bundled-node";
+
+export interface ResolvedDashboardCommand {
+	/** The exact line to send to the terminal. */
+	readonly commandLine: string;
+	readonly tier: DashboardCommandTier;
+}
+
+/** The environment probes, injected so tests never touch the real machine. */
+export interface CommandResolutionDeps {
+	/** Repo directory to register and serve from — always passed explicitly, see below. */
+	readonly cwd: string;
+	/** The extension's `dist/`, holding {@link CLI_ENTRY_FILE}. */
+	readonly distDir: string;
+	readonly flavor: ShellFlavor;
+	/** The host's Electron binary; runs as node under {@link RUN_AS_NODE_ENV}. */
+	readonly execPath: string;
+	readonly runCliPath?: string | undefined;
+	/**
+	 * Version of the winning globally-installed CLI, or null when none wins.
+	 * Resolved by the caller ({@link readWinningGlobalCliVersion}) so this function
+	 * stays pure — it reads no registry and touches no PATH of its own.
+	 */
+	readonly globalCliVersion?: string | null | undefined;
+	/** Whether {@link GLOBAL_BIN_NAME} is on the PATH the terminal will use. */
+	readonly globalBinOnPath?: boolean | undefined;
+	/** The floor a global CLI must clear. Defaults to {@link BUNDLED_CLI_VERSION}. */
+	readonly minGlobalCliVersion?: string | undefined;
+	/** Defaults to {@link isExecutableFile}. */
+	readonly canExecute?: ((path: string) => boolean) | undefined;
+	/** Defaults to a real `existsSync` — tier 2 only needs `Cli.js` to be readable. */
+	readonly fileExists?: ((path: string) => boolean) | undefined;
+}
+
+/**
+ * A regular file the shell can actually run — what tier 1 needs of `run-cli`, and
+ * the default probe tier 0 uses for a PATH candidate.
+ *
+ * BOTH halves are required, and the directory half is not hypothetical: every
+ * directory carries the search bit, so `X_OK` alone says yes to a directory named
+ * `jolli` (or `run-cli`) sitting early on PATH. `statSync` follows symlinks, which
+ * is what a global npm bin is, so the ordinary install still passes.
+ */
+function isExecutableFile(path: string): boolean {
+	try {
+		accessSync(path, constants.X_OK);
+		return statSync(path).isFile();
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Picks the tier and builds its command line, or returns null when none is
+ * usable.
+ *
+ * **The command carries no `--cwd`, by decision.** `executeDashboard` therefore
+ * falls back to `process.cwd()` — the working directory of the shell in the
+ * terminal — and `createTerminal({ cwd })` is the only thing pointing that at the
+ * repo root. That is a weaker guarantee than it looks, and the gap is accepted
+ * rather than unknown: a `cd` in the user's `.zshrc` / `.bashrc` overrides the
+ * spawn directory outright (measured: spawned in the repo, `pwd` reported `/` once
+ * the rc had run). When that happens the button acts on whatever repo the shell is
+ * in — `registerRepo` and `maybeAutoCutover` both take that directory, and the
+ * second FREEZES the orphan branch of the repo it is given. Nothing on screen
+ * distinguishes it, because the dashboard opens either way.
+ *
+ * (Each click gets a FRESH terminal — see {@link TERMINAL_NAME} — so a `cd` the
+ * user typed by hand does not carry into the next launch. The rc-file case is
+ * what remains, and it is the one that fires on every launch alike.)
+ *
+ * ── DELIBERATE — NOT A REVIEW FINDING ────────────────────────────────────────
+ * Both fixes were considered and DROPPED at the product owner's explicit request:
+ * `--cwd` on the command line, and a `cd` line sent ahead of it. The irreversible
+ * consequence above (a fence `jolli enable` cannot clear, on a repo the user did
+ * not point at) was on the table when that call was made. A review that
+ * rediscovers "the dashboard command should pass --cwd" has found the design, not
+ * a bug. Do not add either back without asking the owner first.
+ * ─────────────────────────────────────────────────────────────────────────────
+ */
+export function resolveDashboardCommand(deps: CommandResolutionDeps): ResolvedDashboardCommand | null {
+	const canExecute = deps.canExecute ?? isExecutableFile;
+	const fileExists = deps.fileExists ?? existsSync;
+	const quote = (value: string): string => quoteArg(value, deps.flavor);
+	const tail = "dashboard";
+
+	// Tier 0 — the readable form, and the only tier that is not platform-gated: a
+	// bare name is resolved through `PATHEXT` by PowerShell and cmd themselves, so
+	// a Windows `jolli.cmd` runs here even though nothing may spawn it directly.
+	//
+	// Two conditions, and presence alone is neither of them. A stale global CLI
+	// would shadow a newer bundled one and answer `unknown command 'dashboard'` —
+	// the failure that made an ungated bare-`jolli` tier wrong.
+	// `>=` rather than `>`: an equal version is the same code, so preferring the
+	// readable spelling is free.
+	const globalVersion = deps.globalCliVersion;
+	const floor = deps.minGlobalCliVersion ?? BUNDLED_CLI_VERSION;
+	if (globalVersion != null && compareSemver(globalVersion, floor) >= 0 && deps.globalBinOnPath === true) {
+		return { commandLine: `${GLOBAL_BIN_NAME} ${tail}`, tier: "global-jolli" };
+	}
+
+	// Tier 1 is POSIX-only: `run-cli` carries a `#!/bin/bash` shebang and there is
+	// no `.cmd` / `.ps1` sibling, so PowerShell and cmd cannot run it at all.
+	if (deps.flavor === "posix") {
+		const runCli = deps.runCliPath ?? resolveRunCliPath();
+		if (canExecute(runCli)) {
+			return { commandLine: `${quote(runCli)} ${tail}`, tier: "run-cli" };
+		}
+	}
+
+	const cliEntry = join(deps.distDir, CLI_ENTRY_FILE);
+	if (!fileExists(cliEntry)) return null;
+	// The call operator is what lets PowerShell treat a quoted string as the
+	// command to run rather than as a value to echo.
+	const prefix = deps.flavor === "powershell" ? "& " : "";
+	return {
+		commandLine: `${prefix}${quote(deps.execPath)} ${quote(cliEntry)} ${tail}`,
+		tier: "bundled-node",
+	};
+}
+
+/* ── Terminal ────────────────────────────────────────────────────────────────── */
+
+/**
+ * The subset of `vscode.Terminal` this module uses.
+ *
+ * Deliberately narrow: no `exitStatus` and no `dispose`, because nothing here
+ * inspects or tears down a terminal. Both were here while the launcher reused one,
+ * and they are gone with it rather than left as an invitation.
+ */
+export interface TerminalLike {
+	readonly name: string;
+	show(preserveFocus?: boolean): void;
+	sendText(text: string, addNewLine?: boolean): void;
+}
+
+/** The window interactions this module performs, as a seam. */
+export interface DashboardLauncherHost {
+	readonly createTerminal: (options: {
+		readonly name: string;
+		readonly cwd: string;
+		readonly env: Readonly<Record<string, string>>;
+	}) => TerminalLike;
+	readonly showInfo: (message: string) => Promise<void>;
+	readonly showError: (message: string) => Promise<void>;
+}
+
+/* v8 ignore start -- thin adapters over vscode.window; every test injects its own */
+function defaultHost(): DashboardLauncherHost {
+	return {
+		createTerminal: (options) => vscode.window.createTerminal(options),
+		showInfo: (message) =>
+			Promise.resolve(vscode.window.showInformationMessage(message)).then(() => undefined),
+		showError: (message) => Promise.resolve(vscode.window.showErrorMessage(message)).then(() => undefined),
+	};
+}
+/* v8 ignore stop */
 
 export interface LaunchDashboardOptions {
 	/** Repo directory to register and serve from. */
 	readonly cwd: string;
 	/** The extension's `dist/` — where {@link CLI_ENTRY_FILE} lives. */
 	readonly distDir: string;
-	/** Injected in tests so no real process runs. */
-	readonly spawn?: DashboardSpawner;
 	/** Injected in tests; production uses the real window APIs. */
-	readonly ui?: DashboardLauncherUi;
+	readonly host?: DashboardLauncherHost;
 	/** Injected in tests. Defaults to `vscode.env.remoteName`. */
 	readonly remoteName?: string | undefined;
-}
-
-/* v8 ignore start -- thin adapters over vscode.window/env; every test injects its own */
-function defaultUi(): DashboardLauncherUi {
-	return {
-		withProgress: (title, task) =>
-			Promise.resolve(
-				vscode.window.withProgress({ location: vscode.ProgressLocation.Notification, title }, () => task()),
-			),
-		showError: (message, action) => Promise.resolve(vscode.window.showErrorMessage(message, action)),
-		showInfo: (message) => Promise.resolve(vscode.window.showInformationMessage(message)).then(() => undefined),
-		openExternal: (url) => Promise.resolve(vscode.env.openExternal(vscode.Uri.parse(url))).then(() => undefined),
-		revealLog: () => log.show(),
-	};
-}
-
-function defaultSpawner(distDir: string): DashboardSpawner {
-	return (args, cwd) => {
-		const scriptPath = join(distDir, CLI_ENTRY_FILE);
-		if (!existsSync(scriptPath)) {
-			// Thrown rather than logged: the caller turns this into the user-facing
-			// failure. A log-and-return would leave the button spinning on a child
-			// that was never started.
-			throw new Error(`Jolli CLI entry not found at ${scriptPath} — this build is incomplete.`);
-		}
-		return spawnHidden(process.execPath, [scriptPath, ...args], {
-			// Piped, and NOT unref'd — see the module header's point 4.
-			stdio: ["ignore", "pipe", "pipe"],
-			cwd,
-			env: { ...process.env, ...RUN_AS_NODE_ENV },
-		});
-	};
-}
-/* v8 ignore stop */
-
-/** Shown while the dashboard is starting. */
-export const PROGRESS_TITLE = "Opening the Jolli dashboard…";
-
-/** Shown when the dashboard could not be started. Details are in the output channel. */
-export const FAILURE_MESSAGE = "Could not open the Jolli dashboard.";
-
-/**
- * Shown when the server came up but the host refused to open a browser.
- *
- * Deliberately NOT {@link FAILURE_MESSAGE}: nothing failed except the last step.
- * The dashboard is running and its address is in the output channel, so the only
- * thing left for the user to do is reach it by hand.
- */
-export const BROWSER_FAILURE_MESSAGE =
-	"The Jolli dashboard is running, but no browser could be opened for it — its address is in the Jolli Memory log.";
-
-const FAILURE_ACTION = "Show Log";
-
-/** `err.message` when there is one, its string form otherwise. */
-function describeError(err: unknown): string {
-	return err instanceof Error ? err.message : String(err);
+	/** Injected in tests. Defaults to `vscode.env.shell`. */
+	readonly shell?: string | undefined;
+	/** Injected in tests. Defaults to `process.platform`. */
+	readonly platform?: NodeJS.Platform;
+	/** Injected in tests. Defaults to `process.execPath` (the host's Electron). */
+	readonly execPath?: string;
+	/** Injected in tests, so no case reads the real home directory. */
+	readonly runCliPath?: string;
+	/** Injected in tests. Defaults to a real `X_OK` probe. */
+	readonly canExecute?: (path: string) => boolean;
+	/** Injected in tests. Defaults to a real `existsSync`. */
+	readonly fileExists?: (path: string) => boolean;
+	/** Injected in tests. Defaults to reading the real dist-paths registry. */
+	readonly globalCliVersion?: string | null | undefined;
+	/** Injected in tests. Defaults to {@link BUNDLED_CLI_VERSION}. */
+	readonly minGlobalCliVersion?: string | undefined;
+	/** Injected in tests. Defaults to `process.env.PATH`. */
+	readonly pathEnv?: string | undefined;
+	/** Injected in tests. Defaults to `process.env.PATHEXT` (win32 only). */
+	readonly pathExt?: string | undefined;
 }
 
 /**
- * The dashboard child this window owns, or null.
+ * Opens a new terminal and runs the command in it.
  *
- * Module-level because the callers are independent command invocations — one per
- * click — while what is guarded is shared: one server, one browser tab, and one
- * history import / cutover attempt / backup snapshot against the one machine
- * database. A second click must never start a second one.
- */
-interface LiveDashboard {
-	readonly child: ChildProcess;
-	/** The startup barrier, so a click that arrives early can share the wait. */
-	readonly startup: Promise<void>;
-	/** The URL the child printed, once it has printed one. */
-	url: string | undefined;
-}
-
-let live: LiveDashboard | null = null;
-
-/** Drops the live record so each test starts from a clean launcher. */
-export function __resetDashboardLaunchForTests(): void {
-	live = null;
-}
-
-/**
- * Stops the dashboard this window started, if any.
- *
- * Called from `deactivate`, and available as a command. Idempotent: a child that
- * has already exited is simply forgotten.
- *
- * This is the replacement for the terminal's Ctrl+C, and it is the whole reason
- * the child is not `unref`'d — without an owner, a foreground server started
- * from a button is an invisible background process with no way to stop it.
- */
-export function stopDashboard(): void {
-	const running = live;
-	live = null;
-	if (!running || running.child.exitCode !== null || running.child.killed) return;
-	log.info(TAG, "stopping the dashboard");
-	running.child.kill();
-}
-
-/**
- * True while this window has a dashboard running.
- *
- * A test observer, not a production caller — `live` is module-private and the
- * launch/stop paths both consult it directly, so this exists to let the suite
- * assert the guard was set or cleared without reaching into the module. Wiring it
- * to a `when` clause for `jollimemory.stopDashboard` would need a context key
- * written from both paths; the command is harmless when nothing is running
- * ({@link stopDashboard} is idempotent), so that was not worth the second owner.
- */
-export function isDashboardRunning(): boolean {
-	return live !== null;
-}
-
-/**
- * The generic "it did not open" report, offering the channel that holds why.
- *
- * One function rather than a copy per failure path — a spawn that throws, a
- * child that exits before printing a URL, a child that fails to start — because
- * every one of them owes the user the same thing, and the reveal is easy to
- * forget on a new one.
- */
-async function reportLaunchFailure(ui: DashboardLauncherUi): Promise<void> {
-	if ((await ui.showError(FAILURE_MESSAGE, FAILURE_ACTION)) === FAILURE_ACTION) ui.revealLog();
-}
-
-/**
- * Tells the user the dashboard is up but the browser is not, and offers the log.
- *
- * Without this the whole failure is invisible: the child is serving happily and
- * printing its URL to a channel nobody has open, so the button spins, stops, and
- * nothing else ever happens.
- */
-async function reportBrowserFailure(url: string, err: unknown, ui: DashboardLauncherUi): Promise<void> {
-	log.error(TAG, `could not open a browser for ${url}: ${describeError(err)}`);
-	if ((await ui.showError(BROWSER_FAILURE_MESSAGE, FAILURE_ACTION)) === FAILURE_ACTION) ui.revealLog();
-}
-
-/**
- * What a click does while a dashboard is already running.
- *
- * Starting a second one would bind a second port (the CLI falls back rather than
- * failing), open a second tab, and put a second history import, cutover attempt
- * and backup snapshot against the same database.
- */
-async function rejoinLaunch(running: LiveDashboard, ui: DashboardLauncherUi): Promise<void> {
-	log.info(TAG, "the dashboard is already running — reusing it");
-	const opened = running.url;
-	if (opened === undefined) {
-		// It has not printed its URL yet, so there is nothing to re-open. Share the
-		// barrier instead: this click gets its own progress notification, and the
-		// first launch's browser is what ends it.
-		await ui.withProgress(PROGRESS_TITLE, () => running.startup);
-		return;
-	}
-	// A URL exists, so the click is satisfiable on its own terms — the tab may
-	// well have been closed — without repeating any of the work behind it.
-	try {
-		await ui.openExternal(opened);
-	} catch (err) {
-		void reportBrowserFailure(opened, err, ui);
-	}
-}
-
-/**
- * Drains one of the child's streams into the output channel, and reports the
- * first URL it sees.
- *
- * Line-buffered through `readline` rather than per-chunk, because a chunk
- * boundary can fall inside the URL line and a half-line would neither match
- * {@link URL_PATTERN} nor read sensibly in the channel.
- */
-function drain(stream: NodeJS.ReadableStream | null, onLine: (line: string) => void): void {
-	if (!stream) return;
-	createInterface({ input: stream }).on("line", onLine);
-}
-
-/**
- * Opens the dashboard: starts `jolli dashboard` as a child and opens its URL.
- *
- * The progress notification covers only up to the browser opening, NOT the
- * child's whole life — it serves until stopped, and the history import behind
- * the page can take minutes on a first run. So the notification is released by
- * whichever comes first: the URL line (success) or the child exiting (failure).
- *
- * One dashboard at a time: a click that arrives while one is running is served
- * by {@link rejoinLaunch}.
- *
- * Resolves once the startup phase has settled. Never rejects — a failure becomes
- * a notification.
+ * Resolves once the line has been sent — immediately, without waiting for the
+ * shell, and certainly without waiting for the command. The command keeps
+ * running past that: its output, including the history import that can take
+ * minutes, is on screen instead of behind an output channel. Never rejects.
  */
 export async function launchDashboard(options: LaunchDashboardOptions): Promise<void> {
-	const ui = options.ui ?? defaultUi();
+	const host = options.host ?? defaultHost();
 	// Passed straight through: `isRemoteWorkspace` already defaults an absent
-	// argument to `vscode.env.remoteName`, so coalescing to it here read as a
-	// second opinion while producing the identical answer.
+	// argument to `vscode.env.remoteName`.
 	if (isRemoteWorkspace(options.remoteName)) {
 		log.info(TAG, "remote window — not starting a local dashboard server");
-		await ui.showInfo(REMOTE_HINT);
-		return;
-	}
-	const running = live;
-	if (running) {
-		await rejoinLaunch(running, ui);
-		return;
-	}
-	const spawn = options.spawn ?? defaultSpawner(options.distDir);
-
-	/* v8 ignore next -- the seed no-op only satisfies definite assignment; the Promise executor below runs synchronously and replaces it first. */
-	let releaseStartup: () => void = () => {};
-	const startupSettled = new Promise<void>((resolve) => {
-		releaseStartup = resolve;
-	});
-
-	let child: ChildProcess;
-	try {
-		// `--no-open` because this host opens the URL itself (module header, 3).
-		child = spawn(["dashboard", "--no-open", "--cwd", options.cwd], options.cwd);
-	} catch (err) {
-		// A missing entry, or a spawn that failed synchronously. Nothing to unwind:
-		// `live` is published below, so no guard leaked.
-		log.error(TAG, `dashboard launch threw: ${describeError(err)}`);
-		await reportLaunchFailure(ui);
+		await host.showInfo(REMOTE_HINT);
 		return;
 	}
 
-	const launch: LiveDashboard = { child, startup: startupSettled, url: undefined };
-	live = launch;
-
-	const onLine = (line: string): void => {
-		const text = line.trim();
-		if (text) log.info(TAG, text);
-		if (launch.url !== undefined) return;
-		const match = URL_PATTERN.exec(text);
-		if (!match?.[1]) return;
-		// Recorded before the attempt rather than after it: a click that arrives
-		// during the import should retry this URL even when the first open failed.
-		launch.url = match[1];
-		void (async () => {
-			try {
-				await ui.openExternal(match[1] as string);
-			} catch (err) {
-				// Not awaited by the caller — `showErrorMessage` resolves only when
-				// the user answers it, and the child keeps running regardless.
-				void reportBrowserFailure(match[1] as string, err, ui);
-			} finally {
-				// In `finally` so a browser that refuses to open still ends the
-				// notification: the dashboard IS up, and leaving a spinner on screen
-				// would be the only damage.
-				releaseStartup();
-			}
-		})();
-	};
-	drain(child.stdout, onLine);
-	drain(child.stderr, onLine);
-
-	// `error` and `close` can both fire for one launch — a spawn that fails emits
-	// `error` and then `close`, with no `exit` in between — and each of them ends
-	// in the same notification. Reporting once is the point: two modal errors for
-	// one click is the bug the `close` switch below would otherwise introduce.
-	let reported = false;
-	const reportOnce = (): void => {
-		if (reported) return;
-		reported = true;
-		void reportLaunchFailure(ui);
-	};
-
-	child.on("error", (err) => {
-		log.error(TAG, `dashboard process error: ${describeError(err)}`);
-		if (live === launch) live = null;
-		releaseStartup();
-		reportOnce();
-	});
-	// `close`, NOT `exit`. `exit` fires when the process ends, while the pipes it
-	// wrote to may still hold buffered lines — including the URL line this whole
-	// launch is waiting for. A dashboard stopped moments after it started serving
-	// therefore raced its own `drain`, and losing that race meant `launch.url` was
-	// still undefined here: the user was told the dashboard could not be started,
-	// about a dashboard that had started and printed its URL. `close` waits for
-	// both stdio streams to end, so every line `drain` will ever see has been seen.
-	child.on("close", (code) => {
-		if (live === launch) live = null;
-		const url = launch.url;
-		releaseStartup();
-		// A child that exited BEFORE printing a URL never served anything, so the
-		// click failed and the user has to be told. One that exits afterwards was
-		// either stopped on purpose or died later; the channel already carries why,
-		// and a notification for a dashboard the user closed would be noise.
-		if (url === undefined) {
-			log.error(TAG, `dashboard exited before it started serving (code ${code ?? "null"})`);
-			reportOnce();
-		} else {
-			log.info(TAG, `dashboard stopped (code ${code ?? "null"})`);
-		}
+	const platform = options.platform ?? process.platform;
+	const flavor = detectShellFlavor(options.shell ?? vscode.env.shell, platform);
+	// Both reads are cheap and synchronous — two small files from the registry, and
+	// a directory-by-directory existence check. Neither spawns anything, so the
+	// click pays nothing for the extra tier.
+	const globalCliVersion =
+		options.globalCliVersion !== undefined ? options.globalCliVersion : readWinningGlobalCliVersion();
+	const globalBinOnPath =
+		globalCliVersion !== null &&
+		findExecutableOnPath(GLOBAL_BIN_NAME, {
+			pathEnv: options.pathEnv ?? process.env.PATH,
+			pathExt: options.pathExt ?? process.env.PATHEXT,
+			platform,
+			fileExists: options.fileExists,
+		}) !== null;
+	const resolved = resolveDashboardCommand({
+		cwd: options.cwd,
+		distDir: options.distDir,
+		flavor,
+		execPath: options.execPath ?? process.execPath,
+		runCliPath: options.runCliPath,
+		canExecute: options.canExecute,
+		fileExists: options.fileExists,
+		globalCliVersion,
+		globalBinOnPath,
+		minGlobalCliVersion: options.minGlobalCliVersion,
 	});
 
-	await ui.withProgress(PROGRESS_TITLE, () => startupSettled);
+	if (resolved === null) {
+		// Every tier unavailable means tier 2's own entry is missing from `dist/`,
+		// since tier 2 has no precondition beyond that. Logged with the path so the
+		// report names the thing that is actually wrong.
+		log.error(TAG, `no CLI entry at ${join(options.distDir, CLI_ENTRY_FILE)} and no usable run-cli`);
+		await host.showError(UNAVAILABLE_MESSAGE);
+		return;
+	}
+
+	log.info(TAG, `running the dashboard via ${resolved.tier} (${flavor} shell): ${resolved.commandLine}`);
+	// A new terminal every click. Created only now, after resolution succeeded, so a
+	// build that cannot run the dashboard does not leave an empty terminal behind.
+	const terminal = host.createTerminal({ name: TERMINAL_NAME, cwd: options.cwd, env: RUN_AS_NODE_ENV });
+	// Shown before the line is sent so the first output is already visible, and
+	// with focus preserved: the user clicked a button in the sidebar, not in a
+	// terminal, and stealing the cursor to a panel they did not ask for is worse
+	// than making them click once more to type in it.
+	terminal.show(true);
+	// Sent IMMEDIATELY, into a shell that has not started yet. That is deliberate,
+	// and it is the whole of this function's contract: open a terminal, put the
+	// command in it, return. Nothing here waits for the shell, and nothing waits
+	// for `jolli dashboard` — its output arriving later is the point.
+	//
+	// ── DELIBERATE — NOT A REVIEW FINDING ────────────────────────────────────
+	// The known cost is COSMETIC and measured: `createTerminal` only starts a
+	// shell, so these bytes reach a pty still in canonical mode and the line
+	// discipline echoes them — the command appears once, unprefixed, above the
+	// first prompt, and again after it when the shell's line editor redraws the
+	// pending input. One execution, printed twice. (It was effectively invisible
+	// while the launcher reused a terminal, because that shell was already up;
+	// a fresh terminal per click makes it every time.)
+	//
+	// Both fixes for it were IMPLEMENTED, MEASURED and REVERTED, so do not
+	// re-derive them. Waiting for `onDidChangeTerminalShellIntegration` and then
+	// sending does not work at all: that event fires at zsh's `precmd`, BEFORE
+	// the first prompt, which is still inside the echoing window. Waiting and
+	// then sending via `shellIntegration.executeCommand` does fix the echo, but
+	// costs seconds — click-to-CLI-start went from 1.0-3.9 s (13 samples) to
+	// 5.8-8.4 s (3 samples), because `executeCommand` additionally waits for
+	// VS Code's own command detection to confirm a prompt that accepts input.
+	// A double-printed line is worth far less than 4-6 s on every click, and the
+	// product owner made that trade explicitly. Do not reintroduce a wait here.
+	// ─────────────────────────────────────────────────────────────────────────
+	terminal.sendText(resolved.commandLine);
 }

--- a/vscode/src/views/SidebarScriptBuilder.ts
+++ b/vscode/src/views/SidebarScriptBuilder.ts
@@ -5761,12 +5761,12 @@ export function buildSidebarScript(): string {
     }
     var footerDashboard = e.target.closest('.cmd-btn[data-action="footer-dashboard"]');
     if (footerDashboard) {
-      // Starts the local dashboard and opens the browser. NOTE: no backticks in
-      // this comment -- the whole script is a template literal, so one would end
-      // it. The jolli dashboard command is a foreground command now, so the host
-      // runs it as a child process it owns rather than calling into the CLI
-      // in-process, and there is no reuse of an existing server -- see
-      // services/DashboardLauncher.ts.
+      // Runs the dashboard command in an integrated terminal, which starts the
+      // local server and opens the browser itself -- so its output, including
+      // the history import that runs after the page is up, is visible. NOTE: no
+      // backticks in this comment -- the whole script is a template literal, so
+      // one would end it. See services/DashboardLauncher.ts for which CLI entry
+      // gets invoked.
       vscode.postMessage({ type: 'command', command: 'jollimemory.openDashboard' });
       e.stopPropagation(); return;
     }


### PR DESCRIPTION
## Summary

The sidebar's dashboard button now sends `jolli dashboard` to an integrated terminal instead of running `executeDashboard` inside the extension host, so the command's own output — including the history import, which runs for minutes after the browser opens — is in front of the user. `DashboardLauncher` is left with one decision: which CLI entry to invoke.

## Motivation

Running the launcher in-process needed three editor-shaped plugs, and each one made the command quieter than it is on a command line:

- **The output channel.** The CLI writes to `console`; in the extension host that is the debug console, so every failure reason had to be routed to the "Jolli Memory" channel — which nobody has open. `executeDashboard`'s runtime-floor gate (`canUseDashboardDb()`, naming the required and running Node versions) is one of the messages that went there.
- **An Electron-as-node spawner** for the detached server.
- **`vscode.env.openExternal`** for the URL.

The worst of it was the shape of the launch: the progress notification stops when the startup phase settles, but the history import keeps running for minutes afterwards with nothing on screen to say so — which is exactly the stretch that invites a second click. In a terminal all three plugs go back to their command-line defaults and the user can see what is happening.

The launcher's phases are untouched: the browser still opens (the CLI does it), and the import still runs last, now visibly.

## Changes

### `DashboardLauncher.ts` — three tiers of command resolution

0. **`jolli`**, the readable spelling, used only when a globally-installed CLI both **wins** the dist-paths version competition and is at least as new as the core this bundle carries. Presence is not the gate: an ungated bare `jolli` tier would bypass that competition, so a stale global CLI would shadow a newer bundled one and answer `unknown command 'dashboard'`. The competition is not reimplemented — `readWinningGlobalCliVersion` calls the same `traverseDistPaths` + `pickBestDistPath` pair that `resolve-dist-path` mirrors, so tier 0 fires exactly when tier 1 would have chosen the global CLI anyway.

   One residual gap is accepted and documented in place: the registry answers for the install that **wrote** `dist-paths/cli`, while the terminal resolves the bare name against its **own** PATH (nvm/volta, or a shim earlier on PATH). Closing it needs a `jolli --version` spawn that was ruled out on cost — measured 0.35 s to answer a question the registry already answers for free. The cost of being wrong is one visible error line on a misconfigured machine.

1. **`~/.jolli/jollimemory/run-cli`**, the machine-global dispatcher, which resolves the highest-versioned registered dist. This one tier covers both "the user has a global CLI" and "only the VS Code bundle exists", which is why it — not tier 0 — is the fallback that must always work. POSIX-only, since `run-cli` carries a `#!/bin/bash` shebang and has no `.cmd`/`.ps1` sibling.

2. **The extension's own `dist/Cli.js`**, run by the host's Electron under `ELECTRON_RUN_AS_NODE`. `engines.vscode` (^1.101.0) already guarantees that Node clears the 22.13 `node:sqlite` floor, so this tier needs no user Node at all.

`findExecutableOnPath` takes every platform-dependent choice (PATH separator, join, whether `PATHEXT` applies) from its `platform` **argument**, never from the host — otherwise its tests assert the host's behaviour instead of the target's, which is not hypothetical here: `"C:\\npm"` split on the host delimiter yields `["C", "\\npm"]` on macOS, leaving the win32 path silently unreachable. It probes the **exec bit** rather than mere existence, because a directory named `jolli` early on PATH answers `existsSync` yes and then gets refused by the shell.

### Per-shell quoting

`detectShellFlavor` classifies the terminal's shell by its own path rather than by `process.platform`, so Git Bash on Windows is recognised as POSIX. `quoteArg` single-quotes for POSIX and PowerShell (the only form in either that suppresses interpolation, differing in how a literal quote is escaped) and double-quotes for `cmd`. PowerShell additionally gets the call operator `&`, which is a syntax error at the start of a POSIX line — there is no one string that works everywhere, and a wrong quoting style does not fail loudly, it passes a mangled path to the CLI.

### Two product decisions, with their costs stated

**Every click opens a new terminal.** Reuse and reveal-the-existing-one were implemented and then removed at the product owner's request. The accepted cost is that the old `InFlightLaunch` guard has no replacement: two clicks put two history imports, cutover attempts and backup snapshots concurrently against the one machine database (`acquireSpawnLock` covers only the server spawn, and `maybeAutoCutover`'s throttle reads its timestamp and writes it back with an `await` in between, so both callers pass it). The panel also accumulates terminals.

**The command carries no `--cwd`.** `executeDashboard` therefore falls back to `process.cwd()`, with `createTerminal({ cwd })` the only thing pointing that at the repo root — a weaker guarantee than it looks, since a `cd` in the user's `.zshrc`/`.bashrc` overrides the spawn directory outright (measured: spawned in the repo, `pwd` reported `/` once the rc had run). When that happens the button acts on whatever repo the shell is in, and `maybeAutoCutover` freezes the orphan branch of the repo it is given. Both `--cwd` and a leading `cd` line were considered and dropped at the owner's request, with that consequence on the table.

Both are marked in the source as decisions rather than findings, so a future review does not re-derive them as bugs.

### The duplicated command line, and the two fixes that were reverted

The line is sent immediately, into a shell that has not started yet. `createTerminal` only *starts* a shell, so the bytes reach a pty still in canonical mode and the line discipline echoes them — the command appears once, unprefixed, above the first prompt, and again after it when the shell's line editor redraws the pending input. **One execution, printed twice.** It was effectively invisible while the launcher reused a terminal (that shell was already up); a fresh terminal per click makes it every time.

Both fixes were implemented, measured and reverted, and the numbers are recorded at the send site so neither is re-attempted:

- **Waiting for `onDidChangeTerminalShellIntegration`, then `sendText` — no effect at all.** That event fires when the integration script activates, at zsh's `precmd`, which is *before* the first prompt is drawn and therefore still inside the echoing window.
- **Waiting, then `shellIntegration.executeCommand` — fixes the echo, costs seconds.** Click-to-CLI-start went from **1.0–3.9 s** (13 samples) to **5.8–8.4 s** (3 samples), because that call additionally waits for VS Code's own command detection to confirm a prompt that accepts input. The wait itself is cheap; `executeCommand` is where the time goes.

A duplicated line is worth less than 4–6 s on every click, so the fast path stands. The third option that is both fast and clean — reuse the terminal, so the shell is already up — is the product decision above.

### Build

`DashboardServerEntry` stays in the VS Code esbuild entry list even though the extension no longer spawns it: whichever `Cli.js` wins resolves its server entry as its own **sibling** (`DashboardCommand.defaultSpawnServer`), so a dist without that file serves nothing.

## Two fixes outside the launcher

- **`serveMcpInProcess` (`cli/src/Cli.ts`).** The telemetry module is now imported **inside** the guard and reached through a nullable handle, so an import failure can no longer reject before `startMcpServer` is ever called — the one outcome that function is not allowed to produce. The exit flush bounds both the per-POST timeout and the whole-flush deadline with `BOUNDED_FLUSH_BUDGET_MS` (a filled buffer flushes as several sequential POSTs, so `timeoutMs` alone leaves the worst case a multiple of the budget), and the flush is wrapped because a `finally` that throws *replaces* the exception the server was reporting.

- **Both plugins' `publish_git_repo`.** It now fails **closed** when the commit `--grep` selected carries a non-release subject. `--grep` matches the whole message and anchors `^` per line, so a commit whose *body* holds a release-looking line is selected while its subject is something else; the prefix then does not strip and the baseline is not a version at all. Treating that as "no baseline" would wave a downgrade through, and reaching the version comparison with the garbage stops the publish while printing that subject as though it were the last published version. Overridable with `JOLLI_PUBLISH_FORCE=1`.

## Testing

`npm run all` (clean → build → typecheck → lint → test) passes.

`DashboardLauncher.test.ts` pins the tier selection, per-shell quoting and the call operator, that the repo directory reaches the CLI **only** as the terminal's own cwd, and that every click opens a new terminal. Two cases that read the real `dist-paths` registry were pinned with `globalCliVersion: null` like the rest: without it they asserted tier 1 only while the machine happened to have no available `cli` entry, and building `cli/dist` locally flipped them to tier 0 and turned them red with nothing about their subject having changed.
