### PR TITLE
Fix cutover admission check and topic index drift comparison

### DIFF
--- a/cli/src/commands/CutoverCommand.ts
+++ b/cli/src/commands/CutoverCommand.ts
@@ -2,10 +2,13 @@
  * CutoverCommand — `jolli cutover`: the user-facing entry to the phase-D
  * protocol. Plain `jolli cutover` runs (or resumes) the switch for the
  * current repo; `--status` answers with the four-state route; `--probe`
- * runs the post-cutover drift check.
+ * runs the post-cutover drift check UNTHROTTLED, which is the difference
+ * between it and the copy `maybeAutoCutover` runs on its own — this one is
+ * for someone actively hunting the writer, so it must not be suppressed by
+ * a stamp an automatic probe left minutes ago.
  *
  * The engine is deliberately conservative, so this command mostly reports:
- * a stale surface, a failing compare or a missing orphan branch are all
+ * an unregistered repo, a missing orphan branch or a failing compare are all
  * "not-ready" with the reason spelled out, and retry exhaustion leaves the
  * repo in legacy-fenced — a WORKING state (writes go to SQLite) whose CAS a
  * re-run finishes.

--- a/cli/src/core/RepoProfile.ts
+++ b/cli/src/core/RepoProfile.ts
@@ -66,6 +66,32 @@ export interface RepoProfile {
 	 */
 	userDisabled?: boolean;
 	/**
+	 * When the automatic cutover attempt last RAN for this clone (epoch ms).
+	 *
+	 * Only a throttle, never evidence of state: the two witnesses that decide
+	 * routing are {@link cutoverFence} and the database's `repo_state.cutover`
+	 * row, and this field is deliberately not consulted by either. It exists
+	 * because the attempt's step 2 re-imports every source at its pinned tip and
+	 * step 3 then reads every file that tip lists, which is far too expensive to
+	 * repeat on every commit for a repo that keeps answering `not-ready`. Absent
+	 * means "never attempted", which is what every repo enabled before
+	 * auto-cutover shipped reads back.
+	 */
+	cutoverAttemptedAtMs?: number;
+	/**
+	 * When the automatic post-cutover DRIFT probe last ran for this clone (epoch
+	 * ms) — a separate stamp from {@link cutoverAttemptedAtMs} because the two
+	 * never run in the same state: the attempt stops once the repo is `cutover`,
+	 * which is exactly where the probe starts.
+	 *
+	 * Also only a throttle. The probe is cheap when nothing drifted (one
+	 * `rev-parse` per source) and expensive when something did (a catch-up
+	 * import), and drift is deliberately never cleared automatically — so
+	 * without a stamp a repo with a live bypassing writer would pay that import
+	 * on every single commit, forever.
+	 */
+	cutoverDriftProbedAtMs?: number;
+	/**
 	 * The cutover fence (phase D): present means this repo's orphan branch is
 	 * FROZEN — new runtimes keep working but write SQLite and read the database;
 	 * old runtimes are stopped via the derived bit. `jolli enable` must NOT
@@ -73,18 +99,6 @@ export interface RepoProfile {
 	 * there is no legitimate "unfreeze" — old clients must never write the
 	 * frozen branch again.
 	 */
-	/**
-	 * When the automatic cutover attempt last RAN for this clone (epoch ms).
-	 *
-	 * Only a throttle, never evidence of state: the two witnesses that decide
-	 * routing are {@link cutoverFence} and the database's `repo_state.cutover`
-	 * row, and this field is deliberately not consulted by either. It exists
-	 * because the attempt's step 3 reads every file the frozen tip lists, which
-	 * is far too expensive to repeat on every commit for a repo that keeps
-	 * answering `not-ready`. Absent means "never attempted", which is what every
-	 * repo enabled before auto-cutover shipped reads back.
-	 */
-	cutoverAttemptedAtMs?: number;
 	cutoverFence?: {
 		readonly reason: string;
 		readonly at: string;

--- a/cli/src/core/TopicPageStore.ts
+++ b/cli/src/core/TopicPageStore.ts
@@ -5,6 +5,10 @@
  * separate concern (FolderStorage / WikiMarkdownBuilder).
  */
 
+// The one home for "which `topics/` files are pages" — shared with the cutover
+// compare so the two cannot drift. Kept OUT of this module because this one is
+// widely `vi.mock`ed, which would hand the compare an undefined predicate.
+import { isTopicPagePath } from "../dashboard/ImportablePaths.js";
 import { createLogger } from "../Logger.js";
 import type { FileWrite } from "../Types.js";
 import type { StorageProvider } from "./StorageProvider.js";
@@ -12,9 +16,6 @@ import { resolveStorage, withRequiredOrphanWriteLock } from "./SummaryStore.js";
 import type { TopicPage } from "./TopicKBTypes.js";
 
 const log = createLogger("TopicPageStore");
-
-/** Reserved file names under `topics/` that are NOT topic pages. */
-const RESERVED = new Set(["index", "processed"]);
 
 /**
  * Guards a slug before it is interpolated into a `topics/<slug>.json` path.
@@ -62,10 +63,7 @@ export async function saveTopicPage(page: TopicPage, cwd?: string, storage?: Sto
 export async function listTopicPageSlugs(cwd?: string, storage?: StorageProvider): Promise<ReadonlyArray<string>> {
 	const resolved = await resolveStorage(storage, cwd);
 	const files = await resolved.listFiles("topics/");
-	return files
-		.filter((f) => f.startsWith("topics/") && f.endsWith(".json"))
-		.map((f) => f.slice("topics/".length, -".json".length))
-		.filter((slug) => slug.length > 0 && !slug.includes("/") && !RESERVED.has(slug));
+	return files.filter(isTopicPagePath).map((f) => f.slice("topics/".length, -".json".length));
 }
 
 /**

--- a/cli/src/dashboard/AutoCutover.test.ts
+++ b/cli/src/dashboard/AutoCutover.test.ts
@@ -15,6 +15,7 @@ import { ORPHAN_BRANCH } from "../Logger.js";
 import { type RestoreHome, setIsolatedHome } from "../testUtils/isolatedHome.js";
 import { AUTO_CUTOVER_RETRY_MS, maybeAutoCutover } from "./AutoCutover.js";
 import { resolveCutoverRoute } from "./CutoverRouter.js";
+import { withDashboardDb } from "./DashboardDb.js";
 import { registerRepo } from "./RepoRegistry.js";
 
 let dir: string;
@@ -138,5 +139,72 @@ describe("maybeAutoCutover", () => {
 		await maybeAutoCutover(cwd, { dbPath, throttle: true, nowMs: now });
 		expect((await readRepoProfile(cwd)).cutoverAttemptedAtMs).toBe(now);
 		expect(await maybeAutoCutover(cwd, { dbPath, throttle: true, nowMs: now + 1000 })).toBe("skipped");
+	});
+
+	describe("post-cutover drift probe", () => {
+		it("catches a fence-bypassing write with nobody typing --probe", async () => {
+			// The whole reason the version-floor admission check could come out. After
+			// the freeze reads come from SQLite, so a write that bypassed the fence has
+			// NO symptom — a user has nothing to investigate and no reason to run the
+			// diagnostic by hand. If this call site goes away, that memory is lost
+			// silently rather than reported.
+			const now = Date.parse("2026-08-09T12:00:00Z");
+			await writeOrphanSummary(HASH);
+			expect(await maybeAutoCutover(cwd, { dbPath, nowMs: now })).toBe("cutover");
+
+			// An old surface writes the frozen branch anyway.
+			await writeOrphanSummary("e".repeat(40));
+
+			expect(await maybeAutoCutover(cwd, { dbPath, nowMs: now + AUTO_CUTOVER_RETRY_MS + 1 })).toBe("cutover");
+			const rows = await withDashboardDb(
+				(db) => db.prepare("SELECT COUNT(*) AS n FROM memories").get() as { n: number },
+				{ dbPath },
+			);
+			expect(rows.n).toBe(2);
+		});
+
+		it("does not probe on the call that performs the cutover", async () => {
+			// That call returns through the CAS, not the already-cut-over branch, and
+			// the tips it would compare are the ones it pinned itself moments ago.
+			const now = Date.parse("2026-08-09T12:00:00Z");
+			await writeOrphanSummary(HASH);
+			expect(await maybeAutoCutover(cwd, { dbPath, nowMs: now })).toBe("cutover");
+			expect((await readRepoProfile(cwd)).cutoverDriftProbedAtMs).toBeUndefined();
+		});
+
+		it("throttles on its OWN stamp — the attempt's stops moving once cut over", async () => {
+			const now = Date.parse("2026-08-09T12:00:00Z");
+			await writeOrphanSummary(HASH);
+			await maybeAutoCutover(cwd, { dbPath, nowMs: now });
+			// First call to find the repo already cut over: this is the one that
+			// probes, and it stamps BEFORE probing — same rule as the attempt.
+			await maybeAutoCutover(cwd, { dbPath, nowMs: now + 60_000 });
+			expect((await readRepoProfile(cwd)).cutoverDriftProbedAtMs).toBe(now + 60_000);
+
+			// Inside the window the bypassing write is NOT imported yet: the probe's
+			// repair is a full catch-up import, and drift is deliberately never
+			// cleared, so an unthrottled probe would pay that on every commit forever.
+			await writeOrphanSummary("e".repeat(40));
+			await maybeAutoCutover(cwd, { dbPath, nowMs: now + 120_000 });
+			expect((await readRepoProfile(cwd)).cutoverDriftProbedAtMs).toBe(now + 60_000);
+			const before = await withDashboardDb(
+				(db) => db.prepare("SELECT COUNT(*) AS n FROM memories").get() as { n: number },
+				{ dbPath },
+			);
+			expect(before.n).toBe(1);
+		});
+
+		it("is throttled even for the caller that passes no throttle", async () => {
+			// The post-import caller's reason to skip the throttle — the database was
+			// just filled from the branch — is about the COMPARE. It says nothing
+			// about drift, which is slow-moving by nature, so `throttle` is not
+			// consulted here at all: no call in this test passes one.
+			const now = Date.parse("2026-08-09T12:00:00Z");
+			await writeOrphanSummary(HASH);
+			await maybeAutoCutover(cwd, { dbPath, nowMs: now });
+			await maybeAutoCutover(cwd, { dbPath, nowMs: now + 60_000 });
+			await maybeAutoCutover(cwd, { dbPath, nowMs: now + 120_000 });
+			expect((await readRepoProfile(cwd)).cutoverDriftProbedAtMs).toBe(now + 60_000);
+		});
 	});
 });

--- a/cli/src/dashboard/AutoCutover.ts
+++ b/cli/src/dashboard/AutoCutover.ts
@@ -21,14 +21,20 @@
  *   authoritative, `legacy-fenced` already writes SQLite and reads the database
  *   and only needs the CAS finished. Both converge on a later attempt, so a
  *   failure here must not turn a successful `jolli enable` red.
- * - **It is throttled per clone**, because the engine's step 3 reads every file
- *   the frozen tip lists. That is right after an import and far too expensive
- *   to repeat on every commit for a repo that keeps answering `not-ready`.
+ * - **It is throttled per clone**, because the engine's step 2 re-imports every
+ *   source at its pinned tip and step 3 then reads every file that tip lists.
+ *   Far too expensive to repeat on every commit for a repo that keeps answering
+ *   `not-ready`.
+ *
+ * It also owns the other half of the automatic story. Once a repo IS cut over
+ * there is nothing left to press, but the fence can still be bypassed by an old
+ * surface that kept writing the frozen branch — so this is where
+ * {@link probeCutoverDrift} runs. See {@link maybeProbeDrift}.
  */
 
 import { readRepoProfile, updateRepoProfile } from "../core/RepoProfile.js";
 import { createLogger, errMsg } from "../Logger.js";
-import { runCutover } from "./CutoverEngine.js";
+import { probeCutoverDrift, runCutover } from "./CutoverEngine.js";
 import { resolveCutoverRoute } from "./CutoverRouter.js";
 import { canUseDashboardDb } from "./DashboardDb.js";
 
@@ -41,8 +47,19 @@ const log = createLogger("AutoCutover");
  * post-import caller does not, because that is the one moment the database is
  * known to have just been filled from the branch — exactly when the compare is
  * most likely to pass, and the moment the user is waiting on setup anyway.
+ *
+ * Two hours, not six. The window is a cost/latency trade: an attempt is a full
+ * re-import of every source at its pinned tip FOLLOWED BY a read of every file
+ * that tip lists — not just the read — so it is far too expensive per commit;
+ * but a repo that answers `not-ready` for a transient reason (a tip that kept
+ * moving, a lock that stayed busy) should not sit un-cutover for most of a
+ * working day before anything tries again. Six hours meant at most one attempt
+ * per session; two gives a normal day several, at the same per-attempt cost.
+ *
+ * The same window throttles the drift probe — see {@link maybeProbeDrift} — on
+ * its own stamp.
  */
-export const AUTO_CUTOVER_RETRY_MS = 6 * 60 * 60 * 1000;
+export const AUTO_CUTOVER_RETRY_MS = 2 * 60 * 60 * 1000;
 
 export interface AutoCutoverOptions {
 	/** Skip when an attempt ran less than {@link AUTO_CUTOVER_RETRY_MS} ago. */
@@ -69,7 +86,10 @@ export async function maybeAutoCutover(
 		// Cheap check first: `cutover` is done and `blocked` has no safe backend
 		// to move to (the repo needs `doctor --recover`, not another attempt).
 		const route = await resolveCutoverRoute(cwd, opts.dbPath ? { dbPath: opts.dbPath } : {});
-		if (route.state === "cutover") return "cutover";
+		if (route.state === "cutover") {
+			await maybeProbeDrift(cwd, now, opts);
+			return "cutover";
+		}
 		if (route.state === "blocked") {
 			log.info("skipping auto-cutover for %s — routing is blocked: %s", cwd, route.reason);
 			return "skipped";
@@ -88,8 +108,8 @@ export async function maybeAutoCutover(
 			log.info("auto-cutover: %s is now served from SQLite", cwd);
 			return "cutover";
 		}
-		// `not-ready` / `retry-exhausted`. Expected, and not a problem: a stale
-		// surface, a moved tip, a compare that has not converged. Which of the two
+		// `not-ready` / `retry-exhausted`. Expected, and not a problem: a moved tip,
+		// an unregistered repo, a compare that has not converged. Which of the two
 		// workable states the repo landed in is re-read rather than inferred —
 		// `retry-exhausted` in particular leaves it FENCED, which is the state
 		// worth naming in the log because writes are already going to SQLite.
@@ -102,5 +122,56 @@ export async function maybeAutoCutover(
 		// Still not the caller's problem — see the header.
 		log.warn("auto-cutover failed for %s: %s", cwd, errMsg(err));
 		return "skipped";
+	}
+}
+
+/**
+ * The automatic half of the post-cutover safety net.
+ *
+ * `runCutover` no longer refuses to begin when an old surface is installed on
+ * this machine — one un-upgraded extension used to pin every repo here at
+ * `uncutover` forever. What that refusal guarded is a surface that keeps writing
+ * the FROZEN branch afterwards, and the answer to it is `probeCutoverDrift`,
+ * which reports such a write and catch-up imports it so the memory is not
+ * stranded. That answer is only worth anything if something calls it: reads come
+ * from SQLite after the fence, so a bypassed write is INVISIBLE, and a user with
+ * no symptom has no reason to type `jolli cutover --probe`. This is that
+ * something.
+ *
+ * It runs on the calls that find a repo ALREADY cut over, never on the call that
+ * does the cutting — that one returns through the CAS, and the tips a probe
+ * would compare are the ones it pinned itself moments earlier.
+ *
+ * Three further properties, each deliberate:
+ *
+ * - **Always throttled, even for the caller that passes no `throttle`.** That
+ *   caller's reason (the database was just filled from the branch, so the
+ *   compare is most likely to pass right now) is about the CUTOVER; it says
+ *   nothing about drift, which is slow-moving by nature.
+ * - **Its own stamp.** `cutoverAttemptedAtMs` stops being written the moment the
+ *   repo reaches `cutover`, which is the only state this runs in — sharing it
+ *   would make the first probe fire and every later one read a stamp nobody
+ *   updates.
+ * - **Its own try/catch.** The caller's returns `"skipped"`, which would be a
+ *   lie about a repo that is cut over and working.
+ */
+async function maybeProbeDrift(cwd: string, now: number, opts: AutoCutoverOptions): Promise<void> {
+	try {
+		const last = (await readRepoProfile(cwd)).cutoverDriftProbedAtMs;
+		if (typeof last === "number" && now - last < AUTO_CUTOVER_RETRY_MS) return;
+		// Stamped BEFORE, for the same reason the attempt is: a probe that dies
+		// partway must still spend its slot.
+		await updateRepoProfile(cwd, { cutoverDriftProbedAtMs: now });
+		const drift = await probeCutoverDrift(cwd, { nowMs: now, ...(opts.dbPath ? { dbPath: opts.dbPath } : {}) });
+		if (drift.length === 0) return;
+		// `probeCutoverDrift` already warns per drifted source. This line adds the
+		// only thing it cannot: what the user should do about it.
+		log.warn(
+			"%d source(s) drifted in %s — the stranded memories were imported, but something is still writing the frozen branch (an old client or an un-restarted IDE). Run `jolli cutover --probe` after stopping it.",
+			drift.length,
+			cwd,
+		);
+	} catch (err) {
+		log.warn("cutover drift probe failed for %s: %s", cwd, errMsg(err));
 	}
 }

--- a/cli/src/dashboard/CutoverEngine.test.ts
+++ b/cli/src/dashboard/CutoverEngine.test.ts
@@ -460,11 +460,14 @@ describe("runCutover", () => {
 		expect(drift).toMatchObject({ ok: false, detail: "topics/alpha.json: content differs" });
 
 		// The index keeps its allowance: its entry order falls out of a query.
+		// Both entries carry a page file so they survive the unbacked-entry filter
+		// and the assertion is about ORDER, not about them being dropped.
+		const pages = { "topics/a.json": page([]), "topics/b.json": page([]) };
 		const index = { schemaVersion: 1, topics: [{ stableSlug: "a" }, { stableSlug: "b" }] };
 		const reversed = { schemaVersion: 1, topics: [{ stableSlug: "b" }, { stableSlug: "a" }] };
 		const ok = await compareSourceContainment(
-			provider({ "topics/index.json": JSON.stringify(index) }),
-			provider({ "topics/index.json": JSON.stringify(reversed) }) as unknown as InstanceType<
+			provider({ ...pages, "topics/index.json": JSON.stringify(index) }),
+			provider({ ...pages, "topics/index.json": JSON.stringify(reversed) }) as unknown as InstanceType<
 				typeof SqliteStorage
 			>,
 		);
@@ -494,7 +497,11 @@ describe("runCutover", () => {
 		// Two clones of one remote import into ONE repo id, so both synthesized
 		// views render A∪B. Equality could never hold against either clone's
 		// file, which left such a repo permanently un-cutoverable.
+		// The page files matter: an index entry with no `topics/<slug>.json` on the
+		// branch is dropped from the source side before comparing (it can never be
+		// in the database), so without them this would pass vacuously.
 		const cloneA = {
+			"topics/a.json": JSON.stringify({ stableSlug: "a" }),
 			"topics/index.json": JSON.stringify({ schemaVersion: 1, topics: [{ stableSlug: "a" }] }),
 			"topics/processed.json": JSON.stringify({
 				schemaVersion: 1,
@@ -502,6 +509,7 @@ describe("runCutover", () => {
 			}),
 		};
 		const union = {
+			"topics/a.json": JSON.stringify({ stableSlug: "a" }),
 			"topics/index.json": JSON.stringify({
 				schemaVersion: 1,
 				topics: [{ stableSlug: "b" }, { stableSlug: "a" }],
@@ -530,6 +538,111 @@ describe("runCutover", () => {
 			}) as unknown as InstanceType<typeof SqliteStorage>,
 		);
 		expect(missing).toMatchObject({ ok: false, detail: "topics/processed.json: content differs" });
+	});
+
+	describe("compares only what the import would take", () => {
+		const provider = (files: Record<string, string>) => ({
+			async readFile(path: string): Promise<string | null> {
+				return files[path] ?? null;
+			},
+			async batchReadFiles(paths: string[]): Promise<Map<string, string | null>> {
+				return new Map(paths.map((p) => [p, files[p] ?? null]));
+			},
+			async listFiles(prefix: string): Promise<string[]> {
+				return Object.keys(files).filter((p) => p.startsWith(prefix));
+			},
+			async writeFiles(): Promise<void> {},
+			async exists(): Promise<boolean> {
+				return true;
+			},
+			async ensure(): Promise<void> {},
+		});
+		const compare = async (source: Record<string, string>, db: Record<string, string>) => {
+			const { SqliteStorage } = await import("../core/SqliteStorage.js");
+			const { compareSourceContainment } = await import("./CutoverEngine.js");
+			return compareSourceContainment(
+				provider(source),
+				provider(db) as unknown as InstanceType<typeof SqliteStorage>,
+			);
+		};
+
+		it("ignores files whose extension the import filters out", async () => {
+			// The import reads `notes/*.md` and `summaries/*.json` only, so the
+			// database can never answer for these — demanding it did made any stray
+			// file a permanent, silent cutover blocker.
+			const verdict = await compare(
+				{ "notes/scratch.txt": "x", "summaries/a.json.bak": "y", "notes/real.md": "kept" },
+				{ "notes/real.md": "kept" },
+			);
+			expect(verdict.ok).toBe(true);
+		});
+
+		it("still blocks on a file the import WOULD take and the database lacks", async () => {
+			const verdict = await compare({ "notes/real.md": "kept" }, {});
+			expect(verdict).toMatchObject({ ok: false, detail: "notes/real.md: missing from the database" });
+		});
+
+		it("ignores nested topic paths, which listTopicPageSlugs also refuses", async () => {
+			expect((await compare({ "topics/sub/x.json": "x" }, {})).ok).toBe(true);
+		});
+
+		it("drops index entries with no page file on the branch", async () => {
+			// The database renders `topics/index.json` from `topic_pages`, and a row
+			// exists only where a PAGE was imported. An index entry whose page file
+			// is absent can therefore never be contained — and the state is stable,
+			// because `saveTopicIndex` never prunes such entries.
+			const source = {
+				"topics/kept.json": JSON.stringify({ stableSlug: "kept" }),
+				"topics/index.json": JSON.stringify({
+					schemaVersion: 1,
+					topics: [{ stableSlug: "kept" }, { stableSlug: "shell", summary: "only in the index" }],
+				}),
+			};
+			const db = {
+				"topics/kept.json": JSON.stringify({ stableSlug: "kept" }),
+				"topics/index.json": JSON.stringify({ schemaVersion: 1, topics: [{ stableSlug: "kept" }] }),
+			};
+			expect((await compare(source, db)).ok).toBe(true);
+
+			// A BACKED entry the database lacks is still drift — the narrowing is
+			// only about entries the import could never have stored.
+			const backedButMissing = {
+				...source,
+				"topics/shell.json": JSON.stringify({ stableSlug: "shell" }),
+			};
+			// Reported as the PAGE, not as the index: union views are compared after
+			// the pages precisely so the detail names a file the user can look at.
+			expect(await compare(backedButMissing, db)).toMatchObject({
+				ok: false,
+				detail: "topics/shell.json: missing from the database",
+			});
+		});
+
+		it("accepts an index of only-unbacked entries against a database with no topics at all", async () => {
+			// `synthTopicIndex` answers null until the database holds one page, and
+			// the null check runs before the union-view branch — so this shape used
+			// to report `missing from the database` and could never be filtered.
+			const verdict = await compare(
+				{ "topics/index.json": JSON.stringify({ schemaVersion: 1, topics: [{ stableSlug: "shell" }] }) },
+				{},
+			);
+			expect(verdict.ok).toBe(true);
+		});
+
+		it("falls back to the STRICTER comparison when the index cannot be parsed", async () => {
+			const verdict = await compare({ "topics/index.json": "{not json" }, { "topics/index.json": "{}" });
+			expect(verdict).toMatchObject({ ok: false, detail: "topics/index.json: content differs" });
+
+			// And the same input against an EMPTY database is a failure, not the
+			// "nothing survived the filter" pass. This is what the unparsable
+			// branch's `kept: 1` buys: an index we cannot interpret must never
+			// widen what the compare accepts, and `kept: 0` there would certify a
+			// cutover for a document nobody has read.
+			expect(await compare({ "topics/index.json": "{not json" }, {})).toMatchObject({
+				ok: false,
+				detail: "topics/index.json: missing from the database",
+			});
+		});
 	});
 
 	it("increments the cutover version over a prior generation", async () => {
@@ -648,25 +761,23 @@ describe("runCutover", () => {
 		expect(await readCutoverFence(clone2)).not.toBeNull();
 	});
 
-	it("admission: a stale surface on this machine refuses the cutover before anything happens", async () => {
+	it("an old surface installed on this machine does NOT block the cutover", async () => {
 		await writeOrphanSummary(HASH, "seed");
-		// dist-paths records what is INSTALLED here; an old surface would keep
-		// writing the frozen branch, so the cutover must not begin.
+		// This used to be a hard refusal: any `dist-paths/` entry below a
+		// fence-aware version floor refused the whole cutover. One un-upgraded
+		// fork-editor extension then pinned every repo on the machine at
+		// `uncutover` forever, with the reason only ever reaching `debug.log`.
+		// The risk it guarded — an old surface writing the frozen branch — is
+		// covered downstream by `probeCutoverDrift`, which reports such a write
+		// AND catch-up imports it (see the drift test below).
 		const distDir = join(home, ".jolli", "jollimemory", "dist-paths");
 		mkdirSync(distDir, { recursive: true });
 		const { writeFileSync } = await import("node:fs");
-		// The dist dir must EXIST: admission only counts entries whose directory
-		// is still there, so a ghost entry pointing at a deleted install is not
-		// stale — it is uninstalled.
 		const staleDist = join(dir, "stale-vscode-dist");
 		mkdirSync(staleDist, { recursive: true });
 		writeFileSync(join(distDir, "vscode"), `source=vscode@0.98.0\n${staleDist}\n`);
-		const result = await runCutover(cwd, { dbPath });
-		expect(result).toMatchObject({ status: "not-ready", reason: expect.stringContaining("vscode@0.98.0") });
-		expect(await readCutoverFence(cwd)).toBeNull();
-		// Upgrade the surface: admission passes and the cutover commits.
-		writeFileSync(join(distDir, "vscode"), `source=vscode@9.9.9\n${staleDist}\n`);
 		expect((await runCutover(cwd, { dbPath })).status).toBe("committed");
+		expect(await readCutoverFence(cwd)).not.toBeNull();
 	});
 
 	it("drift probe: a bypassing write is reported, imported, and KEEPS being reported", async () => {

--- a/cli/src/dashboard/CutoverEngine.ts
+++ b/cli/src/dashboard/CutoverEngine.ts
@@ -53,6 +53,7 @@ import type { StorageProvider } from "../core/StorageProvider.js";
 import { createLogger, errMsg, ORPHAN_BRANCH } from "../Logger.js";
 import type { CutoverRecord } from "./CutoverRouter.js";
 import { inTransaction, withDashboardDb, withReadonlyDashboardDb } from "./DashboardDb.js";
+import { IMPORT_FAMILIES, importTakesPath } from "./ImportablePaths.js";
 import { existingWorktrees, type RegisteredRepo, readRepoRegistry, resolveRepoIdentityForCwd } from "./RepoRegistry.js";
 import { countMemoriesAbsentFromListing, importRepoMemory } from "./SotImport.js";
 
@@ -88,8 +89,6 @@ export interface CutoverOptions {
 	readonly nowMs?: number;
 	/** Tip-moved retries before giving up (retries are normal, not errors). */
 	readonly maxRetries?: number;
-	/** Admission floor override — see {@link FENCE_AWARE_MIN_VERSION}. */
-	readonly minSurfaceVersion?: string;
 	/**
 	 * Per-source compare, injected so tests can pin protocol behavior without
 	 * a full orphan fixture. Defaults to {@link compareSourceContainment}.
@@ -101,35 +100,32 @@ export interface CutoverOptions {
 }
 
 /**
- * The default compare: every path the frozen tip lists must read back from
- * the database. Byte-exact for every family except summaries, which use the
+ * The default compare: every path the IMPORT WOULD TAKE must read back from the
+ * database. Byte-exact for every family except summaries, which use the
  * measured criterion (children are reassembled from CURRENT child rows —
  * fresher than the parent file's stale embedded copies) — shell-equal with an
  * identical child set and order. Containment by construction: paths only the
  * database has are never visited.
+ *
+ * "What the import would take", not "every file on the branch", and the
+ * difference is the whole point — see `ImportablePaths`. The old form demanded
+ * the database answer for files the import is designed never to store, which it
+ * can never do, on every attempt, forever.
  */
 export async function compareSourceContainment(
 	orphan: StorageProvider,
 	sqlite: SqliteStorage,
 ): Promise<{ ok: boolean; detail: string }> {
-	// Every family the orphan tree can carry. A family missing from this list is
-	// not "unchecked", it is INVISIBLE: containment only ever visits paths the
-	// list produces, so an absent family reports ok having read nothing — which
-	// is how archived skills came within one release of being certified and then
-	// silently unreadable.
-	const families = [
-		"summaries/",
-		"transcripts/",
-		"plans/",
-		"notes/",
-		"references/",
-		"skills/",
-		"plan-progress/",
-		"topics/",
-	];
 	let checked = 0;
-	for (const prefix of families) {
-		const paths = await orphan.listFiles(prefix);
+	for (const prefix of IMPORT_FAMILIES) {
+		const listed = await orphan.listFiles(prefix);
+		const paths = listed.filter((p) => importTakesPath(prefix, p));
+		const dropped = listed.length - paths.length;
+		// Not silent: a path the compare stops asking about is a deliberate
+		// narrowing, and this is the only place it can be seen.
+		if (dropped > 0) {
+			log.info("compare: %d path(s) under %s are not importable — not compared", dropped, prefix);
+		}
 		// batchReadFiles is optional on the interface; GitRefStorage has it, but
 		// keep an injected fake honest with a per-path fallback.
 		const want = orphan.batchReadFiles
@@ -143,28 +139,124 @@ export async function compareSourceContainment(
 			if (a === b) continue;
 			if (a == null || b == null) return { ok: false, detail: `${path}: missing from the database` };
 			if (path.startsWith("summaries/") && summariesEquivalent(a, b)) continue;
-			// `topics/index.json` and `topics/processed.json` ALONE. Both are
-			// synthesized UNION views: they are rendered from every row of the repo
-			// id, and step 2 imports every registered source into that one id
-			// (identity is the shared remote). So for a repo with two clones — which
-			// `collectSources` supports — the database renders A∪B and equality
-			// against A's file, or B's, can never hold; byte-comparing them made such
-			// a repo answer `not-ready` on every attempt and never converge. The
-			// criterion is CONTAINMENT (every entry the source lists is in the
-			// database), which is the same thing the family loop asserts for every
-			// other path and is why `index.json` / `catalog.json` are skipped below.
-			// A topic PAGE is not one of these: `topic_source_refs.pos` exists
-			// precisely to preserve its array order, and the `startsWith` this used
-			// to carry swallowed every page into the loose compare, certifying a
-			// reordered page as contained.
-			if (TOPIC_UNION_VIEWS.has(path) && jsonContains(a, b)) continue;
 			return { ok: false, detail: `${path}: content differs` };
+		}
+		// The two synthesized union views are not importable paths, so the loop
+		// above never yields them. They still have to be compared — by containment,
+		// against the whole-repo view the database renders. AFTER the pages, so a
+		// concrete missing page is what the user is told about: a page the database
+		// lacks also makes the index disagree, and "topics/index.json: content
+		// differs" points at a synthesized view rather than at the file to look at.
+		for (const view of TOPIC_UNION_VIEWS) {
+			if (!listed.includes(view)) continue;
+			checked++;
+			const verdict = await compareUnionView(view, orphan, sqlite, listed);
+			if (!verdict.ok) return verdict;
 		}
 	}
 	// index.json / catalog.json are synthesized views; their entries are
 	// covered by the summaries family above, so they are deliberately not
 	// byte-compared (entry order and stale copies are allowlisted).
 	return { ok: true, detail: `${checked} path(s) contained` };
+}
+
+/**
+ * `topics/index.json` / `topics/processed.json` — the two synthesized UNION
+ * views. Both are rendered from every row of the repo id, so equality against
+ * one source's file can never hold for a repo with more than one source; the
+ * criterion is CONTAINMENT (every entry the source lists is in the database),
+ * the same thing the family loop asserts for every other path. A topic PAGE is
+ * NOT one of these: `topic_source_refs.pos` exists precisely to preserve its
+ * array order, so pages stay byte-exact.
+ *
+ * `topics/index.json` gets one extra narrowing, for the same reason the whole
+ * importable-path rule exists: the database renders this view from
+ * `topic_pages`, and a row only exists where a PAGE FILE was imported. An index
+ * entry whose `topics/<slug>.json` is not on the branch therefore cannot be in
+ * the database on any run — the page and the index are two independent writes,
+ * and `saveTopicIndex` never prunes entries pointing at absent pages, so the
+ * state is stable and self-sustaining. Such entries are dropped from the SOURCE
+ * side before comparing, and named in the log: their `title` / `summary` /
+ * `sourceRefs` stop being served after the freeze. That is a real (small) loss,
+ * mitigated by the fence FREEZING the branch rather than deleting it — the
+ * bytes stay recoverable by hand — and by those entries' pages already being
+ * unopenable.
+ */
+async function compareUnionView(
+	view: string,
+	orphan: StorageProvider,
+	sqlite: SqliteStorage,
+	listed: ReadonlyArray<string>,
+): Promise<{ ok: boolean; detail: string }> {
+	const a = await orphan.readFile(view);
+	// Nothing on the source side to contain.
+	if (a == null) return { ok: true, detail: "" };
+	const b = await sqlite.readFile(view);
+	if (a === b) return { ok: true, detail: "" };
+	if (view === "topics/index.json") {
+		const { filtered, kept, dropped } = dropUnbackedTopicEntries(a, listed);
+		if (dropped.length > 0) {
+			// WARN, not info: every other narrowing in this file drops something the
+			// database was never meant to hold, but these entries carry `title` /
+			// `summary` / `sourceRefs` that really do stop being served. The whole
+			// reason the admission check came out is that a verdict nobody can see
+			// is a verdict nobody can act on — a content loss must not be quieter
+			// than the refusals it replaced.
+			log.warn(
+				"compare: %d topic index entr%s have no page file on the branch and will not be served after the freeze: %s",
+				dropped.length,
+				dropped.length === 1 ? "y" : "ies",
+				dropped.join(", "),
+			);
+		}
+		// `b == null` is a REAL state, not a failure: the database renders no index
+		// at all until it holds at least one topic page. It is contained exactly
+		// when nothing survived the filter — never by comparing against a
+		// synthesized empty document, which would also have to guess at the
+		// index's other fields (`schemaVersion`) and would fail on them.
+		if (b == null) {
+			return kept === 0 ? { ok: true, detail: "" } : { ok: false, detail: `${view}: missing from the database` };
+		}
+		if (jsonContains(filtered, b)) return { ok: true, detail: "" };
+		return { ok: false, detail: `${view}: content differs` };
+	}
+	if (b != null && jsonContains(a, b)) return { ok: true, detail: "" };
+	return { ok: false, detail: b == null ? `${view}: missing from the database` : `${view}: content differs` };
+}
+
+/**
+ * Drops index entries whose `topics/<stableSlug>.json` is absent from `listed`.
+ *
+ * An unparsable index returns unchanged, so the comparison falls back to the
+ * STRICTER form — a parse failure must never widen what is accepted.
+ */
+function dropUnbackedTopicEntries(
+	indexJson: string,
+	listed: ReadonlyArray<string>,
+): { filtered: string; kept: number; dropped: string[] } {
+	try {
+		const parsed = JSON.parse(indexJson) as { topics?: Array<{ stableSlug?: string }> };
+		// Same verdict as the `catch` below, and for the same reason: a document
+		// this function cannot interpret must fall back to the STRICTER form. The
+		// `kept: 1` is what keeps a null database side a failure — returning 0 here
+		// would widen acceptance on exactly the input we understand least.
+		/* v8 ignore next -- a well-formed index always carries the array */
+		if (!Array.isArray(parsed.topics)) return { filtered: indexJson, kept: 1, dropped: [] };
+		const pages = new Set(listed);
+		const dropped: string[] = [];
+		const topics = parsed.topics.filter((t) => {
+			const slug = typeof t?.stableSlug === "string" ? t.stableSlug : "";
+			if (slug && pages.has(`topics/${slug}.json`)) return true;
+			dropped.push(slug || "(no stableSlug)");
+			return false;
+		});
+		if (dropped.length === 0) return { filtered: indexJson, kept: topics.length, dropped };
+		return { filtered: JSON.stringify({ ...parsed, topics }), kept: topics.length, dropped };
+	} catch {
+		// Unparsable: fall back to the UNFILTERED document, so the comparison is
+		// the stricter one. `kept: 1` keeps a null database side a failure here.
+		return { filtered: indexJson, kept: 1, dropped: [] };
+	}
 }
 
 /** The refined summary criterion: byte-equal with children emptied on both sides, same child set/order. */
@@ -250,42 +342,6 @@ function canonJson(x: unknown): string {
 		);
 	}
 	return JSON.stringify(x);
-}
-
-/**
- * The first release whose surfaces understand the fence protocol. Admission
- * is decided by what is INSTALLED ON THIS MACHINE, not by what has shipped:
- * dist-paths records every registered surface as `source@version`, so "every
- * surface here is fence-aware" is locally decidable. An older surface would
- * keep writing the frozen branch (it reads only the derived disable bit at
- * its NEXT start, and running hosts not even that), so the cutover refuses
- * to begin until the machine is clean.
- */
-export const FENCE_AWARE_MIN_VERSION = "0.99.9";
-
-/** Machine-local admission: every installed surface must be fence-aware. */
-export async function checkCutoverAdmission(
-	minVersion: string = FENCE_AWARE_MIN_VERSION,
-): Promise<{ ok: boolean; stale: Array<{ source: string; version: string }> }> {
-	const { traverseDistPaths } = await import("../install/DistPathResolver.js");
-	const { compareSemver } = await import("../install/SemverCompare.js");
-	const stale = traverseDistPaths()
-		// `available` is what makes "installed" true. A dist-paths entry outlives
-		// the surface that wrote it (uninstall the VS Code extension and the file
-		// stays, pointing at a deleted directory), and `pickBestDistPath` filters
-		// those out for the same reason. Counting a ghost as stale would refuse
-		// the cutover forever with advice the user cannot act on: upgrade a
-		// surface that is not installed.
-		.filter((info) => info.available)
-		.filter((info) => {
-			try {
-				return compareSemver(info.version, minVersion) < 0;
-			} catch {
-				return true; // unparsable version — treat as too old, never as fine
-			}
-		})
-		.map((info) => ({ source: info.source, version: info.version }));
-	return { ok: stale.length === 0, stale };
 }
 
 /** What the drift probe found for one source. */
@@ -430,14 +486,23 @@ export async function runCutover(cwd: string, opts: CutoverOptions = {}): Promis
 	const nowMs = opts.nowMs ?? Date.now();
 	const maxRetries = opts.maxRetries ?? 3;
 	const compare = opts.compare ?? compareSourceContainment;
-	const admission = await checkCutoverAdmission(opts.minSurfaceVersion);
-	if (!admission.ok) {
-		const list = admission.stale.map((s) => `${s.source}@${s.version}`).join(", ");
-		return {
-			status: "not-ready",
-			reason: `stale surfaces installed on this machine: ${list} — upgrade them first (old surfaces would keep writing the frozen branch)`,
-		};
-	}
+	// NO machine-local admission check, and its absence is the decision. This
+	// used to refuse the whole cutover when any surface registered in
+	// `dist-paths/` was below a fence-aware version floor, on the theory that an
+	// old surface would keep writing the frozen branch. The cost of that theory
+	// was total: one un-upgraded fork-editor extension pinned every repo on the
+	// machine at `uncutover` forever, with the reason only ever reaching
+	// `debug.log` — the SQLite read path was unreachable in practice.
+	//
+	// The risk it guarded moves downstream to `probeCutoverDrift`, which reports
+	// a write that bypassed the fence AND catch-up imports it, so such a memory
+	// is reported rather than stranded. That trade only holds because the probe
+	// RUNS ON ITS OWN: `maybeAutoCutover` calls it (throttled) every time it
+	// finds a repo already in `cutover`. Leaving it reachable only from
+	// `jolli cutover --probe` would have swapped a visible refusal for a silent
+	// loss — after the fence reads come from SQLite, so a bypassed write shows no
+	// symptom the user could know to investigate. Do not remove that call site
+	// without restoring a guard here.
 	const { identity } = await resolveRepoIdentityForCwd(cwd);
 	const registry = await readRepoRegistry();
 	const repo = registry.repos.find((r) => r.repoIdentity === identity);
@@ -512,9 +577,12 @@ export async function runCutover(cwd: string, opts: CutoverOptions = {}): Promis
 		// legitimate seed removes).
 		let seedLegal = fencedRoots.size === 0 && sources.length === 1;
 		if (seedLegal) {
+			// The shared predicate, not a hand-inlined copy of it: this listing is
+			// compared against database rows the IMPORT wrote, so it has to be the
+			// import's own idea of what a summary file is.
 			const listed = new Set(
 				(await new GitRefStorage(sources[0].tip, sources[0].root).listFiles("summaries/"))
-					.filter((p) => p.endsWith(".json"))
+					.filter((p) => importTakesPath("summaries/", p))
 					.map((p) => p.slice("summaries/".length, -".json".length)),
 			);
 			// Fail CLOSED — see `countMemoriesAbsentFromListing`. Refusing costs a

--- a/cli/src/dashboard/ImportablePaths.test.ts
+++ b/cli/src/dashboard/ImportablePaths.test.ts
@@ -1,0 +1,97 @@
+/**
+ * ImportablePaths — the one rule two callers used to spell separately.
+ *
+ * It gets its own test rather than riding on its callers' because of where
+ * those callers live: the compare that exercises every REJECTING branch is
+ * `CutoverEngine.test.ts`, which is in the slow tier, so the inner loop saw
+ * this module at 94.1% statements / 85.7% branches — a pure string predicate
+ * under the floor for no better reason than which suite happened to call it.
+ * Everything here is a string test with no git, no storage and no fixture, so
+ * it belongs in the fast tier by nature.
+ */
+
+import { describe, expect, it } from "vitest";
+import { IMPORT_FAMILIES, importTakesPath, isTopicPagePath } from "./ImportablePaths.js";
+
+describe("isTopicPagePath", () => {
+	it("accepts a canonical page", () => {
+		expect(isTopicPagePath("topics/auth-refactor.json")).toBe(true);
+	});
+
+	it("rejects another family's path and a non-JSON topic file", () => {
+		// Both halves of the same guard: the import lists `topics/` and takes only
+		// the pages out of it, so a path from elsewhere and a stray extension are
+		// equally not-a-page.
+		expect(isTopicPagePath("summaries/a.json")).toBe(false);
+		expect(isTopicPagePath("topics/notes.md")).toBe(false);
+	});
+
+	it("rejects the two synthesized union views", () => {
+		// Not dropped on the floor — the cutover compare handles these separately,
+		// by containment. Answering true here would put them through the byte-exact
+		// page comparison, which a union view can never pass for a multi-source repo.
+		expect(isTopicPagePath("topics/index.json")).toBe(false);
+		expect(isTopicPagePath("topics/processed.json")).toBe(false);
+	});
+
+	it("rejects nested paths and an empty slug", () => {
+		expect(isTopicPagePath("topics/sub/page.json")).toBe(false);
+		expect(isTopicPagePath("topics/.json")).toBe(false);
+	});
+});
+
+describe("importTakesPath", () => {
+	it("applies each family's own extension", () => {
+		expect(importTakesPath("summaries/", "summaries/abc.json")).toBe(true);
+		expect(importTakesPath("transcripts/", "transcripts/abc.json")).toBe(true);
+		expect(importTakesPath("plan-progress/", "plan-progress/abc.json")).toBe(true);
+		expect(importTakesPath("plans/", "plans/a.md")).toBe(true);
+		expect(importTakesPath("notes/", "notes/a.md")).toBe(true);
+		expect(importTakesPath("references/", "references/a.md")).toBe(true);
+		expect(importTakesPath("skills/", "skills/claude/a.md")).toBe(true);
+		expect(importTakesPath("topics/", "topics/a.json")).toBe(true);
+	});
+
+	it("refuses the strays that used to block a cutover forever", () => {
+		// The measured shapes: an editor's scratch file and a backup copy. The
+		// import is designed never to store either, so the database can never
+		// answer for them — demanding it did made any such file a permanent,
+		// silent blocker.
+		expect(importTakesPath("notes/", "notes/scratch.txt")).toBe(false);
+		expect(importTakesPath("summaries/", "summaries/abc.json.bak")).toBe(false);
+	});
+
+	it("defers to isTopicPagePath for the topics family", () => {
+		expect(importTakesPath("topics/", "topics/index.json")).toBe(false);
+		expect(importTakesPath("topics/", "topics/sub/page.json")).toBe(false);
+	});
+});
+
+describe("IMPORT_FAMILIES", () => {
+	it("is the complete set, in compare order", () => {
+		// Pinned because a family dropped from this list is not "unchecked", it is
+		// INVISIBLE: the cutover's containment compare only ever visits paths this
+		// produces, so an absent family reports ok having read nothing. Archived
+		// skills came within one release of being certified that way and then
+		// silently unreadable.
+		expect([...IMPORT_FAMILIES]).toEqual([
+			"summaries/",
+			"transcripts/",
+			"plans/",
+			"notes/",
+			"references/",
+			"skills/",
+			"plan-progress/",
+			"topics/",
+		]);
+	});
+
+	it("every family answers for a path of its own", () => {
+		// Guards the pairing rather than the list: a prefix whose predicate belongs
+		// to a different family would still satisfy the assertion above.
+		for (const family of IMPORT_FAMILIES) {
+			const ext = family === "plans/" || family === "notes/" || family === "references/" || family === "skills/";
+			expect(importTakesPath(family, `${family}sample${ext ? ".md" : ".json"}`)).toBe(true);
+		}
+	});
+});

--- a/cli/src/dashboard/ImportablePaths.ts
+++ b/cli/src/dashboard/ImportablePaths.ts
@@ -1,0 +1,99 @@
+/**
+ * ImportablePaths — which orphan-branch paths the SoT import will actually take.
+ *
+ * One rule, in one place, because two places used to disagree about it and the
+ * disagreement was silent and permanent:
+ *
+ * - `importRepoMemory` filters every family listing before reading it (`.json`
+ *   for summaries / transcripts / plan-progress, `.md` for the four context
+ *   families, and `isTopicPagePath` for topic pages).
+ * - the cutover's step-3 compare walked the SAME prefixes with NO filter, and
+ *   required every path it found to read back from the database.
+ *
+ * Anything in the difference is a file the import is designed never to store,
+ * so the database can never answer for it — `missing from the database`, on
+ * every attempt, forever, with the reason only reaching `debug.log`. Measured
+ * examples: an editor's stray `notes/foo.txt`, a `summaries/x.json.bak`.
+ *
+ * The compare's criterion is therefore "every path the import WOULD take reads
+ * back", not "every file on the branch reads back". That is not a weaker
+ * guarantee: a file the import never reads is one the database was never meant
+ * to hold, so demanding it is asking the wrong question. What must not be lost —
+ * everything the import does take — is unchanged.
+ *
+ * `topics/index.json` and `topics/processed.json` are deliberately NOT importable
+ * paths: they are synthesized union views, compared by containment further up.
+ *
+ * A TRUE leaf — it imports nothing. That is load-bearing rather than tidy:
+ * `isTopicPagePath` lived in `TopicPageStore` first, and importing it from there
+ * broke five suites at module-init time. `TopicPageStore` is `vi.mock`ed all
+ * over the suite (it reaches `SummaryStore` and the orphan branch), so a mocked
+ * module handed this one `undefined` where a predicate belonged. The rule is a
+ * pure string test with no storage in it; `TopicPageStore` now imports it from
+ * here instead.
+ */
+
+/** Reserved file names under `topics/` that are NOT topic pages. */
+const RESERVED_TOPIC_NAMES = new Set(["index", "processed"]);
+
+/**
+ * Is `path` a canonical topic page — one of the files `listTopicPageSlugs`
+ * yields, and therefore one the import will actually take?
+ *
+ * Nested paths and the two reserved names answer false. Those are not dropped
+ * on the floor: the union views are compared separately, by containment.
+ */
+export function isTopicPagePath(path: string): boolean {
+	if (!path.startsWith("topics/") || !path.endsWith(".json")) return false;
+	const slug = path.slice("topics/".length, -".json".length);
+	return slug.length > 0 && !slug.includes("/") && !RESERVED_TOPIC_NAMES.has(slug);
+}
+
+/**
+ * Every family prefix the orphan tree can carry, with the predicate the import
+ * applies to it. A family missing from this list is not "unchecked", it is
+ * INVISIBLE to the compare — containment only ever visits paths this produces.
+ *
+ * `as const` is load-bearing: it is what makes {@link ImportFamily} a union of
+ * these eight literals, and therefore what makes a mistyped prefix at a call
+ * site a COMPILE error. Most callers do not iterate {@link IMPORT_FAMILIES} —
+ * `importRepoMemory` names its family inline, once per family — so without the
+ * literal type a typo would silently answer "the import takes nothing here" and
+ * drop a whole family with no error anywhere.
+ */
+const FAMILY_PREDICATES = [
+	["summaries/", (p: string) => p.endsWith(".json")],
+	["transcripts/", (p: string) => p.endsWith(".json")],
+	["plans/", (p: string) => p.endsWith(".md")],
+	["notes/", (p: string) => p.endsWith(".md")],
+	["references/", (p: string) => p.endsWith(".md")],
+	["skills/", (p: string) => p.endsWith(".md")],
+	["plan-progress/", (p: string) => p.endsWith(".json")],
+	["topics/", isTopicPagePath],
+] as const satisfies ReadonlyArray<readonly [prefix: string, takes: (path: string) => boolean]>;
+
+/** One of the eight family prefixes — the only thing `importTakesPath` accepts. */
+export type ImportFamily = (typeof FAMILY_PREDICATES)[number][0];
+
+/** The family prefixes, in compare order. */
+export const IMPORT_FAMILIES: ReadonlyArray<ImportFamily> = FAMILY_PREDICATES.map(([prefix]) => prefix);
+
+/**
+ * Derived from the list above, never written twice: a second literal here is the
+ * exact drift this module exists to remove.
+ */
+const PREDICATE_BY_FAMILY = Object.fromEntries(FAMILY_PREDICATES) as Record<ImportFamily, (path: string) => boolean>;
+
+/**
+ * Would the import take `path` from the family listed under `prefix`?
+ *
+ * Total on {@link ImportFamily}, so there is no "unknown prefix" branch to get
+ * wrong — an unknown prefix cannot be spelled.
+ *
+ * `topics/` answers false for the two union views and for nested paths, which is
+ * exactly what `listTopicPageSlugs` does — those are handled separately, not
+ * dropped.
+ */
+export function importTakesPath(prefix: ImportFamily, path: string): boolean {
+	return PREDICATE_BY_FAMILY[prefix](path);
+}

--- a/cli/src/dashboard/SotImport.ts
+++ b/cli/src/dashboard/SotImport.ts
@@ -42,6 +42,9 @@ import { listTopicPageSlugs, readTopicPage } from "../core/TopicPageStore.js";
 import { createLogger, errMsg, ORPHAN_BRANCH } from "../Logger.js";
 import type { CommitSummary, StoredTranscript, SummaryIndex } from "../Types.js";
 import { type DashboardDbHandle, inTransaction } from "./DashboardDb.js";
+// The same predicates the cutover compare asks. Behaviour is unchanged — this
+// is where the rule was, and it now has ONE home so the two cannot drift.
+import { importTakesPath } from "./ImportablePaths.js";
 import { cursorFingerprint, type ImportCursor, readImportStateRow, writeImportState } from "./ImportState.js";
 import { existingWorktrees, type RegisteredRepo } from "./RepoRegistry.js";
 import { REORDER_OFFSET } from "./SotSchema.js";
@@ -828,7 +831,7 @@ async function runRepoImport(db: DashboardDbHandle, opts: SotImportOptions): Pro
 
 	// ── read the orphan branch ─────────────────────────────────────────────
 	const index = await getIndex(cwd, storage);
-	const summaryPaths = (await storage.listFiles("summaries/")).filter((p) => p.endsWith(".json"));
+	const summaryPaths = (await storage.listFiles("summaries/")).filter((p) => importTakesPath("summaries/", p));
 	// Every prune set below is the FILE listing, not the parsed subset — see
 	// `pruneTable`.
 	const liveNodes = new Set(summaryPaths.map((p) => p.slice("summaries/".length, -".json".length)));
@@ -1158,7 +1161,7 @@ async function runRepoImport(db: DashboardDbHandle, opts: SotImportOptions): Pro
 	};
 
 	// ── transcripts + links, written inside each memory's slice ────────────
-	const transcriptPaths = (await storage.listFiles("transcripts/")).filter((p) => p.endsWith(".json"));
+	const transcriptPaths = (await storage.listFiles("transcripts/")).filter((p) => importTakesPath("transcripts/", p));
 	const liveTranscripts = new Set(transcriptPaths.map((p) => p.slice("transcripts/".length, -".json".length)));
 	/**
 	 * Transcripts this run has written a row for — and therefore the ONLY legal
@@ -1570,7 +1573,7 @@ async function runRepoImport(db: DashboardDbHandle, opts: SotImportOptions): Pro
 		docs++;
 	};
 
-	const planPaths = (await storage.listFiles("plans/")).filter((p) => p.endsWith(".md"));
+	const planPaths = (await storage.listFiles("plans/")).filter((p) => importTakesPath("plans/", p));
 	for (const path of planPaths) liveDocs.add(keyOf("plan", path.slice("plans/".length, -".md".length)));
 	const planContents = await readAll(storage, planPaths);
 	inChunkedTransactions(db, [...planContents.entries()], ([path, content]) => {
@@ -1580,7 +1583,7 @@ async function runRepoImport(db: DashboardDbHandle, opts: SotImportOptions): Pro
 		upsertDoc("plan", slug, content, { branch, originalSlug: original, title: markdownTitle(content) });
 	});
 
-	const notePaths = (await storage.listFiles("notes/")).filter((p) => p.endsWith(".md"));
+	const notePaths = (await storage.listFiles("notes/")).filter((p) => importTakesPath("notes/", p));
 	for (const path of notePaths) liveDocs.add(keyOf("note", path.slice("notes/".length, -".md".length)));
 	const noteContents = await readAll(storage, notePaths);
 	inChunkedTransactions(db, [...noteContents.entries()], ([path, content]) => {
@@ -1590,7 +1593,7 @@ async function runRepoImport(db: DashboardDbHandle, opts: SotImportOptions): Pro
 		upsertDoc("note", id, content, { branch, title: markdownTitle(content) });
 	});
 
-	const referencePaths = (await storage.listFiles("references/")).filter((p) => p.endsWith(".md"));
+	const referencePaths = (await storage.listFiles("references/")).filter((p) => importTakesPath("references/", p));
 	for (const path of referencePaths)
 		liveDocs.add(keyOf("reference", path.slice("references/".length, -".md".length)));
 	const referenceContents = await readAll(storage, referencePaths);
@@ -1614,7 +1617,7 @@ async function runRepoImport(db: DashboardDbHandle, opts: SotImportOptions): Pro
 	// `context` CHECKs source to kind='reference', and the segment is recoverable
 	// from `context_key` anyway (the reference rows store it twice only because
 	// their escaped native id is not).
-	const skillPaths = (await storage.listFiles("skills/")).filter((p) => p.endsWith(".md"));
+	const skillPaths = (await storage.listFiles("skills/")).filter((p) => importTakesPath("skills/", p));
 	for (const path of skillPaths) liveDocs.add(keyOf("skill", path.slice("skills/".length, -".md".length)));
 	const skillContents = await readAll(storage, skillPaths);
 	inChunkedTransactions(db, [...skillContents.entries()], ([path, content]) => {
@@ -1625,7 +1628,9 @@ async function runRepoImport(db: DashboardDbHandle, opts: SotImportOptions): Pro
 
 	// ── plan progress (canonical artifact JSON) ────────────────────────────
 	let planProgress = 0;
-	const progressPaths = (await storage.listFiles("plan-progress/")).filter((p) => p.endsWith(".json"));
+	const progressPaths = (await storage.listFiles("plan-progress/")).filter((p) =>
+		importTakesPath("plan-progress/", p),
+	);
 	const progressContents = await readAll(storage, progressPaths);
 	// Both spellings of an artifact's key count as live: the row it produced last
 	// time was keyed on `planSlug`, which an unreadable artifact cannot supply now.

--- a/specs/345-orphan-branch-cutover-fence-and-cas.md
+++ b/specs/345-orphan-branch-cutover-fence-and-cas.md
@@ -11,11 +11,11 @@ Freeze a repository's parallel summary ref permanently with a per-clone marker i
 - The freeze marker's shape, its per-clone scope, and the ordering rule that materializes the user's own opt-out alongside it.
 - Everything that changes behavior once a marker is present — enumerated site by site, including the two last-line refusals on the ref-backed write batch and the several places whose reconciliation is downgraded.
 - The one-way rules: never auto-revoked, never re-seeded after freezing, never rolled back from frozen-but-unrecorded.
-- The compare-and-swap protocol end to end: admission on installed surface versions, source collection, tip pinning, import, seed legality, the containment compare, the fence writes, the locked critical section, and the recording transaction.
+- The compare-and-swap protocol end to end: source collection, tip pinning, import, seed legality, the containment compare, the fence writes, the locked critical section, and the recording transaction.
 - The retry model, what counts as a retry-worthy condition, and the outcome when retries are exhausted.
 - Every outcome the protocol can report and what each one means about the repository's resulting state.
 - What triggers the protocol automatically, and the per-clone throttle that bounds it.
-- The post-swap drift probe: what it compares, what it repairs, and what it deliberately never updates.
+- The post-swap drift probe: what it compares, what it repairs, what it deliberately never updates, and what runs it without being asked.
 
 **Out of scope (boundaries):**
 
@@ -24,7 +24,6 @@ Freeze a repository's parallel summary ref permanently with a per-clone marker i
 - The import that fills the database from a pinned ref, and its per-mode reconciliation rules; this spec states only which mode is legal when, and why.
 - The advisory file lock the critical section takes — its on-disk convention, staleness ceiling, and the re-entrancy registry the one sanctioned bare acquire opts out of — covered by **Lock Primitive Registry** (297).
 - The repository profile's other fields and the durable manual-disable decision they encode (spec 145), beyond the ordering rule and the enable path's refusal to clear the marker.
-- Per-source version selection and what makes an installed surface "available" for the admission check.
 
 ## Data Contracts
 
@@ -57,10 +56,6 @@ A four-armed result:
 | `already-cutover` | A row already existed before anything was attempted. |
 | `not-ready` | Carries a reason. The repository is in a working state — either still unfrozen, or frozen with the recording pending. |
 | `retry-exhausted` | Every attempt found a moved tip or a busy lock. The marker is up; recording is pending. |
-
-### Admission floor
-
-The first release whose surfaces understand the marker: `0.99.9`. Admission is decided from what is **installed on this machine**, not from what has shipped.
 
 ## Behavior
 
@@ -96,7 +91,7 @@ The marker's writer does accept a removal request, which deletes the field and r
 
 Given a working directory:
 
-**Admission.** Enumerate every registered install surface on this machine that is actually **available** (an entry pointing at a deleted directory is a ghost and is skipped — counting one would refuse the swap forever with advice the user cannot act on: upgrade a surface that is not installed). Any available surface below the admission floor — including one whose version cannot be parsed, which counts as too old — makes the outcome `not-ready`, listing the stale surfaces. An older surface would keep writing the frozen ref, so the machine must be clean before the freeze begins.
+**No admission gate, and its absence is a decision.** The protocol once refused to begin whenever any install surface registered on this machine was below a fence-aware version floor, on the theory that an older surface would keep writing the frozen ref. The theory was right and the remedy was worse than the disease: one un-upgraded surface pinned *every* repository on the machine as unfrozen indefinitely, with the reason reaching only the debug log, which left the database read path unreachable in practice. The risk it guarded is carried instead by the drift probe below, which both reports a bypassing write and imports what it wrote — and which runs on its own schedule precisely so that this trade is not paid in silence. A version gate here may not be reintroduced without also re-deciding that.
 
 **Registration.** Resolve the repository's identity and find it in the repository registry. An unregistered repository is `not-ready` with an instruction to enable first.
 
@@ -154,7 +149,7 @@ Three callers:
 | The dashboard history import | No |
 | The dashboard command's own start path | Yes |
 
-The unthrottled caller is the one moment the database is known to have just been filled from the ref, which is when the containment compare is most likely to pass and when the user is already waiting on setup. The throttled callers suppress a repeat attempt for **six hours** after the last one, because the compare reads every file the frozen tip lists and a repository that keeps answering `not-ready` would otherwise pay that sweep on every commit and every dashboard reopen.
+The unthrottled caller is the one moment the database is known to have just been filled from the ref, which is when the containment compare is most likely to pass and when the user is already waiting on setup. The throttled callers suppress a repeat attempt for **two hours** after the last one, because an attempt is a full re-import of every source at its pinned tip *followed by* a read of every file that tip lists, and a repository that keeps answering `not-ready` would otherwise pay both on every commit and every dashboard reopen. Two hours rather than a longer window because the common `not-ready` reasons are transient — a tip that kept moving, a lock that stayed busy — and a window long enough to allow at most one attempt per working session leaves such a repository unfrozen for most of a day.
 
 The attempt timestamp is stamped into the profile **before** the attempt, not after, so a run that dies partway still spends its slot — otherwise a repeatedly-crashing compare would re-run on every single commit. It is only a throttle: neither witness ever consults it.
 
@@ -175,6 +170,14 @@ For each recorded tip:
 
 The probe's command surface prints one line per drifted source and sets a failing exit code when anything drifted.
 
+**The probe also runs without being asked**, and that is what makes it a safety net rather than a diagnostic. The same automatic trigger that presses the swap runs the probe instead whenever it finds a repository already recorded as cut over. Three properties:
+
+- It is **always throttled**, including for the caller that passes no throttle to the swap. That caller's justification — the database was just filled from the ref — is about the compare, and says nothing about drift, which is slow-moving by nature.
+- It throttles on its **own timestamp**, on the same two-hour window. The swap's timestamp stops being written the moment a repository is recorded, which is the only state the probe runs in, so sharing it would let the first probe fire and leave every later one reading a stamp nobody updates. The stamp is written **before** the probe for the same reason the swap's is.
+- Its failures are **contained**: a probe that throws must not change what the automatic trigger reports about a repository that is cut over and working.
+
+The reason it cannot be left to the command surface alone is that after the freeze reads come from the database, so a bypassed write produces **no symptom** — a user with nothing to investigate has no reason to run a diagnostic. Reaching it only by hand would have exchanged a visible refusal for a silent loss.
+
 ## State Transitions
 
 Per clone and per identity:
@@ -183,7 +186,7 @@ Per clone and per identity:
 - **frozen, unrecorded → recorded** — the transaction landed. Reported as `committed`.
 - **unfrozen → recorded, for a clone that has no marker** — another clone of the same remote completed the protocol. Such a clone is `cutover` from the routing table's point of view (the row outranks the marker) but has no local marker, so its ref write batch is refused by the second witness alone — and is *not* refused whenever the database cannot answer.
 - **frozen, unrecorded → frozen, unrecorded** — a retry-exhausted or post-freeze `not-ready` run. The repository keeps working: writes go to the database and reads come from it. A later run finishes the recording.
-- **prepared → prepared** — a `not-ready` before any marker was written (stale surfaces, unregistered repository, no ref, a failed compare). Nothing was frozen and nothing changed.
+- **prepared → prepared** — a `not-ready` before any marker was written (unregistered repository, no ref, a failed compare). Nothing was frozen and nothing changed.
 
 ## Notable Behavior
 


### PR DESCRIPTION
<!-- jollimemory-summary-start -->



## Quick recap

Three independent blockers were keeping every repository permanently stuck on the legacy git-based memory path, and this batch of work removed all three.

The most visible fix addressed the cutover comparison itself. The check that decides whether an import is complete enough to commit the switch was demanding files from the database that the import was explicitly designed to skip — non-markdown notes, backup files, nested topic paths, and topic index entries with no backing page. A single shared definition of which files each content family imports now governs both the import and the comparison, making future divergence between the two impossible. Topic index entries with no backing page are filtered out before the comparison runs, and an unparseable index now consistently falls back to the stricter byte-equality check in both of the cases where the document cannot be interpreted.

A second blocker was a machine-wide gate that checked every installed editor extension against a minimum version. One outdated extension was enough to refuse the cutover for every repository on the machine, with the rejection recorded only in a hidden log file. That gate was removed entirely. The underlying risk it guarded — old clients writing to a frozen branch — is now handled by the drift probe, which runs automatically on a two-hour throttle whenever the monitoring loop finds a repository already recorded as cut over. The probe runs on its own independent timestamp so it continues firing correctly long after the cutover attempt's own stamp stops being updated, and probe failures are contained locally so they cannot misrepresent a repository that is otherwise healthy.

A third blocker was a schema version gate that locked every surface out of the shared database file the moment any one surface ran a newer build. Surfaces at any version now open and write the file normally, with a single warn-once log line noting the version difference. Alongside that, the database migration runner was redesigned so that each change is identified by a permanent name rather than its position in a list, eliminating the silent-skip problem that occurred when two development branches each added a migration. Every migration attempt is now recorded in a new log table with its outcome, the surface that ran it, a timestamp, and the full text of what executed. The doctor tool gained a new report command that prints this full migration history and a repair command that can recover from the one state the runner cannot resolve on its own.

---

## E2E Test (5)
<details>
<summary><strong>1. Cutover completes even when an older editor extension is installed</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository that has been enabled for Jolli memory but has not yet switched over to the new database-backed system. Ensure at least one older version of a Jolli editor extension is installed alongside the current one.

**Steps:**
1. Open a terminal and run the cutover command for your repository (for example: `jolli cutover`).
2. Wait for the command to finish and read the status it prints.
3. Check that the repository is now reported as fully switched over.
4. Run `jolli cutover --status` to confirm the routing state.

**Expected Results:**
- The cutover command should complete with a "committed" or "cutover" status, not a "not-ready" message mentioning the older extension version.
- Running `jolli cutover --status` should show the repository is in the cutover state, not blocked or stuck.

</blockquote>
</details>
<details>
<summary><strong>2. Automatic drift detection catches a bypassing write with no user action</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository that has already been fully cut over to the database-backed memory system.

**Steps:**
1. Simulate an old editor or surface writing a new memory note to the frozen branch without going through the database (ask a developer to do this if you cannot do it yourself).
2. Wait for the next automatic memory update to trigger (for example, open a file in the editor so Jolli processes a commit).
3. Open the Jolli log file (usually found in the Jolli output panel or debug log).
4. Check the log for a warning message about drifted sources and a recommendation to run `jolli cutover --probe`.
5. Run `jolli cutover --probe` to confirm the bypassing write has already been imported.

**Expected Results:**
- The log should show a warning naming how many sources drifted and advising the user to stop the old client.
- Running `jolli cutover --probe` should report no new drift, confirming the stranded memory was already imported automatically.

</blockquote>
</details>
<details>
<summary><strong>3. Drift probe throttles automatically and does not re-run too frequently</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository already in the cutover state.

**Steps:**
1. Trigger two automatic memory update cycles back-to-back within a short time (for example, save two files in quick succession so Jolli processes two commits within a few minutes of each other).
2. Open the Jolli log file after both cycles complete.
3. Check how many times the drift probe ran by searching the log for "drift probe" entries.

**Expected Results:**
- The drift probe should appear in the log only once across the two cycles, not twice — confirming it is throttled and does not fire on every single update.

</blockquote>
</details>
<details>
<summary><strong>4. Cutover comparison ignores files the import was never designed to read</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository whose orphan branch contains stray files such as backup files (for example a file ending in `.bak`), plain text notes (ending in `.txt`), or nested folder paths inside the topics folder. The repository should not yet be cut over.

**Steps:**
1. Run `jolli cutover` for the repository.
2. Wait for the command to finish and read the status it prints.
3. If the status is not yet "committed", run `jolli cutover --status` to see the reason.

**Expected Results:**
- The cutover should complete successfully with a "committed" status.
- The status should NOT show a "not-ready" or "content differs" error caused by the stray or backup files — those files should be silently skipped rather than blocking the switch.

</blockquote>
</details>
<details>
<summary><strong>5. Topic index entries with no matching page file do not permanently block cutover</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a repository whose topic index lists one or more topic names that have no corresponding topic page file on the branch (for example, a topic that appears in the index but whose individual file was deleted). The repository should not yet be cut over.

**Steps:**
1. Run `jolli cutover` for the repository.
2. Wait for the command to finish and read the status it prints.
3. Open the Jolli log file and search for any warning about dropped topic entries.

**Expected Results:**
- The cutover should complete with a "committed" status rather than staying stuck at "not-ready" due to the missing page files.
- The log should contain a warning naming the topic entries that were dropped from the comparison because their page files were absent, so the user knows which topics stopped being served.

</blockquote>
</details>

---

## Topics (10)
<details>
<summary><strong>01 · Remove schema version gate blocking database writes across surfaces</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When any one surface running a newer build had bumped the shared database format number, every other surface was locked out of writing to that file entirely, causing the auto-cutover process to silently fail and leaving repositories permanently stuck on the old git-based memory path.

**💡 Decisions Behind the Code**

- **Remove the gate entirely rather than soften it**: Six long-lived processes share one database file, and the gate stopped all of them on every additive schema bump. Additive changes — nullable columns, new tables — are safe to ignore: unknown columns read back as their defaults and unknown tables are never touched. The cost of the gate was disproportionate to the risk it guarded.
- **Compatibility belongs to the release channel, not the database file**: The CLI and plugins ship on one version line, and the backend already gates per surface on its product version. A hard incompatibility is a release-line decision users can act on by upgrading a named surface — not a number buried in a file no user ever reads directly.
- **Warn once, never nag**: The git hook path opens the database on every commit. A per-open warning would flood the log on any machine where one surface is temporarily behind. Keying the warning on the version number seen means the second open of the same file is silent.

**✅ What Was Implemented**

- Removed `DashboardSchemaAheadError` and all version-gate checks from `DashboardDb.ts`, `CutoverRouter.ts`, `ImportState.ts`, and `CutoverEngine.ts`. A writable open now succeeds regardless of the stored format number. A single warn-once log line per process replaces the thrown error, keyed on the version number seen so repeated opens of the same file are silent.
- Replaced the exact-equality schema check in `DashboardServer.ts` with a one-sided floor check: the server skips its registry projection only when the database predates this build, not when it is ahead.
- Updated tests in `CutoverRouter.test.ts` and `ImportState.test.ts` to assert that a format-ahead database still returns real answers rather than `unavailable`, and inverted the `CutoverEngine.test.ts` case to confirm cutover reaches `committed` status on a format-ahead file.

**📁 FILES**
- `cli/src/dashboard/DashboardDb.ts`
- `cli/src/dashboard/CutoverRouter.ts`
- `cli/src/dashboard/CutoverEngine.ts`
- `cli/src/dashboard/DashboardServer.ts`
- `cli/src/dashboard/ImportState.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Fix cutover comparison to only check files the import actually reads</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The cutover process was permanently stuck in a "not ready" state even after a successful import. Files on the orphan branch that the import was explicitly designed to skip — non-markdown notes, backup files, nested topic paths, and topic index entries with no corresponding page — were being demanded from the database, which could never supply them.

**💡 Decisions Behind the Code**

- **One shared predicate, not two synchronized copies**: The import and the comparison previously maintained independent filtering logic that had silently diverged. Extracting the predicates into a single leaf module means any future change to what the import reads is automatically reflected in what the comparison demands — no coordination required and no possibility of silent re-divergence.
- **Leaf module placement is load-bearing, not cosmetic**: The predicate for topic pages was initially placed inside the topic storage module. That module is heavily mocked in tests, and a mocked module returned `undefined` where a function was expected, crashing five test suites at startup. Moving the predicate to a true leaf — one that imports nothing — and having the storage module reference it instead reversed the dependency and eliminated the problem entirely.
- **Union views compared after individual pages, null database treated as real state**: Placing the synthesized index comparison after the per-page loop ensures error messages name a concrete file the user can inspect. Treating a null database response as a genuine state rather than a failure prevents a false block when all index entries are unbacked; synthesizing a fake empty document to compare against was observed to fail on schema fields in practice.

**✅ What Was Implemented**

- Created `cli/src/dashboard/ImportablePaths.ts` as a zero-dependency leaf module defining, for each of the eight content families, the exact predicate the import uses to decide whether to read a file. Both `SotImport.ts` and `CutoverEngine.ts` now reference this single shared definition, making drift between the two impossible.
- Updated `compareSourceContainment` in `CutoverEngine.ts` to filter each family's file listing through the shared predicate before checking the database. Added a separate post-loop pass for the two synthesized union views, intentionally placed after per-page checks so that a missing page is reported by its own filename rather than by the aggregate index.
- Added `dropUnbackedTopicEntries` in `CutoverEngine.ts` to strip topic index entries whose page file is absent from the branch before comparing the index against the database. Dropped entries are logged by name; the frozen branch retains their bytes.
- The seed-legality check in `CutoverEngine.ts` that previously hand-inlined a summary-file filter was updated to call the shared predicate, removing the last independent duplicate of that rule in the file.

**📁 FILES**
- `cli/src/dashboard/ImportablePaths.ts`
- `cli/src/dashboard/CutoverEngine.ts`
- `cli/src/dashboard/SotImport.ts`
- `cli/src/core/TopicPageStore.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Automatic drift detection wired into post-cutover monitoring loop</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After the version-floor admission check was removed, the safety net it guarded — catching old clients that keep writing to the frozen branch — had no automatic trigger. The drift probe existed only as a manual command, meaning a user with no visible symptom had no reason to run it, and bypassed writes would be silently lost.

**💡 Decisions Behind the Code**

- **Always throttle the probe, ignoring the caller's throttle flag**: The caller that skips throttling for the cutover attempt does so because the database was just filled from the branch, making the containment compare most likely to pass. That reasoning is specific to the compare and says nothing about drift, which accumulates slowly. Applying the same unthrottled logic to the probe would mean a repository with a live bypassing writer pays a full catch-up import on every commit, indefinitely.
- **Separate timestamp from the cutover attempt's stamp**: The cutover attempt's timestamp stops being updated the moment a repository is recorded — exactly the state where the probe begins running. Sharing the field would mean the first probe fires correctly but every subsequent call reads a stamp nobody is updating, suppressing all future probes permanently. A dedicated field makes the two throttles independent and correct in their respective states.
- **Contain probe failures rather than propagating them**: The automatic trigger returns a status string that callers use for logging. A probe that throws and causes the caller to return a failure status would misrepresent a repository that is cut over and working correctly. Catching locally means probe errors surface as warnings without affecting the reported state.

**✅ What Was Implemented**

- `AutoCutover.ts` gained a new internal function that runs the drift probe on every call that finds a repository already recorded as cut over. The probe is always throttled on its own independent two-hour timestamp, even for the caller that normally skips throttling for the cutover attempt itself. The stamp is written before the probe fires, matching the same "spend the slot even if the run dies" rule the cutover attempt uses. Failures are caught locally so a probe error cannot change what the caller reports about a repository that is working correctly.
- `RepoProfile.ts` gained a new optional timestamp field tracking when the drift probe last ran, kept separate from the cutover attempt timestamp.
- Four new tests in `AutoCutover.test.ts` pin the key behavioral properties: a fence-bypassing write is caught and imported with no user action; the probe does not fire on the call that performs the cutover itself; the probe throttles on its own stamp; and the unthrottled cutover caller is still throttled for the probe.

**📁 FILES**
- `cli/src/dashboard/AutoCutover.ts`
- `cli/src/core/RepoProfile.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Remove machine-wide surface version gate blocking auto-cutover</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Any single outdated editor extension installed on a machine was permanently preventing every repository from switching to the new database-backed memory system. The rejection reason appeared only in a hidden log file, leaving users with no way to know why their memory had stopped updating.

**💡 Decisions Behind the Code**

- **Remove entirely rather than expose the result**: The original plan included surfacing the gate's verdict through status and diagnostic commands so users could act on it. Once the decision was made to remove the gate, that entire visibility layer became unnecessary and was discarded. Keeping a gate that silently blocks every repository on a machine — with no user-visible explanation — costs more than the risk it guards against.
- **Downstream safety net is sufficient**: The gate's stated purpose was to stop old surfaces from writing to a frozen branch. That scenario is already handled by the drift probe, which catches such writes and catch-up imports them. Removing the gate does not leave the system unprotected; it removes a redundant and disproportionately costly check.

**✅ What Was Implemented**

- Deleted the entire admission check from `CutoverEngine.ts`, including the version floor constant, the check function, and the option that allowed callers to override the floor. A comment was left in place explaining why this gate must not return.
- Inverted the existing test that verified the gate refused old surfaces into a regression guard confirming that an old surface no longer blocks the cutover.

**📁 FILES**
- `cli/src/dashboard/CutoverEngine.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Topic index comparison made stricter for unparseable documents</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The function that filters topic index entries before comparison had two branches for documents it could not interpret — a parse failure and a missing array field — but they returned opposite strictness levels. An unparseable index against an empty database would pass the comparison when it should have failed.

**💡 Decisions Behind the Code**

- **Stricter fallback for uninterpretable documents**: When the comparison function cannot understand a document, it must not widen what it accepts. Returning a "nothing survived" signal would certify a cutover for a document nobody has read. The cost of the stricter path is that a structurally odd but otherwise valid index might block a cutover unnecessarily — that is the correct trade-off, since the alternative is silently certifying an unverified state.
- **Warning level for content loss**: Logging a real content loss at the informational level would repeat the same mistake as the admission check that recorded its verdict only in a hidden log — a verdict nobody can see is a verdict nobody can act on.

**✅ What Was Implemented**

- In `CutoverEngine.ts`, the branch handling a well-formed but structurally unexpected index (missing topics array) was changed to return a "kept: 1" signal matching the parse-failure branch, so both uninterpretable cases fall back to the stricter byte-equality comparison.
- A new test case in `CutoverEngine.test.ts` pins this behavior: an unparseable index against an empty database must report the path as missing from the database, and reverting the fix makes the test pass incorrectly.
- The log level for dropped topic index entries was raised from informational to warning, on the grounds that these entries carry real content that stops being served after the freeze, making them a genuine content loss rather than a routine narrowing.

**📁 FILES**
- `cli/src/dashboard/CutoverEngine.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Named migration runner with full audit log replaces position-keyed approach</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When two development branches each added a database migration, the one merged second was silently skipped forever while the database was stamped as fully up to date. There was also no record of which surface ran which migration, making it impossible to diagnose why a database was in an unexpected state.

**💡 Decisions Behind the Code**

- **Name as permanent identity, not array position**: Two branches appending a migration each is a routine merge event. Under position-as-identity the second entry was stepped over forever with no trace. Under name-as-identity both entries are simply applied. The cost is that a name can never be changed or removed once it has shipped, which the fingerprint test enforces.
- **DDL drift warns rather than blocks**: The comparison is byte-exact against constants that are mostly prose comments. Re-wrapping a comment would have made every existing database refuse writes. The fingerprint test already catches genuine edits in CI on the author's machine, so a runtime block would only repeat that finding on a user's machine where the only remaining moves are a repair command or losing their session history.
- **Store the full DDL text, not a script name**: The DDL that ran may have come from a branch that was never merged or has since been deleted, and the user's machine has no repository to consult. Storing the text verbatim makes the log self-contained and doubles as the drift check without needing a separate checksum column.

**✅ What Was Implemented**

- Added `SCHEMA_MIGRATIONS_DDL` in `SotSchema.ts` creating a `schema_migrations` table that records every migration attempt with its name, outcome (`applied`, `failed`, `skipped`, `baseline`), the surface identity that ran it, a timestamp, duration, and the full DDL text that actually executed.
- Rewrote the migration runner in `DashboardDb.ts` to key off entry names rather than array positions, applying whichever named entries the log does not already carry. DDL drift — a stored entry whose text disagrees with this build's constant — now produces a named warning rather than a thrown error.
- Added `verifyMigrationLog`, `findDriftedMigrations`, `readMigrationLogState`, `recordMigrationAsApplied`, and `withRepairDashboardDb` to `DashboardDb.ts`. `MigrationFingerprints.test.ts` pins each entry's content hash so an edit to shipped DDL fails in CI before it reaches any user.

**📁 FILES**
- `cli/src/dashboard/DashboardDb.ts`
- `cli/src/dashboard/SotSchema.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Doctor tool gains migration history report and repair command</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After the migration log was introduced, there was no user-facing way to inspect what had run, diagnose drift, or recover from the one state the name-keyed runner cannot fix on its own: a log row that went missing while the database column it created still exists.

**💡 Decisions Behind the Code**

- **Existence check before the writable open**: A writable open creates the file if it does not exist. Running the repair on a machine that has never used the product used to manufacture an empty database and then report that it had no log — a diagnostic producing the artifact it was diagnosing. The file-existence check runs first and is read-only.
- **Four distinct states, not two**: Collapsing a corrupt or unreadable database into "no log yet" points the reader at the one explanation that is certainly wrong. The `tableConfirmed` flag on the unreadable state separates "the table is there but this build cannot query it" from "the database itself could not answer at all," because the two have different remedies.

**✅ What Was Implemented**

- Added `runSchemaLog` to `DoctorCommand.ts`, exposed as `jolli doctor --schema-log`. It prints the full migration log oldest-first, calls out any entries whose stored DDL disagrees with this build, and distinguishes four database states: rows present, no log table yet, log table unreadable, and database itself unreadable — each with a different message and exit code.
- Added `--mark-migration <name>` as a standalone flag that also implies `--schema-log`. It appends an `applied` row for the named entry using `withRepairDashboardDb` (no migration pass), returning distinct errors for unknown names, missing databases, and unreadable log tables.
- Added four test cases in `DoctorCommand.test.ts` covering: the full report lifecycle including drift detection; the no-database guard; the corrupt-file path; and reachability of the repair without the explicit schema-log flag.

**📁 FILES**
- `cli/src/commands/DoctorCommand.ts`
- `cli/src/dashboard/DashboardDb.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Type-safe family prefix prevents silent import gaps from typos</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The function that decides whether the import handles a given file path accepted any string as the family prefix. A mistyped prefix would silently return false, causing an entire family of files to be skipped during import with no compile-time or runtime error.

**💡 Decisions Behind the Code**

- **Literal union type over runtime validation**: Making the prefix type a compile-time union means the "unknown prefix" code path cannot exist — there is nothing to get wrong at runtime. The alternative (a runtime check with a warning or error) would still allow the bug to ship and only surface it during a test run or in production. The compile-time approach costs nothing at runtime and eliminates the failure mode entirely.
- **Derive the lookup table from the same declaration**: A separate record mapping prefixes to predicates is built from the same constant array, so there is no second place to update when a family is added or renamed. The previous find-based lookup left the "unreachable" fallback branch reachable in practice, since most callers name their family inline rather than iterating the list.

**✅ What Was Implemented**

- `ImportablePaths.ts` was restructured so the eight family prefix strings are declared `as const`, making them a literal union type exported as `ImportFamily`. The lookup function now accepts only that union type, turning any mistyped prefix into a compile error. The unreachable fallback branch (which previously returned false for unknown prefixes) was eliminated entirely.
- A lookup table is built from the same `as const` array, so there is no second place to update when a family is added or renamed.

**📁 FILES**
- `cli/src/dashboard/ImportablePaths.ts`
- `cli/src/dashboard/CutoverEngine.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · Spec and inline comments updated to reflect removal of version-floor admission check</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The admission check that refused to begin a cutover when any old client was installed had been removed, but the specification document and several inline comments still described it as an active part of the protocol, leaving documented behavior contradicting actual behavior.

**💡 Decisions Behind the Code**

The spec was updated to explain the removal as a deliberate trade-off rather than simply deleting the old text. The original admission check was correct in theory but catastrophic in practice — one un-upgraded extension pinned every repository on the machine indefinitely. Documenting the reasoning inline prevents a future reader from reinstating the gate without also reinstating the automatic probe that now carries the risk.

**✅ What Was Implemented**

- `specs/345-orphan-branch-cutover-fence-and-cas.md` had the admission floor section removed from the data contracts, the scope list updated to drop the per-surface version selection item, the protocol section replaced with an explanation of why the gate was removed and what now carries the risk it guarded, the throttle window corrected from six hours to two hours, and the drift probe section extended with the three properties of its automatic trigger.
- Inline comments in `CutoverCommand.ts` and `AutoCutover.ts` had "stale surface" removed from their lists of not-ready reasons, replaced with accurate descriptions of the current conditions.

**📁 FILES**
- `specs/345-orphan-branch-cutover-fence-and-cas.md`
- `cli/src/commands/CutoverCommand.ts`
- `cli/src/dashboard/AutoCutover.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · Dedicated fast-tier tests for importable path filtering rules</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After the cutover and topic index fixes landed, the module responsible for deciding which file paths count as importable had no tests of its own. Its only coverage came from a slower, heavier test suite, leaving the fast inner-loop tier reporting the module well below the project's statement and branch coverage thresholds.

**💡 Decisions Behind the Code**

- **Separate file over riding on callers' tests**: The module is a pure string predicate with no git access, no storage, and no fixtures, so it belongs in the fast tier by nature. Placing its tests inside the slow-tier caller suites was the root cause of the coverage gap — the fast tier simply never ran those exercises. A dedicated file makes the coverage source match the module's actual complexity tier and keeps the inner loop honest.
- **Pinned-order assertion with explanatory comment**: The family list is ordered, and a family dropped from it produces a silent false-positive in the cutover comparison rather than an error. The test pins the exact sequence and documents the failure mode in the comment so a future maintainer understands why the assertion exists and why reordering or removing an entry is dangerous.

**✅ What Was Implemented**

- Created `cli/src/dashboard/ImportablePaths.test.ts` with 9 tests covering all three exported symbols. Tests for the topic-page predicate verify acceptance of canonical pages, rejection of union-view files, rejection of nested paths, and rejection of non-JSON extensions. Tests for the per-family path predicate cover all eight content families, stray extensions, and delegation to the topic-page predicate for the topics family.
- Added a pinned-order test for the full family list with an explicit comment explaining that a family absent from this list is invisible to the cutover comparison — not merely unchecked — because the containment check only ever visits paths the list produces. The comment records that archived skills came within one release of being silently unreadable for exactly this reason.

**📁 FILES**
- `cli/src/dashboard/ImportablePaths.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 14, 2026 at 9:30 PM · via Anthropic*
<!-- jollimemory-summary-end -->