### PR TITLE
release: intellij 0.99.13

### DIFF
--- a/intellij/CHANGELOG.md
+++ b/intellij/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.99.13
+
+### Changes
+
+- **The FILES panel now matches the VS Code sidebar** — discard and "leave out of this memory" moved onto each row as hover buttons, so the panel's **AI Commit** and **Discard Selected** header buttons are gone. Committing lives on the Current Memory card.
+- **You can discard a single file from the Working Memory review too**, not just from the sidebar.
+
+### Fixes & Improvements
+
+- **Discarding a file is reliable now.** The bundled CLI does the work, so every kind of file behaves: renamed, copied, untracked and conflicted files used to fail quietly or remove the wrong thing, and one case left a file gone from both your disk and git.
+- **The confirmation matches what happens** — it used to promise to discard your changes and then delete the file.
+- **A discard that fails now tells you**, instead of reporting success while nothing happened.
+- **Unsaved editor changes are written to disk first** — without that, discarding a file you were still editing quietly did nothing.
+- **Files whose names contain `[`, `*` or `?` are safe** — discarding one of them could change a different file.
+- **Projects opened on a subdirectory of a repository work** — staging and discarding used to build the wrong paths.
+- **A repository moved to the local database is no longer shown as disabled.**
+
+### Performance
+
+- **Lighter with several AI sessions open** — one MCP server per checkout instead of one per session.
+- **Daily backups keep their own schedule** instead of waiting for a commit to wake Jolli up.
+
 ## 0.99.11
 
 ### New Features

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = "ai.jolli"
-version = "0.99.11"
+version = "0.99.13"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Bumps `intellij/build.gradle.kts` to **0.99.13** and adds the matching `CHANGELOG.md` section, which the changelog plugin renders into the JetBrains Marketplace change notes.

IntelliJ never shipped 0.99.12 — that version went out for the CLI and VS Code only — so this entry covers everything since the 0.99.11 release commit (b91621a9).

## No new features this release

Four commits touched `intellij/` in that window (`12a64762`, `3d45b46b`, `144ff3eb`, `7a5ea5a7`) and none of them is a user-facing new feature, so there is no **New Features** section.

The substance is `12a64762`, which moved the whole file-discard path into the bundled CLI's `FileDiscardService`. The plugin's own Kotlin copy of those rules handled three of the six index/worktree cases, and the ones it missed could destroy work:

- a rename it could not revert at all — the original path was dropped while parsing the file list;
- a both-added conflict unstaged and **deleted** despite `HEAD` having the file;
- a capitalisation-only rename that left neither path on disk while reporting success.

The rest of the entry follows from the same change (confirmation wording, failure reporting, unsaved editor buffers, literal pathspecs, subdirectory-opened projects), plus `3d45b46b`'s fix for a cutover-fenced repository reading back as user-disabled.

## Deliberately left out

Same judgment `b91621a9` made about the dashboard — listing either would advertise something the plugin cannot do:

- **The three reference sources CLI 0.99.12 added** (Vercel, Figma, Sentry). The `SourceId` enum stops at `zoom_meeting`, so a reference from one of them falls through to `SourceDisplay`'s neutral `R` / "Reference" placeholder with no source name or colour. Worth closing before it is announced.
- **`jolli dashboard`**, which still has no IntelliJ entry point. `3d45b46b` only made the sandbox build fail when the bundled CLI is missing its assets.

## Changelog style

Deliberately shorter than the 0.99.11 entry: one line per user-visible change in plain language, with the porcelain-status detail left to the commits it summarises.

## Verification

**Not verified with Gradle** — this machine has no JDK installed, so no `./gradlew` task can run here. Two reasons the parse is low-risk anyway: the changelog header format is unchanged from 0.99.11, and `changeNotes` renders `changelog.getAll()` rather than looking up one version, so it is not version-sensitive.

Reviewer with a JDK can confirm with:

    ./gradlew getChangelog

## Release note

`publish-intellij.yaml` takes no tag input — it publishes whatever `version` sits in `build.gradle.kts` on the branch you select. So this needs to be merged to `main` before the workflow is run against it.