### PR TITLE
Add session activity tracking and agent concurrency

### DIFF
--- a/cli/src/commands/DoctorCommand.test.ts
+++ b/cli/src/commands/DoctorCommand.test.ts
@@ -1,11 +1,17 @@
 /**
- * DoctorCommand tests — focused on the local-agent tool-selection diagnostic.
+ * DoctorCommand tests.
  *
  * Covers:
  *   - `getBackend` is probed with the configured `localAgentTool` (defaulting
  *     to "claude-code" when unset)
  *   - a failed probe's message includes that tool's login hint (LOCAL_AGENT_TOOLS)
  *     so a not-signed-in user gets actionable guidance
+ *   - `doctor --recover`'s survey / restore arms, against a real database
+ *   - the parked-event diagnostic and its `--fix`, also against a real database
+ *
+ * Note for anyone adding a case here: `withDashboardDb` must NOT be mocked in
+ * this file. Two describes build a real database through it, so a module-level
+ * replacement would silently rewire them into passing for the wrong reason.
  */
 
 import { mkdtemp, writeFile } from "node:fs/promises";
@@ -41,6 +47,8 @@ const h = vi.hoisted(() => ({
 	// one candidate fail without touching any other test's real repair behavior.
 	throwHash: "f".repeat(40),
 	findStrandedRoots: vi.fn(),
+	unparkStuckEvents: vi.fn(),
+	withReadonlyDashboardDb: vi.fn(),
 }));
 
 vi.mock("../dashboard/SessionSyncRunner.js", () => ({ runSessionSync: h.runSessionSync }));
@@ -124,6 +132,24 @@ vi.mock("../core/repair/StrandedTrees.js", () => ({ findStrandedRoots: h.findStr
 vi.mock("../install/DistPathResolver.js", () => ({ traverseDistPaths: h.traverseDistPaths }));
 vi.mock("../install/Installer.js", () => ({ getStatus: h.getStatus, install: h.install }));
 vi.mock("../PluginLoader.js", () => ({ inspectPlugins: h.inspectPlugins }));
+// Spread the originals and override ONLY the parked-event surface: `Backup.ts`
+// and `Recovery.ts` both import `withDashboardDb` from this module, so replacing
+// it wholesale would silently rewire the `doctor --recover` tests below.
+//
+// `withReadonlyDashboardDb` is NOT exclusive to the parked-event check, though it
+// once was: `runSchemaLog` reads the migration log through the same helper, so the
+// `doctor --schema-log` describe hands this seam back to the real implementation in
+// its own `beforeEach`. Under the default (a rejected open) that command reports an
+// unavailable database and prints no listing — a green-looking mock that answers the
+// wrong question.
+vi.mock("../dashboard/DashboardDb.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../dashboard/DashboardDb.js")>()),
+	withReadonlyDashboardDb: h.withReadonlyDashboardDb,
+}));
+vi.mock("../dashboard/StatsWriter.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../dashboard/StatsWriter.js")>()),
+	unparkStuckEvents: h.unparkStuckEvents,
+}));
 vi.mock("../Logger.js", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("../Logger.js")>();
 	return {
@@ -165,25 +191,42 @@ async function runDoctor(args: string[] = []): Promise<string[]> {
 
 const BASE_CONFIG: Partial<JolliMemoryConfig> = {};
 
-describe("DoctorCommand — local-agent tool diagnostic", () => {
-	beforeEach(() => {
-		vi.clearAllMocks();
-		process.exitCode = undefined;
-		h.resolveProjectDir.mockReturnValue("/repo");
-		h.readManualDisableFlag.mockResolvedValue(false);
-		h.getStatus.mockResolvedValue({ gitHookInstalled: true, claudeHookInstalled: true, geminiHookInstalled: true });
-		h.orphanBranchExists.mockResolvedValue(true);
-		h.resolveSotBackend.mockResolvedValue({ ok: true, state: "uncutover", storage: {} });
-		h.isWorkerLockStale.mockResolvedValue(false);
-		h.loadAllSessions.mockResolvedValue([]);
-		h.countActiveQueueEntries.mockResolvedValue(0);
-		h.loadConfig.mockResolvedValue(BASE_CONFIG);
-		h.resolveLlmCredentialSource.mockReturnValue("local-agent");
-		h.getGlobalConfigDir.mockReturnValue("/global");
-		h.traverseDistPaths.mockReturnValue([]);
-		h.inspectPlugins.mockResolvedValue([]);
-		h.findStrandedRoots.mockResolvedValue([]);
+/**
+ * Puts every probe on its healthy answer. Shared by the describes below so a
+ * new diagnostic's setup does not have to restate fifteen unrelated mocks —
+ * each test then overrides only the probe it is about.
+ */
+function healthyDefaults(): void {
+	vi.clearAllMocks();
+	process.exitCode = undefined;
+	h.resolveProjectDir.mockReturnValue("/repo");
+	h.readManualDisableFlag.mockResolvedValue(false);
+	h.getStatus.mockResolvedValue({ gitHookInstalled: true, claudeHookInstalled: true, geminiHookInstalled: true });
+	h.orphanBranchExists.mockResolvedValue(true);
+	h.resolveSotBackend.mockResolvedValue({ ok: true, state: "uncutover", storage: {} });
+	h.isWorkerLockStale.mockResolvedValue(false);
+	h.loadAllSessions.mockResolvedValue([]);
+	h.countActiveQueueEntries.mockResolvedValue(0);
+	h.loadConfig.mockResolvedValue(BASE_CONFIG);
+	h.resolveLlmCredentialSource.mockReturnValue("local-agent");
+	h.findStrandedRoots.mockResolvedValue([]);
+	// A discoverable agent CLI: without it the local-agent probe fails and pushes
+	// `exitCode` to 1, which then confounds any OTHER check's exit-code assertion.
+	h.getBackend.mockReturnValue({
+		discoverExecutable: vi.fn().mockResolvedValue({ file: "/usr/bin/claude", version: "2.0.0" }),
 	});
+	h.getGlobalConfigDir.mockReturnValue("/global");
+	h.traverseDistPaths.mockReturnValue([]);
+	h.inspectPlugins.mockResolvedValue([]);
+	// Default: no database to consult — the shape of a machine where no writer has
+	// ever run, and the state every other describe in this file already assumes.
+	// `getDashboardDbPath()` resolves under the mocked `/global` config dir, which
+	// does not exist, so `probeParkedEvents` returns `absent` before any open.
+	h.withReadonlyDashboardDb.mockRejectedValue(new Error("unable to open database file"));
+}
+
+describe("DoctorCommand — local-agent tool diagnostic", () => {
+	beforeEach(healthyDefaults);
 
 	afterEach(() => {
 		vi.clearAllMocks();
@@ -866,6 +909,16 @@ describe("doctor --recover", () => {
 });
 
 describe("doctor --schema-log", () => {
+	// The file-wide mock of `withReadonlyDashboardDb` exists for the parked-event
+	// check and defaults to a rejected open. `runSchemaLog` reads the log through
+	// the same helper, so without this every assertion below would be measuring the
+	// mock's failure rather than the command.
+	beforeEach(async () => {
+		const realDb =
+			await vi.importActual<typeof import("../dashboard/DashboardDb.js")>("../dashboard/DashboardDb.js");
+		h.withReadonlyDashboardDb.mockImplementation(realDb.withReadonlyDashboardDb);
+	});
+
 	it("prints the log, names a drift, and records a migration whose row went missing", async () => {
 		const { mkdtempSync, rmSync } = await import("node:fs");
 		const { tmpdir } = await import("node:os");
@@ -1107,106 +1160,182 @@ describe("doctor --schema-log", () => {
 	});
 });
 
-describe("doctor — parked events", () => {
-	it("reports parked events, and says nothing when there are none", async () => {
-		// Until this row a parked event was invisible in every direction: the projection
-		// wrote no `sessions` row to notice missing, nothing queries `events_raw`, and
-		// the prune deletes only `projected` rows so a failure does not even age out.
+describe("DoctorCommand — parked dashboard events", () => {
+	beforeEach(healthyDefaults);
+
+	afterEach(() => {
+		vi.clearAllMocks();
+		process.exitCode = undefined;
+	});
+
+	/** The one printed row this describe is about. */
+	const eventRow = (lines: ReadonlyArray<string>): string => lines.find((l) => l.includes("Dashboard events")) ?? "";
+
+	/**
+	 * Point `getDashboardDbPath()` at an isolated home and create the db FILE, so
+	 * `probeParkedEvents` passes its `existsSync` guard and reaches the (mocked)
+	 * open. The file's contents never matter — `withReadonlyDashboardDb` is the seam
+	 * that decides `counted` vs `unreadable`. Returns a teardown that removes it.
+	 */
+	async function withPresentDb(): Promise<() => void> {
+		const { mkdtempSync, rmSync, mkdirSync, writeFileSync } = await import("node:fs");
+		const { tmpdir } = await import("node:os");
+		const { join } = await import("node:path");
+		const home = mkdtempSync(join(tmpdir(), "jolli-doctor-parked-present-"));
+		const restoreHome = setIsolatedHome(home);
+		const configDir = join(home, ".jolli", "jollimemory");
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(join(configDir, "jollimemory.db"), "present");
+		h.getGlobalConfigDir.mockReturnValue(configDir);
+		return () => {
+			restoreHome();
+			rmSync(home, { recursive: true, force: true });
+		};
+	}
+
+	// Asserted on the ROW ICON rather than on `process.exitCode`: the exit code is
+	// the whole check list's verdict, so any unrelated probe (dist-paths is `✗`
+	// under these mocks) would make the assertion pass or fail for the wrong
+	// reason. The icon is this check's own status.
+
+	it("reports none parked when the database cannot be consulted at all", async () => {
+		// The default `getDashboardDbPath()` (under `/global`) does not exist, so the
+		// probe returns `absent` before any open — the honest shape of a machine where
+		// no writer has ever run. Doctor must still complete and still print the row:
+		// it is the command a user runs when things are broken.
+		const row = eventRow(await runDoctor());
+		expect(row).toMatch(/✓/);
+		expect(row).toMatch(/none parked/);
+	});
+
+	it("reports the database as present but unreadable when the open throws", async () => {
+		// The state that permanently disables the daemon's re-scan, and the one doctor
+		// used to print NOTHING for: the file exists (so `absent` is wrong) and the
+		// open throws (so a count is impossible). Its own row, no fixer — re-queuing
+		// cannot repair a database that will not open.
+		const teardown = await withPresentDb();
+		try {
+			h.withReadonlyDashboardDb.mockRejectedValue(new Error("database disk image is malformed"));
+			const row = eventRow(await runDoctor());
+			expect(row).toMatch(/⚠/);
+			expect(row).toMatch(/present but unreadable/);
+			expect(row).toMatch(/malformed/);
+			expect(row).toMatch(/re-scan is stopped/);
+		} finally {
+			teardown();
+		}
+	});
+
+	it("warns with the count rather than failing the run", async () => {
+		const teardown = await withPresentDb();
+		try {
+			// `probeParkedEvents` counts via `withReadonlyDashboardDb(countStuckEvents)`;
+			// the seam resolves the count directly.
+			h.withReadonlyDashboardDb.mockResolvedValue(10);
+			const row = eventRow(await runDoctor());
+			// ⚠ not ✗: the memories are safe in the system of record, so an otherwise
+			// healthy install must not start exiting non-zero over dashboard gaps.
+			expect(row).toMatch(/⚠/);
+			expect(row).not.toMatch(/✗/);
+			expect(row).toMatch(/10 event\(s\) parked/);
+		} finally {
+			teardown();
+		}
+	});
+
+	it("offers no fixer when nothing is parked", async () => {
+		const teardown = await withPresentDb();
+		try {
+			h.withReadonlyDashboardDb.mockResolvedValue(0);
+			await runDoctor(["--fix"]);
+			expect(h.unparkStuckEvents).not.toHaveBeenCalled();
+		} finally {
+			teardown();
+		}
+	});
+
+	it("--fix revives and drains against a real database, reporting both numbers", async () => {
+		// Against a REAL database rather than a stub: `withDashboardDb` cannot be
+		// mocked in this file (the `doctor --recover` test above builds a real
+		// database through it), and the fixer's whole claim is that the numbers are
+		// correct when the command exits — which only a real drain can show.
 		const { mkdtempSync, rmSync } = await import("node:fs");
 		const { tmpdir } = await import("node:os");
 		const { join } = await import("node:path");
 		const home = mkdtempSync(join(tmpdir(), "jolli-doctor-parked-"));
 		const restoreHome = setIsolatedHome(home);
-		const st = await import("../core/SessionTracker.js");
-		vi.mocked(st.getGlobalConfigDir).mockReturnValue(join(home, ".jolli", "jollimemory"));
-		try {
-			const { withDashboardDb } = await import("../dashboard/DashboardDb.js");
-
-			// No database at all — a normal state, not a fault, so the row is absent
-			// rather than reading a confident "0".
-			expect((await runDoctor()).join("\n")).not.toContain("Dashboard events");
-
-			// An empty database says nothing either.
-			await withDashboardDb(() => undefined);
-			expect((await runDoctor()).join("\n")).not.toContain("Dashboard events");
-
-			await withDashboardDb((db) =>
-				db
-					.prepare(
-						`INSERT INTO events_raw
-						   (event_id, repo_identity, type, schema_version, received_at, data_json,
-						    projection_status, failed_kind, attempts)
-						 VALUES ('session:r:codex:s', 'r', 'session.upserted', 1, '2026-08-01T00:00:00.000Z',
-						         '{}', 'failed', 'error', 5)`,
-					)
-					.run(),
-			);
-
-			const out = (await runDoctor()).join("\n");
-			expect(out).toContain("Dashboard events");
-			expect(out).toContain("1 event(s) parked unprojected");
-		} finally {
-			restoreHome();
-			rmSync(home, { recursive: true, force: true });
-		}
-	});
-
-	it("does not count a row the next writable open revives by itself", async () => {
-		// `drainPending` un-parks `unknown-type` rows whose type this build now understands
-		// on every writable open — a version-skew artefact (an older CLI parked an event a
-		// newer VS Code build wrote) whose repair is the upgrade that already happened.
-		// Counting them made this row assert "some conversations may be missing from the
-		// dashboard", with no fixer to offer, for rows the next commit silently revives.
-		const { mkdtempSync, rmSync } = await import("node:fs");
-		const { tmpdir } = await import("node:os");
-		const { join } = await import("node:path");
-		const home = mkdtempSync(join(tmpdir(), "jolli-doctor-revivable-"));
-		const restoreHome = setIsolatedHome(home);
-		const st = await import("../core/SessionTracker.js");
-		vi.mocked(st.getGlobalConfigDir).mockReturnValue(join(home, ".jolli", "jollimemory"));
-		try {
-			const { withDashboardDb } = await import("../dashboard/DashboardDb.js");
-			await withDashboardDb((db) =>
-				db
-					.prepare(
-						`INSERT INTO events_raw
-						   (event_id, repo_identity, type, schema_version, received_at, data_json,
-						    projection_status, failed_kind, attempts)
-						 VALUES ('session:r:codex:revivable', 'r', 'session.upserted', 1,
-						         '2026-08-01T00:00:00.000Z', '{}', 'failed', 'unknown-type', 5)`,
-					)
-					.run(),
-			);
-
-			expect((await runDoctor()).join("\n")).not.toContain("Dashboard events");
-		} finally {
-			restoreHome();
-			rmSync(home, { recursive: true, force: true });
-		}
-	});
-
-	it("says a database that is present and unreadable, instead of nothing at all", async () => {
-		// The state the bare `catch { return null }` folded in with "no database": a zero-byte
-		// or truncated `jollimemory.db` opens READ-ONLY without error and throws on the first
-		// statement. It is also the state that permanently stops the daemon's re-scan, and the
-		// one command whose job is to tell these apart printed no row for it.
-		const { mkdirSync, mkdtempSync, rmSync, writeFileSync } = await import("node:fs");
-		const { tmpdir } = await import("node:os");
-		const { join } = await import("node:path");
-		const home = mkdtempSync(join(tmpdir(), "jolli-doctor-unreadable-"));
-		const restoreHome = setIsolatedHome(home);
-		const st = await import("../core/SessionTracker.js");
 		const configDir = join(home, ".jolli", "jollimemory");
-		vi.mocked(st.getGlobalConfigDir).mockReturnValue(configDir);
+		h.getGlobalConfigDir.mockReturnValue(configDir);
+		// Delegate the mocked seam back to the real implementations for this test.
+		const real = await vi.importActual<typeof import("../dashboard/StatsWriter.js")>("../dashboard/StatsWriter.js");
+		const realDb =
+			await vi.importActual<typeof import("../dashboard/DashboardDb.js")>("../dashboard/DashboardDb.js");
+		// `probeParkedEvents` counts via `withReadonlyDashboardDb(countStuckEvents)` —
+		// countStuckEvents stays REAL (spread), so only the read-only handle and the
+		// fixer's un-park need delegating back to their real implementations.
+		h.unparkStuckEvents.mockImplementation(real.unparkStuckEvents);
+		h.withReadonlyDashboardDb.mockImplementation(realDb.withReadonlyDashboardDb);
 		try {
-			const { getDashboardDbPath } = await import("../dashboard/DashboardDb.js");
-			const dbPath = getDashboardDbPath();
-			mkdirSync(join(dbPath, ".."), { recursive: true });
-			writeFileSync(dbPath, "");
+			const { STATS_EVENT_SCHEMA_VERSION } = await import("../dashboard/DashboardModel.js");
+			const dbPath = join(configDir, "jollimemory.db");
+			// One event that cannot be projected, driven to `failed` the only way a
+			// real one gets there: by spending its whole attempt budget.
+			await realDb.withDashboardDb(
+				(db) =>
+					db
+						.prepare(
+							`INSERT INTO events_raw (event_id, type, schema_version, received_at, data_json)
+							 VALUES ('bad', 'session.upserted', ?, 't', 'not json')`,
+						)
+						.run(STATS_EVENT_SCHEMA_VERSION),
+				{ dbPath },
+			);
+			for (let i = 0; i < 5; i++) await real.applyStatsEvents([], { producerKind: "cli", dbPath });
+			expect(await realDb.withReadonlyDashboardDb((db) => real.countStuckEvents(db), { dbPath })).toBe(1);
 
-			const out = (await runDoctor()).join("\n");
-			expect(out).toContain("Dashboard events");
-			expect(out).toContain("present but unreadable");
+			const lines = (await runDoctor(["--fix"])).join("\n");
+
+			// Nothing was actually recovered: one drain spends ONE attempt, so the row
+			// is back to `pending` rather than projected or re-parked. The message has
+			// to say that — "1 revived" alone would read as a completed repair. The
+			// leftover is COUNTED off the table (`drainPending`'s `pending`), not
+			// derived as `revived - projected` — that subtraction ignored the
+			// `DRAIN_BATCH_SIZE` cap and could go negative when rows were already
+			// queued before the un-park.
+			expect(lines).toMatch(/Dashboard events: 1 revived, 0 projected, 1 still queued \(will retry\)/);
+
+			// Park it again — the fix above left it `pending`, and the point of the
+			// next assertion is that the FIXER is what recovers it.
+			for (let i = 0; i < 5; i++) await real.applyStatsEvents([], { producerKind: "cli", dbPath });
+			expect(await realDb.withReadonlyDashboardDb((db) => real.countStuckEvents(db), { dbPath })).toBe(1);
+
+			// Now the blocker is gone — the real case: an event that failed against a
+			// table a skipped migration never created, replayed after the repair.
+			await realDb.withDashboardDb(
+				(db) =>
+					db.prepare("UPDATE events_raw SET data_json = ? WHERE event_id = 'bad'").run(
+						JSON.stringify({
+							type: "session.upserted",
+							repoIdentity: "repo-1",
+							source: "claude",
+							sessionId: "s1",
+							updatedAtMs: 1_700_000_000_000,
+							messageCount: 1,
+							models: [],
+							tokenCoverage: "none",
+						}),
+					),
+				{ dbPath },
+			);
+			expect((await runDoctor(["--fix"])).join("\n")).toMatch(/Dashboard events: 1 revived, 1 projected/);
+
+			// The race the fixer guards against: the diagnosis saw a parked row on its
+			// own read-only handle, but by the time the fixer took the write lock
+			// another doctor had already revived it. Forced here by making the probe's
+			// read-only count report one while the real database (which the fixer's
+			// writable handle sees) is clean.
+			h.withReadonlyDashboardDb.mockResolvedValue(1);
+			expect((await runDoctor(["--fix"])).join("\n")).toMatch(/Dashboard events: nothing parked/);
 		} finally {
 			restoreHome();
 			rmSync(home, { recursive: true, force: true });

--- a/cli/src/commands/DoctorCommand.ts
+++ b/cli/src/commands/DoctorCommand.ts
@@ -51,7 +51,6 @@ import {
 } from "../dashboard/Recovery.js";
 import { backupRepoRegistry, forgetRepos, type RegistrySurvey, surveyRepoRegistry } from "../dashboard/RepoForget.js";
 import { getRepoRegistryPath, type RegistryRepair, repairRegistryEntries } from "../dashboard/RepoRegistry.js";
-import { countStuckEvents } from "../dashboard/StatsWriter.js";
 import { traverseDistPaths } from "../install/DistPathResolver.js";
 import { getStatus, install } from "../install/Installer.js";
 import { createLogger, errMsg, ORPHAN_BRANCH, setLogDir } from "../Logger.js";
@@ -59,48 +58,6 @@ import { inspectPlugins } from "../PluginLoader.js";
 import { resolveProjectDir, VERSION } from "./CliUtils.js";
 
 const log = createLogger("doctor");
-
-/** What {@link probeParkedEvents} could establish about the event log. */
-type ParkedProbe =
-	/** Counted. `stuck` excludes the rows a later build revives by itself. */
-	| { readonly kind: "counted"; readonly stuck: number }
-	/** No database to ask — below the `node:sqlite` floor, or never opened. */
-	| { readonly kind: "absent" }
-	/** A database that is there and cannot be read. */
-	| { readonly kind: "unreadable"; readonly reason: string };
-
-/**
- * Asks the event log how many parked events need a human, distinguishing the three
- * answers a diagnostic must not conflate.
- *
- * The bare `catch { return null }` this replaced folded "no database" together with
- * "corrupt database" — and got the second one exactly backwards for the one command whose
- * job is to tell them apart. A zero-byte or truncated `jollimemory.db` opens read-only
- * WITHOUT error and throws on the first statement, so it landed in the same silent branch
- * as a machine that has simply never opened the dashboard, and `jolli doctor` printed no row
- * at all for the state that permanently disables the daemon's re-scan
- * (`idleReason: "database-unusable"`).
- *
- * Absence is decided BEFORE the open, by `existsSync`, and not from the error — measured:
- * a read-only open of a missing file throws `ERR_SQLITE_ERROR: unable to open database
- * file`, carrying no `ENOENT` code, so an error-shape test cannot tell "never created" from
- * "there and broken" at all. Same order, and the same reason, as `dbRescanSessions`'
- * `no-database` / `database-unusable` split.
- *
- * Read-only on purpose, in both directions: `withReadonlyDashboardDb` throws where the
- * writable handle would CREATE the file, and a diagnostic must not drain the log either —
- * counting through a writable handle would run `drainPending` and change the answer it is
- * reporting.
- */
-async function probeParkedEvents(): Promise<ParkedProbe> {
-	if (!canUseDashboardDb()) return { kind: "absent" };
-	if (!existsSync(getDashboardDbPath())) return { kind: "absent" };
-	try {
-		return { kind: "counted", stuck: await withReadonlyDashboardDb((db) => countStuckEvents(db)) };
-	} catch (err: unknown) {
-		return { kind: "unreadable", reason: errMsg(err) };
-	}
-}
 
 /** Individual check result returned by each diagnostic probe. */
 export interface DoctorCheck {
@@ -311,6 +268,96 @@ export function formatRepoRegistryReadFailure(reason: string, path: string): Doc
 			"      · no repo can register until this is resolved; move the file aside and re-run `jolli enable`\n" +
 			"        in each repo to rebuild it (every registration in it is lost)",
 	};
+}
+
+/** What {@link probeParkedEvents} could establish about the event log. */
+type ParkedProbe =
+	/** Counted. `stuck` excludes the rows a later build revives by itself. */
+	| { readonly kind: "counted"; readonly stuck: number }
+	/** No database to ask — below the `node:sqlite` floor, or never opened. */
+	| { readonly kind: "absent" }
+	/** A database that is there and cannot be read. */
+	| { readonly kind: "unreadable"; readonly reason: string };
+
+/**
+ * Asks the event log how many parked events need a human, distinguishing the
+ * three answers a diagnostic must not conflate.
+ *
+ * Folding "no database" together with "corrupt database" gets the second one
+ * backwards for the one command whose job is to tell them apart. A zero-byte or
+ * truncated `jollimemory.db` opens read-only WITHOUT error and throws on the first
+ * statement, so it lands in the same silent branch as a machine that has never
+ * opened the dashboard — and `jolli doctor` then prints no row at all for the
+ * state that permanently disables the daemon's re-scan (`database-unusable`).
+ *
+ * Absence is decided BEFORE the open, by `existsSync`, not from the error — a
+ * read-only open of a missing file throws `ERR_SQLITE_ERROR: unable to open
+ * database file` carrying no `ENOENT`, so an error-shape test cannot tell "never
+ * created" from "there and broken".
+ *
+ * Read-only on purpose: `withReadonlyDashboardDb` throws where a writable handle
+ * would CREATE the file, and a diagnostic must not drain the log — counting
+ * through a writable handle would run `drainPending` and change the answer it is
+ * reporting. {@link countStuckEvents} is the count deliberately: it matches the
+ * daemon's own `failedEvents` metric (whose log line points here) and the set
+ * {@link unparkStuckEvents} `--fix` can actually reach.
+ */
+async function probeParkedEvents(): Promise<ParkedProbe> {
+	if (!canUseDashboardDb()) return { kind: "absent" };
+	if (!existsSync(getDashboardDbPath())) return { kind: "absent" };
+	try {
+		const { countStuckEvents } = await import("../dashboard/StatsWriter.js");
+		return { kind: "counted", stuck: await withReadonlyDashboardDb((db) => countStuckEvents(db)) };
+	} catch (err) {
+		return { kind: "unreadable", reason: errMsg(err) };
+	}
+}
+
+/**
+ * `doctor --fix` for parked events: returns them to the queue AND drains, so the
+ * numbers are correct when the command exits.
+ *
+ * Draining here rather than leaving it to the next natural drain is the point.
+ * Un-parking alone is honest but useless as a fix: the next drain is whatever
+ * comes first — a commit's QueueWorker or the editor's 60 s tick — so a user who
+ * is not committing right now would read `10 event(s) returned to the queue`,
+ * see the dashboard unchanged, and reasonably conclude `--fix` did nothing. The
+ * cost is that doctor now does projection work while holding the writable
+ * handle, contending with hooks for SQLite's single writer; one bounded batch
+ * (`DRAIN_BATCH_SIZE`) covers any realistic parked set, and doctor is an
+ * interactive command, not a hot path.
+ *
+ * The projected count is reported alongside the revived one because they can
+ * differ, and the difference is the whole answer: an event that fails again is
+ * NOT re-parked by this call. Measured: one drain spends exactly ONE attempt, so
+ * a still-defective row comes back `pending` with `attempts = 1` and only re-parks
+ * after five failed drains. Reporting "1 revived" alone would read as a completed
+ * repair when nothing was actually recovered.
+ *
+ * What is left over is taken from `drainPending`'s own `pending` — a COUNT off
+ * the table — never from `revived - projected`. That subtraction was wrong in
+ * both directions: the drain is capped at `DRAIN_BATCH_SIZE`, so a large parked
+ * set leaves rows this pass never claimed and the difference understates them;
+ * and `projected` also counts pending rows that were already queued before the
+ * un-park, so it can exceed `revived` and make the difference negative. The
+ * table knows the answer, and it is asked.
+ *
+ * Fixer contract (see the "Git hooks" fixer): THROW on failure so the doctor
+ * loop records it; return a string describing what was done on success.
+ */
+async function repairParkedDashboardEvents(): Promise<string> {
+	const { withDashboardDb } = await import("../dashboard/DashboardDb.js");
+	const { drainPending, unparkStuckEvents } = await import("../dashboard/StatsWriter.js");
+	return await withDashboardDb((db) => {
+		const revived = unparkStuckEvents(db);
+		// Reachable despite the fixer being attached only when the count is
+		// non-zero: the diagnosis read a different, read-only handle, and another
+		// doctor may have won the race in between.
+		if (revived === 0) return "nothing parked";
+		const { projected, pending } = drainPending(db);
+		if (pending === 0) return `${revived} revived, ${projected} projected`;
+		return `${revived} revived, ${projected} projected, ${pending} still queued (will retry)`;
+	});
 }
 
 /**
@@ -668,38 +715,42 @@ async function runDoctor(cwd: string, fix: boolean, dryRun = false, forgetDead =
 		checks.push(formatRepoRegistryReadFailure(errMsg(err), getRepoRegistryPath()));
 	}
 
-	// 12. Parked events. A `session.upserted` that never projected is a conversation
-	// the dashboard will never show, and until this row nothing reported one: no
-	// projected row to notice missing, no reader that queries `events_raw`, and a
-	// prune that only ever deletes `projected` rows so a failure does not even age
-	// out. WARN rather than fail, and with no fixer — deciding what to do with a
-	// parked event needs its reason, so this row's whole job is to make the number
-	// visible before anyone designs that.
+	// 12. Parked dashboard events — the ONE fault in this list that is otherwise
+	// invisible. An event that never projects is a conversation the dashboard will
+	// never show, and nothing else reports one: no projected row to notice missing,
+	// no reader that queries `events_raw`, and a prune that only deletes `projected`
+	// rows so a failure never even ages out. `warn` rather than `fail`: the memories
+	// themselves are safe in the system of record, so this must not make an
+	// otherwise-healthy install exit non-zero.
 	//
-	// Two rows, because the probe has two failure answers and they need opposite
-	// wording. `countStuckEvents` already excludes the `unknown-type` rows a later
-	// build un-parks by itself, so a non-zero count here really does need a human —
-	// the count it replaced included them, and asserted "some conversations may be
-	// missing" for rows the next commit silently revives, with no fixer to offer.
-	// An unreadable database is the state that permanently disables the daemon's
-	// re-scan, and the whole point of this row is that `jolli doctor` used to print
-	// nothing at all for it.
-	//
-	// The name is 16 characters in both, because the printer below pads to 16 and does
-	// not truncate — a longer name pushes the message out of the aligned column.
+	// The probe has three answers and they need different wording. `counted` uses
+	// `countStuckEvents`, which excludes the `unknown-type` rows a later build revives
+	// by itself — so a non-zero count really does need a human — and matches BOTH the
+	// daemon's `failedEvents` metric (whose log line sends the user here) and the set
+	// `--fix` (`unparkStuckEvents`) can actually return to the queue. `unreadable` is
+	// its own row because an unreadable database is precisely the state that
+	// permanently disables the daemon's re-scan, and doctor used to print nothing at
+	// all for it; no fixer, because re-queuing cannot repair a database that will not
+	// open.
 	const parked = await probeParkedEvents();
-	if (parked.kind === "counted" && parked.stuck > 0) {
-		checks.push({
-			name: "Dashboard events",
-			status: "warn",
-			message: `${parked.stuck} event(s) parked unprojected — some conversations may be missing from the dashboard`,
-		});
-	}
 	if (parked.kind === "unreadable") {
 		checks.push({
 			name: "Dashboard events",
 			status: "warn",
 			message: `dashboard database present but unreadable (${parked.reason}) — the background re-scan is stopped`,
+		});
+	} else {
+		const stuck = parked.kind === "counted" ? parked.stuck : 0;
+		checks.push({
+			name: "Dashboard events",
+			status: stuck > 0 ? "warn" : "ok",
+			message:
+				stuck > 0
+					? `${stuck} event(s) parked after repeated projection failures — dashboard figures are incomplete`
+					: "none parked",
+			// Attached only when there is something to do, so `--fix` on a healthy
+			// machine does not print a line about work it did not need to perform.
+			...(stuck > 0 ? { fixer: repairParkedDashboardEvents } : {}),
 		});
 	}
 

--- a/cli/src/commands/IdeBridgeCommand.test.ts
+++ b/cli/src/commands/IdeBridgeCommand.test.ts
@@ -254,6 +254,13 @@ vi.mock("../core/JolliMemoryPushOrchestrator.js", () => ({
 	latestPlanPerName: vi.fn((plans: unknown[]) => plans),
 }));
 
+// The push-time session enrichment the `serialize-summary` op now derives (there is
+// no Kotlin equivalent). Defaults to "no sessions" so the existing serialize cases
+// behave exactly as before; the enrichment case overrides it per-test.
+vi.mock("../core/TranscriptSessionMeta.js", () => ({
+	collectTranscriptSessionMeta: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock("../core/GitRemoteUtils.js", () => ({
 	getCanonicalRepoUrl: vi.fn().mockResolvedValue("git@github.com:acme/repo.git"),
 	deriveRepoNameFromUrl: vi.fn().mockReturnValue("repo"),
@@ -3111,6 +3118,47 @@ describe("runIdeBridgeAction — jolli-api", () => {
 		vi.mocked(serializeSummaryJson).mockReturnValue(undefined);
 		const result = await runIdeBridgeAction("jolli-api", "/r", { operation: "serialize-summary", summary: {} });
 		expect(result).toEqual({ json: null });
+	});
+
+	it("enriches the summary with derived transcript sessions before serializing", async () => {
+		// Parity with the CLI push path: the JVM host has no way to compute the
+		// push-time session enrichment, so the bridge must derive it and weave it in
+		// before serializing — otherwise every IntelliJ-initiated share ships the
+		// pre-enrichment sidecar silently.
+		const { serializeSummaryJson } = await import("../core/JolliMemoryPushOrchestrator.js");
+		const { collectTranscriptSessionMeta } = await import("../core/TranscriptSessionMeta.js");
+		const sessions = [{ sessionId: "s1", messageCount: 3 }];
+		vi.mocked(collectTranscriptSessionMeta).mockResolvedValueOnce(sessions as never);
+		vi.mocked(serializeSummaryJson).mockReturnValue('{"enriched":true}');
+
+		const result = await runIdeBridgeAction("jolli-api", "/r", {
+			operation: "serialize-summary",
+			summary: { commitHash: "abc" },
+		});
+
+		expect(result).toEqual({ json: '{"enriched":true}' });
+		expect(vi.mocked(serializeSummaryJson)).toHaveBeenCalledWith(
+			expect.objectContaining({ commitHash: "abc", transcriptSessions: sessions }),
+		);
+	});
+
+	it("leaves an already-enriched summary untouched", async () => {
+		// A host that learns to compute the enrichment itself wins: the bridge must not
+		// recompute (or clobber) a `transcriptSessions` the caller already supplied.
+		const { serializeSummaryJson } = await import("../core/JolliMemoryPushOrchestrator.js");
+		const { collectTranscriptSessionMeta } = await import("../core/TranscriptSessionMeta.js");
+		vi.mocked(serializeSummaryJson).mockReturnValue('{"kept":true}');
+
+		const supplied = [{ sessionId: "host", messageCount: 1 }];
+		await runIdeBridgeAction("jolli-api", "/r", {
+			operation: "serialize-summary",
+			summary: { commitHash: "abc", transcriptSessions: supplied },
+		});
+
+		expect(vi.mocked(collectTranscriptSessionMeta)).not.toHaveBeenCalled();
+		expect(vi.mocked(serializeSummaryJson)).toHaveBeenCalledWith(
+			expect.objectContaining({ transcriptSessions: supplied }),
+		);
 	});
 
 	it("pushes a payload via JolliMemoryPushClient", async () => {

--- a/cli/src/commands/IdeBridgeCommand.ts
+++ b/cli/src/commands/IdeBridgeCommand.ts
@@ -1108,7 +1108,22 @@ async function runJolliApiAction(cwd: string, request: JsonObject): Promise<unkn
 	}
 	if (operation === "serialize-summary") {
 		const { serializeSummaryJson } = await import("../core/JolliMemoryPushOrchestrator.js");
-		return { json: serializeSummaryJson(request.summary as Parameters<typeof serializeSummaryJson>[0]) ?? null };
+		const { collectTranscriptSessionMeta } = await import("../core/TranscriptSessionMeta.js");
+		const summary = request.summary as Parameters<typeof serializeSummaryJson>[0];
+		// Parity with the CLI push path (`pushSummary`): the enrichment is derived, not
+		// carried by the caller, and there is no Kotlin equivalent — so a JVM-initiated
+		// share reached here with `transcriptSessions` absent and shipped the pre-
+		// enrichment sidecar silently. Derive it from the artifacts this tree references
+		// (`storage` resolves from `cwd`), skip when the caller already supplied it (a
+		// host that learns to compute it wins), and omit when empty so absence never
+		// reads as a measured zero. `collectTranscriptSessionMeta` degrades to `[]` on
+		// any read fault, so this never blocks the serialize.
+		let enriched = summary;
+		if (summary.transcriptSessions === undefined) {
+			const transcriptSessions = await collectTranscriptSessionMeta(summary, cwd);
+			if (transcriptSessions.length > 0) enriched = { ...summary, transcriptSessions };
+		}
+		return { json: serializeSummaryJson(enriched) ?? null };
 	}
 	// spec 306: the memory-mutating operations must consult the per-repo
 	// outbound-push opt-out — the SAME gate the CLI drains, the manual/MCP push, and

--- a/cli/src/core/AntigravitySessionDiscoverer.ts
+++ b/cli/src/core/AntigravitySessionDiscoverer.ts
@@ -37,7 +37,7 @@ import { mapWithConcurrency, withIoBudget } from "../util/Concurrency.js";
 import { getAntigravityVariants } from "./AntigravityDetector.js";
 import { unwrapUserRequest } from "./AntigravityTranscriptReader.js";
 import { type AlreadyCurrent, type DiskSession, sessionsForRepo } from "./DiskSessionScan.js";
-import { listWorktrees } from "./GitOps.js";
+import { resolveWorktreeRoots } from "./GitOps.js";
 import { sessionDirBelongsToRepo } from "./SessionDirMatch.js";
 import { classifyScanError, hasNodeSqliteSupport, type SqliteScanError, withSqliteDb } from "./SqliteHelpers.js";
 
@@ -147,29 +147,6 @@ async function readTitle(transcriptPath: string): Promise<string | undefined> {
 		log.debug("readTitle stream failed for %s: %s", transcriptPath, errMsg(err));
 	}
 	return undefined;
-}
-
-/**
- * Resolves the set of worktree roots (raw, unnormalized paths) for the repo
- * containing `projectDir`. Antigravity records the checkout the IDE was opened
- * in, which is frequently a *different* worktree than the one committing (e.g.
- * the IDE sits on the main checkout while commits happen from a linked feature
- * worktree), so matching against every worktree root attributes the conversation
- * to the same repo regardless of which worktree runs the hook. Falls back to
- * just `projectDir` when git is unavailable or the dir is not inside a repo.
- *
- * Paths are kept raw (not `normalizePathForCompare`d) because the caller feeds
- * them to `sessionDirBelongsToRepo`, whose nested-repo `.git` walk needs the
- * real on-disk path; that helper does the separator/case folding itself.
- */
-async function resolveWorktreeRoots(projectDir: string): Promise<ReadonlySet<string>> {
-	const roots = new Set<string>([projectDir]);
-	try {
-		for (const wt of await listWorktrees(projectDir)) roots.add(wt);
-	} catch (err) {
-		log.debug("listWorktrees failed for %s (falling back to exact match): %s", projectDir, errMsg(err));
-	}
-	return roots;
 }
 
 /**
@@ -489,7 +466,7 @@ export async function antigravitySessionsForRepo(
 	scanned: ReadonlyArray<DiskSession>,
 	projectDir: string,
 ): Promise<ReadonlyArray<SessionInfo>> {
-	const worktreeRoots = [...(await resolveWorktreeRoots(projectDir))];
+	const worktreeRoots = await resolveWorktreeRoots(projectDir);
 	const mine = sessionsForRepo(scanned, (dir) => worktreeRoots.some((root) => sessionDirBelongsToRepo(dir, root)));
 	return mapWithConcurrency(mine, async (session) => {
 		// Streams with an early exit on the first user turn, so it claims a slot and

--- a/cli/src/core/GitOps.test.ts
+++ b/cli/src/core/GitOps.test.ts
@@ -72,6 +72,7 @@ import {
 	resolveGitHooksDir,
 	resolveStateRoot,
 	resolveWorktreeRootOrNull,
+	resolveWorktreeRoots,
 	writeFileToBranch,
 	writeMultipleFilesToBranch,
 } from "./GitOps.js";
@@ -1753,6 +1754,52 @@ describe("GitOps", () => {
 		it("should throw on failure", async () => {
 			mockFailure(128, "fatal: not a git repository");
 			await expect(listWorktrees("/not/a/repo")).rejects.toThrow("Failed to list worktrees");
+		});
+	});
+
+	describe("resolveWorktreeRoots", () => {
+		it("returns the queried directory first, then its siblings", async () => {
+			mockSuccess(
+				"worktree /main/repo\nHEAD abc123\nbranch refs/heads/main\n\n" +
+					"worktree /main/worktrees/feature-a\nHEAD def456\nbranch refs/heads/feature/feature-a\n",
+			);
+			await expect(resolveWorktreeRoots("/main/repo")).resolves.toEqual([
+				"/main/repo",
+				"/main/worktrees/feature-a",
+			]);
+		});
+
+		it("does not repeat a directory git also lists", async () => {
+			// The queried directory seeds the set, so a linked worktree asking about
+			// ITSELF must not appear twice — callers feed this straight into per-root
+			// scans, and a duplicate root is a duplicate pass over every store.
+			mockSuccess(
+				"worktree /main/repo\nHEAD abc123\nbranch refs/heads/main\n\n" +
+					"worktree /main/worktrees/feature-a\nHEAD def456\nbranch refs/heads/feature/feature-a\n",
+			);
+			await expect(resolveWorktreeRoots("/main/worktrees/feature-a")).resolves.toEqual([
+				"/main/worktrees/feature-a",
+				"/main/repo",
+			]);
+		});
+
+		it("degrades to the directory itself when git cannot answer", async () => {
+			// The property every caller depends on: this runs on a sweep's critical path,
+			// so a missing git or a non-checkout must cost the widened scope, never the
+			// pass. Same answer the code had before roots existed.
+			mockFailure(128, "fatal: not a git repository");
+			await expect(resolveWorktreeRoots("/not/a/repo")).resolves.toEqual(["/not/a/repo"]);
+		});
+
+		it("dedupes a checkout git spells with different separators, keeping the caller's", async () => {
+			// `listWorktrees` returns git's own spelling (forward slashes, even on
+			// Windows) while `dir` arrives in the caller's (often backslashes). A
+			// raw-string Set kept BOTH — and the sole direct consumer that does not
+			// re-dedupe (Antigravity's per-repo narrowing) then pays a streamed title
+			// read per duplicate. The compare key folds `\` -> `/` on every platform, so
+			// this holds on the Linux runner too; the surviving string is the caller's.
+			mockSuccess("worktree /srv/repo\nHEAD abc123\nbranch refs/heads/main\n");
+			await expect(resolveWorktreeRoots("\\srv\\repo")).resolves.toEqual(["\\srv\\repo"]);
 		});
 	});
 

--- a/cli/src/core/GitOps.ts
+++ b/cli/src/core/GitOps.ts
@@ -11,11 +11,11 @@
 import { once } from "node:events";
 import { readFile, stat } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
-import { createLogger } from "../Logger.js";
+import { createLogger, errMsg } from "../Logger.js";
 import type { CommitInfo, DiffStats, FileWrite, GitCommandResult } from "../Types.js";
 import { execFileAsyncHidden, execFileSyncHidden, spawnHidden } from "../util/Subprocess.js";
 import { resolveGitFsLayout } from "./GitFsLayout.js";
-import { toForwardSlash } from "./PathUtils.js";
+import { normalizePathForCompare, toForwardSlash } from "./PathUtils.js";
 
 const MAX_GIT_BUFFER_BYTES = 10 * 1024 * 1024; // 10MB
 /** NUL byte — used as entry separator in `git ls-tree -z` output. */
@@ -1199,6 +1199,52 @@ export async function listWorktrees(cwd: string): Promise<ReadonlyArray<string>>
 		.filter((line) => line.startsWith("worktree "))
 		.map((line) => line.slice("worktree ".length).trim());
 	return paths;
+}
+
+/**
+ * {@link listWorktrees} that never throws — `dir` plus every sibling checkout of
+ * the same repository, deduped, `dir` first.
+ *
+ * The "one repo, many checkouts" question comes up wherever an artifact records
+ * the directory it was produced in and a caller has to decide which repository
+ * that is. An agent session is the case that matters most: transcripts are keyed
+ * by the cwd the conversation ran in, so a linked worktree's sessions live under
+ * ITS path, and a scope built from one checkout alone silently answers for a
+ * fraction of the repo's work. Measured while this was still per-checkout: of 94
+ * in-window Claude sessions on a repo with six live worktrees, 65 belonged to a
+ * sibling and were invisible to the back-fill — and they are exactly the parallel
+ * work the agent-concurrency figure exists to show.
+ *
+ * Returned paths are kept RAW (the caller's / git's own spelling): callers feed
+ * them to {@link sessionDirBelongsToRepo}, whose nested-repo `.git` walk needs a
+ * real on-disk path, and which folds separators and case itself. The DEDUPE key,
+ * however, is `normalizePathForCompare`d — same trade as `dedupeRoots`. Without it
+ * the Set keyed on raw strings: `listWorktrees` returns git's own output
+ * (forward-slash paths on Windows) while `dir` arrives in the caller's spelling
+ * (often backslash), so one checkout would survive as BOTH spellings, and the sole
+ * direct consumer that does not re-dedupe (Antigravity's per-repo narrowing, the
+ * reason `forRepoSpansWorktrees` exists) pays a streamed title read per duplicate.
+ *
+ * Falling back to `[dir]` rather than propagating is what makes this usable on a
+ * caller's critical path: git being absent, or `dir` not being a checkout at all,
+ * degrades to the previous single-root behaviour instead of failing a sweep.
+ */
+export async function resolveWorktreeRoots(dir: string): Promise<ReadonlyArray<string>> {
+	const seen = new Set<string>();
+	const roots: string[] = [];
+	const add = (root: string): void => {
+		const key = normalizePathForCompare(root);
+		if (seen.has(key)) return;
+		seen.add(key);
+		roots.push(root);
+	};
+	add(dir);
+	try {
+		for (const worktree of await listWorktrees(dir)) add(worktree);
+	} catch (err) {
+		log.debug("listWorktrees failed for %s -- using it as the only root: %s", dir, errMsg(err));
+	}
+	return roots;
 }
 
 /**

--- a/cli/src/core/JolliMemoryPushOrchestrator.test.ts
+++ b/cli/src/core/JolliMemoryPushOrchestrator.test.ts
@@ -25,16 +25,29 @@ vi.mock("../Logger.js", async (importOriginal) => {
 vi.mock("./GitOps.js", () => ({ getDefaultBranch: vi.fn() }));
 vi.mock("./PrDescription.js", () => ({ loadBranchSummaries: vi.fn() }));
 vi.mock("./PushPendingStore.js", () => ({ loadPushPending: vi.fn() }));
-vi.mock("./SummaryStore.js", () => ({
-	getActiveStorage: vi.fn(),
-	getIndexEntryMap: vi.fn(async () => new Map()),
-	getSummary: vi.fn(),
-	readNoteFromBranch: vi.fn(),
-	readPlanFromBranch: vi.fn(),
-	readReferenceFromBranch: vi.fn(),
-	readSkillFromBranch: vi.fn(),
-	storeSummary: vi.fn(),
-}));
+vi.mock("./SummaryStore.js", () => {
+	// Enrichment path (TranscriptSessionMeta) reads through `readTranscriptsBatch`
+	// now, not `readTranscript` — but every existing test drives it via the
+	// latter's single-value `mockResolvedValue`, so the batch mock fans that same
+	// value out to every id it's asked for rather than duplicating each test.
+	const readTranscript = vi.fn(async () => null);
+	return {
+		getActiveStorage: vi.fn(),
+		getIndexEntryMap: vi.fn(async () => new Map()),
+		getSummary: vi.fn(),
+		readNoteFromBranch: vi.fn(),
+		readPlanFromBranch: vi.fn(),
+		readTranscript,
+		readTranscriptsBatch: vi.fn(async (ids: ReadonlyArray<string>) => {
+			const result = new Map<string, unknown>();
+			for (const id of ids) result.set(id, await readTranscript());
+			return result;
+		}),
+		readReferenceFromBranch: vi.fn(),
+		readSkillFromBranch: vi.fn(),
+		storeSummary: vi.fn(),
+	};
+});
 vi.mock("./GitRemoteUtils.js", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("./GitRemoteUtils.js")>();
 	return { ...actual, getCanonicalRepoUrl: vi.fn() };
@@ -98,6 +111,7 @@ import {
 	readPlanFromBranch,
 	readReferenceFromBranch,
 	readSkillFromBranch,
+	readTranscript,
 	storeSummary,
 } from "./SummaryStore.js";
 
@@ -223,6 +237,75 @@ describe("serializeSummaryJson", () => {
 		const huge = "x".repeat(2_000_000);
 		const s = { commitHash: "a", commitMessage: huge } as unknown as CommitSummary;
 		expect(serializeSummaryJson(s)).toBeUndefined();
+	});
+});
+
+describe("serializeSummaryJson session enrichment", () => {
+	/** A summary whose `recap` alone lands just under the 1.5 MB cap. */
+	function summaryOfRecapSize(chars: number): CommitSummary {
+		return {
+			version: 5,
+			commitHash: "b".repeat(40),
+			commitMessage: "feat: big",
+			commitAuthor: "Dev",
+			commitDate: "2026-08-01T10:00:00.000Z",
+			branch: "feature/x",
+			generatedAt: "2026-08-01T10:05:00.000Z",
+			recap: "x".repeat(chars),
+		} as CommitSummary;
+	}
+
+	it("carries transcriptSessions through when the payload fits", () => {
+		const json = serializeSummaryJson({
+			...summaryOfRecapSize(10),
+			transcriptSessions: [
+				{
+					sessionId: "s1",
+					source: "claude",
+					messageCount: 3,
+					startedAt: "2026-08-01T09:00:00.000Z",
+					endedAt: "2026-08-01T10:10:00.000Z",
+				},
+			],
+		});
+
+		expect(json).toBeDefined();
+		expect(JSON.parse(json as string).transcriptSessions).toEqual([
+			{
+				sessionId: "s1",
+				source: "claude",
+				messageCount: 3,
+				startedAt: "2026-08-01T09:00:00.000Z",
+				endedAt: "2026-08-01T10:10:00.000Z",
+			},
+		]);
+	});
+
+	it("drops only the enrichment when it is what pushes the payload over the cap", () => {
+		// 1.5 MB is 1_572_864 bytes; leave under 400 bytes of headroom so a handful
+		// of session rows is the difference between fitting and not.
+		const base = summaryOfRecapSize(1_572_500);
+		const withoutEnrichment = serializeSummaryJson(base);
+		expect(withoutEnrichment).toBeDefined();
+
+		const json = serializeSummaryJson({
+			...base,
+			transcriptSessions: Array.from({ length: 20 }, (_, i) => ({
+				sessionId: `session-${i}`,
+				source: "claude",
+				messageCount: 10,
+				startedAt: "2026-08-01T09:00:00.000Z",
+				endedAt: "2026-08-01T10:10:00.000Z",
+			})),
+		});
+
+		// The sidecar survives; only the enrichment is gone.
+		expect(json).toBe(withoutEnrichment);
+		expect(JSON.parse(json as string)).not.toHaveProperty("transcriptSessions");
+	});
+
+	it("still returns undefined when the payload is oversized without any enrichment", () => {
+		expect(serializeSummaryJson(summaryOfRecapSize(2_000_000))).toBeUndefined();
 	});
 });
 
@@ -2197,5 +2280,109 @@ describe("skill attachments", () => {
 		const owned = assignOwnedContext([older, newer]).get("skill");
 		expect(owned?.owned.get("1111111111111")).toBeUndefined();
 		expect(owned?.owned.get("2222222222222")).toHaveLength(1);
+	});
+});
+
+describe("session enrichment on the push path", () => {
+	beforeEach(() => {
+		vi.mocked(storeSummary).mockReset().mockResolvedValue(undefined);
+		vi.mocked(readPlanFromBranch).mockReset().mockResolvedValue(null);
+		vi.mocked(readNoteFromBranch).mockReset().mockResolvedValue(null);
+		vi.mocked(loadPushPending).mockReset().mockResolvedValue({ version: 1, entries: {} });
+		vi.mocked(getIndexEntryMap).mockReset().mockResolvedValue(new Map());
+		vi.mocked(readReferenceFromBranch).mockReset().mockResolvedValue(null);
+		vi.mocked(saveSpaceBindingCache).mockReset().mockResolvedValue(undefined);
+		vi.mocked(clearSpaceBindingCache).mockReset().mockResolvedValue(undefined);
+		vi.mocked(readTranscript).mockReset().mockResolvedValue(null);
+	});
+
+	const ONE_SESSION = {
+		sessions: [
+			{
+				sessionId: "s1",
+				source: "claude" as const,
+				entries: [
+					{ role: "human" as const, content: "a", timestamp: "2026-08-01T09:00:00.000Z" },
+					{ role: "assistant" as const, content: "b", timestamp: "2026-08-01T10:10:00.000Z" },
+				],
+			},
+		],
+	};
+
+	/** A v5 root that lists one artifact, plus a child that lists none. */
+	function summaryWithChild(): CommitSummary {
+		return {
+			version: 5,
+			commitHash: "c".repeat(40),
+			commitMessage: "feat: x",
+			commitAuthor: "Dev",
+			commitDate: "2026-08-01T10:00:00.000Z",
+			branch: "feature/x",
+			generatedAt: "2026-08-01T10:05:00.000Z",
+			transcripts: ["t1"],
+			children: [
+				{
+					version: 5,
+					commitHash: "d".repeat(40),
+					commitMessage: "wip",
+					commitAuthor: "Dev",
+					commitDate: "2026-08-01T09:30:00.000Z",
+					branch: "feature/x",
+					generatedAt: "2026-08-01T09:35:00.000Z",
+					transcripts: [],
+				},
+			],
+		} as CommitSummary;
+	}
+
+	/** The `summaryJson` sidecar of the last summary article this client pushed. */
+	function lastPushedSummaryJson(client: ReturnType<typeof fakeClient>): Record<string, unknown> {
+		const payload = vi
+			.mocked(client.push)
+			.mock.calls.map((c) => c[0] as PushPayload)
+			.filter((p) => p.docType === "summary")
+			.at(-1);
+		return JSON.parse(payload?.summaryJson as string);
+	}
+
+	it("stamps the rows on the root only, never on a child", async () => {
+		vi.mocked(readTranscript).mockResolvedValue(ONE_SESSION);
+		const client = fakeClient();
+
+		await pushSummary(summaryWithChild(), baseCtx(client));
+		const pushed = lastPushedSummaryJson(client);
+
+		expect(pushed.transcriptSessions).toEqual([
+			{
+				sessionId: "s1",
+				source: "claude",
+				messageCount: 2,
+				startedAt: "2026-08-01T09:00:00.000Z",
+				endedAt: "2026-08-01T10:10:00.000Z",
+			},
+		]);
+		// A child copy would activate the server's keep-first merge and truncate.
+		expect((pushed.children as Array<Record<string, unknown>>)[0]).not.toHaveProperty("transcriptSessions");
+	});
+
+	it("omits the key entirely when no session is derivable", async () => {
+		vi.mocked(readTranscript).mockResolvedValue(null);
+		const client = fakeClient();
+
+		await pushSummary(summaryWithChild(), baseCtx(client));
+
+		// An empty array would read as "measured: zero conversations" and would also
+		// disable the server's bare-transcript-id fallback.
+		expect(lastPushedSummaryJson(client)).not.toHaveProperty("transcriptSessions");
+	});
+
+	it("never persists the enrichment to the stored summary", async () => {
+		vi.mocked(readTranscript).mockResolvedValue(ONE_SESSION);
+		const ctx = baseCtx(fakeClient());
+
+		await pushSummary(summaryWithChild(), ctx);
+
+		const stored = vi.mocked(storeSummary).mock.calls.at(-1)?.[0] as CommitSummary;
+		expect(stored).not.toHaveProperty("transcriptSessions");
 	});
 });

--- a/cli/src/core/JolliMemoryPushOrchestrator.ts
+++ b/cli/src/core/JolliMemoryPushOrchestrator.ts
@@ -54,6 +54,7 @@ import {
 	pushTopicsSection,
 } from "./SummaryMarkdownBuilder.js";
 import { getActiveStorage, getIndexEntryMap, getSummary, storeSummary } from "./SummaryStore.js";
+import { collectTranscriptSessionMeta, type TranscriptSessionMeta } from "./TranscriptSessionMeta.js";
 
 /**
  * Re-exported so every existing importer (the ide-bridge, `PushExecutor`, the
@@ -76,6 +77,19 @@ const log = createLogger("JolliMemoryPushOrchestrator");
 const MAX_SUMMARY_JSON_BYTES = 1_572_864;
 
 /**
+ * A summary as the PUSH path sees it: the stored record plus the push-time
+ * session enrichment.
+ *
+ * The extra field lives here, not on `CommitSummary`, on purpose — the storage
+ * path cannot name it, so it cannot persist it. That is what keeps this change
+ * clear of the stored-schema lockstep contracts (FolderStorage's hidden layer
+ * and the IntelliJ readers over it).
+ */
+export type EnrichedPushSummary = CommitSummary & {
+	readonly transcriptSessions?: ReadonlyArray<TranscriptSessionMeta>;
+};
+
+/**
  * Serializes a summary for the `summaryJson` push field: the enriched
  * `summaryForMarkdown` copy (plan/note URLs woven in) minus the client push-state
  * fields — `jolliDocId`/`jolliDocUrl` and their skill-article siblings
@@ -86,8 +100,13 @@ const MAX_SUMMARY_JSON_BYTES = 1_572_864;
  * unchanged content, so the server upsert can no-op — per-plan/note `jolliPlan*`/
  * `jolliNote*` ids nested inside `plans[]`/`notes[]` are untouched and can still
  * churn). Returns undefined above {@link MAX_SUMMARY_JSON_BYTES}.
+ *
+ * If the payload is over the cap and carries the `transcriptSessions` push-time
+ * enrichment, retries once without it before giving up on the whole sidecar —
+ * the enrichment is a small optional extra, so shedding it alone is strictly
+ * better than losing the entire JSON to it.
  */
-export function serializeSummaryJson(summary: CommitSummary): string | undefined {
+export function serializeSummaryJson(summary: EnrichedPushSummary): string | undefined {
 	const {
 		jolliDocId: _docId,
 		jolliDocUrl: _docUrl,
@@ -103,13 +122,24 @@ export function serializeSummaryJson(summary: CommitSummary): string | undefined
 		...content
 	} = summary;
 	const json = JSON.stringify(content);
-	if (Buffer.byteLength(json, "utf-8") > MAX_SUMMARY_JSON_BYTES) {
-		log.warn(
-			`Summary JSON for ${summary.commitHash.substring(0, 8)} exceeds ${MAX_SUMMARY_JSON_BYTES} bytes — pushing markdown only`,
-		);
-		return;
+	if (Buffer.byteLength(json, "utf-8") <= MAX_SUMMARY_JSON_BYTES) return json;
+	// The session enrichment is a push-time extra, so shedding it is strictly
+	// better than shedding the whole sidecar — which is what the cap otherwise
+	// does. Worst case becomes the pre-enrichment behavior, never worse.
+	if (content.transcriptSessions !== undefined) {
+		const { transcriptSessions: _sessions, ...withoutSessions } = content;
+		const retry = JSON.stringify(withoutSessions);
+		if (Buffer.byteLength(retry, "utf-8") <= MAX_SUMMARY_JSON_BYTES) {
+			log.warn(
+				`Summary JSON for ${summary.commitHash.substring(0, 8)} exceeds ${MAX_SUMMARY_JSON_BYTES} bytes — pushing without session metadata`,
+			);
+			return retry;
+		}
 	}
-	return json;
+	log.warn(
+		`Summary JSON for ${summary.commitHash.substring(0, 8)} exceeds ${MAX_SUMMARY_JSON_BYTES} bytes — pushing markdown only`,
+	);
+	return;
 }
 
 /**
@@ -403,11 +433,18 @@ export async function pushSummary(
 
 	const published = await pushContextAttachments(summary, ctx, envKey, selection);
 
+	// Push-time session enrichment. Read from the artifacts this tree references,
+	// stamped on the root only (the server merges duplicate rows keep-first), and
+	// omitted entirely when empty so absence never reads as a measured zero.
+	const transcriptSessions = await collectTranscriptSessionMeta(summary, ctx.cwd, ctx.storage);
 	// Weave the published URLs into the copy the markdown is rendered from, so the
 	// article's Context list links to the published docs. `reduceOwnItems` first:
 	// only the reduced set was uploaded (same-named plan snapshots collapse), so the
 	// rendered body must list the same set.
-	const summaryForMarkdown = applyPublishedUrls(reduceOwnItems(summary), published);
+	const summaryForMarkdown: EnrichedPushSummary = {
+		...applyPublishedUrls(reduceOwnItems(summary), published),
+		...(transcriptSessions.length > 0 && { transcriptSessions }),
+	};
 	const markdown = buildPushMarkdown(summaryForMarkdown);
 	// The structured twin of the markdown article, from the same enriched copy —
 	// the share page renders it directly instead of regex-parsing the markdown.

--- a/cli/src/core/SummaryStore.test.ts
+++ b/cli/src/core/SummaryStore.test.ts
@@ -88,6 +88,7 @@ import {
 	readReferenceFromBranch,
 	readSkillFromBranch,
 	readTranscript,
+	readTranscriptsBatch,
 	readTranscriptsForCommits,
 	removeFromIndex,
 	resolveReadStorage,
@@ -2580,6 +2581,85 @@ describe("SummaryStore", () => {
 			expect(fakeStorage?.readFile).toHaveBeenNthCalledWith(1, "transcripts/h1.json");
 			expect(fakeStorage?.readFile).toHaveBeenNthCalledWith(2, "transcripts/h2.json");
 			expect(result.size).toBe(2);
+		});
+
+		describe("readTranscriptsBatch", () => {
+			it("returns an empty map without touching storage when ids is empty", async () => {
+				const fakeStorage = {
+					readFile: vi.fn(),
+					batchReadFiles: vi.fn(),
+				} as unknown as Parameters<typeof readTranscriptsBatch>[2];
+
+				const result = await readTranscriptsBatch([], undefined, fakeStorage);
+
+				expect(result.size).toBe(0);
+				expect(fakeStorage?.readFile).not.toHaveBeenCalled();
+				expect(fakeStorage?.batchReadFiles).not.toHaveBeenCalled();
+			});
+
+			it("uses batchReadFiles in a single call when the backend implements it", async () => {
+				const batchReadFiles = vi.fn().mockResolvedValue(
+					new Map([
+						["transcripts/h1.json", JSON.stringify({ sessions: [{ sessionId: "a", entries: [] }] })],
+						["transcripts/h2.json", null],
+					]),
+				);
+				const fakeStorage = {
+					readFile: vi.fn(),
+					batchReadFiles,
+				} as unknown as Parameters<typeof readTranscriptsBatch>[2];
+
+				const result = await readTranscriptsBatch(["h1", "h2"], undefined, fakeStorage);
+
+				expect(batchReadFiles).toHaveBeenCalledTimes(1);
+				expect(batchReadFiles).toHaveBeenCalledWith(["transcripts/h1.json", "transcripts/h2.json"]);
+				expect(fakeStorage?.readFile).not.toHaveBeenCalled();
+				expect(result.get("h1")?.sessions[0]?.sessionId).toBe("a");
+				expect(result.get("h2")).toBeNull();
+			});
+
+			it("falls back to a per-path readFile loop when batchReadFiles is absent (FolderStorage)", async () => {
+				const fakeStorage = {
+					readFile: vi
+						.fn()
+						.mockResolvedValueOnce(JSON.stringify({ sessions: [{ sessionId: "a", entries: [] }] }))
+						.mockResolvedValueOnce(null),
+				} as unknown as Parameters<typeof readTranscriptsBatch>[2];
+
+				const result = await readTranscriptsBatch(["h1", "h2"], undefined, fakeStorage);
+
+				expect(fakeStorage?.readFile).toHaveBeenCalledTimes(2);
+				expect(fakeStorage?.readFile).toHaveBeenNthCalledWith(1, "transcripts/h1.json");
+				expect(fakeStorage?.readFile).toHaveBeenNthCalledWith(2, "transcripts/h2.json");
+				expect(result.get("h1")?.sessions[0]?.sessionId).toBe("a");
+				expect(result.get("h2")).toBeNull();
+			});
+
+			it("maps a malformed JSON body to null rather than throwing", async () => {
+				const batchReadFiles = vi.fn().mockResolvedValue(new Map([["transcripts/h1.json", "not json"]]));
+				const fakeStorage = {
+					readFile: vi.fn(),
+					batchReadFiles,
+				} as unknown as Parameters<typeof readTranscriptsBatch>[2];
+
+				const result = await readTranscriptsBatch(["h1"], undefined, fakeStorage);
+
+				expect(result.get("h1")).toBeNull();
+			});
+
+			it("maps one throwing readFile to null in the fallback loop without failing the other ids", async () => {
+				const fakeStorage = {
+					readFile: vi.fn().mockImplementation(async (path: string) => {
+						if (path === "transcripts/bad.json") throw new Error("simulated read failure");
+						return JSON.stringify({ sessions: [{ sessionId: "good", entries: [] }] });
+					}),
+				} as unknown as Parameters<typeof readTranscriptsBatch>[2];
+
+				const result = await readTranscriptsBatch(["bad", "good"], undefined, fakeStorage);
+
+				expect(result.get("bad")).toBeNull();
+				expect(result.get("good")?.sessions[0]?.sessionId).toBe("good");
+			});
 		});
 
 		it("should write and delete transcript files in a single batch", async () => {

--- a/cli/src/core/SummaryStore.ts
+++ b/cli/src/core/SummaryStore.ts
@@ -16,7 +16,7 @@
  *   - Cached aliases (`commitAliases`) so repeated lookups skip git calls
  */
 
-import { createLogger, isManuallyDisabled } from "../Logger.js";
+import { createLogger, errMsg, isManuallyDisabled } from "../Logger.js";
 import type {
 	CatalogEntry,
 	CatalogTopic,
@@ -40,6 +40,7 @@ import type {
 	TopicSummary,
 } from "../Types.js";
 import { CURRENT_SCHEMA_VERSION } from "../Types.js";
+import { mapWithConcurrency } from "./Concurrency.js";
 import { getDiffStats, getTreeHash } from "./GitOps.js";
 import { acquireOrphanWriteLock, OrphanWriteBusyError, releaseOrphanWriteLock } from "./Locks.js";
 import { OrphanBranchStorage } from "./OrphanBranchStorage.js";
@@ -1748,6 +1749,93 @@ export async function readTranscriptsForCommits(
 			result.set(hash, transcript);
 		}
 	}
+	return result;
+}
+
+/**
+ * Reads many transcripts in ONE logical operation, keyed by id. The batch twin
+ * of {@link readTranscript} — same path shape (`transcripts/{id}.json`), same
+ * per-entry contract (`null` for missing or unparseable), but a single round
+ * trip instead of N.
+ *
+ * Uses `storage.batchReadFiles` when the backend implements it (one `git
+ * cat-file --batch` subprocess instead of N spawns — see the method's
+ * docstring on `StorageProvider`); falls back to a per-path `readFile` loop
+ * when it's absent (FolderStorage, where a local read is already cheap). Both
+ * branches are live in production: `DualWriteStorage` always has the method
+ * (delegating to its orphan-branch primary), `FolderStorage` never does.
+ *
+ * A missing artifact and a malformed JSON body both map to `null` — the
+ * caller (`collectTranscriptSessionMeta`) treats either as "no sessions from
+ * this id", never as fatal.
+ *
+ * Resolves through {@link resolveReadStorage}, not {@link resolveStorage}: this
+ * is a pure read, and the write-side resolver warns on its fallback. `vscode/src`
+ * never calls `setActiveStorage` and the push path threads no storage, so every
+ * VS Code push would otherwise log "The Memory Bank side will miss this write"
+ * about a write that was never attempted — the healthy-behaviour warning
+ * `resolveReadStorage` exists to stop.
+ */
+export async function readTranscriptsBatch(
+	ids: ReadonlyArray<string>,
+	cwd?: string,
+	storage?: StorageProvider,
+): Promise<Map<string, StoredTranscript | null>> {
+	const result = new Map<string, StoredTranscript | null>();
+	if (ids.length === 0) return result;
+	const store = await resolveReadStorage(storage, cwd);
+	const pathFor = (id: string): string => `transcripts/${id}.json`;
+	const paths = ids.map(pathFor);
+	const rawByPath = store.batchReadFiles ? await store.batchReadFiles(paths) : await readFilesLooped(store, paths);
+	for (const id of ids) {
+		const raw = rawByPath.get(pathFor(id));
+		if (!raw) {
+			result.set(id, null);
+			continue;
+		}
+		try {
+			result.set(id, JSON.parse(raw) as StoredTranscript);
+		} catch {
+			log.warn("Failed to parse transcript for %s", id.substring(0, 8));
+			result.set(id, null);
+		}
+	}
+	return result;
+}
+
+/**
+ * Bound on concurrent `readFile`s in {@link readFilesLooped}. A v3 squash root can
+ * reference ~100 artifacts and this is the path a `batchReadFiles`-less backend
+ * takes, so a strictly serial loop paid ~100 disk round-trips in series; a small
+ * fixed width overlaps them without unbounded fan-out.
+ */
+const READ_FILES_CONCURRENCY = 8;
+
+/**
+ * Per-path `readFile` — the fallback `readTranscriptsBatch` uses when the backend
+ * has no `batchReadFiles` (FolderStorage). Reads run with bounded concurrency
+ * ({@link READ_FILES_CONCURRENCY}) rather than strictly serially, because the batch
+ * path exists precisely for the ~100-artifact squash root and awaiting each read in
+ * turn serialized every one of those disk round-trips. A single path throwing
+ * (rather than resolving to `null`) must not fail the whole batch — mirrors
+ * `batchReadFiles`' own contract, where one missing/unreadable entry never aborts
+ * the request for the rest, so `onError` records `null` and the others proceed.
+ */
+async function readFilesLooped(
+	store: StorageProvider,
+	paths: ReadonlyArray<string>,
+): Promise<Map<string, string | null>> {
+	const values = await mapWithConcurrency<string, string | null>(
+		paths,
+		READ_FILES_CONCURRENCY,
+		(path) => store.readFile(path),
+		(path, err) => {
+			log.warn("readFile failed for %s: %s", path, errMsg(err));
+			return null;
+		},
+	);
+	const result = new Map<string, string | null>();
+	for (let i = 0; i < paths.length; i++) result.set(paths[i] as string, values[i] ?? null);
 	return result;
 }
 

--- a/cli/src/core/TranscriptSessionMeta.test.ts
+++ b/cli/src/core/TranscriptSessionMeta.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest";
+import type { CommitSummary, StoredTranscript } from "../Types.js";
+import type { StorageProvider } from "./StorageProvider.js";
+import { collectTranscriptSessionMeta } from "./TranscriptSessionMeta.js";
+
+/**
+ * Minimal StorageProvider that serves the given `transcripts/<id>.json` bodies
+ * and nothing else, with NO `batchReadFiles` — exercises `readTranscriptsBatch`'s
+ * per-path `readFile` fallback loop (the FolderStorage shape). `resolveStorage`
+ * short-circuits on an injected provider, so no other method is reached — the
+ * casts keep the fake to the surface actually exercised.
+ */
+function fakeStorage(files: Record<string, string>, opts?: { readonly throwOn?: string }): StorageProvider {
+	return {
+		readFile: async (path: string) => {
+			if (opts?.throwOn === path) throw new Error("simulated read failure");
+			return files[path] ?? null;
+		},
+	} as unknown as StorageProvider;
+}
+
+/**
+ * Batch-capable fake — exercises `readTranscriptsBatch`'s `batchReadFiles`
+ * branch (the OrphanBranchStorage/DualWriteStorage shape), which is the other
+ * path live in production. Counts calls so a test can prove the read is ONE
+ * round trip, not N.
+ */
+function fakeBatchStorage(
+	files: Record<string, string>,
+	opts?: { readonly throwAll?: boolean },
+): StorageProvider & { readonly batchCalls: number[] } {
+	const batchCalls: number[] = [];
+	return {
+		readFile: async (path: string) => files[path] ?? null,
+		batchReadFiles: async (paths: ReadonlyArray<string>) => {
+			batchCalls.push(paths.length);
+			if (opts?.throwAll) throw new Error("simulated batch failure");
+			const result = new Map<string, string | null>();
+			for (const path of paths) result.set(path, files[path] ?? null);
+			return result;
+		},
+		batchCalls,
+	} as unknown as StorageProvider & { readonly batchCalls: number[] };
+}
+
+function transcriptJson(transcript: StoredTranscript): string {
+	return JSON.stringify(transcript);
+}
+
+/** A v5 root: `transcripts` is authoritative, so no tree walk is needed. */
+function rootWith(transcriptIds: ReadonlyArray<string>, children?: ReadonlyArray<CommitSummary>): CommitSummary {
+	return {
+		version: 5,
+		commitHash: "a".repeat(40),
+		commitMessage: "feat: something",
+		commitAuthor: "Dev",
+		commitDate: "2026-08-01T10:00:00.000Z",
+		branch: "feature/x",
+		generatedAt: "2026-08-01T10:05:00.000Z",
+		transcripts: transcriptIds,
+		...(children !== undefined && { children }),
+	} as CommitSummary;
+}
+
+describe("collectTranscriptSessionMeta", () => {
+	it("sums messageCount and spans min→max across a session's slices in two artifacts", async () => {
+		// The amend shape: one session archived into a base artifact and a delta artifact.
+		const storage = fakeStorage({
+			"transcripts/base.json": transcriptJson({
+				sessions: [
+					{
+						sessionId: "s1",
+						source: "claude",
+						entries: [
+							{ role: "human", content: "a", timestamp: "2026-08-01T10:00:00.000Z" },
+							{ role: "assistant", content: "b", timestamp: "2026-08-01T10:10:00.000Z" },
+						],
+					},
+				],
+			}),
+			"transcripts/delta.json": transcriptJson({
+				sessions: [
+					{
+						sessionId: "s1",
+						source: "claude",
+						entries: [{ role: "human", content: "c", timestamp: "2026-08-01T09:00:00.000Z" }],
+					},
+				],
+			}),
+		});
+
+		const rows = await collectTranscriptSessionMeta(rootWith(["base", "delta"]), "/repo", storage);
+
+		expect(rows).toEqual([
+			{
+				sessionId: "s1",
+				source: "claude",
+				messageCount: 3,
+				startedAt: "2026-08-01T09:00:00.000Z",
+				endedAt: "2026-08-01T10:10:00.000Z",
+			},
+		]);
+	});
+
+	it("keeps sessions with the same id but different sources apart", async () => {
+		const storage = fakeStorage({
+			"transcripts/t1.json": transcriptJson({
+				sessions: [
+					{ sessionId: "dup", source: "claude", entries: [{ role: "human", content: "a" }] },
+					{ sessionId: "dup", source: "codex", entries: [{ role: "human", content: "b" }] },
+				],
+			}),
+		});
+
+		const rows = await collectTranscriptSessionMeta(rootWith(["t1"]), "/repo", storage);
+
+		expect(rows).toHaveLength(2);
+		expect(rows.map((r) => r.source).sort()).toEqual(["claude", "codex"]);
+	});
+
+	it("defaults a missing source to claude", async () => {
+		const storage = fakeStorage({
+			"transcripts/t1.json": transcriptJson({
+				sessions: [{ sessionId: "s1", entries: [{ role: "human", content: "a" }] }],
+			}),
+		});
+
+		const rows = await collectTranscriptSessionMeta(rootWith(["t1"]), "/repo", storage);
+
+		expect(rows[0]?.source).toBe("claude");
+	});
+
+	it("omits both bounds when no entry carries a parseable timestamp", async () => {
+		const storage = fakeStorage({
+			"transcripts/t1.json": transcriptJson({
+				sessions: [
+					{
+						sessionId: "s1",
+						source: "claude",
+						entries: [
+							{ role: "human", content: "a" },
+							{ role: "assistant", content: "b", timestamp: "not a date" },
+						],
+					},
+				],
+			}),
+		});
+
+		const rows = await collectTranscriptSessionMeta(rootWith(["t1"]), "/repo", storage);
+
+		expect(rows[0]).toEqual({ sessionId: "s1", source: "claude", messageCount: 2 });
+		expect(rows[0]).not.toHaveProperty("startedAt");
+		expect(rows[0]).not.toHaveProperty("endedAt");
+	});
+
+	it("returns an empty array when no artifact resolves", async () => {
+		const rows = await collectTranscriptSessionMeta(rootWith(["missing"]), "/repo", fakeStorage({}));
+
+		expect(rows).toEqual([]);
+	});
+
+	it("skips an unreadable artifact and still emits the readable ones", async () => {
+		const storage = fakeStorage(
+			{
+				"transcripts/good.json": transcriptJson({
+					sessions: [{ sessionId: "s1", source: "claude", entries: [{ role: "human", content: "a" }] }],
+				}),
+			},
+			{ throwOn: "transcripts/bad.json" },
+		);
+
+		const rows = await collectTranscriptSessionMeta(rootWith(["bad", "good"]), "/repo", storage);
+
+		expect(rows).toEqual([{ sessionId: "s1", source: "claude", messageCount: 1 }]);
+	});
+
+	it("skips a session with no sessionId rather than emitting a keyless row", async () => {
+		const storage = fakeStorage({
+			"transcripts/t1.json": transcriptJson({
+				sessions: [
+					{ sessionId: "", source: "claude", entries: [{ role: "human", content: "a" }] },
+					{ sessionId: "s1", source: "claude", entries: [{ role: "human", content: "b" }] },
+				],
+			}),
+		});
+
+		const rows = await collectTranscriptSessionMeta(rootWith(["t1"]), "/repo", storage);
+
+		expect(rows).toEqual([{ sessionId: "s1", source: "claude", messageCount: 1 }]);
+	});
+
+	it("counts a repeated artifact id once, so messageCount is not doubled", async () => {
+		// The pre-v5 fallback path can yield the same id twice; the dedupe guard is
+		// what keeps the total equal to the de-duplicated entry count.
+		const storage = fakeStorage({
+			"transcripts/t1.json": transcriptJson({
+				sessions: [{ sessionId: "s1", source: "claude", entries: [{ role: "human", content: "a" }] }],
+			}),
+		});
+
+		const rows = await collectTranscriptSessionMeta(rootWith(["t1", "t1"]), "/repo", storage);
+
+		expect(rows).toEqual([{ sessionId: "s1", source: "claude", messageCount: 1 }]);
+	});
+
+	it("gathers ids listed on children, not only the root's index", async () => {
+		const storage = fakeStorage({
+			"transcripts/child.json": transcriptJson({
+				sessions: [{ sessionId: "s-child", source: "claude", entries: [{ role: "human", content: "a" }] }],
+			}),
+		});
+		const child = rootWith(["child"]);
+		// A root whose own index is empty while a child still lists an id — the shape
+		// `resolveTranscriptIdsForUsage` exists to handle.
+		const root = { ...rootWith([]), children: [child] } as CommitSummary;
+
+		const rows = await collectTranscriptSessionMeta(root, "/repo", storage);
+
+		expect(rows).toEqual([{ sessionId: "s-child", source: "claude", messageCount: 1 }]);
+	});
+
+	it("tolerates a transcript whose session carries no entries array", async () => {
+		// `readTranscript` casts JSON.parse output, so the type is a promise, not a guarantee.
+		const storage = fakeStorage({ "transcripts/t1.json": '{"sessions":[{"sessionId":"s1"}]}' });
+
+		const rows = await collectTranscriptSessionMeta(rootWith(["t1"]), "/repo", storage);
+
+		expect(rows).toEqual([{ sessionId: "s1", source: "claude", messageCount: 0 }]);
+	});
+
+	it("reads every referenced artifact in a single batchReadFiles call, not one per artifact", async () => {
+		// The perf fix this guards: a squash root can reference many artifacts, and
+		// serial per-artifact `git show` subprocesses eat the pre-push hook's
+		// budget. `readTranscriptsBatch` must fold them into one round trip.
+		const storage = fakeBatchStorage({
+			"transcripts/base.json": transcriptJson({
+				sessions: [
+					{
+						sessionId: "s1",
+						source: "claude",
+						entries: [{ role: "human", content: "a", timestamp: "2026-08-01T10:00:00.000Z" }],
+					},
+				],
+			}),
+			"transcripts/delta.json": transcriptJson({
+				sessions: [{ sessionId: "s1", source: "claude", entries: [{ role: "human", content: "b" }] }],
+			}),
+		});
+
+		const rows = await collectTranscriptSessionMeta(rootWith(["base", "delta"]), "/repo", storage);
+
+		expect(storage.batchCalls).toEqual([2]);
+		expect(rows).toEqual([
+			{
+				sessionId: "s1",
+				source: "claude",
+				messageCount: 2,
+				startedAt: "2026-08-01T10:00:00.000Z",
+				endedAt: "2026-08-01T10:00:00.000Z",
+			},
+		]);
+	});
+
+	it("degrades to an empty array (not a throw) when the whole batch read fails", async () => {
+		// A detached/pruned repo state, or the `git cat-file --batch` subprocess
+		// itself erroring, must not block the push — same non-fatal contract as a
+		// single unreadable artifact, just at the batch level.
+		const storage = fakeBatchStorage({}, { throwAll: true });
+
+		const rows = await collectTranscriptSessionMeta(rootWith(["t1"]), "/repo", storage);
+
+		expect(rows).toEqual([]);
+	});
+});

--- a/cli/src/core/TranscriptSessionMeta.ts
+++ b/cli/src/core/TranscriptSessionMeta.ts
@@ -1,0 +1,157 @@
+/**
+ * Per-conversation metadata for the pushed summary sidecar.
+ *
+ * A PUSH-TIME enrichment, never stored: the rows are derived from the transcript
+ * artifacts a summary tree already references, so every memory already on disk
+ * gains its time axis on its next push. Deliberately absent from
+ * `CommitSummary` — see `EnrichedPushSummary` in `JolliMemoryPushOrchestrator.ts`
+ * for the type boundary that keeps the storage path unable to name this field.
+ *
+ * Timestamps only, no conversation content, so the `BranchShareScope.transcripts
+ * = false` contract is untouched.
+ */
+
+import { createLogger, errMsg } from "../Logger.js";
+import type { CommitSummary, StoredSession, StoredTranscript, TranscriptEntry } from "../Types.js";
+import type { StorageProvider } from "./StorageProvider.js";
+import { readTranscriptsBatch } from "./SummaryStore.js";
+import { resolveTranscriptIdsForUsage } from "./SummaryTree.js";
+
+const log = createLogger("TranscriptSessionMeta");
+
+/** Back-compat convention shared with the server: a source-less session is a Claude one. */
+const DEFAULT_SOURCE = "claude";
+
+/**
+ * One conversation's bounds and size. `startedAt`/`endedAt` are omitted together
+ * when the session carries no parseable timestamp — a journey of unknown length
+ * must render as unmeasured, never as an instant one, so an epoch or an empty
+ * string here would be worse than the gap.
+ */
+export interface TranscriptSessionMeta {
+	readonly sessionId: string;
+	readonly source: string;
+	readonly messageCount: number;
+	readonly startedAt?: string;
+	readonly endedAt?: string;
+}
+
+/** Running total for one `<source>:<sessionId>` key. The `*Ms` fields never leave this module. */
+interface SessionAccumulator {
+	readonly sessionId: string;
+	readonly source: string;
+	messageCount: number;
+	startedAt?: string;
+	startedMs?: number;
+	endedAt?: string;
+	endedMs?: number;
+}
+
+/** The original string when it parses as a date, else undefined. Never coerced. */
+function usableTimestamp(value: string | undefined): { readonly at: string; readonly ms: number } | undefined {
+	if (!value) return undefined;
+	const ms = Date.parse(value);
+	return Number.isNaN(ms) ? undefined : { at: value, ms };
+}
+
+/**
+ * Widens the accumulator's span to cover `entries`. Compares parsed epoch millis
+ * rather than the ISO strings: two timestamps can be the same instant in
+ * different offsets, where a lexicographic comparison picks the wrong one.
+ */
+function foldEntryTimes(acc: SessionAccumulator, entries: ReadonlyArray<TranscriptEntry>): void {
+	for (const entry of entries) {
+		const parsed = usableTimestamp(entry.timestamp);
+		if (!parsed) continue;
+		if (acc.startedMs === undefined || parsed.ms < acc.startedMs) {
+			acc.startedAt = parsed.at;
+			acc.startedMs = parsed.ms;
+		}
+		if (acc.endedMs === undefined || parsed.ms > acc.endedMs) {
+			acc.endedAt = parsed.at;
+			acc.endedMs = parsed.ms;
+		}
+	}
+}
+
+function toMeta(acc: SessionAccumulator): TranscriptSessionMeta {
+	return {
+		sessionId: acc.sessionId,
+		source: acc.source,
+		messageCount: acc.messageCount,
+		...(acc.startedAt !== undefined && { startedAt: acc.startedAt }),
+		...(acc.endedAt !== undefined && { endedAt: acc.endedAt }),
+	};
+}
+
+/** Folds one archived session's slice into the running per-session map. */
+function foldSession(byKey: Map<string, SessionAccumulator>, session: StoredSession): void {
+	// A row with no id has no join key server-side, so it would be dropped there anyway.
+	if (!session.sessionId) return;
+	const source = session.source ?? DEFAULT_SOURCE;
+	const key = `${source}:${session.sessionId}`;
+	const acc = byKey.get(key) ?? { sessionId: session.sessionId, source, messageCount: 0 };
+	// `readTranscript` casts JSON.parse output, so `entries` can be absent in older data.
+	const entries = session.entries ?? [];
+	acc.messageCount += entries.length;
+	foldEntryTimes(acc, entries);
+	byKey.set(key, acc);
+}
+
+/**
+ * Derives the tree-wide per-session rows for one summary — the root's artifacts
+ * and every child's, aggregated by `<source>:<sessionId>`.
+ *
+ * Aggregated rather than keep-first because one session legitimately spans
+ * several artifacts (an amend delta plus its base): `messageCount` sums and the
+ * bounds span min→max, matching the field's "across all of the session's
+ * transcript slices" contract. The result is stamped on the ROOT only — the
+ * server merges duplicate rows keep-first, so a copy on a squash child would
+ * have it silently truncate both the count and the span.
+ *
+ * Returns `[]` when nothing is derivable; the caller omits the field entirely
+ * rather than sending an empty array, which would read as a measurement of zero
+ * conversations and disable the server's bare-transcript-id fallback.
+ *
+ * `storage` is injected rather than resolved so this stays off git — which is
+ * also what keeps its tests in the fast tier.
+ *
+ * Reads every referenced artifact in ONE batch (`readTranscriptsBatch`)
+ * instead of one `git show` subprocess per id: a squash root that re-lists
+ * every descendant transcript can reference ~100 artifacts, and at ~22 ms per
+ * subprocess that serial form eats most of the pre-push hook's 3 s inline
+ * budget by itself. `readTranscriptsBatch` already degrades to a per-path
+ * `readFile` loop when the backend has no batch primitive (FolderStorage), so
+ * this stays correct there too.
+ *
+ * The whole body is guarded, not just the batch read: id resolution and the
+ * fold loop can fail too (a malformed summary tree, a corrupt artifact), and
+ * this is an optional extra — see the module docstring. Any failure degrades
+ * to "no sessions derivable" rather than throwing, so a caller can always
+ * `await` this without a try/catch of its own.
+ */
+export async function collectTranscriptSessionMeta(
+	summary: CommitSummary,
+	cwd?: string,
+	storage?: StorageProvider,
+): Promise<ReadonlyArray<TranscriptSessionMeta>> {
+	try {
+		const byKey = new Map<string, SessionAccumulator>();
+		// De-duped, not just an optimisation: the pre-v5 fallback path can list one
+		// id twice, which would double-count messageCount if folded twice.
+		const ids = [...new Set(resolveTranscriptIdsForUsage(summary))];
+		const transcripts: Map<string, StoredTranscript | null> = await readTranscriptsBatch(ids, cwd, storage);
+		for (const id of ids) {
+			const transcript = transcripts.get(id);
+			if (!transcript) continue;
+			for (const session of transcript.sessions ?? []) foldSession(byKey, session);
+		}
+		return [...byKey.values()].map(toMeta);
+	} catch (err) {
+		// A detached/pruned repo state, a malformed summary tree, or the batch
+		// read itself erroring must not block the push — this degrades to "no
+		// sessions derivable" rather than throwing.
+		log.debug("Transcript session enrichment failed, skipping: %s", errMsg(err));
+		return [];
+	}
+}

--- a/cli/src/core/sessions/SessionSourceDefinition.ts
+++ b/cli/src/core/sessions/SessionSourceDefinition.ts
@@ -116,6 +116,31 @@ export interface SessionSourceSpec<T> {
 		windowMs?: number,
 	) => ReadonlyArray<SessionInfo> | Promise<ReadonlyArray<SessionInfo>>;
 	/**
+	 * True when {@link forRepo} resolves the repo's OWN worktree set from the
+	 * directory it is handed, so one call already answers for every checkout.
+	 *
+	 * Declared because the collector asks each root separately (a conversation is
+	 * keyed by the directory it ran in, and every other source matches against the
+	 * one `cwd` it is given). For a source that spans worktrees by itself, that
+	 * loop is not a wider search — it is the SAME search run N times, and the
+	 * dedupe throws all but one result away. Antigravity is the entry that
+	 * declares it, and its narrowing reads a title per claimed session, so the
+	 * discarded passes are the expensive kind: N × one streamed transcript read
+	 * per session, on a repo with six worktrees.
+	 *
+	 * A source that declares this is asked once per REGISTERED CHECKOUT; the rest
+	 * are asked per root. Per checkout rather than once overall, because what such
+	 * a source resolves is the worktree set of the repository it is HANDED — one
+	 * call covers one clone's linked checkouts and reaches no other clone's `.git`,
+	 * while a repo identity is a remote and can have several clones. Both routes
+	 * into the source obey it: the narrowing of a supplied scan AND the per-repo
+	 * `scanForRepo` fallback, which is the more expensive of the two.
+	 *
+	 * Getting it wrong in the other direction LOSES sessions rather than costing
+	 * time, so it stays opt-in and false by default.
+	 */
+	readonly forRepoSpansWorktrees?: boolean;
+	/**
 	 * The per-repo fallback: discover this source's sessions for ONE repo,
 	 * without a machine-wide scan behind it.
 	 *
@@ -151,6 +176,7 @@ export interface SessionSourceDefinition {
 		cwd: string,
 		windowMs?: number,
 	) => ReadonlyArray<SessionInfo> | Promise<ReadonlyArray<SessionInfo>>;
+	readonly forRepoSpansWorktrees: boolean;
 	readonly scanForRepo?: (cwd: string, windowMs?: number) => Promise<ReadonlyArray<SessionInfo>>;
 }
 
@@ -172,6 +198,7 @@ export function defineSessionSource<T>(spec: SessionSourceSpec<T>): SessionSourc
 		daemonRescan: spec.daemonRescan ?? false,
 		scan: spec.scan,
 		forRepo: (scanned, cwd, windowMs) => spec.forRepo(scanned as ReadonlyArray<T>, cwd, windowMs),
+		forRepoSpansWorktrees: spec.forRepoSpansWorktrees ?? false,
 		...(spec.scanForRepo ? { scanForRepo: spec.scanForRepo } : {}),
 	};
 }

--- a/cli/src/core/sessions/SessionSources.ts
+++ b/cli/src/core/sessions/SessionSources.ts
@@ -219,6 +219,9 @@ const cursorCliSource = defineSessionSource<DiskSession>({
 const antigravitySource = defineSessionSource<DiskSession>({
 	source: "antigravity",
 	usesAlreadyRecorded: true,
+	// The only entry that declares it: `antigravitySessionsForRepo` runs its own
+	// `resolveWorktreeRoots`, so asking it once already covers every checkout.
+	forRepoSpansWorktrees: true,
 	scan: async ({ windowMs, alreadyRecorded }) => {
 		const mod = await import("../AntigravitySessionDiscoverer.js");
 		const result = alreadyRecorded

--- a/cli/src/dashboard/ActivityBuckets.test.ts
+++ b/cli/src/dashboard/ActivityBuckets.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import type { TranscriptEntry } from "../Types.js";
+import { ACTIVITY_BUCKET_MS, bucketsFrom } from "./ActivityBuckets.js";
+
+const entry = (timestamp?: string): TranscriptEntry => ({
+	role: "human",
+	content: "x",
+	...(timestamp ? { timestamp } : {}),
+});
+
+describe("bucketsFrom", () => {
+	it("floors each timestamp to its quarter-hour start", () => {
+		// 2026-08-11T10:07:23Z falls in the 10:00 bucket.
+		expect(bucketsFrom([entry("2026-08-11T10:07:23.000Z")])).toEqual([Date.parse("2026-08-11T10:00:00.000Z")]);
+		// 10:44:59 falls in the 10:30 bucket, not 10:45.
+		expect(bucketsFrom([entry("2026-08-11T10:44:59.000Z")])).toEqual([Date.parse("2026-08-11T10:30:00.000Z")]);
+	});
+
+	it("dedupes messages sharing a bucket and returns ascending order", () => {
+		const out = bucketsFrom([
+			entry("2026-08-11T10:50:00.000Z"),
+			entry("2026-08-11T10:07:00.000Z"),
+			entry("2026-08-11T10:12:00.000Z"),
+		]);
+		expect(out).toEqual([Date.parse("2026-08-11T10:00:00.000Z"), Date.parse("2026-08-11T10:45:00.000Z")]);
+	});
+
+	it("occupies only the buckets a resumed session spoke in, never the span between", () => {
+		// The measured 18-hour session shape: two messages, a night apart.
+		const out = bucketsFrom([entry("2026-08-10T22:00:00.000Z"), entry("2026-08-11T16:00:00.000Z")]);
+		expect(out).toHaveLength(2);
+	});
+
+	it("skips entries with no timestamp, and unparseable ones, without dropping the rest", () => {
+		expect(bucketsFrom([entry(), entry("not-a-date"), entry("2026-08-11T10:07:00.000Z")])).toEqual([
+			Date.parse("2026-08-11T10:00:00.000Z"),
+		]);
+	});
+
+	it("returns empty when nothing is timestamped — the caller turns that into an ABSENT field", () => {
+		expect(bucketsFrom([entry(), entry()])).toEqual([]);
+		expect(bucketsFrom([])).toEqual([]);
+	});
+
+	it("produces integral buckets, which the STRICT column requires", () => {
+		for (const b of bucketsFrom([entry("2026-08-11T10:07:23.456Z")])) {
+			expect(Number.isInteger(b)).toBe(true);
+			expect(b % ACTIVITY_BUCKET_MS).toBe(0);
+		}
+	});
+});

--- a/cli/src/dashboard/ActivityBuckets.ts
+++ b/cli/src/dashboard/ActivityBuckets.ts
@@ -1,0 +1,35 @@
+/**
+ * Quarter-hour activity bucketing — the one place a transcript's per-message
+ * timestamps become the rows behind the concurrency figure.
+ *
+ * Kept apart from the collector because it is pure and is the only piece of
+ * this feature with arithmetic worth pinning on its own.
+ */
+
+import type { TranscriptEntry } from "../Types.js";
+
+/** Bucket width. 15 minutes: coarse enough that a pause mid-thought does not
+ *  fragment a session, fine enough that "the same bucket" still reads as "at
+ *  the same time" to a person. */
+export const ACTIVITY_BUCKET_MS = 15 * 60 * 1000;
+
+/**
+ * The quarter-hour bucket starts a slice of transcript touched, deduped and
+ * ascending.
+ *
+ * An EMPTY result means no entry carried a parseable timestamp — the caller
+ * must turn that into an ABSENT `activityBuckets` field, never `[]`, so that a
+ * source whose reader emits no timestamps is reported as uncovered rather than
+ * as "used no agents". Entries without a timestamp are skipped individually, so
+ * one malformed line cannot cost the rest of the session its buckets.
+ */
+export function bucketsFrom(entries: ReadonlyArray<TranscriptEntry>): ReadonlyArray<number> {
+	const seen = new Set<number>();
+	for (const e of entries) {
+		if (!e.timestamp) continue;
+		const at = Date.parse(e.timestamp);
+		if (!Number.isFinite(at)) continue;
+		seen.add(Math.floor(at / ACTIVITY_BUCKET_MS) * ACTIVITY_BUCKET_MS);
+	}
+	return [...seen].sort((a, b) => a - b);
+}

--- a/cli/src/dashboard/DashboardCollector.test.ts
+++ b/cli/src/dashboard/DashboardCollector.test.ts
@@ -5,6 +5,11 @@ import type { GitCommandResult, SessionInfo, TranscriptReadResult, TranscriptSou
 vi.mock("../core/GitOps.js", () => ({
 	execGit: vi.fn(),
 	getCurrentBranch: vi.fn(),
+	// Antigravity's narrowing asks the repo for its checkouts. These fixtures have
+	// exactly one, which is also what the real helper degrades to when git cannot
+	// answer — so returning the identity keeps the attribution assertions about
+	// attribution rather than about worktree enumeration.
+	resolveWorktreeRoots: vi.fn(async (dir: string) => [dir]),
 }));
 vi.mock("../core/SummaryStore.js", () => ({
 	getIndex: vi.fn(),
@@ -20,6 +25,16 @@ vi.mock("../core/SummaryStore.js", () => ({
 vi.mock("../core/TranscriptReader.js", async (importOriginal) => {
 	const original = await importOriginal<typeof import("../core/TranscriptReader.js")>();
 	return { ...original, readTranscript: vi.fn() };
+});
+// PARTIAL, for the same reason as above: the default stays the REAL per-source
+// dispatcher, so a Claude session still lands on the mocked `readTranscript`
+// and `readTranscriptLinesForSource` keeps feeding the line-oriented extractors
+// that `sessionContentFor` shares. The per-source tests override the dispatch
+// with `mockResolvedValueOnce`, which is what lets them assert a codex or
+// cursor session without a real SQLite/JSONL fixture.
+vi.mock("../core/TranscriptSourceReader.js", async (importOriginal) => {
+	const original = await importOriginal<typeof import("../core/TranscriptSourceReader.js")>();
+	return { ...original, readTranscriptForSource: vi.fn(original.readTranscriptForSource) };
 });
 // The default session loader fans out to every discoverer; mock the registry
 // loader so `loadAllSessions` has one deterministic success and the rest of
@@ -40,10 +55,11 @@ import type { ClaudeDiskSession } from "../core/ClaudeSessionDiscoverer.js";
 import type { CodexDiskSession } from "../core/CodexSessionDiscoverer.js";
 import { discoverCodexSessions } from "../core/CodexSessionDiscoverer.js";
 import type { DiskSession } from "../core/DiskSessionScan.js";
-import { execGit, getCurrentBranch } from "../core/GitOps.js";
+import { execGit, getCurrentBranch, resolveWorktreeRoots } from "../core/GitOps.js";
 import { loadAllSessions as loadRegistrySessions } from "../core/SessionTracker.js";
 import { getIndex, getSummary, readTranscriptsForCommits } from "../core/SummaryStore.js";
 import { readTranscript } from "../core/TranscriptReader.js";
+import { readTranscriptForSource } from "../core/TranscriptSourceReader.js";
 import {
 	collectCommitEvents,
 	collectFilesForCommits,
@@ -52,6 +68,7 @@ import {
 	collectWorktreeEvent,
 	loadAllSessions,
 	parseNumstatLog,
+	sessionEventFromInfo,
 	sessionPassKey,
 	sourceOfSessionPassKey,
 	summaryEventFromCommitSummary,
@@ -154,14 +171,202 @@ describe("collectSessionEvents", () => {
 		expect(events[0].models?.[0].estCostUsd).toBeGreaterThan(0);
 	});
 
-	it("labels a Claude session with no usage as sessions-only", async () => {
+	it("asks every worktree root, not just cwd", async () => {
+		// The gap this closes: a conversation is keyed by the directory it RAN IN, so a
+		// linked worktree's sessions live under its own path and under its own
+		// `sessions.json`. Scoping to the registered checkout alone made them invisible
+		// to the sweep while their rows already existed — written live by the StopHook
+		// running inside that worktree.
+		vi.mocked(readTranscript).mockResolvedValue(transcript({ usageByModel: [] }));
+		const asked: string[] = [];
+		const events = await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: "/w/main",
+			worktreeRoots: ["/w/main", "/w/feature"],
+			loadSessions: async (root) => {
+				asked.push(root);
+				return root === "/w/feature" ? [claudeSession({ sessionId: "in-sibling" })] : [];
+			},
+		});
+		expect(asked).toEqual(["/w/main", "/w/feature"]);
+		expect(events.map((e) => e.sessionId)).toEqual(["in-sibling"]);
+	});
+
+	it("collects a session two roots both claim exactly once", async () => {
+		// What makes asking N roots safe. Roots overlap in practice — a source that
+		// cannot scope its store answers the same session for every root it is asked
+		// about — and the dedupe on `(source, sessionId)` is the only thing standing
+		// between that and one conversation counted once per checkout.
+		vi.mocked(readTranscript).mockResolvedValue(transcript({ usageByModel: [] }));
+		const events = await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: "/w/main",
+			worktreeRoots: ["/w/main", "/w/feature"],
+			loadSessions: async () => [claudeSession({ sessionId: "shared" })],
+		});
+		expect(events.map((e) => e.sessionId)).toEqual(["shared"]);
+	});
+
+	it("falls back to cwd when no roots are supplied", async () => {
+		vi.mocked(readTranscript).mockResolvedValue(transcript({ usageByModel: [] }));
+		const asked: string[] = [];
+		await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: "/w",
+			worktreeRoots: [],
+			loadSessions: async (root) => {
+				asked.push(root);
+				return [];
+			},
+		});
+		expect(asked).toEqual(["/w"]);
+	});
+
+	it("still asks cwd when the supplied roots leave it out", async () => {
+		// The roots come from a `git worktree list` that degrades to its input on
+		// failure, so a caller can hand over a list that does not name this checkout.
+		// Replacing `cwd` with it would drop THIS worktree's own `sessions.json` — the
+		// hook registry is per-project, so that is the one file nothing else reads —
+		// and the loss is silent: the sweep reports a clean run over a checkout it
+		// never opened. Union, never substitute.
+		vi.mocked(readTranscript).mockResolvedValue(transcript({ usageByModel: [] }));
+		const asked: string[] = [];
+		const events = await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: "/w/main",
+			worktreeRoots: ["/w/feature"],
+			loadSessions: async (root) => {
+				asked.push(root);
+				return root === "/w/main" ? [claudeSession({ sessionId: "in-cwd" })] : [];
+			},
+		});
+		expect(asked).toEqual(["/w/main", "/w/feature"]);
+		expect(events.map((e) => e.sessionId)).toEqual(["in-cwd"]);
+	});
+
+	it("reads one checkout once when cwd is also named in the roots", async () => {
+		// The common case — a caller that already unioned `cwd` in. The dedupe is on
+		// the compare-folded spelling, so `/w/Main` and `/w/main` are one checkout on
+		// a case-insensitive filesystem; the SURVIVING string is the caller's own,
+		// because `sessionDirBelongsToRepo` walks it as a real on-disk path.
+		vi.mocked(readTranscript).mockResolvedValue(transcript({ usageByModel: [] }));
+		const asked: string[] = [];
+		await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: "/w/main",
+			worktreeRoots: ["/w/main", "/w/feature"],
+			loadSessions: async (root) => {
+				asked.push(root);
+				return [];
+			},
+		});
+		expect(asked).toEqual(["/w/main", "/w/feature"]);
+	});
+
+	it("asks a worktree-spanning source once, not once per root", async () => {
+		// Antigravity is the one definition that declares `forRepoSpansWorktrees`: its
+		// narrowing runs its OWN `resolveWorktreeRoots`, so one call already covers
+		// every checkout. Asking it per root is the identical search N times, and the
+		// dedupe throws all but one result away — while each discarded pass still pays
+		// a streamed title read per claimed session. The mocked resolver is the probe:
+		// one call means one narrowing.
+		const events = await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: WORKTREE,
+			worktreeRoots: [WORKTREE, "/w/feature", "/w/third"],
+			loadSessions: async () => [],
+			preScanned: { antigravity: [diskEntry("antigravity", "ag-1")] },
+		});
+		expect(vi.mocked(resolveWorktreeRoots)).toHaveBeenCalledTimes(1);
+		expect(events.map((e) => e.sessionId)).toEqual(["ag-1"]);
+	});
+
+	it("asks a worktree-spanning source once per CHECKOUT, so a second clone is not lost", async () => {
+		// `worktreeRoots` is a union across clones — two checkouts of one remote share
+		// a repo identity — while a spanning source resolves the worktrees of the
+		// repository it is HANDED. So one call covers one clone's `.git` and reaches no
+		// other's: asking only at `cwd` dropped the second clone's sessions for this
+		// source alone, while every other source picked them up from the root list.
+		vi.mocked(resolveWorktreeRoots).mockImplementation(async (dir: string) =>
+			dir === "/w/clone-b" ? ["/w/clone-b", "/w/clone-b-feature"] : [dir, "/w/feature"],
+		);
+		const events = await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: WORKTREE,
+			worktreeRoots: [WORKTREE, "/w/feature", "/w/clone-b", "/w/clone-b-feature"],
+			checkoutRoots: [WORKTREE, "/w/clone-b"],
+			loadSessions: async () => [],
+			preScanned: {
+				antigravity: [
+					diskEntry("antigravity", "ag-1"),
+					diskEntry("antigravity", "ag-2", ["/w/clone-b-feature"]),
+				],
+			},
+		});
+		// Once per checkout — not once per worktree root (four), not once overall.
+		expect(vi.mocked(resolveWorktreeRoots)).toHaveBeenCalledTimes(2);
+		expect(events.map((e) => e.sessionId).sort()).toEqual(["ag-1", "ag-2"]);
+	});
+
+	it("runs a spanning source's per-repo FALLBACK once per checkout, not once per root", async () => {
+		// The degraded path: the machine-wide scan failed, so the source arrives as
+		// `undefined` and its own `scanForRepo` runs instead. That route used to ride
+		// inside `loadAllSessions`, which is driven per worktree root — so the full
+		// sweep this flag exists to run once ran N times concurrently, on exactly the
+		// path that was already the expensive one.
+		await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: WORKTREE,
+			worktreeRoots: [WORKTREE, "/w/feature", "/w/third"],
+			checkoutRoots: [WORKTREE, "/w/clone-b"],
+			// The real `loadAllSessions`, so the fallback is reached the way production
+			// reaches it; `antigravity` is absent from `preScanned`, which is how a
+			// failed machine-wide scan arrives.
+		});
+		// The probe is the same one the narrowing test uses: Antigravity's per-repo scan
+		// ends in `antigravitySessionsForRepo`, which resolves the worktrees of the
+		// directory it was handed. Two directories, not the three worktree roots.
+		expect(
+			vi
+				.mocked(resolveWorktreeRoots)
+				.mock.calls.map((c) => c[0])
+				.sort(),
+		).toEqual(["/w/clone-b", WORKTREE]);
+	});
+
+	it("keeps a spanning source out of the slice the per-root loader is handed", async () => {
+		// The other half of the same rule, asserted at the seam: `loadAllSessions` runs
+		// per worktree root, so anything left in its `defs` is asked N times.
+		const handed: Array<ReadonlyArray<string>> = [];
+		await collectSessionEvents({
+			repoIdentity: "r",
+			cwd: WORKTREE,
+			worktreeRoots: [WORKTREE, "/w/feature"],
+			loadSessions: async (_cwd, _windowMs, _pre, defs) => {
+				handed.push((defs ?? []).map((d) => d.source));
+				return [];
+			},
+		});
+		expect(handed).toHaveLength(2);
+		for (const sources of handed) {
+			expect(sources).not.toContain("antigravity");
+			// The slice is a narrowing, not an emptying — every other source is still there.
+			expect(sources).toContain("codex");
+		}
+	});
+
+	it("leaves tokenCoverage absent for a Claude session with no usage", async () => {
+		// Absent, not an explicit `sessions-only`: `StatsWriter` defaults absence to
+		// `sessions-only` on first write but PRESERVES an existing `full` on re-read, so
+		// a transcript whose retention window dropped its usage cannot downgrade a row
+		// that once measured full usage.
 		vi.mocked(readTranscript).mockResolvedValue(transcript({ usageByModel: [] }));
 		const events = await collectSessionEvents({
 			repoIdentity: "r",
 			cwd: "/w",
 			loadSessions: async () => [claudeSession()],
 		});
-		expect(events[0].tokenCoverage).toBe("sessions-only");
+		expect(events[0]).not.toHaveProperty("tokenCoverage");
 		expect(events[0].models).toBeUndefined();
 	});
 
@@ -259,6 +464,53 @@ describe("collectSessionEvents", () => {
 			}),
 		]);
 		expect(readTranscript).not.toHaveBeenCalled();
+	});
+
+	it("buckets a session's activity, but attributes tokens only where per-turn usage exists", async () => {
+		vi.mocked(readTranscriptForSource).mockResolvedValueOnce({
+			entries: [
+				{ role: "human", content: "hi", timestamp: "2026-08-11T10:07:00.000Z" },
+				{ role: "assistant", content: "yo", timestamp: "2026-08-11T10:41:00.000Z" },
+			],
+			newCursor: { lineNumber: 2 },
+			totalLinesRead: 2,
+		} as unknown as TranscriptReadResult);
+
+		const event = await sessionEventFromInfo("repo-1", {
+			sessionId: "s1",
+			source: "codex",
+			transcriptPath: "/tmp/s1.jsonl",
+			updatedAt: "2026-08-11T10:41:00.000Z",
+		} as SessionInfo);
+
+		expect(event?.messageCount).toBe(2);
+		expect(event?.activityBuckets).toEqual([
+			Date.parse("2026-08-11T10:00:00.000Z"),
+			Date.parse("2026-08-11T10:30:00.000Z"),
+		]);
+		// Codex carries no per-turn usage, so nothing is attributed — the event leaves
+		// `tokenCoverage` ABSENT and `StatsWriter` defaults it to `sessions-only` on
+		// first write (while preserving an existing `full` on re-read).
+		expect(event).not.toHaveProperty("tokenCoverage");
+		expect(event?.models).toBeUndefined();
+	});
+
+	it("omits activityBuckets entirely when no entry is timestamped", async () => {
+		vi.mocked(readTranscriptForSource).mockResolvedValueOnce({
+			entries: [{ role: "human", content: "hi" }],
+			newCursor: { lineNumber: 1 },
+			totalLinesRead: 1,
+		} as unknown as TranscriptReadResult);
+
+		const event = await sessionEventFromInfo("repo-1", {
+			sessionId: "s2",
+			source: "cursor",
+			transcriptPath: "/tmp/s2.db#c1",
+			updatedAt: "2026-08-11T10:41:00.000Z",
+		} as SessionInfo);
+
+		// ABSENT, not `[]` — "uncovered", not "used no agents".
+		expect(event).not.toHaveProperty("activityBuckets");
 	});
 
 	it("dedupes (source, sessionId), keeping the newest, and drops unparseable timestamps", async () => {

--- a/cli/src/dashboard/DashboardCollector.ts
+++ b/cli/src/dashboard/DashboardCollector.ts
@@ -17,6 +17,7 @@ import { UNTITLED_SESSION } from "../core/FallbackTitle.js";
 import { execGit, getCurrentBranch } from "../core/GitOps.js";
 import { JOLLI_REFS_EXCLUDE_GLOB } from "../core/JolliRefs.js";
 import { extractRepoName, getRemoteUrl, resolveKBPath } from "../core/KBPathResolver.js";
+import { normalizePathForCompare } from "../core/PathUtils.js";
 import { estimateModelCostUsd, PRICES_AS_OF } from "../core/Pricing.js";
 import { resolveSessionTitle } from "../core/SessionTitleResolver.js";
 import { loadConfig } from "../core/SessionTracker.js";
@@ -25,6 +26,7 @@ import { getIndex, getSummary, readTranscriptsForCommits } from "../core/Summary
 import { collectDisplayTopics, getTranscriptIds } from "../core/SummaryTree.js";
 import type { SessionContent } from "../core/sessions/SessionSignalExtractor.js";
 import { extractSessionSignals } from "../core/sessions/SessionSignals.js";
+import type { SessionSourceDefinition } from "../core/sessions/SessionSourceDefinition.js";
 import { SESSION_SOURCES } from "../core/sessions/SessionSources.js";
 import { isMissingTranscriptError, readTranscript } from "../core/TranscriptReader.js";
 import { readTranscriptForSource, readTranscriptLinesForSource } from "../core/TranscriptSourceReader.js";
@@ -41,6 +43,7 @@ import type {
 	TranscriptSource,
 } from "../Types.js";
 import { mapWithConcurrency, withIoBudget } from "../util/Concurrency.js";
+import { bucketsFrom } from "./ActivityBuckets.js";
 import type {
 	CommitCreatedEvent,
 	CommitFileChange,
@@ -149,7 +152,54 @@ export type SessionLoader = (
 	cwd: string,
 	windowMs?: number,
 	preScanned?: PreScannedSessions,
+	defs?: ReadonlyArray<SessionSourceDefinition>,
 ) => Promise<ReadonlyArray<SessionInfo>>;
+
+/**
+ * The per-repo fallbacks this call is responsible for, as unstarted thunks.
+ *
+ * Shared by {@link loadAllSessions} and by {@link collectSessionEvents}'s
+ * worktree-spanning half, so that BOTH routes into a source — the narrowing of a
+ * supplied scan and the fallback when there is none — obey the same granularity.
+ * They used to disagree: the spanning split was applied to `preScannedForRepo`
+ * alone, so a source whose machine-wide scan failed had its full sweep re-run
+ * once per worktree root, concurrently. That is the exact N× cost the flag
+ * exists to prevent, reached by the path that is already the degraded one.
+ */
+function scanForRepoThunks(
+	defs: ReadonlyArray<SessionSourceDefinition>,
+	pre: PreScannedSessions,
+	cwd: string,
+	windowMs: number | undefined,
+): Array<() => Promise<ReadonlyArray<SessionInfo>>> {
+	const thunks: Array<() => Promise<ReadonlyArray<SessionInfo>>> = [];
+	// EVERY registered source is skippable, because every one of them reads a store
+	// keyed by something other than the repo — so a caller that already scanned it
+	// machine-wide must not have it read a second time, once per repo.
+	//
+	// The check is `!== undefined`, never truthiness: `[]` is the positive claim "the
+	// scan ran and found nothing", and re-running the per-repo loader on that would
+	// undo the hoist for exactly the sources that are cheapest to get wrong about.
+	for (const def of defs) {
+		const perRepo = def.scanForRepo;
+		if (!perRepo || pre[def.source] !== undefined) continue;
+		thunks.push(() => perRepo(cwd, windowMs));
+	}
+	return thunks;
+}
+
+/** Runs discovery thunks concurrently, logging and skipping the ones that throw. */
+async function settleLoaders(
+	loaders: ReadonlyArray<() => Promise<ReadonlyArray<SessionInfo>>>,
+): Promise<ReadonlyArray<SessionInfo>> {
+	const settled = await Promise.allSettled(loaders.map((load) => load()));
+	const sessions: SessionInfo[] = [];
+	for (const result of settled) {
+		if (result.status === "fulfilled") sessions.push(...result.value);
+		else log.warn("session discoverer failed during dashboard collection: %s", errMsg(result.reason));
+	}
+	return sessions;
+}
 
 /**
  * Default loader: every per-source discoverer, failures logged and skipped.
@@ -159,11 +209,19 @@ export type SessionLoader = (
  * history back-fill is the only caller that does — see
  * {@link BACKFILL_SESSION_WINDOW_MS} for why widening the constants instead would
  * have reached the post-commit summary and corrupted what it stores.
+ *
+ * `defs` is the slice of {@link SESSION_SOURCES} this call answers for; the whole
+ * registry is the default and is what every single-root caller wants. The one
+ * caller that narrows it is {@link collectSessionEvents}, which drives the
+ * worktree-spanning sources on their own granularity — see
+ * {@link SessionSourceDefinition.forRepoSpansWorktrees}. The hook registry read is
+ * NOT part of that slice: it is per-project, so it belongs to every root.
  */
 export async function loadAllSessions(
 	cwd: string,
 	windowMs?: number,
 	preScanned: PreScannedSessions = {},
+	defs: ReadonlyArray<SessionSourceDefinition> = SESSION_SOURCES,
 ): Promise<ReadonlyArray<SessionInfo>> {
 	// Lazy imports throughout, same rationale as ActiveSessionAggregator: several
 	// discoverers reach for node:sqlite, and loading them eagerly would emit the
@@ -191,26 +249,9 @@ export async function loadAllSessions(
 		// `saveSession`, so widening a window cannot bring them back — only a Gemini
 		// disk scanner could, and that is deliberately its own change.
 		async () => (await import("../core/SessionTracker.js")).loadAllSessions(cwd, windowMs),
+		...scanForRepoThunks(defs, preScanned, cwd, windowMs),
 	];
-	// EVERY registered source is skippable, because every one of them reads a store
-	// keyed by something other than the repo — so a caller that already scanned it
-	// machine-wide must not have it read a second time, once per repo.
-	//
-	// The check is `!== undefined`, never truthiness: `[]` is the positive claim "the
-	// scan ran and found nothing", and re-running the per-repo loader on that would
-	// undo the hoist for exactly the sources that are cheapest to get wrong about.
-	for (const def of SESSION_SOURCES) {
-		const perRepo = def.scanForRepo;
-		if (!perRepo || preScanned[def.source] !== undefined) continue;
-		loaders.push(() => perRepo(cwd, windowMs));
-	}
-	const settled = await Promise.allSettled(loaders.map((load) => load()));
-	const sessions: SessionInfo[] = [];
-	for (const result of settled) {
-		if (result.status === "fulfilled") sessions.push(...result.value);
-		else log.warn("session discoverer failed during dashboard collection: %s", errMsg(result.reason));
-	}
-	return sessions;
+	return settleLoaders(loaders);
 }
 
 /**
@@ -270,11 +311,53 @@ export interface SessionPassCounts {
 export interface CollectSessionsOptions {
 	readonly repoIdentity: string;
 	readonly cwd: string;
+	/**
+	 * Every checkout whose sessions belong to this repo — `cwd` plus its linked
+	 * worktrees. Defaults to `[cwd]`, and `cwd` is unioned in regardless, so a
+	 * list that omits it (or spells it differently) can only ADD roots, never
+	 * take this checkout's own registry away.
+	 *
+	 * A conversation is keyed by the directory it RAN IN, and a developer running
+	 * agents across `git worktree` checkouts produces sessions under each of them.
+	 * One root therefore does not scope a repo, it scopes a checkout: measured on a
+	 * repo with six live worktrees, 65 of 94 in-window Claude sessions belonged to a
+	 * sibling and were invisible — and they are precisely the parallel work the
+	 * agent-concurrency figure exists to show.
+	 *
+	 * The rules are unchanged and stay where they are: every root is asked the same
+	 * per-source question, and {@link sessionDirBelongsToRepo}'s nested-`.git` walk
+	 * still excludes a checkout nested INSIDE another (that one answers for itself,
+	 * as its own root in this list). Widening the predicate instead would have
+	 * re-opened the cross-context bleed it exists to prevent.
+	 *
+	 * Cost is one narrowing pass per root over scans that were already read once for
+	 * the whole run; the dedupe on `(source, sessionId)` below is what makes asking
+	 * N roots safe — a session two roots both claim is collected once.
+	 */
+	readonly worktreeRoots?: ReadonlyArray<string>;
+	/**
+	 * One entry per REGISTERED checkout of this repo — a second clone of the same
+	 * remote is a second entry, its own linked worktrees are not. Defaults to
+	 * `[cwd]`, and `cwd` is unioned in regardless, for the same reason
+	 * {@link worktreeRoots} is.
+	 *
+	 * This is the granularity a {@link SessionSourceDefinition.forRepoSpansWorktrees}
+	 * source is asked at, and the distinction from `worktreeRoots` is exactly what
+	 * that flag claims: such a source resolves the worktrees of the repository it is
+	 * HANDED, so one call covers every linked checkout of one clone and no call
+	 * covers a different clone's `.git`. Asking only at `cwd` therefore dropped the
+	 * second clone's sessions outright — silently, and for that source alone, since
+	 * every other source is matched against each root in `worktreeRoots`.
+	 *
+	 * The cost of one redundant entry is one repeated narrowing that the dedupe on
+	 * `(source, sessionId)` reconciles; the cost of a missing one is lost sessions.
+	 */
+	readonly checkoutRoots?: ReadonlyArray<string>;
 	/** Injected for tests. Defaults to {@link loadAllSessions}. */
 	readonly loadSessions?: SessionLoader;
 	/**
-	 * Reads a transcript's usage. Injected for tests; the default reads real
-	 * Claude JSONL via `readTranscript`.
+	 * Reads a transcript's usage. Injected for tests; the default dispatches
+	 * to the reader each source requires via `readTranscriptForSource`.
 	 */
 	readonly readUsage?: typeof readTranscript;
 	/**
@@ -400,10 +483,13 @@ async function resolveTitle(s: SessionInfo): Promise<string | undefined> {
  * session recorded live and the same session re-collected later land on the
  * identical row with identical semantics.
  *
- * Token figures come from the transcript itself and only Claude transcripts
- * carry per-turn usage — every other source is honestly labelled
- * `sessions-only`, which the UI renders as a session count instead of a token
- * figure (the mockups' G-3 coverage split).
+ * Every source's transcript is now read, via the same per-source dispatch
+ * the active-conversations sidebar uses (`readTranscriptForSource`) — not
+ * only Claude's. That is what lets `activityBuckets` be derived for every
+ * source. Token figures still come from per-turn usage, which today only
+ * Claude transcripts carry: every other source gets `activityBuckets` and
+ * `messageCount` but no `models`/`tokenCoverage`, which `StatsWriter`
+ * defaults to `sessions-only` when absent (the mockups' G-3 coverage split).
  *
  * Returns null when the discoverer's timestamp is unparseable — an event
  * without a valid `updatedAtMs` cannot be bucketed anywhere.
@@ -475,7 +561,12 @@ export async function sessionEventFromInfo(
 	// read per session.
 	const sessionContent = sessionContentFor(source, s.transcriptPath, readUsage);
 	try {
+		// Cursor-less, so this is the WHOLE session rather than a slice. Two things
+		// downstream depend on that and would fail quietly against a partial read:
+		// `projectSession`'s wholesale replace of the model/tool rows, and the
+		// activity buckets below.
 		const read = await sessionContent.read();
+		const buckets = bucketsFrom(read.entries);
 		const models: StatsModelUsage[] = toStatsModelUsage(read.usageByModel ?? []);
 		// Priced here, beside the aggregate, from the SAME model→provider mapping the
 		// aggregate was priced with — the two read the same transcript lines, so a
@@ -516,12 +607,16 @@ export async function sessionEventFromInfo(
 			...(Number.isFinite(startedAtMs) && Number.isFinite(endedAtMs) && endedAtMs > startedAtMs
 				? { durationMs: endedAtMs - startedAtMs }
 				: {}),
-			// `sessions-only` is now reached by a source having no per-turn usage to
-			// report rather than by it not being Claude. Same outcome for the sources
-			// that carry none, and an honest `full` for any that does.
-			...(models.length > 0
-				? { models, tokenCoverage: "full" as const, pricesAsOf: PRICES_AS_OF }
-				: { tokenCoverage: "sessions-only" as const }),
+			// Only the `full` case sets `tokenCoverage`. A source with no per-turn usage
+			// leaves it ABSENT rather than writing `sessions-only`, because the merge in
+			// `StatsWriter` reads absence as "preserve": `event.tokenCoverage ??
+			// existing?.token_coverage ?? "sessions-only"`. On first write the default
+			// still lands `sessions-only`; on a RE-read that lost its usage (a Claude
+			// transcript whose retention window dropped the per-turn data) an explicit
+			// `sessions-only` would DOWNGRADE a row that had measured `full` — and the
+			// token COUNTS on the same row already fall back to the existing values, so
+			// clearing only the coverage flag would leave the row self-contradictory.
+			...(models.length > 0 ? { models, tokenCoverage: "full" as const, pricesAsOf: PRICES_AS_OF } : {}),
 			// Forwarded whenever the reader says this source is usage-capable,
 			// including an EMPTY set: a re-read that can see usage but nothing
 			// datable must clear the rows an earlier, better read left behind —
@@ -531,6 +626,10 @@ export async function sessionEventFromInfo(
 			// "called no tools" and is worth storing; absence means "this source cannot
 			// report them", and the two must not collapse.
 			...(signals.tools ? { tools: signals.tools } : {}),
+			// ABSENT, never `[]`: a source whose reader emits no timestamps computes an
+			// empty array on every read, and emitting it would assert "measured, no
+			// activity" about a source that was never measurable.
+			...(buckets.length > 0 ? { activityBuckets: buckets } : {}),
 		};
 	} catch (err) {
 		// A moved or deleted transcript still counts as a session — record it
@@ -624,7 +723,33 @@ function sessionContentFor(
 }
 
 /**
+ * Distinct checkout roots, first spelling wins, order preserved.
+ *
+ * Folded with `normalizePathForCompare` for the COMPARISON only — the surviving
+ * string is the caller's own, because every consumer downstream feeds it either
+ * to `sessionDirBelongsToRepo` (whose nested-`.git` walk needs a real on-disk
+ * path) or to a `sessions.json` read, and a lower-cased path is neither on a
+ * case-sensitive filesystem. Same trade `resolveWorktreeRoots` documents.
+ */
+function dedupeRoots(roots: ReadonlyArray<string>): string[] {
+	const seen = new Set<string>();
+	const out: string[] = [];
+	for (const root of roots) {
+		const key = normalizePathForCompare(root);
+		if (seen.has(key)) continue;
+		seen.add(key);
+		out.push(root);
+	}
+	return out;
+}
+
+/**
  * Narrows every supplied machine-wide scan to one repo.
+ *
+ * `defs` is the slice of {@link SESSION_SOURCES} this call is responsible for —
+ * the caller splits the registry on {@link SessionSourceDefinition.forRepoSpansWorktrees}
+ * and drives the two halves differently. Passing the whole registry is the
+ * single-root case and is what every non-worktree-aware caller wants.
  *
  * Each source's own `…SessionsForRepo` does its own matching — this only decides
  * WHICH ones to ask, and asks exactly those the caller supplied. Two are async and
@@ -640,10 +765,11 @@ function sessionContentFor(
 async function preScannedForRepo(
 	pre: PreScannedSessions,
 	cwd: string,
-	windowMs?: number,
+	windowMs: number | undefined,
+	defs: ReadonlyArray<SessionSourceDefinition>,
 ): Promise<ReadonlyArray<SessionInfo>> {
 	const out: SessionInfo[] = [];
-	for (const def of SESSION_SOURCES) {
+	for (const def of defs) {
 		const scanned = pre[def.source];
 		// `!== undefined` rather than truthiness: `[]` means the scan ran and found
 		// nothing, which must still be narrowed (to nothing) rather than treated as
@@ -673,8 +799,53 @@ export async function collectSessionEvents(opts: CollectSessionsOptions): Promis
 	// A source supplied as a pre-scan is NOT loaded again by the fan-out — otherwise
 	// its store would be read twice per repo, which is the opposite of the point. One
 	// object drives both halves, so the two cannot disagree.
-	const discovered = await load(opts.cwd, opts.windowMs, preScanned);
-	const sessions = [...discovered, ...(await preScannedForRepo(preScanned, opts.cwd, opts.windowMs))];
+	// Every checkout, not just `cwd` — see `CollectSessionsOptions.worktreeRoots`. The
+	// two halves are asked per root for the same reason: `loadAllSessions` reads the
+	// PER-PROJECT hook registry (each worktree has its own `sessions.json`, so a single
+	// root reads one of six files), and `preScannedForRepo` runs each source's own
+	// path-containment rule, which a sibling checkout fails by construction.
+	//
+	// `cwd` is UNIONED in rather than replaced by the supplied list, and the direction
+	// matters: the roots come from a `git worktree list` that degrades to its input on
+	// failure, and a caller that resolved them at a sibling — or against a realpath
+	// that folds differently from the one it passes as `cwd` — would otherwise drop
+	// this checkout's own `sessions.json` with nothing logged. A redundant root costs
+	// one registry read and is reconciled by the dedupe below; a missing one is silent
+	// data loss. Deduped on the compare-folded spelling so two spellings of one
+	// checkout do not read the same file twice.
+	const roots = dedupeRoots([opts.cwd, ...(opts.worktreeRoots ?? [])]);
+	// The registry is split because the two halves answer at different granularity.
+	// A source that resolves the repo's worktrees itself (`forRepoSpansWorktrees`) is
+	// asked once per CHECKOUT — running it per worktree root re-runs an identical
+	// search whose results the dedupe discards, and for Antigravity each discarded
+	// pass costs a streamed title read per claimed session. Everything else matches
+	// against the single directory it is handed and must be asked per root.
+	//
+	// Per checkout, and not simply once at `cwd`: what such a source resolves is the
+	// worktree set of the repository it is HANDED, so one call covers one clone's
+	// linked checkouts and reaches no other clone's `.git` — while `worktreeRoots` is
+	// deliberately a union ACROSS clones (two checkouts of one remote share an
+	// identity). See `CollectSessionsOptions.checkoutRoots`.
+	const spanning = SESSION_SOURCES.filter((def) => def.forRepoSpansWorktrees);
+	const perRootDefs = SESSION_SOURCES.filter((def) => !def.forRepoSpansWorktrees);
+	const checkouts = dedupeRoots([opts.cwd, ...(opts.checkoutRoots ?? [])]);
+	const perRoot = await Promise.all(
+		roots.map(async (root) => [
+			...(await load(root, opts.windowMs, preScanned, perRootDefs)),
+			...(await preScannedForRepo(preScanned, root, opts.windowMs, perRootDefs)),
+		]),
+	);
+	// Both routes into a spanning source — narrowing a supplied scan, and the
+	// per-repo fallback when there is none — run here, on the same granularity. The
+	// fallback used to ride inside `load` above, which put it back on the per-root
+	// loop that the split exists to keep it off.
+	const perCheckout = await Promise.all(
+		checkouts.map(async (root) => [
+			...(await settleLoaders(scanForRepoThunks(spanning, preScanned, root, opts.windowMs))),
+			...(await preScannedForRepo(preScanned, root, opts.windowMs, spanning)),
+		]),
+	);
+	const sessions = [...perRoot.flat(), ...perCheckout.flat()];
 
 	// Dedupe on (source, id), newest wins — two discoverers can surface the same
 	// session (e.g. a registry entry and a rescan of the same store).

--- a/cli/src/dashboard/DashboardDb.test.ts
+++ b/cli/src/dashboard/DashboardDb.test.ts
@@ -328,6 +328,62 @@ describe("withDashboardDb", () => {
 		);
 		expect(count).toBe(0);
 	});
+
+	it("creates session_activity, keyed per (session, bucket) and rejecting a REAL bucket", async () => {
+		const rows = await withDashboardDb(
+			(db) =>
+				db
+					.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'session_activity'")
+					.all() as ReadonlyArray<{ name: string }>,
+			{ dbPath },
+		);
+		expect(rows).toHaveLength(1);
+
+		// STRICT is what turns a forgotten Math.floor into a loud failure instead
+		// of a fractional bucket that silently defeats the primary key.
+		await withDashboardDb(
+			(db) => {
+				// `enabled_at` is NOT NULL with no default — omitting it fails the insert.
+				db.prepare(
+					"INSERT INTO repos (repo_identity, repo_name, worktree_root, enabled_at) VALUES (?, ?, ?, ?)",
+				).run("repo-1", "repo-1", "/tmp/repo-1", "2026-08-11T00:00:00.000Z");
+				db.prepare(
+					`INSERT INTO sessions (event_id, repo_id, source, session_id, updated_at_ms)
+				 VALUES ('s-evt', 1, 'claude', 's1', 1786425300000)`,
+				).run();
+				db.prepare(
+					"INSERT INTO session_activity (session_event_id, bucket_ms, recorded_at_ms) VALUES (?, ?, ?)",
+				).run("s-evt", 1786425300000, 1786425400000);
+				expect(() =>
+					db
+						.prepare(
+							"INSERT INTO session_activity (session_event_id, bucket_ms, recorded_at_ms) VALUES (?, ?, ?)",
+						)
+						.run("s-evt", 1786425300000.5, 1786425400000),
+				).toThrow(/REAL/);
+
+				// `recorded_at_ms` is NOT NULL with no default — the in-place edit to
+				// migration entry 5 is what bought that (an appended ALTER TABLE could
+				// only have added it nullable), so pin it rather than let a future
+				// "just append a migration" quietly relax it.
+				expect(() =>
+					db
+						.prepare("INSERT INTO session_activity (session_event_id, bucket_ms) VALUES (?, ?)")
+						.run("s-evt", 1),
+				).toThrow(/NOT NULL/);
+			},
+			{ dbPath },
+		);
+	});
+
+	it("ends at the version this build declares", async () => {
+		// Against the CONSTANT, never a literal: a literal here is a second place to
+		// remember on every append, and `MigrationFingerprints.test.ts` already pins
+		// the constant to `MIGRATIONS.length`. What this adds is that a real database
+		// actually arrives there — the fingerprint test never opens one.
+		const version = await withDashboardDb((db) => readSchemaVersion(db), { dbPath });
+		expect(version).toBe(DASHBOARD_SCHEMA_VERSION);
+	});
 });
 
 describe("withReadonlyDashboardDb", () => {

--- a/cli/src/dashboard/DashboardDb.ts
+++ b/cli/src/dashboard/DashboardDb.ts
@@ -37,6 +37,7 @@ import {
 	RECALL_RECEIPTS_DDL,
 	REPOS_DELETE_ALLOWED_DDL,
 	SCHEMA_MIGRATIONS_DDL,
+	SESSION_ACTIVITY_DDL,
 	SESSION_USAGE_EVENTS_DDL,
 	SKILL_CONTEXT_KIND_DDL,
 	STATS_DAILY_DAY_INDEX_DDL,
@@ -71,11 +72,12 @@ const log = createLogger("DashboardDb");
  * cumulative total under a single timestamp cannot be split across the days the
  * conversation actually spanned), the `stats_daily` rollup cache plus the
  * `commits.written_at_ms` that detects a stale day, the stamp and keyset indexes
- * those two need, and the backfill that gives every stamp a number.
+ * those two need, and the backfill that gives every stamp a number; entry 8 adds
+ * `session_activity`.
  *
- * ONE entry because the intermediate versions those steps produced (8 through 13)
- * exist on no database anybody will ever ship or receive — they were this
- * branch's own development history, and a version the release cannot reach is
+ * Entry 7 is ONE entry because the intermediate versions its steps produced
+ * (8 through 13 of that branch's own development) exist on no database anybody
+ * will ever ship or receive, and a version the release cannot reach is
  * bookkeeping nobody can act on. That merge is only legal because the feature has
  * not shipped; once it has, the append-only rule below takes over and the next
  * feature's steps must each be their own entry. The cost of getting this wrong is
@@ -84,6 +86,21 @@ const log = createLogger("DashboardDb");
  * seven steps — three index entries, an ALTER and a backfill, none of which can
  * introduce a table an older build cannot see — would each have disabled that
  * cache on every older build for nothing.
+ *
+ * Entry 8 (`session_activity`) is what the collision below produced: it and the
+ * session-statistics sync were two unreleased branches that each appended an
+ * "entry 7", and the merge kept BOTH — the sync as 7, session_activity as 8 —
+ * exactly because the log is keyed by NAME, not by position.
+ *
+ * **The number no longer decides anything, and that is what makes appending
+ * safe.** It was once the whole key — the loop ran `MIGRATIONS.slice(from)` — so
+ * two unreleased branches appending DIFFERENT entries under the same one
+ * collided on the machine-global database: whichever ran first stamped it, and
+ * the second build then saw `stored >= claimed`, ran nothing, and failed at
+ * query time with `no such table`, which reads like a code bug. That is why the
+ * log below is keyed by NAME. A branch that appends an entry the file has never
+ * seen now gets it applied whatever the stamp says, so the only remaining job of
+ * this number is migration bookkeeping.
  *
  * Bumping it is NOT a cross-surface event any more, and that is the one thing
  * worth knowing about it: nothing refuses a database over this number (see the
@@ -109,7 +126,7 @@ const log = createLogger("DashboardDb");
  * user's database (other processes may hold the file open, and the memory half
  * is the only copy there is).
  */
-export const DASHBOARD_SCHEMA_VERSION = 8;
+export const DASHBOARD_SCHEMA_VERSION = 9;
 
 /**
  * NOTE ON COMPATIBILITY, because its absence here is a decision.
@@ -317,11 +334,27 @@ export interface Migration {
  * being read under the old session-time fallback rather than dropping out of
  * every window for want of a value.
  *
- * There is no entry normalising a stored `0` in that column, and that absence is
- * a decision: the writers cannot produce one, and the reader treats one as
- * absent (`TOOL_CALL_TIME_SQL`'s `NULLIF`), which is both permanent and free
- * where a sixth entry would have been neither. See the note in `SotSchema.ts`
- * where that entry used to be.
+ * Entry 8 adds `session_activity`, with `recorded_at_ms` NOT NULL from the
+ * start. Carrying the column in the CREATE rather than appending it later is the
+ * whole reason it can be NOT NULL: SQLite's `ADD COLUMN` takes only a CONSTANT
+ * default, and the value is a wall-clock instant. That is entry 4's
+ * `last_call_at_ms` shape, whose permanent `NULLIF` handling at every read site
+ * is the price of having had no choice — here there was one, so it was taken.
+ *
+ * A dev machine that ran an EARLIER draft of this entry has the table under the
+ * same name, so the name key reads it as applied and does not replay it. If the
+ * draft's shape differed, that is drift rather than a missing table:
+ * {@link findDriftedMigrations} reports it and `jolli doctor --schema-log` lists
+ * it, and the repair is the operator's — `DROP TABLE session_activity`, then
+ * `jolli doctor --mark-migration` or a stamp the entry can replay under. Nothing
+ * here self-heals a column, and nothing should: replaying DDL over a table whose
+ * contents this build cannot vouch for is how a half-migrated file is made.
+ *
+ * There is no entry normalising a stored `0` in `last_call_at_ms`, and that
+ * absence is a decision: the writers cannot produce one, and the reader treats
+ * one as absent (`TOOL_CALL_TIME_SQL`'s `NULLIF`), which is permanent where a
+ * migration entry runs once. See the note in `SotSchema.ts` where that entry
+ * used to be.
  *
  * Exported for tests: they execute entries directly to build a database at a
  * chosen version rather than hand-rolling copies of the DDL, which would drift.
@@ -386,6 +419,7 @@ BEGIN SELECT RAISE(ABORT, 'repos are never deleted: set disabled_at instead'); E
 			SYNC_KEYSET_INDEX_DDL +
 			SYNC_STAMP_NULL_BACKFILL_DDL,
 	},
+	{ name: "SESSION_ACTIVITY_DDL", ddl: SESSION_ACTIVITY_DDL },
 ];
 
 /** Reads the stored schema version, treating a fresh DB as 0. */

--- a/cli/src/dashboard/DashboardModel.ts
+++ b/cli/src/dashboard/DashboardModel.ts
@@ -88,6 +88,19 @@ export interface SessionUpsertedEvent {
 	 * without tool parsing from erasing what a full read collected.
 	 */
 	readonly tools?: ReadonlyArray<ToolCallCount>;
+	/**
+	 * Quarter-hour buckets in which this session produced a message. REPLACES
+	 * the stored set when present; `undefined` means "this producer could not
+	 * see per-message timestamps" and leaves the rows alone — which is what
+	 * keeps a re-upsert from a source without timestamps from erasing what a
+	 * full read collected.
+	 *
+	 * Producers must send `undefined`, never `[]`, when nothing was timestamped:
+	 * a source whose reader emits no timestamps computes an empty array on every
+	 * read, and emitting it would assert "measured, no activity" about a source
+	 * that was never measurable.
+	 */
+	readonly activityBuckets?: ReadonlyArray<number>;
 }
 
 /**
@@ -1101,6 +1114,55 @@ export interface HourBucket {
 	readonly sessions: number;
 }
 
+/** One quarter-hour and how many distinct agent sessions were active in it. */
+export interface ConcurrencyBucket {
+	readonly bucketMs: number;
+	readonly sessions: number;
+}
+
+/**
+ * How many agents ran at the same time — machine-global and self-only.
+ *
+ * Deliberately NOT filtered by the page's repo scope: concurrency means "how
+ * many things was this person doing at once", which is a property of the person
+ * and not of a repository. A per-repo figure truncates the number into
+ * something with no actionable meaning.
+ */
+export interface ConcurrencyModel {
+	/** Only buckets with at least one session; ascending. */
+	readonly buckets: ReadonlyArray<ConcurrencyBucket>;
+	/** Bucket width, carried on the wire so a renderer never hardcodes it. */
+	readonly bucketMinutes: number;
+	/**
+	 * Highest session count in any one bucket — an UPPER BOUND on instantaneous
+	 * concurrency, not the thing itself: two sessions active in the same quarter
+	 * hour need not overlap at any instant. Any label must say "agents active
+	 * within the same 15 minutes", never "running simultaneously".
+	 */
+	readonly peak: number;
+	/**
+	 * Mean session count over ACTIVE buckets. The denominator is deliberately
+	 * the buckets with activity, not the buckets in the window: a 7-day window
+	 * holds 672 buckets and dividing by all of them yields ~0.2, a figure with
+	 * no meaning. Any label must state the denominator.
+	 */
+	readonly meanActive: number;
+	/** Sources that contributed at least one bucket in the window. */
+	readonly measuredSources: ReadonlyArray<string>;
+	/**
+	 * Sources whose in-window sessions produced NO activity bucket at all —
+	 * uncovered, not idle.
+	 *
+	 * Deliberately not the complement of {@link measuredSources}: that one is
+	 * scoped to buckets inside the window and answers "did this source draw a
+	 * bar", which a session admitted by `updatedAt` while all its turns predate
+	 * the window fails despite being perfectly measurable. This asks whether the
+	 * source's own sessions ever produced a bucket at all. The two lists can
+	 * therefore overlap, and the overlap is honest.
+	 */
+	readonly uncoveredSources: ReadonlyArray<string>;
+}
+
 export interface FunStats {
 	readonly legendarySessionMinutes: number;
 	readonly legendarySessionTitle?: string;
@@ -1355,6 +1417,10 @@ export interface StatsModel {
 	readonly decisions?: DecisionsCard;
 	/** Skills, MCP servers and the tool mix — Claude-only coverage, stated. */
 	readonly toolUsage: ToolUsage;
+	/** Absent when no bucket falls in the window — a consumer shows "no data",
+	 *  never a zero. Under forward-only collection this is the normal state for
+	 *  the first days after deployment. */
+	readonly concurrency?: ConcurrencyModel;
 }
 
 /** A commit row on the Standup page. */

--- a/cli/src/dashboard/DashboardQuery.test.ts
+++ b/cli/src/dashboard/DashboardQuery.test.ts
@@ -1023,6 +1023,130 @@ describe("buildDashboardModel", () => {
 			expect(old.heatmap.every((cell) => cell.sessions === 0)).toBe(true);
 		});
 	});
+
+	describe("concurrency", () => {
+		// Two adjacent quarter-hours inside the default window.
+		const B0 = Math.floor((nowMs - 3_600_000) / 900_000) * 900_000;
+		const B1 = B0 + 900_000;
+
+		const model = async () =>
+			withDashboardDb(
+				(db) => buildDashboardModel(db, { view: "stats", scope: { kind: "all" }, timeZone: "UTC", nowMs }),
+				{ dbPath },
+			);
+
+		it("counts one agent session once even when it touched two repos", async () => {
+			// `sessions` is unique on (repo_id, source, session_id), so the SAME
+			// agent session in two repos is two rows with two event ids. Counting
+			// event ids would report one agent as two — and this figure is
+			// machine-global, which makes that certain rather than latent.
+			await applyStatsEvents(
+				[
+					session({ repoIdentity: "repo-1", source: "cursor", sessionId: "s1", activityBuckets: [B0] }),
+					session({ repoIdentity: "repo-2", source: "cursor", sessionId: "s1", activityBuckets: [B0] }),
+				],
+				{ producerKind: "cli", dbPath },
+			);
+			expect((await model()).stats?.concurrency?.peak).toBe(1);
+		});
+
+		it("reports the peak and the mean over ACTIVE buckets only", async () => {
+			await applyStatsEvents(
+				[
+					session({ source: "claude", sessionId: "s1", activityBuckets: [B0, B1] }),
+					session({ source: "codex", sessionId: "s2", activityBuckets: [B0] }),
+				],
+				{ producerKind: "cli", dbPath },
+			);
+			const stats = (await model()).stats;
+			// B0 holds 2 sessions, B1 holds 1. The mean over the two ACTIVE buckets
+			// is 1.5 — not 3/672, which is what dividing by the window would give.
+			expect(stats?.concurrency?.peak).toBe(2);
+			expect(stats?.concurrency?.meanActive).toBeCloseTo(1.5);
+			expect(stats?.concurrency?.buckets).toHaveLength(2);
+			expect(stats?.concurrency?.bucketMinutes).toBe(15);
+		});
+
+		it("names sources that contributed sessions but no buckets as uncovered", async () => {
+			await applyStatsEvents(
+				[
+					session({ source: "claude", sessionId: "s1", activityBuckets: [B0] }),
+					session({ source: "opencode", sessionId: "s2" }),
+				],
+				{ producerKind: "cli", dbPath },
+			);
+			const stats = (await model()).stats;
+			expect(stats?.concurrency?.measuredSources).toEqual(["claude"]);
+			// Uncovered, NOT "ran zero agents".
+			expect(stats?.concurrency?.uncoveredSources).toEqual(["opencode"]);
+		});
+
+		it("does not call a source uncovered when its buckets merely predate the window", async () => {
+			// A session enters the window by `updated_at_ms`, but its buckets are keyed
+			// by its TURNS — and the two come apart in practice. A conversation resumed
+			// just after midnight, or one from a source whose `updatedAt` is its store
+			// row's timestamp rather than its last turn, is in-window with every bucket
+			// older than the window.
+			//
+			// `measuredSources` correctly says it drew no bar. Deriving "uncovered" by
+			// subtracting that set turned the same fact into a claim about the AGENT —
+			// "this one carries no per-turn timestamps" — which is exactly what the
+			// label is read as, and which is false here.
+			const oldTurnMs = nowMs - 45 * 86_400_000;
+			await applyStatsEvents(
+				[
+					session({ source: "claude", sessionId: "s1", activityBuckets: [B0] }),
+					session({
+						source: "opencode",
+						sessionId: "resumed",
+						// In-window by its update instant …
+						updatedAtMs: nowMs,
+						// … while its only turn is well before the 30-day window starts.
+						activityBuckets: [Math.floor(oldTurnMs / 900_000) * 900_000],
+					}),
+				],
+				{ producerKind: "cli", dbPath },
+			);
+			const stats = (await model()).stats;
+			// It drew no bar in the window — that half is honest and unchanged.
+			expect(stats?.concurrency?.measuredSources).not.toContain("opencode");
+			// But it is measurable, so it must not be named as uncovered.
+			expect(stats?.concurrency?.uncoveredSources).toEqual([]);
+		});
+
+		it("ignores the repo scope — concurrency is a property of the person", async () => {
+			await applyStatsEvents(
+				[
+					session({ repoIdentity: "repo-1", source: "claude", sessionId: "s1", activityBuckets: [B0] }),
+					session({ repoIdentity: "repo-2", source: "codex", sessionId: "s2", activityBuckets: [B0] }),
+				],
+				{ producerKind: "cli", dbPath },
+			);
+			const scoped = await withDashboardDb(
+				(db) =>
+					buildDashboardModel(db, {
+						view: "stats",
+						scope: { kind: "repo", repoIdentities: ["repo-1"] },
+						timeZone: "UTC",
+						nowMs,
+					}),
+				{ dbPath },
+			);
+			// Both agents still count: filtering here would truncate the number
+			// into something with no actionable meaning.
+			expect(scoped.stats?.concurrency?.peak).toBe(2);
+		});
+
+		it("omits the field entirely when no bucket falls in the window", async () => {
+			await applyStatsEvents([session({ source: "claude", sessionId: "s1" })], {
+				producerKind: "cli",
+				dbPath,
+			});
+			// Absent, not a zero: under forward-only collection this is the normal
+			// state for the first days after deployment.
+			expect((await model()).stats?.concurrency).toBeUndefined();
+		});
+	});
 });
 
 describe("buildDashboardModel — tool usage", () => {

--- a/cli/src/dashboard/DashboardQuery.ts
+++ b/cli/src/dashboard/DashboardQuery.ts
@@ -23,10 +23,12 @@ import { TOOL_RECORDING_SOURCES } from "../core/TranscriptParser.js";
 import type { TranscriptRepairState } from "../core/TranscriptRepair.js";
 import { createLogger, errMsg } from "../Logger.js";
 import type { CommitSummary } from "../Types.js";
+import { ACTIVITY_BUCKET_MS } from "./ActivityBuckets.js";
 import type { DashboardDbHandle } from "./DashboardDb.js";
 import type {
 	AdoptionTier,
 	CommitInsightKind,
+	ConcurrencyModel,
 	CoverageNote,
 	DashboardMenus,
 	DashboardModel,
@@ -966,6 +968,7 @@ function buildStats(
 	// has no summarized commits, so this comes back empty and the renderer shows
 	// the session list instead.
 	const memoryFeed = buildMemoryCards(db, scope, window, reachable);
+	const concurrency = buildConcurrency(db, window);
 
 	return {
 		...seriesResult,
@@ -986,6 +989,7 @@ function buildStats(
 		rangeFrom: window.from,
 		rangeTo: window.to,
 		toolUsage: buildToolUsage(db, scope, window),
+		...(concurrency !== undefined ? { concurrency } : {}),
 		...(pricesAsOf ? { pricesAsOf } : {}),
 		...(memoriesCreated !== undefined ? { memoriesCreated } : {}),
 		...(decisions !== undefined ? { decisionsCaptured: decisions.keptCount, decisions } : {}),
@@ -1423,6 +1427,93 @@ function decisionCountsFor(
 function withModel(summary: CommitSummary): { model?: string } {
 	const model = dominantWorkingModel(summary);
 	return model ? { model } : {};
+}
+
+// ── Concurrency ──────────────────────────────────────────────────────────────
+
+/**
+ * The concurrency figure. Takes a window but NOT a scope: it is machine-global
+ * by design (see {@link ConcurrencyModel}).
+ */
+function buildConcurrency(db: DashboardDbHandle, window: ResolvedWindow): ConcurrencyModel | undefined {
+	const rows = db
+		.prepare(
+			// COUNT(DISTINCT session_event_id) would be WRONG: `sessions` is unique
+			// on (repo_id, source, session_id), so one agent session that touched
+			// two repos is two rows with two event ids and would count as two
+			// agents. Machine-global aggregation makes that certain, not latent.
+			`SELECT a.bucket_ms AS bucket_ms,
+			        COUNT(DISTINCT s.source || ':' || s.session_id) AS n
+			   FROM session_activity a
+			   JOIN sessions s ON s.event_id = a.session_event_id
+			  WHERE a.bucket_ms >= ? AND a.bucket_ms < ?
+			  GROUP BY a.bucket_ms
+			  ORDER BY a.bucket_ms`,
+		)
+		.all(window.startMs, window.endMs) as ReadonlyArray<{ bucket_ms: number; n: number }>;
+	if (rows.length === 0) return undefined;
+
+	const buckets = rows.map((r) => ({ bucketMs: r.bucket_ms, sessions: r.n }));
+	const peak = buckets.reduce((max, b) => (b.sessions > max ? b.sessions : max), 0);
+	const total = buckets.reduce((sum, b) => sum + b.sessions, 0);
+
+	// Derived per query, never a declared list: the declarative alternative is
+	// the shape of `PARSER_BACKED_SOURCES`, which omits `kimi` even though
+	// `getParserForSource` accepts it.
+	const measured = new Set(
+		(
+			db
+				.prepare(
+					`SELECT DISTINCT s.source AS source
+					   FROM session_activity a
+					   JOIN sessions s ON s.event_id = a.session_event_id
+					  WHERE a.bucket_ms >= ? AND a.bucket_ms < ?`,
+				)
+				.all(window.startMs, window.endMs) as ReadonlyArray<{ source: string }>
+		).map((r) => r.source),
+	);
+	// "Uncovered" is asked of the SESSIONS, not of the chart, and the two are
+	// different questions — which is why this is its own query rather than
+	// `seen − measured`.
+	//
+	// `measured` above is window-scoped on `bucket_ms`, so it answers "did this
+	// source draw a bar". A session is admitted to the window by `updated_at_ms`
+	// instead, and the two need not agree: a conversation resumed just after
+	// midnight, or one from a source whose `updatedAt` is its store row's own
+	// timestamp rather than its last turn, is in-window while every one of its
+	// buckets predates the window. Subtracting `measured` reported that agent as
+	// carrying no per-turn timestamps at all, when the truth is only that its
+	// timestamps are older than the range being looked at.
+	//
+	// NOT a boundary-rounding problem, which is the tempting reading and is
+	// wrong: `resolveWindow` puts both bounds through `addLocalDays`, which snaps
+	// to a local midnight, and every IANA offset is a multiple of 15 minutes — so
+	// a window bound is always bucket-aligned, and a bucket holding an in-window
+	// turn is always in-window itself.
+	//
+	// `EXISTS` over the session's own activity rows, unwindowed, is the honest
+	// test: a session that produced ANY bucket proves its source can be measured.
+	// What is left is what the label means — transcripts with no turn timestamps.
+	const uncovered = (
+		db
+			.prepare(
+				`SELECT s.source AS source
+				   FROM sessions s
+				  WHERE s.updated_at_ms >= ? AND s.updated_at_ms < ?
+				  GROUP BY s.source
+				 HAVING SUM(EXISTS (SELECT 1 FROM session_activity a WHERE a.session_event_id = s.event_id)) = 0`,
+			)
+			.all(window.startMs, window.endMs) as ReadonlyArray<{ source: string }>
+	).map((r) => r.source);
+
+	return {
+		buckets,
+		bucketMinutes: ACTIVITY_BUCKET_MS / 60_000,
+		peak,
+		meanActive: total / buckets.length,
+		measuredSources: [...measured].sort(),
+		uncoveredSources: uncovered.sort(),
+	};
 }
 
 // ── Tool / skill / MCP usage ────────────────────────────────────────────────

--- a/cli/src/dashboard/DbBackfill.test.ts
+++ b/cli/src/dashboard/DbBackfill.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -31,6 +31,11 @@ vi.mock("../core/GitOps.js", () => ({
 	// reaches this export; unmocked it would spawn git against a worktree these
 	// tests never create.
 	listFilesInBranch: vi.fn(),
+	// The session tier scopes itself to every linked worktree. The real helper
+	// shells `git worktree list`; here the fixture repo IS the only checkout, so
+	// the default answer is the identity — the same thing the real one degrades to
+	// when git cannot answer.
+	resolveWorktreeRoots: vi.fn(async (dir: string) => [dir]),
 }));
 vi.mock("../core/SummaryStore.js", () => ({
 	getIndex: vi.fn(),
@@ -114,7 +119,7 @@ import { scanCopilotSessionsOnDisk } from "../core/CopilotSessionDiscoverer.js";
 import { scanCursorCliSessionsOnDisk } from "../core/CursorCliSessionDiscoverer.js";
 import { scanCursorComposersOnDisk } from "../core/CursorSessionDiscoverer.js";
 import { scanDevinSessionsOnDisk } from "../core/DevinSessionDiscoverer.js";
-import { execGit, getHeadHash, listFilesInBranch } from "../core/GitOps.js";
+import { execGit, getHeadHash, listFilesInBranch, resolveWorktreeRoots } from "../core/GitOps.js";
 import { scanKimiSessionsOnDisk } from "../core/KimiSessionDiscoverer.js";
 import { scanOpenCodeSessionsOnDisk } from "../core/OpenCodeSessionDiscoverer.js";
 import { readCutoverFence, readManualDisableFlagSync } from "../core/RepoProfile.js";
@@ -295,7 +300,7 @@ describe("dbBackfillRepo — bootstrap", () => {
 			// full transcript read produced the stored session rows, and it is the only
 			// thing that makes the per-session skip safe to trust. See
 			// `SESSION_READ_GENERATION`.
-			{ source: "sessions-read-generation", cursor: "4" },
+			{ source: "sessions-read-generation", cursor: "5" },
 			// The memory import's own signal: the orphan tip (a hash of everything it
 			// reads) plus the mode, since seed and catch-up do not write the same rows.
 			{ source: "sot-import", cursor: `${"ab".repeat(20)}#seed` },
@@ -744,6 +749,26 @@ describe("dbBackfillRepos", () => {
 		expect(scanCursorComposersOnDisk).not.toHaveBeenCalled();
 	});
 
+	it("hands the session tier its checkouts and its worktrees as SEPARATE lists", async () => {
+		// Two granularities, and conflating them loses sessions. `worktreeRoots` is the
+		// union of every linked worktree of every registered checkout, because a
+		// conversation is keyed by the directory it ran in. `checkoutRoots` names the
+		// checkouts themselves, because that is what a worktree-spanning source is asked
+		// at — such a source resolves the worktrees of the repository it is HANDED, so
+		// one call answers for one clone and reaches no other clone's `.git`.
+		const cloneB = join(dir, "clone-b");
+		mkdirSync(cloneB, { recursive: true });
+		vi.mocked(resolveWorktreeRoots).mockImplementation(async (root: string) => [root, join(root, "wt")]);
+
+		await dbBackfillRepos([{ ...repo, worktrees: [repo.worktreeRoot, cloneB] }], { dbPath });
+
+		const opts = vi.mocked(collectSessionEvents).mock.calls[0][0];
+		expect([...(opts.checkoutRoots ?? [])].sort()).toEqual([repo.worktreeRoot, cloneB].sort());
+		// The linked worktrees reach the per-root half and only that half.
+		expect(opts.worktreeRoots).toContain(join(cloneB, "wt"));
+		expect(opts.checkoutRoots).not.toContain(join(cloneB, "wt"));
+	});
+
 	it("keeps a custom session loader isolated from real machine-global stores", async () => {
 		const loadSessions = vi.fn(async () => []);
 
@@ -1090,7 +1115,7 @@ describe("dbBackfillRepo — per-session skip", () => {
 		const cursors = await query<{ source: string; cursor: string }>(
 			"SELECT source, cursor FROM ingest_cursors WHERE source = 'sessions-read-generation'",
 		);
-		expect(cursors).toEqual([{ source: "sessions-read-generation", cursor: "4" }]);
+		expect(cursors).toEqual([{ source: "sessions-read-generation", cursor: "5" }]);
 		// And the second sweep is the one that gets a predicate.
 		await dbBackfillRepo({ repo, dbPath });
 		expect(vi.mocked(collectSessionEvents).mock.calls.at(-1)?.[0].isAlreadyCurrent).toBeDefined();
@@ -1125,7 +1150,7 @@ describe("dbBackfillRepo — per-session skip", () => {
 		const cursors = await query<{ cursor: string }>(
 			"SELECT cursor FROM ingest_cursors WHERE source = 'sessions-read-generation'",
 		);
-		expect(cursors).toEqual([{ cursor: "4" }]);
+		expect(cursors).toEqual([{ cursor: "5" }]);
 	});
 });
 
@@ -1802,6 +1827,54 @@ describe("dbBackfillRepo — sessions sweep", () => {
 		expect(await loggedSessions("s1")).toBe(2);
 		const row = await query<{ title: string }>("SELECT title FROM sessions WHERE session_id = 's1'");
 		expect(row).toEqual([{ title: "a conversation" }]);
+	});
+
+	it("still projects a session whose activity buckets arrived later", async () => {
+		// The regression this comparison exists to stop repeating: `session_activity`
+		// shipped as a new table, so every already-stored session was byte-identical on
+		// every OTHER column and the event was dropped before the projection could
+		// insert a single bucket. Re-reading the transcript does not help — it rebuilds
+		// the event, and this is the gate the event dies at.
+		vi.mocked(collectSessionEvents).mockResolvedValue([richSession]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		vi.mocked(collectSessionEvents).mockResolvedValue([
+			{ ...richSession, activityBuckets: [1_700_000_000_000, 1_700_000_900_000] },
+		]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		const rows = await query<{ bucket_ms: number }>(
+			`SELECT a.bucket_ms FROM session_activity a
+			   JOIN sessions s ON s.event_id = a.session_event_id
+			  WHERE s.session_id = 's1' ORDER BY a.bucket_ms`,
+		);
+		expect(rows).toEqual([{ bucket_ms: 1_700_000_000_000 }, { bucket_ms: 1_700_000_900_000 }]);
+	});
+
+	it("does not re-enqueue a session whose buckets are all stored, including a shrinking re-read", async () => {
+		// CONTAINMENT, not set equality. A re-read that yields FEWER buckets is routine
+		// (a host truncated its store, Devin's regenerated main chain walks a different
+		// branch), and the insert-only projection would keep the missing ones anyway —
+		// so calling that a change would re-project the session on every pass forever to
+		// write nothing at all.
+		const withBuckets = { ...richSession, activityBuckets: [1_700_000_000_000, 1_700_000_900_000] };
+		vi.mocked(collectSessionEvents).mockResolvedValue([withBuckets]);
+		await dbBackfillRepo({ repo, dbPath });
+		expect(await loggedSessions("s1")).toBe(1);
+
+		vi.mocked(collectSessionEvents).mockResolvedValue([withBuckets]);
+		await dbBackfillRepo({ repo, dbPath });
+		vi.mocked(collectSessionEvents).mockResolvedValue([{ ...richSession, activityBuckets: [1_700_000_000_000] }]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(1);
+		const rows = await query<{ c: number }>(
+			`SELECT COUNT(*) c FROM session_activity a
+			   JOIN sessions s ON s.event_id = a.session_event_id
+			  WHERE s.session_id = 's1'`,
+		);
+		expect(rows).toEqual([{ c: 2 }]);
 	});
 
 	it("still projects a session whose model split arrived later", async () => {
@@ -2620,6 +2693,33 @@ describe("dbRescanSessions", () => {
 		await dbRescanSessions({ repos: [repo], dbPath, windowMs: 12_345, emitted: new Map() });
 
 		expect(scanCodexSessionsOnDisk).toHaveBeenCalledWith(12_345);
+	});
+
+	it("passes every sibling checkout and worktree to the collector, matching the back-fill", async () => {
+		// Regression: the tick used to hand `collectSessionEvents` only `cwd`, so it
+		// narrowed `preScanned` against one checkout and a sibling's sessions failed
+		// every source's path-containment rule by construction — invisible until the
+		// next full back-fill. It must pass the SAME roots `dbBackfillRepo` does.
+		const a = mkdtempSync(join(tmpdir(), "jolli-rescan-a-"));
+		const b = mkdtempSync(join(tmpdir(), "jolli-rescan-b-"));
+		try {
+			vi.mocked(resolveWorktreeRoots).mockImplementation(async (root: string) => [root, join(root, "wt")]);
+			const multi = { ...repo, worktrees: [a, b] };
+			await dbBackfillRepo({ repo: multi, dbPath });
+			vi.mocked(collectSessionEvents).mockClear();
+
+			await dbRescanSessions({ repos: [multi], dbPath, emitted: new Map() });
+
+			// Order is `existingWorktrees`' (newest checkout first), not asserted here —
+			// what matters for the regression is that BOTH checkouts and BOTH their
+			// linked worktrees reach the collector.
+			const call = vi.mocked(collectSessionEvents).mock.calls.at(-1)?.[0];
+			expect([...(call?.checkoutRoots ?? [])].sort()).toEqual([a, b].sort());
+			expect([...(call?.worktreeRoots ?? [])].sort()).toEqual([a, join(a, "wt"), b, join(b, "wt")].sort());
+		} finally {
+			rmSync(a, { recursive: true, force: true });
+			rmSync(b, { recursive: true, force: true });
+		}
 	});
 
 	it("accepts a baseline recorded at an OLDER read generation", async () => {

--- a/cli/src/dashboard/DbBackfill.ts
+++ b/cli/src/dashboard/DbBackfill.ts
@@ -32,7 +32,7 @@
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import type { AlreadyCurrent } from "../core/DiskSessionScan.js";
-import { execGit, getHeadHash } from "../core/GitOps.js";
+import { execGit, getHeadHash, resolveWorktreeRoots } from "../core/GitOps.js";
 import { GitRefStorage, resolveCommittish } from "../core/GitRefStorage.js";
 import { isJolliInternalRef } from "../core/JolliRefs.js";
 import { BACKFILL_SESSION_WINDOW_MS } from "../core/SessionWindow.js";
@@ -164,8 +164,29 @@ const CURSOR_SOT = "sot-import";
  * cannot be invalidated — an already-scanned Codex Desktop session therefore reads as
  * three skills here and zero in the SKILLS panel. That asymmetry is understood and
  * accepted; `scanSkillsWithCursor` carries the decision and is where to argue with it.
+ *
+ * `5` — a full read now yields `activityBuckets`, the quarter-hour presence rows behind
+ * `session_activity`. That table arrived as its own schema entry, so an existing database
+ * HAS it and simply holds nothing for any session read under `4`; measured on a real
+ * machine, 1826 stored sessions produced 6 rows across 3 conversations — only the ones
+ * that happened to speak after the new build landed. Nothing else can reach the rest:
+ * the table is insert-only and deliberately ships no repair path (see
+ * `SESSION_ACTIVITY_DDL`), and the live producers only touch a session whose instant
+ * moved, which a finished conversation's never does.
+ *
+ * What this bump does NOT recover is accepted rather than deferred. Discovery is a
+ * 7-day window (`BACKFILL_SESSION_WINDOW_MS`), so anything older is never re-opened and
+ * stays without buckets for good — a permanent edge on the concurrency figure, which
+ * reads recent rhythm and does not claim to answer for last month.
+ *
+ * `5` also covers the SCOPE change made in the same release: the session tier now asks
+ * every linked worktree, not just the registered checkout (`sessionWorktreeRoots`). A
+ * sibling worktree's sessions already had rows — the StopHook runs inside them and
+ * resolves the identity from the remote — so they carry a read receipt and would be
+ * skipped by `isAlreadyCurrent` forever, having never once been reached by a sweep.
+ * One un-skipped pass is what lets the widened scope see them.
  */
-const SESSION_READ_GENERATION = "4";
+const SESSION_READ_GENERATION = "5";
 
 /**
  * Content fingerprint of the summary index — the summaries cursor value.
@@ -975,17 +996,21 @@ interface StoredToolRow {
 }
 
 /**
- * One session as it is currently stored: its own row plus BOTH child tables.
+ * One session as it is currently stored: its own row plus ALL THREE child tables.
  *
  * The child maps are keyed the way their table is keyed — `session_model_usage`
  * by `model`, `session_tool_use` by `(tool_name, kind)` — so a comparison that
  * walks them cannot accidentally merge two rows the schema keeps apart (a skill
  * and a builtin may share a name; see that table's DDL).
+ *
+ * `buckets` is a bare set because `session_activity` has no payload beyond its own
+ * key: a `(session, bucket)` pair either exists or does not.
  */
 interface StoredSession {
 	readonly row: Record<string, unknown>;
 	readonly models: ReadonlyMap<string, StoredModelRow>;
 	readonly tools: ReadonlyMap<string, StoredToolRow>;
+	readonly buckets: ReadonlySet<number>;
 }
 
 /** `(tool_name, kind)` — the `session_tool_use` primary key, minus the session. */
@@ -1005,7 +1030,10 @@ function storedSessionRows(db: DashboardDbHandle, repoIdentity: string): Map<str
 		)
 		.all(repoIdentity) as ReadonlyArray<Record<string, unknown> & { source: string; session_id: string }>;
 	const sessions = new Map<string, StoredSession>(
-		rows.map((r) => [`${r.source}\0${r.session_id}`, { row: r, models: new Map(), tools: new Map() }]),
+		rows.map((r) => [
+			`${r.source}\0${r.session_id}`,
+			{ row: r, models: new Map(), tools: new Map(), buckets: new Set<number>() },
+		]),
 	);
 
 	// Joined back through `sessions` rather than read by `session_event_id`: the
@@ -1062,6 +1090,20 @@ function storedSessionRows(db: DashboardDbHandle, repoIdentity: string): Map<str
 			calls: r.calls,
 			lastCallAtMs: r.last_call_at_ms,
 		});
+	}
+
+	const bucketRows = db
+		.prepare(
+			`SELECT s.source, s.session_id, a.bucket_ms
+			   FROM session_activity a
+			   JOIN sessions s ON s.event_id = a.session_event_id
+			   JOIN repos r    ON r.id = s.repo_id
+			  WHERE r.repo_identity = ?`,
+		)
+		.all(repoIdentity) as ReadonlyArray<{ source: string; session_id: string; bucket_ms: number }>;
+	for (const r of bucketRows) {
+		const target = sessions.get(`${r.source}\0${r.session_id}`);
+		(target?.buckets as Set<number>)?.add(r.bucket_ms);
 	}
 	return sessions;
 }
@@ -1225,6 +1267,14 @@ function sameToolSet(tools: ReadonlyArray<ToolCallCount>, stored: ReadonlyMap<st
  *    comparison has to happen ahead of the carry-forward return.
  *  - Both child tables are replace-when-observed, under the same predicate
  *    `projectSession` uses to decide it wrote at all.
+ *  - `session_activity` is the THIRD child and the one exception to that shape: it
+ *    is insert-only, so it is compared by containment rather than equality. Adding
+ *    a derived output to `projectSession` without adding it here is silent — the
+ *    event is judged unchanged and dropped before the projection ever runs, so the
+ *    new table simply stays empty for every session that was already stored. That
+ *    is exactly how the buckets went missing (52 rows against 1826 sessions), and
+ *    bumping {@link SESSION_READ_GENERATION} did not fix it: re-reading a
+ *    transcript only rebuilds the EVENT, and this is the gate the event dies at.
  */
 function unchangedSessionEvent(event: SessionUpsertedEvent, stored: StoredSession | undefined): boolean {
 	if (!stored) return false;
@@ -1247,6 +1297,18 @@ function unchangedSessionEvent(event: SessionUpsertedEvent, stored: StoredSessio
 	// "unobserved", and the projection leaves the stored split alone.
 	if (hasUsage && event.models !== undefined && !sameModelSplit(models, stored.models)) return false;
 	if (event.tools !== undefined && !sameToolSet(event.tools, stored.tools)) return false;
+	// CONTAINMENT, not set equality — the one comparison here that does not mirror a
+	// replace. `session_activity` is insert-only (see `SESSION_ACTIVITY_DDL`), so the
+	// question is only "would the INSERT OR IGNORE add a row", and a stored bucket the
+	// event no longer produces is a fact the projection would keep anyway. Set equality
+	// would call such a session changed on every pass forever, re-projecting it to write
+	// nothing — which is the churn this whole comparator exists to remove.
+	//
+	// Compared BEFORE the carry-forward return below, for the same reason `est_cost_usd`
+	// is: buckets do not ride on `hasUsage`. A source with no per-turn usage — every
+	// agent but Claude — reaches that return, so gating this behind it would mean their
+	// presence never reached the table.
+	if (event.activityBuckets?.some((bucket) => !stored.buckets.has(bucket))) return false;
 
 	const sum = (read: (m: StatsModelUsage) => number): number => models.reduce((total, m) => total + read(m), 0);
 	// `COALESCE`d, so only a non-null derived value can move it — but compared
@@ -1395,9 +1457,22 @@ export async function dbBackfillRepo(opts: DbBackfillOptions): Promise<DbBackfil
 	const worktrees = existingWorktrees(repo);
 	// The newest checkout is "the" repo for anything that must pick one: HEAD-based
 	// cursors, the summary index (dual-written per repo, so identical in each
-	// clone), sessions (recorded per project, not per checkout) and the knowledge
-	// graph.
+	// clone) and the knowledge graph.
+	//
+	// Sessions are NOT one of those, and used to be listed here as "recorded per
+	// project, not per checkout". They are recorded per DIRECTORY: an agent writes its
+	// transcript under the cwd the conversation ran in, and the hook registry is a file
+	// inside that worktree. So the session tier below scopes itself to every linked
+	// worktree of every registered checkout instead — see `sessionWorktreeRoots`.
 	const cwd = worktrees[0];
+	// Resolved once per repo, ahead of the sweep: one `git worktree list` per
+	// REGISTERED checkout (two clones of one remote each enumerate their own linked
+	// worktrees), deduped because two entries can enumerate the same set. Failure
+	// degrades to the checkout itself, so a repo whose git is unavailable keeps the
+	// behaviour it had before this existed rather than losing its session tier.
+	const sessionWorktreeRoots = [
+		...new Set((await Promise.all(worktrees.map((root) => resolveWorktreeRoots(root)))).flat()),
+	];
 
 	// Filled by the session tier inside the callback below and read by the same
 	// callback's `return`. It sits out here so the tier that PRODUCES it and the result
@@ -1727,6 +1802,12 @@ export async function dbBackfillRepo(opts: DbBackfillOptions): Promise<DbBackfil
 				},
 				repoIdentity: repo.repoIdentity,
 				cwd,
+				worktreeRoots: sessionWorktreeRoots,
+				// The registered checkouts themselves, NOT their linked worktrees: this is
+				// the granularity a worktree-spanning source is asked at, and one call
+				// answers for one clone's `.git` only. Handing over just `cwd` would drop a
+				// second clone's sessions for that source alone.
+				checkoutRoots: worktrees,
 				// The one caller that widens the horizon past every source's 48 h default.
 				windowMs: BACKFILL_SESSION_WINDOW_MS,
 				...(opts.preScanned ? { preScanned: opts.preScanned } : {}),
@@ -2869,15 +2950,28 @@ export async function dbRescanSessions(opts: SessionRescanOptions): Promise<Sess
 	// stores.
 	for (const repo of ready) {
 		const known = baselines.get(repo.repoIdentity) ?? new Map<string, number>();
-		// The newest surviving checkout, exactly as `dbBackfillRepo` picks it: sessions
-		// are recorded per project, not per checkout.
+		// The registered checkouts of this repo, and its `cwd` the newest of them —
+		// exactly as `dbBackfillRepo` picks it.
 		//
 		// Not null-checked, and that is not an oversight: `existingWorktrees` is documented
 		// to never return empty while the repo is registered (it falls back to the recorded
 		// path), and `live` has already been filtered by `hasLiveWorktree`, so this repo has
 		// a checkout on disk. A guard here would be an unreachable branch spending the
 		// suite's branch-coverage floor and reading to the next maintainer as a real case.
-		const cwd = existingWorktrees(repo)[0] as string;
+		const worktrees = existingWorktrees(repo);
+		const cwd = worktrees[0] as string;
+		// The SAME sibling coverage `dbBackfillRepo` passes, and for the same reason:
+		// `collectSessionEvents` narrows `preScanned` by running each source's own
+		// path-containment rule against these roots, and a session that ran in a sibling
+		// checkout fails that rule against `cwd` alone "by construction" (see
+		// `collectSessionEvents`). Omitting them made the 30 s tick blind to every
+		// sibling-worktree session until the next full back-fill — measured at 65 of 94
+		// in-window sessions on a repo with six live worktrees. `worktreeRoots` is every
+		// linked worktree of every registered checkout; `checkoutRoots` is the checkouts
+		// themselves (the granularity a worktree-spanning source is asked at).
+		const sessionWorktreeRoots = [
+			...new Set((await Promise.all(worktrees.map((root) => resolveWorktreeRoots(root)))).flat()),
+		];
 		// Two questions, ORed. The shared predicate answers "the database already holds
 		// this version"; the emission gate answers "I already emitted for this version",
 		// which is the state the shared one structurally cannot see (see `emitted`).
@@ -2899,6 +2993,8 @@ export async function dbRescanSessions(opts: SessionRescanOptions): Promise<Sess
 			const events = await collectSessionEvents({
 				repoIdentity: repo.repoIdentity,
 				cwd,
+				worktreeRoots: sessionWorktreeRoots,
+				checkoutRoots: worktrees,
 				windowMs,
 				preScanned,
 				// Every session in this pass comes from `preScanned`, which the collector

--- a/cli/src/dashboard/MigrationFingerprints.test.ts
+++ b/cli/src/dashboard/MigrationFingerprints.test.ts
@@ -54,6 +54,7 @@ const EXPECTED: ReadonlyArray<readonly [name: string, fingerprint: string]> = [
 	// the documented repair, and it is the reason no further merge may happen after
 	// the first release.
 	["SESSION_STATS_SYNC_DDL", "e0c166639049"],
+	["SESSION_ACTIVITY_DDL", "67be18551dae"],
 ];
 
 describe("migration fingerprints", () => {

--- a/cli/src/dashboard/SessionPushManifest.ts
+++ b/cli/src/dashboard/SessionPushManifest.ts
@@ -99,6 +99,16 @@ export const NEVER_SYNCED_TABLES = [
 	// of the no-timezone rule in this module's header: instants go up, days are
 	// cut by whoever is asking.
 	"stats_daily",
+	// The per-quarter-hour agent-activity buckets behind the LOCAL agent-concurrency
+	// figure. Collected on this branch, uploaded by nothing: cloud upload was an
+	// explicit deferral of the concurrency work (there is no front-end that reads it
+	// yet either). Its `recorded_at_ms` column was built as a sync cursor in advance
+	// (see `SESSION_ACTIVITY_DDL`), so wiring it up later is this line plus its
+	// `SYNCED_COLUMNS`, `SYNC_STAMP_COLUMNS`, `KEYSET_COLUMNS`, `WINDOW_SOURCES` and
+	// `BATCH_LIMITS` entries — but that is a privacy decision (activity timestamps
+	// leaving the machine) to make when the manager view actually consumes them, not
+	// a default to reach for on sight.
+	"session_activity",
 	// The memory half. It travels on the commit-push channel, which has its own
 	// binding rules, and `commit_aliases` answers a rebase-matching question that
 	// does not exist on a server where commits and memories arrive together.

--- a/cli/src/dashboard/SotSchema.ts
+++ b/cli/src/dashboard/SotSchema.ts
@@ -544,13 +544,20 @@ ALTER TABLE session_tool_use ADD COLUMN last_call_at_ms INTEGER;
  *    long finished by the time that writer stores its first 0. Only the read can
  *    be permanent, which is why `TOOL_CALL_TIME_SQL` wraps the column in
  *    `NULLIF` rather than trusting what is on disk.
- *  - **It cost a cross-surface version bump for a provably empty set.** Every
- *    surface refuses a database stamped ahead of its own build, so a bump locks
- *    older CLI / VS Code / IntelliJ builds out of the machine-global file. What
- *    the sweep would have cleaned is 0 rows, and not merely by measurement:
- *    both write paths DELETE the session's rows before inserting, so `ON
- *    CONFLICT` can only fire on a duplicate `(tool_name, kind)` within one
- *    event, which `ToolUseTally` cannot emit — that pair is its bucket key.
+ *  - **It would have cleaned a provably empty set**, and not merely by
+ *    measurement: both write paths DELETE the session's rows before inserting,
+ *    so `ON CONFLICT` can only fire on a duplicate `(tool_name, kind)` within
+ *    one event, which `ToolUseTally` cannot emit — that pair is its bucket key.
+ *    An entry that does nothing is not a cheap precaution: a shipped entry's
+ *    name is permanent and its DDL is frozen, so it stays in `MIGRATIONS`, in
+ *    the fingerprint test and in every database's log forever.
+ *
+ * The argument originally written here was the cross-surface cost of the
+ * version bump — every surface refusing a file stamped ahead of its own build.
+ * That premise is gone: the compatibility gate was removed, and a newer file is
+ * now opened and written normally with one warn-once line (see
+ * `DASHBOARD_SCHEMA_VERSION`). The conclusion is unchanged on the two reasons
+ * above, which never depended on it.
  */
 
 /**
@@ -776,6 +783,90 @@ CREATE INDEX ix_schema_migrations_name ON schema_migrations(name, seq);
  */
 export const REPOS_DELETE_ALLOWED_DDL = `
 DROP TRIGGER IF EXISTS repos_no_delete;
+`;
+
+/**
+ * One row per (session, 15-minute bucket) in which that session produced a
+ * message — the input to the concurrency figure.
+ *
+ * `bucket_ms` holds an ABSOLUTE epoch-ms bucket start, not a localised day or
+ * hour key: time zone is a render-time concern that `localDayKey` / `localHour`
+ * already handle in the query layer, and a stored localised copy would be a
+ * second answer to a question that already has one.
+ *
+ * Buckets rather than a stored `(start, end)` interval because a resumed
+ * session is common and its span is not its presence — measured, the longest
+ * session on the author's machine spans 18 hours across 28 messages. A bucket
+ * list occupies only the quarter-hours the session actually spoke in, with no
+ * gap-threshold parameter to tune.
+ *
+ * `INTEGER` under STRICT is load-bearing twice: `node:sqlite` returns these as
+ * JS numbers (epoch ms sits ~5000x below `Number.MAX_SAFE_INTEGER`), and STRICT
+ * REJECTS a REAL here, so a missing `Math.floor` upstream fails at insert
+ * instead of storing a fractional bucket that defeats the primary key.
+ *
+ * ## This table is INSERT-ONLY, unlike its two siblings
+ *
+ * `projectSession` replaces `session_model_usage` and `session_tool_use`
+ * wholesale on every observed read, and this table deliberately does NOT follow
+ * that contract. Those two restate a CURRENT TOTAL — a re-read that attributes
+ * tokens to fewer models supersedes the old split, and leaving a stale row would
+ * stop the split summing to the scalar columns. A bucket is not a total; it is a
+ * MONOTONE HISTORICAL FACT. "This session produced a message in this
+ * quarter-hour" cannot become false, so there is no read whose result should
+ * remove one.
+ *
+ * The reads that would have removed one are all cases where the EVIDENCE went
+ * away, not the fact:
+ *
+ *  - A host that rotates or truncates its own store (the SQLite-backed sources
+ *    own their retention; nothing here does).
+ *  - Devin, whose `message_nodes` is a forest: a regeneration moves
+ *    `sessions.main_chain_id`, so a re-read walks a DIFFERENT chain, not a
+ *    superset of the old one. The developer was still present in those buckets.
+ *
+ * Under the old wholesale replace, both of those deleted true presence and the
+ * transcript could no longer prove it — an unrecoverable loss. The cost of
+ * insert-only is the mirror image and is recoverable: a bucket computed from a
+ * BAD read (a parser reading Devin's epoch SECONDS as ms, a local-time string
+ * parsed as UTC) now persists instead of being corrected by the next re-read.
+ * That is a deliberate trade — a wrong row can be repaired by an explicit
+ * rebuild, a deleted row cannot be repaired at all — and it is why no repair
+ * path ships with this: the failure it guards against needs a parser bug first.
+ *
+ * `ON DELETE CASCADE` stays, and is not a hole in the above: nothing deletes
+ * from `sessions` today, and if something ever does, these rows reference a
+ * parent that no longer exists. Insert-only is a rule about RE-OBSERVATION, not
+ * about referential cleanup.
+ *
+ * ## `recorded_at_ms` is a sync cursor, not a business time
+ *
+ * The instant the row was first INSERTed locally — deliberately NOT anything
+ * about the conversation. `bucket_ms` cannot serve as a cursor: a backfill over
+ * old transcripts inserts old buckets today, and a `bucket_ms > lastSync` reader
+ * would skip every one of them. This column answers only "what is new SINCE my
+ * last upload", which is the one question a downstream sync has to ask without
+ * knowing anything about what a bucket means.
+ *
+ * `INSERT OR IGNORE` is what makes it stable: a re-observed bucket keeps the
+ * timestamp of its FIRST insert rather than being bumped, so re-reading a
+ * session every 60 s does not re-present its whole history as new work.
+ *
+ * Two properties a consumer must not assume. The clock is `Date.now()`, so it is
+ * not monotonic across an NTP correction — pair the cursor with an idempotent
+ * upstream upsert and resume at `>= lastSync` rather than `>`, which also
+ * absorbs the same-millisecond boundary. And it is a LOCAL time: two machines
+ * belonging to one developer stamp independently.
+ */
+export const SESSION_ACTIVITY_DDL = `
+CREATE TABLE session_activity (
+  session_event_id TEXT NOT NULL REFERENCES sessions(event_id) ON DELETE CASCADE,
+  bucket_ms        INTEGER NOT NULL,
+  recorded_at_ms   INTEGER NOT NULL,
+  PRIMARY KEY (session_event_id, bucket_ms)
+) STRICT;
+CREATE INDEX ix_activity_bucket ON session_activity(bucket_ms);
+CREATE INDEX ix_activity_recorded ON session_activity(recorded_at_ms);
 `;
 
 /**

--- a/cli/src/dashboard/StatsWriter.test.ts
+++ b/cli/src/dashboard/StatsWriter.test.ts
@@ -19,6 +19,7 @@ import {
 	drainPending,
 	observeWorktree,
 	pruneProjectedEvents,
+	unparkStuckEvents,
 } from "./StatsWriter.js";
 
 vi.mock("../core/GitOps.js", () => ({
@@ -782,6 +783,107 @@ describe("session_tool_use projection", () => {
 		});
 		await applyStatsEvents([sessionEvent({ tools: [] })], { producerKind: "cli", dbPath });
 		expect(await tools()).toEqual([]);
+	});
+});
+
+describe("session_activity projection", () => {
+	const readBuckets = (db: DashboardDbHandle) =>
+		(
+			db.prepare("SELECT bucket_ms FROM session_activity ORDER BY bucket_ms").all() as ReadonlyArray<{
+				bucket_ms: number;
+			}>
+		).map((r) => r.bucket_ms);
+
+	const readRows = (db: DashboardDbHandle) =>
+		db.prepare("SELECT bucket_ms, recorded_at_ms FROM session_activity ORDER BY bucket_ms").all() as ReadonlyArray<{
+			bucket_ms: number;
+			recorded_at_ms: number;
+		}>;
+
+	it("stores one row per bucket and KEEPS ones a later read no longer sees", async () => {
+		await applyStatsEvents([envelope(session({ activityBuckets: [1_700_000_000_000, 1_700_000_900_000] }))], {
+			producerKind: "cli",
+			dbPath,
+		});
+		await withDashboardDb(
+			(db) => {
+				expect(readBuckets(db)).toEqual([1_700_000_000_000, 1_700_000_900_000]);
+			},
+			{ dbPath },
+		);
+
+		// A truncating host, or Devin regenerating onto a different main chain,
+		// makes a full re-read return a NON-superset. The developer was still
+		// present in the dropped bucket and the transcript can no longer prove
+		// it, so this table must not take the re-read's word for its absence.
+		await applyStatsEvents([envelope(session({ activityBuckets: [1_700_000_000_000] }))], {
+			producerKind: "cli",
+			dbPath,
+		});
+		await withDashboardDb(
+			(db) => {
+				expect(readBuckets(db)).toEqual([1_700_000_000_000, 1_700_000_900_000]);
+			},
+			{ dbPath },
+		);
+	});
+
+	it("stamps recorded_at_ms at insert and does not bump it on re-observation", async () => {
+		await applyStatsEvents([envelope(session({ activityBuckets: [1_700_000_000_000] }))], {
+			producerKind: "cli",
+			dbPath,
+			now: () => 5_000,
+		});
+		// The 60 s tick re-reads the same session and finds one further bucket.
+		// Only the NEW row may carry the new instant — bumping the old one would
+		// re-present already-synced history to a cursor reading this column.
+		await applyStatsEvents([envelope(session({ activityBuckets: [1_700_000_000_000, 1_700_000_900_000] }))], {
+			producerKind: "cli",
+			dbPath,
+			now: () => 9_000,
+		});
+		await withDashboardDb(
+			(db) => {
+				expect(readRows(db)).toEqual([
+					{ bucket_ms: 1_700_000_000_000, recorded_at_ms: 5_000 },
+					{ bucket_ms: 1_700_000_900_000, recorded_at_ms: 9_000 },
+				]);
+			},
+			{ dbPath },
+		);
+	});
+
+	it("leaves stored buckets alone when the field is ABSENT", async () => {
+		await applyStatsEvents([envelope(session({ activityBuckets: [1_700_000_000_000] }))], {
+			producerKind: "cli",
+			dbPath,
+		});
+		// A producer that cannot see timestamps re-upserts the same session.
+		await applyStatsEvents([envelope(session())], { producerKind: "cli", dbPath });
+		await withDashboardDb(
+			(db) => {
+				expect(readBuckets(db)).toEqual([1_700_000_000_000]);
+			},
+			{ dbPath },
+		);
+	});
+
+	// The inverse of what this asserted before insert-only. `[]` still MEANS
+	// "observed, measured none" and stays distinct from absent everywhere else —
+	// it just no longer authorises a delete, because "I saw none this time" is
+	// not evidence that a bucket recorded earlier never happened.
+	it("adds nothing and removes nothing when an observed read found none", async () => {
+		await applyStatsEvents([envelope(session({ activityBuckets: [1_700_000_000_000] }))], {
+			producerKind: "cli",
+			dbPath,
+		});
+		await applyStatsEvents([envelope(session({ activityBuckets: [] }))], { producerKind: "cli", dbPath });
+		await withDashboardDb(
+			(db) => {
+				expect(readBuckets(db)).toEqual([1_700_000_000_000]);
+			},
+			{ dbPath },
+		);
 	});
 });
 
@@ -1778,6 +1880,34 @@ describe("sync stamps", () => {
 		expect(s?.written_at_ms).toBe(2_000);
 	});
 
+	it("preserves an existing full row when a re-read reports no usage", async () => {
+		// The downgrade F3 guards against: a Claude transcript whose retention window
+		// dropped its per-turn usage re-reads with no models, so the collector leaves
+		// `tokenCoverage` absent. The merge must PRESERVE the `full` the row already
+		// carries — the token counts on the same row already fall back to their existing
+		// values, so clearing the coverage flag alone would make the row contradict itself.
+		await applyStatsEvents([envelope(session())], { producerKind: "cli", dbPath });
+		const [before] = await query<{ token_coverage: string; input_tokens: number }>("SELECT * FROM sessions");
+		expect(before?.token_coverage).toBe("full");
+
+		await applyStatsEvents([envelope(session({ models: undefined, tokenCoverage: undefined }))], {
+			producerKind: "cli",
+			dbPath,
+		});
+		const [after] = await query<{ token_coverage: string; input_tokens: number }>("SELECT * FROM sessions");
+		expect(after?.token_coverage).toBe("full");
+		expect(after?.input_tokens).toBe(before?.input_tokens);
+	});
+
+	it("defaults an absent tokenCoverage to sessions-only on first write", async () => {
+		await applyStatsEvents([envelope(session({ models: undefined, tokenCoverage: undefined }))], {
+			producerKind: "cli",
+			dbPath,
+		});
+		const [row] = await query<{ token_coverage: string }>("SELECT * FROM sessions");
+		expect(row?.token_coverage).toBe("sessions-only");
+	});
+
 	// THE regression this column exists for. `projectCommitSummary` upgrades a
 	// `sessions-only` row to `full` without touching `updated_at_ms` — correctly,
 	// since the only clock it holds is the commit's. A sync keyed on that column
@@ -1878,5 +2008,145 @@ describe("sync stamps", () => {
 		const [r] = await query<{ at_ms: number; updated_at_ms: number }>("SELECT * FROM recall_receipts");
 		expect(r?.at_ms).toBe(1_700_000_300_000);
 		expect(r?.updated_at_ms).toBe(7_000);
+	});
+});
+
+describe("unparkStuckEvents", () => {
+	/**
+	 * Parks one genuinely-defective event (`error`) and one whose type this build
+	 * does not recognise (`unknown-type`, type not in `KNOWN_EVENT_TYPES`). BOTH are
+	 * stuck for this build: `drainPending` only auto-revives `unknown-type` rows
+	 * whose type IS known, so nothing returns either of these to the queue on its
+	 * own — which is why `unparkStuckEvents` (sharing `REVIVABLE_PREDICATE` with the
+	 * count `probeParkedEvents` reports) must reach both.
+	 */
+	async function parkTwo(): Promise<void> {
+		await withDashboardDb(
+			(db) => {
+				db.prepare(
+					`INSERT INTO events_raw (event_id, type, schema_version, received_at, data_json)
+				 VALUES ('bad', 'session.upserted', ?, 't', 'not json')`,
+				).run(STATS_EVENT_SCHEMA_VERSION);
+				db.prepare(
+					`INSERT INTO events_raw (event_id, type, schema_version, received_at, data_json)
+				 VALUES ('future', 'commit.vibes', ?, 't', '{"type":"commit.vibes"}')`,
+				).run(STATS_EVENT_SCHEMA_VERSION);
+			},
+			{ dbPath },
+		);
+		for (let i = 0; i < 5; i++) await applyStatsEvents([], { producerKind: "cli", dbPath });
+	}
+
+	it("reports zero — and stays silent — when there is nothing to revive", async () => {
+		await applyStatsEvents([envelope(session())], { producerKind: "cli", dbPath });
+		expect(await withDashboardDb((db) => unparkStuckEvents(db), { dbPath })).toBe(0);
+	});
+
+	it("returns EVERY stuck row to the queue with its attempt budget reset", async () => {
+		await parkTwo();
+		// Two, not one: an `unknown-type` whose type this build still cannot project is
+		// as stuck as an `error` row — `drainPending` never revives it — so `--fix`
+		// must reach it too, matching the count `probeParkedEvents`/`countStuckEvents`
+		// reports. An earlier revision un-parked only `error`, leaving this row counted
+		// but unreachable.
+		expect(await withDashboardDb((db) => unparkStuckEvents(db), { dbPath })).toBe(2);
+		const rows = await withDashboardDb(
+			(db) =>
+				db
+					.prepare(
+						"SELECT event_id, projection_status, attempts, failed_kind FROM events_raw ORDER BY event_id",
+					)
+					.all(),
+			{ dbPath },
+		);
+		expect(rows).toEqual([
+			{ event_id: "bad", projection_status: "pending", attempts: 0, failed_kind: null },
+			{ event_id: "future", projection_status: "pending", attempts: 0, failed_kind: null },
+		]);
+	});
+
+	it("leaves an auto-revivable unknown-type row for drainPending to own", async () => {
+		// The exclusion `REVIVABLE_PREDICATE` encodes: a row parked `unknown-type`
+		// whose type this build DOES know heals on the next drain, so touching it here
+		// would reset a budget `drainPending` already owns. It is not in the stuck set,
+		// so `unparkStuckEvents` must leave it exactly as it found it.
+		await withDashboardDb(
+			(db) =>
+				db
+					.prepare(
+						`INSERT INTO events_raw (event_id, type, schema_version, received_at, data_json,
+						                         projection_status, attempts, failed_kind)
+						 VALUES ('revivable', 'session.upserted', ?, 't', '{}', 'failed', 5, 'unknown-type')`,
+					)
+					.run(STATS_EVENT_SCHEMA_VERSION),
+			{ dbPath },
+		);
+		expect(await withDashboardDb((db) => unparkStuckEvents(db), { dbPath })).toBe(0);
+		const row = await withDashboardDb(
+			(db) =>
+				db
+					.prepare(
+						"SELECT projection_status, attempts, failed_kind FROM events_raw WHERE event_id = 'revivable'",
+					)
+					.get(),
+			{ dbPath },
+		);
+		expect(row).toEqual({ projection_status: "failed", attempts: 5, failed_kind: "unknown-type" });
+	});
+
+	it("actually recovers the data once the blocker is gone", async () => {
+		// The real case this exists for: the event failed against a table a skipped
+		// migration never created. With the table present, the same row projects.
+		await parkTwo();
+		await withDashboardDb(
+			(db) =>
+				db.prepare("UPDATE events_raw SET data_json = ? WHERE event_id = 'bad'").run(JSON.stringify(session())),
+			{ dbPath },
+		);
+		await withDashboardDb((db) => unparkStuckEvents(db), { dbPath });
+		// Only 'bad' projects — 'future' is still an unknown type to this build, so it
+		// re-parks. The point is that the fixed row genuinely recovered.
+		expect((await applyStatsEvents([], { producerKind: "cli", dbPath })).projected).toBe(1);
+	});
+
+	it("re-parks a row that is still defective instead of retrying it forever", async () => {
+		// The cost of the exit being manual: reviving a genuinely poison event spends
+		// one drain cycle and lands back on 'failed'. That is why nothing calls this
+		// automatically. Both stuck rows come back parked (neither is projectable here).
+		await parkTwo();
+		await withDashboardDb((db) => unparkStuckEvents(db), { dbPath });
+		for (let i = 0; i < 5; i++) await applyStatsEvents([], { producerKind: "cli", dbPath });
+		expect(await withDashboardDb((db) => countStuckEvents(db), { dbPath })).toBe(2);
+	});
+
+	it("un-parks every failed row on a pre-migration schema (no failed_kind column)", () => {
+		// The fallback that mirrors `countStuckEvents`: before the `failed_kind`
+		// migration there is no column to null out or narrow by, so every `failed` row
+		// is stuck and the whole set is un-parked with an UPDATE that never names it.
+		let statements = 0;
+		const handle = {
+			prepare: () => {
+				statements += 1;
+				if (statements === 1)
+					return {
+						run: () => {
+							throw new Error("no such column: failed_kind");
+						},
+					};
+				return { run: () => ({ changes: 4 }) };
+			},
+		} as unknown as DashboardDbHandle;
+		expect(unparkStuckEvents(handle)).toBe(4);
+	});
+
+	it("rethrows a genuine fault rather than un-parking around it", () => {
+		const handle = {
+			prepare: () => ({
+				run: () => {
+					throw new Error("database disk image is malformed");
+				},
+			}),
+		} as unknown as DashboardDbHandle;
+		expect(() => unparkStuckEvents(handle)).toThrow(/malformed/);
 	});
 });

--- a/cli/src/dashboard/StatsWriter.ts
+++ b/cli/src/dashboard/StatsWriter.ts
@@ -478,11 +478,13 @@ function isUnknownTypeError(err: unknown): boolean {
 /**
  * Dispatches one event to its projection. Must run inside a transaction.
  *
- * `nowMs` is the wall clock for the per-row sync stamps (see `SYNC_STAMP_DDL`).
- * It is threaded rather than read inside each projection so tests can pin it,
- * and so it is visibly NOT one of the event's own business timestamps — writing
- * `event.updatedAtMs` into a stamp would quietly turn it into a second business
- * clock and defeat the column's only purpose.
+ * `nowMs` is the wall clock for the per-row sync stamps (see `SYNC_STAMP_DDL`)
+ * and for the one projection that stamps a row with wall-clock
+ * (`session_activity.recorded_at_ms`). It is read once per drained row and
+ * threaded rather than read from `Date.now` inside each projection, so tests can
+ * pin it, and so it is visibly NOT one of the event's own business timestamps —
+ * writing `event.updatedAtMs` into a stamp would quietly turn it into a second
+ * business clock and defeat the column's only purpose.
  */
 function projectEvent(db: DashboardDbHandle, event: StatsEvent, nowMs: number): void {
 	switch (event.type) {
@@ -1031,6 +1033,31 @@ function projectSession(db: DashboardDbHandle, event: SessionUpsertedEvent, nowM
 			);
 		}
 	}
+
+	// NOT the replace-when-observed contract the two blocks above use, and the
+	// asymmetry is the point: a bucket is a monotone historical fact, not a
+	// restatement of a current total, so no read may remove one. See
+	// SESSION_ACTIVITY_DDL for why (a truncating host and Devin's regenerated
+	// main chain both make a re-read return a non-superset, and deleting there
+	// destroys presence the transcript can no longer prove).
+	//
+	// The `!== undefined` guard therefore no longer decides whether to DELETE —
+	// it now only skips the loop for a source that measures no timestamps. It
+	// stays because `[]` and absent still MEAN different things everywhere else,
+	// and collapsing them here would invite collapsing them upstream.
+	//
+	// `OR IGNORE` keeps a re-observed bucket's ORIGINAL `recorded_at_ms`, which
+	// is what stops a 60 s tick re-presenting a whole session as new to a sync
+	// cursor reading that column.
+	if (event.activityBuckets !== undefined) {
+		const recordedAtMs = nowMs;
+		const insertBucket = db.prepare(
+			"INSERT OR IGNORE INTO session_activity (session_event_id, bucket_ms, recorded_at_ms) VALUES (?, ?, ?)",
+		);
+		for (const bucket of event.activityBuckets) {
+			insertBucket.run(eventId, bucket, recordedAtMs);
+		}
+	}
 }
 
 /**
@@ -1535,5 +1562,60 @@ export function pruneProjectedEvents(db: DashboardDbHandle, now: () => number = 
 		// Housekeeping must never fail a write that already succeeded.
 		log.debug("%sevent pruning skipped: %s", tag, errMsg(err));
 		return 0;
+	}
+}
+
+/**
+ * Returns every STUCK event to the queue with a fresh attempt budget, and reports
+ * how many were revived.
+ *
+ * "Stuck" is exactly {@link countStuckEvents}' set — both statements share
+ * {@link REVIVABLE_PREDICATE} so the number doctor COUNTS and the number `--fix`
+ * can REACH cannot disagree. That excludes the `unknown-type` rows a drain revives
+ * on its own (touching them would reset an attempt budget the build still cannot
+ * spend) and INCLUDES the rows nothing revives automatically: `failed_kind =
+ * 'error'`, the pre-migration `NULL` rows, and an `unknown-type` whose event type
+ * this build still does not recognise. An earlier revision narrowed this to
+ * `failed_kind = 'error'` alone, which left both NULL and unrecognised-type rows
+ * counted-but-unfixable — reported to the user with no way to act on them.
+ *
+ * **Deliberately manual.** The automatic revivals are each keyed to evidence the
+ * blocker is gone — a lock contention never spends the budget, `unknown-type` is
+ * scoped to types this build now understands. A stuck row carries no such
+ * evidence, so the only honest trigger is an operator who has just fixed something
+ * (upgraded the CLI, restored a migration). Calling this on every drain would
+ * spend attempts forever on a genuinely defective event.
+ *
+ * The caller supplies the writable handle: this runs inside whatever transaction
+ * or lock the caller already holds, and the caller is the one that knows whether
+ * a drain should follow.
+ *
+ * Degrades on a pre-migration schema exactly as {@link countStuckEvents} does —
+ * there is no `failed_kind` column to null out or to narrow by, and every `failed`
+ * row is stuck there, so the whole set is un-parked.
+ */
+export function unparkStuckEvents(db: DashboardDbHandle): number {
+	const revivable = KNOWN_EVENT_TYPES.map(() => "?").join(", ");
+	try {
+		const result = db
+			.prepare(
+				`UPDATE events_raw SET projection_status = 'pending', attempts = 0, failed_kind = NULL
+				  WHERE projection_status = 'failed'
+				    AND NOT (${REVIVABLE_PREDICATE} AND type IN (${revivable}))`,
+			)
+			.run(...KNOWN_EVENT_TYPES) as { changes?: number | bigint };
+		const revived = Number(result?.changes ?? 0);
+		if (revived > 0) log.info("un-parked %d stuck event(s) for reprojection", revived);
+		return revived;
+	} catch (err) {
+		if (!/no such column: failed_kind/i.test(errMsg(err))) throw err;
+		const result = db
+			.prepare(
+				"UPDATE events_raw SET projection_status = 'pending', attempts = 0 WHERE projection_status = 'failed'",
+			)
+			.run() as { changes?: number | bigint };
+		const revived = Number(result?.changes ?? 0);
+		if (revived > 0) log.info("un-parked %d stuck event(s) for reprojection (pre-migration schema)", revived);
+		return revived;
 	}
 }

--- a/docs/superpowers/plans/2026-08-06-transcript-session-timestamps.md
+++ b/docs/superpowers/plans/2026-08-06-transcript-session-timestamps.md
@@ -1,0 +1,890 @@
+# Transcript session timestamps on the pushed summary — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Emit a root-stamped, tree-wide `transcriptSessions[]` array on the pushed `summaryJson`, carrying `{sessionId, source, messageCount, startedAt, endedAt}` per conversation, so the coaching dashboard's time axis has a producer.
+
+**Architecture:** Push-time enrichment. A new pure-ish module derives the rows from the transcript artifacts a summary tree references, and the two push weave points fold the result into the copy that `serializeSummaryJson` serializes. Nothing is added to the stored summary schema, so the change is clear of the FolderStorage / IntelliJ-reader lockstep contracts and applies retroactively to every already-stored memory on its next push.
+
+**Tech Stack:** TypeScript (ESM, Node 22.5+), Vitest, Biome.
+
+**Spec:** [`docs/superpowers/specs/2026-08-06-transcript-session-timestamps-design.md`](../specs/2026-08-06-transcript-session-timestamps-design.md)
+
+> **⚠ SUPERSEDED where it names the batch push path — read against the as-shipped code, not literally.** This plan was written when `JolliMemoryPushOrchestrator` still had TWO weave points: `pushSummary` and a `buildOneBatchItem` on a batch endpoint. That batch endpoint has since been removed (the per-kind batch assembly now lives in [`cli/src/core/push/ContextPush.ts`](../../../cli/src/core/push/ContextPush.ts) and `buildOneBatchItem` no longer exists), so:
+> - **Task 3 ("both push paths") has ONE CLI weave point as shipped**, `pushSummary`'s `summaryForMarkdown` — the "lines 604–609 / `buildOneBatchItem`" half no longer applies. Do not go looking for that function.
+> - **A THIRD weave point was added after this plan**: the ide-bridge `serialize-summary` op ([`cli/src/commands/IdeBridgeCommand.ts`](../../../cli/src/commands/IdeBridgeCommand.ts)) derives the same enrichment for JVM-initiated shares, which have no Kotlin equivalent of `collectTranscriptSessionMeta`.
+> - **Task 1's pasted implementation predates the batch removal too** — the shipped `collectTranscriptSessionMeta` reads through `readTranscriptsBatch`, not the `readTranscript`-per-id loop reproduced below. Trust [`cli/src/core/TranscriptSessionMeta.ts`](../../../cli/src/core/TranscriptSessionMeta.ts) over the snippet.
+
+## Global Constraints
+
+- **Per task: run only that task's own test file(s), then commit. Never run `npm run all` before Task 4.** The full gate is 3.5–9 minutes and belongs at the end; a single test file is seconds. So each of Tasks 1–3 ends with `npx vitest run <its own test file>` and a `git commit -s`, and Task 4 is the one place the whole chain runs. Do not expand a task's test command into the suite, the workspace script, or `npm run all` — that substitution is the specific thing this constraint forbids. (Ruled 2026-08-06: the plan originally deferred both the runs and the commits to Task 4, which left the per-task reviews with no diff and no test evidence.)
+- **DCO sign-off on the commit:** `git commit -s`. No `Co-Authored-By: Claude …` trailer, no `🤖 Generated with …` footer.
+- **The single-file test command, verified — use exactly this form, run from the `cli/` directory:**
+
+  ```bash
+  npx vitest run --coverage=false src/core/<file>.test.ts
+  ```
+
+  Both obvious alternatives are dead ends, so do not "fix" this into either of them:
+  - Dropping `--coverage=false` fails on the coverage floor. `cli`'s `test` script is `vitest run --coverage`, and the 97 % thresholds are computed over the **whole** `src` tree — so a single-file run reports every other file as uncovered and goes red. That red is the command's fault, not the code's.
+  - The root-level form AGENTS.md documents (`npm run test -w @jolli.ai/cli -- …`) **cannot** take the flag: the script already hardcodes `--coverage`, and vitest rejects the duplicate with `Expected a single value for option "--coverage", received [true, false]`.
+
+- **CLI coverage floor is 97 % statements / 96 % branches / 97 % functions / 97 % lines.** Never lower it; never edit `cli/vite.config.ts` or `cli/biome.json`.
+- **Tests must not spawn `git`.** Inject a fake `StorageProvider` instead. Real-`git` test files are the ones that CPU-starve and time out under a full `--coverage` run, and a timeout is indistinguishable at a glance from a real regression.
+- **Biome:** tabs, 4-wide, 120-column limit. `noExplicitAny: error`, `noUnusedImports`/`noUnusedVariables: error`. CI runs `biome check --error-on-warnings`, so warnings fail.
+- **Do not touch:** `CommitSummary` (`cli/src/Types.ts`), `FolderStorage`, the IntelliJ `FolderStorageReader` / `KBFolderReader`, the orphan-branch layout, `QueueWorker`, any git hook, or the config schema. No new configuration option.
+- **No network call may be added to the push path.** The inline pre-push hook's whole budget is `PRE_PUSH_SYNC_BUDGET_MS = 3_000` with `INLINE_MIN_HTTP_BUDGET_MS = 500` reserved for the request; exceeding it defers the entire batch rather than degrading a field.
+
+---
+
+### Task 1: The derivation module
+
+Derives the per-session rows from a summary tree's transcript artifacts. Pure aggregation over injected reads — no git, no network.
+
+**Files:**
+- Create: `cli/src/core/TranscriptSessionMeta.ts`
+- Test: `cli/src/core/TranscriptSessionMeta.test.ts`
+
+**Interfaces:**
+- Consumes: `resolveTranscriptIdsForUsage(summary)` from `./SummaryTree.js`; `readTranscript(id, cwd?, storage?)` from `./SummaryStore.js`; types `CommitSummary`, `StoredTranscript`, `TranscriptEntry` from `../Types.js`; `StorageProvider` from `./StorageProvider.js`.
+- Produces:
+  - `export interface TranscriptSessionMeta { readonly sessionId: string; readonly source: string; readonly messageCount: number; readonly startedAt?: string; readonly endedAt?: string }`
+  - `export async function collectTranscriptSessionMeta(summary: CommitSummary, cwd?: string, storage?: StorageProvider): Promise<ReadonlyArray<TranscriptSessionMeta>>` — returns `[]` when nothing is derivable.
+
+**Background the implementer needs:**
+
+`summary.transcripts` holds *transcript artifact ids*, not session ids. Each id maps to one `transcripts/<id>.json` file holding a `StoredTranscript` — `{ sessions: StoredSession[] }` — and each `StoredSession` has `{sessionId, source?, entries: TranscriptEntry[]}`. `TranscriptEntry.timestamp` is optional.
+
+Use `resolveTranscriptIdsForUsage` for id gathering; do not hand-roll it and do not use `getTranscriptIds`. Its docstring explains why: it returns every id any node in the tree lists, and falls back to the commit-hash ids of a pre-v5 tree when no node lists any. Both properties matter here — a child-listed id must not be missed, and legacy trees are exactly the retroactive coverage this design exists for.
+
+`readTranscript`'s first parameter is named `commitHash` for legacy reasons; it is interpolated straight into `transcripts/${id}.json`, so passing a transcript id is correct. `resolveStorage(storage)` short-circuits on an injected provider, so passing a fake `StorageProvider` keeps the whole path off git.
+
+Two deliberate simplifications from the spec's §4 wording, both narrowing rather than widening:
+- **No cross-summary artifact cache.** The stated purpose was "avoid re-reading the artifacts a squash tree references repeatedly", and a per-call `seen` set of ids achieves exactly that. A cache spanning summaries would add lifetime management for a case that does not arise (different commits reference different artifacts).
+- The `seen` set is **required**, not an optimisation: the `getTranscriptIds` fallback path (`collectAllTranscriptHashes`) can yield the same id twice, which would double-count `messageCount`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+import { describe, expect, it } from "vitest";
+import type { CommitSummary, StoredTranscript } from "../Types.js";
+import type { StorageProvider } from "./StorageProvider.js";
+import { collectTranscriptSessionMeta } from "./TranscriptSessionMeta.js";
+
+/**
+ * Minimal StorageProvider that serves the given `transcripts/<id>.json` bodies
+ * and nothing else. `readTranscript` calls only `readFile`, and
+ * `resolveStorage` short-circuits on an injected provider, so no other method
+ * is reached — the casts keep the fake to the surface actually exercised.
+ */
+function fakeStorage(files: Record<string, string>, opts?: { readonly throwOn?: string }): StorageProvider {
+	return {
+		readFile: async (path: string) => {
+			if (opts?.throwOn === path) throw new Error("simulated read failure");
+			return files[path] ?? null;
+		},
+	} as unknown as StorageProvider;
+}
+
+function transcriptJson(transcript: StoredTranscript): string {
+	return JSON.stringify(transcript);
+}
+
+/** A v5 root: `transcripts` is authoritative, so no tree walk is needed. */
+function rootWith(transcriptIds: ReadonlyArray<string>, children?: ReadonlyArray<CommitSummary>): CommitSummary {
+	return {
+		version: 5,
+		commitHash: "a".repeat(40),
+		commitMessage: "feat: something",
+		commitAuthor: "Dev",
+		commitDate: "2026-08-01T10:00:00.000Z",
+		branch: "feature/x",
+		generatedAt: "2026-08-01T10:05:00.000Z",
+		transcripts: transcriptIds,
+		...(children !== undefined && { children }),
+	} as CommitSummary;
+}
+
+describe("collectTranscriptSessionMeta", () => {
+	it("sums messageCount and spans min→max across a session's slices in two artifacts", async () => {
+		// The amend shape: one session archived into a base artifact and a delta artifact.
+		const storage = fakeStorage({
+			"transcripts/base.json": transcriptJson({
+				sessions: [
+					{
+						sessionId: "s1",
+						source: "claude",
+						entries: [
+							{ role: "human", content: "a", timestamp: "2026-08-01T10:00:00.000Z" },
+							{ role: "assistant", content: "b", timestamp: "2026-08-01T10:10:00.000Z" },
+						],
+					},
+				],
+			}),
+			"transcripts/delta.json": transcriptJson({
+				sessions: [
+					{
+						sessionId: "s1",
+						source: "claude",
+						entries: [{ role: "human", content: "c", timestamp: "2026-08-01T09:00:00.000Z" }],
+					},
+				],
+			}),
+		});
+
+		const rows = await collectTranscriptSessionMeta(rootWith(["base", "delta"]), "/repo", storage);
+
+		expect(rows).toEqual([
+			{
+				sessionId: "s1",
+				source: "claude",
+				messageCount: 3,
+				startedAt: "2026-08-01T09:00:00.000Z",
+				endedAt: "2026-08-01T10:10:00.000Z",
+			},
+		]);
+	});
+
+	it("keeps sessions with the same id but different sources apart", async () => {
+		const storage = fakeStorage({
+			"transcripts/t1.json": transcriptJson({
+				sessions: [
+					{ sessionId: "dup", source: "claude", entries: [{ role: "human", content: "a" }] },
+					{ sessionId: "dup", source: "codex", entries: [{ role: "human", content: "b" }] },
+				],
+			}),
+		});
+
+		const rows = await collectTranscriptSessionMeta(rootWith(["t1"]), "/repo", storage);
+
+		expect(rows).toHaveLength(2);
+		expect(rows.map((r) => r.source).sort()).toEqual(["claude", "codex"]);
+	});
+
+	it("defaults a missing source to claude", async () => {
+		const storage = fakeStorage({
+			"transcripts/t1.json": transcriptJson({
+				sessions: [{ sessionId: "s1", entries: [{ role: "human", content: "a" }] }],
+			}),
+		});
+
+		const rows = await collectTranscriptSessionMeta(rootWith(["t1"]), "/repo", storage);
+
+		expect(rows[0]?.source).toBe("claude");
+	});
+
+	it("omits both bounds when no entry carries a parseable timestamp", async () => {
+		const storage = fakeStorage({
+			"transcripts/t1.json": transcriptJson({
+				sessions: [
+					{
+						sessionId: "s1",
+						source: "claude",
+						entries: [
+							{ role: "human", content: "a" },
+							{ role: "assistant", content: "b", timestamp: "not a date" },
+						],
+					},
+				],
+			}),
+		});
+
+		const rows = await collectTranscriptSessionMeta(rootWith(["t1"]), "/repo", storage);
+
+		expect(rows[0]).toEqual({ sessionId: "s1", source: "claude", messageCount: 2 });
+		expect(rows[0]).not.toHaveProperty("startedAt");
+		expect(rows[0]).not.toHaveProperty("endedAt");
+	});
+
+	it("returns an empty array when no artifact resolves", async () => {
+		const rows = await collectTranscriptSessionMeta(rootWith(["missing"]), "/repo", fakeStorage({}));
+
+		expect(rows).toEqual([]);
+	});
+
+	it("skips an unreadable artifact and still emits the readable ones", async () => {
+		const storage = fakeStorage(
+			{
+				"transcripts/good.json": transcriptJson({
+					sessions: [{ sessionId: "s1", source: "claude", entries: [{ role: "human", content: "a" }] }],
+				}),
+			},
+			{ throwOn: "transcripts/bad.json" },
+		);
+
+		const rows = await collectTranscriptSessionMeta(rootWith(["bad", "good"]), "/repo", storage);
+
+		expect(rows).toEqual([{ sessionId: "s1", source: "claude", messageCount: 1 }]);
+	});
+
+	it("skips a session with no sessionId rather than emitting a keyless row", async () => {
+		const storage = fakeStorage({
+			"transcripts/t1.json": transcriptJson({
+				sessions: [
+					{ sessionId: "", source: "claude", entries: [{ role: "human", content: "a" }] },
+					{ sessionId: "s1", source: "claude", entries: [{ role: "human", content: "b" }] },
+				],
+			}),
+		});
+
+		const rows = await collectTranscriptSessionMeta(rootWith(["t1"]), "/repo", storage);
+
+		expect(rows).toEqual([{ sessionId: "s1", source: "claude", messageCount: 1 }]);
+	});
+
+	it("counts a repeated artifact id once, so messageCount is not doubled", async () => {
+		// The pre-v5 fallback path can yield the same id twice; the dedupe guard is
+		// what keeps the total equal to the de-duplicated entry count.
+		const storage = fakeStorage({
+			"transcripts/t1.json": transcriptJson({
+				sessions: [{ sessionId: "s1", source: "claude", entries: [{ role: "human", content: "a" }] }],
+			}),
+		});
+
+		const rows = await collectTranscriptSessionMeta(rootWith(["t1", "t1"]), "/repo", storage);
+
+		expect(rows).toEqual([{ sessionId: "s1", source: "claude", messageCount: 1 }]);
+	});
+
+	it("gathers ids listed on children, not only the root's index", async () => {
+		const storage = fakeStorage({
+			"transcripts/child.json": transcriptJson({
+				sessions: [{ sessionId: "s-child", source: "claude", entries: [{ role: "human", content: "a" }] }],
+			}),
+		});
+		const child = rootWith(["child"]);
+		// A root whose own index is empty while a child still lists an id — the shape
+		// `resolveTranscriptIdsForUsage` exists to handle.
+		const root = { ...rootWith([]), children: [child] } as CommitSummary;
+
+		const rows = await collectTranscriptSessionMeta(root, "/repo", storage);
+
+		expect(rows).toEqual([{ sessionId: "s-child", source: "claude", messageCount: 1 }]);
+	});
+
+	it("tolerates a transcript whose session carries no entries array", async () => {
+		// `readTranscript` casts JSON.parse output, so the type is a promise, not a guarantee.
+		const storage = fakeStorage({ "transcripts/t1.json": '{"sessions":[{"sessionId":"s1"}]}' });
+
+		const rows = await collectTranscriptSessionMeta(rootWith(["t1"]), "/repo", storage);
+
+		expect(rows).toEqual([{ sessionId: "s1", source: "claude", messageCount: 0 }]);
+	});
+});
+```
+
+- [ ] **Step 2: Write the implementation**
+
+```typescript
+/**
+ * Per-conversation metadata for the pushed summary sidecar.
+ *
+ * A PUSH-TIME enrichment, never stored: the rows are derived from the transcript
+ * artifacts a summary tree already references, so every memory already on disk
+ * gains its time axis on its next push. Deliberately absent from
+ * `CommitSummary` — see `EnrichedPushSummary` in `JolliMemoryPushOrchestrator.ts`
+ * for the type boundary that keeps the storage path unable to name this field.
+ *
+ * Timestamps only, no conversation content, so the `BranchShareScope.transcripts
+ * = false` contract is untouched.
+ */
+
+import { createLogger, errMsg } from "../Logger.js";
+import type { CommitSummary, StoredSession, TranscriptEntry } from "../Types.js";
+import type { StorageProvider } from "./StorageProvider.js";
+import { readTranscript } from "./SummaryStore.js";
+import { resolveTranscriptIdsForUsage } from "./SummaryTree.js";
+
+const log = createLogger("TranscriptSessionMeta");
+
+/** Back-compat convention shared with the server: a source-less session is a Claude one. */
+const DEFAULT_SOURCE = "claude";
+
+/**
+ * One conversation's bounds and size. `startedAt`/`endedAt` are omitted together
+ * when the session carries no parseable timestamp — a journey of unknown length
+ * must render as unmeasured, never as an instant one, so an epoch or an empty
+ * string here would be worse than the gap.
+ */
+export interface TranscriptSessionMeta {
+	readonly sessionId: string;
+	readonly source: string;
+	readonly messageCount: number;
+	readonly startedAt?: string;
+	readonly endedAt?: string;
+}
+
+/** Running total for one `<source>:<sessionId>` key. The `*Ms` fields never leave this module. */
+interface SessionAccumulator {
+	readonly sessionId: string;
+	readonly source: string;
+	messageCount: number;
+	startedAt?: string;
+	startedMs?: number;
+	endedAt?: string;
+	endedMs?: number;
+}
+
+/** The original string when it parses as a date, else undefined. Never coerced. */
+function usableTimestamp(value: string | undefined): { readonly at: string; readonly ms: number } | undefined {
+	if (!value) return undefined;
+	const ms = Date.parse(value);
+	return Number.isNaN(ms) ? undefined : { at: value, ms };
+}
+
+/**
+ * Widens the accumulator's span to cover `entries`. Compares parsed epoch millis
+ * rather than the ISO strings: two timestamps can be the same instant in
+ * different offsets, where a lexicographic comparison picks the wrong one.
+ */
+function foldEntryTimes(acc: SessionAccumulator, entries: ReadonlyArray<TranscriptEntry>): void {
+	for (const entry of entries) {
+		const parsed = usableTimestamp(entry.timestamp);
+		if (!parsed) continue;
+		if (acc.startedMs === undefined || parsed.ms < acc.startedMs) {
+			acc.startedAt = parsed.at;
+			acc.startedMs = parsed.ms;
+		}
+		if (acc.endedMs === undefined || parsed.ms > acc.endedMs) {
+			acc.endedAt = parsed.at;
+			acc.endedMs = parsed.ms;
+		}
+	}
+}
+
+function toMeta(acc: SessionAccumulator): TranscriptSessionMeta {
+	return {
+		sessionId: acc.sessionId,
+		source: acc.source,
+		messageCount: acc.messageCount,
+		...(acc.startedAt !== undefined && { startedAt: acc.startedAt }),
+		...(acc.endedAt !== undefined && { endedAt: acc.endedAt }),
+	};
+}
+
+/** Folds one archived session's slice into the running per-session map. */
+function foldSession(byKey: Map<string, SessionAccumulator>, session: StoredSession): void {
+	// A row with no id has no join key server-side, so it would be dropped there anyway.
+	if (!session.sessionId) return;
+	const source = session.source ?? DEFAULT_SOURCE;
+	const key = `${source}:${session.sessionId}`;
+	const acc = byKey.get(key) ?? { sessionId: session.sessionId, source, messageCount: 0 };
+	// `readTranscript` casts JSON.parse output, so `entries` can be absent in older data.
+	const entries = session.entries ?? [];
+	acc.messageCount += entries.length;
+	foldEntryTimes(acc, entries);
+	byKey.set(key, acc);
+}
+
+/**
+ * Derives the tree-wide per-session rows for one summary — the root's artifacts
+ * and every child's, aggregated by `<source>:<sessionId>`.
+ *
+ * Aggregated rather than keep-first because one session legitimately spans
+ * several artifacts (an amend delta plus its base): `messageCount` sums and the
+ * bounds span min→max, matching the field's "across all of the session's
+ * transcript slices" contract. The result is stamped on the ROOT only — the
+ * server merges duplicate rows keep-first, so a copy on a squash child would
+ * have it silently truncate both the count and the span.
+ *
+ * Returns `[]` when nothing is derivable; the caller omits the field entirely
+ * rather than sending an empty array, which would read as a measurement of zero
+ * conversations and disable the server's bare-transcript-id fallback.
+ *
+ * `storage` is injected rather than resolved so this stays off git — which is
+ * also what keeps its tests in the fast tier.
+ */
+export async function collectTranscriptSessionMeta(
+	summary: CommitSummary,
+	cwd?: string,
+	storage?: StorageProvider,
+): Promise<ReadonlyArray<TranscriptSessionMeta>> {
+	const byKey = new Map<string, SessionAccumulator>();
+	const seen = new Set<string>();
+	for (const id of resolveTranscriptIdsForUsage(summary)) {
+		// Required, not an optimisation: the pre-v5 fallback path can list one id
+		// twice, which would double-count messageCount.
+		if (seen.has(id)) continue;
+		seen.add(id);
+		try {
+			const transcript = await readTranscript(id, cwd, storage);
+			if (!transcript) continue;
+			for (const session of transcript.sessions ?? []) foldSession(byKey, session);
+		} catch (err) {
+			// A detached or pruned artifact must not block a push — its sessions are
+			// simply absent, which the server reports as unmeasured.
+			log.debug("Transcript %s unreadable, skipping: %s", id, errMsg(err));
+		}
+	}
+	return [...byKey.values()].map(toMeta);
+}
+```
+
+**Note on the fake in the test:** `StorageProvider` has more methods than `readFile`, but `readTranscript` calls only `readFile` and `resolveStorage` short-circuits on an injected provider, so the single-method fake with a cast is honest about the surface exercised rather than a shortcut.
+
+- [ ] **Step 3: Run this task's test file**
+
+From the `cli/` directory:
+
+```bash
+npx vitest run --coverage=false src/core/TranscriptSessionMeta.test.ts
+```
+
+Expected: 10 passed. Do not run any other test file, the suite, or `npm run all` — see the Global Constraints for why, and for the two forms of this command that fail for reasons unrelated to the code.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cli/src/core/TranscriptSessionMeta.ts cli/src/core/TranscriptSessionMeta.test.ts
+git commit -s -m "feat(cli): derive per-session transcript bounds from a summary tree
+
+Aggregates each conversation's message count and its min/max entry
+timestamp across every transcript artifact the tree references, keyed by
+source:sessionId. One session legitimately spans several artifacts (an
+amend delta plus its base), so the fold sums and spans rather than taking
+the first row.
+
+A session with no parseable timestamp emits neither bound: a journey of
+unknown length must read as unmeasured, never as an instant one. Reads go
+through an injected StorageProvider, which keeps the derivation off git."
+```
+
+---
+
+### Task 2: The push-layer type and the size-cap retry
+
+Introduces the type boundary that keeps the enrichment out of storage, and stops the enrichment from being able to cost a summary its whole sidecar.
+
+**Files:**
+- Modify: `cli/src/core/JolliMemoryPushOrchestrator.ts` — `serializeSummaryJson` at lines 87–103
+- Test: `cli/src/core/JolliMemoryPushOrchestrator.test.ts`
+
+**Interfaces:**
+- Consumes: `TranscriptSessionMeta` from `./TranscriptSessionMeta.js` (Task 1).
+- Produces:
+  - `export type EnrichedPushSummary = CommitSummary & { readonly transcriptSessions?: ReadonlyArray<TranscriptSessionMeta> }`
+  - `serializeSummaryJson(summary: EnrichedPushSummary): string | undefined` — signature widened from `CommitSummary`. Every existing caller still type-checks, since `CommitSummary` is assignable to the intersection's optional-extra form.
+
+**Why the retry exists:** the server validates `summaryJson` with `z.string().max(2_000_000)`, so one character over 400s the *whole request* and the markdown article fails with it. That is why the client drops the entire sidecar above `MAX_SUMMARY_JSON_BYTES` (1.5 MB). A session row is ~150 bytes, so the enrichment is ~0.3 % of the cap — but a summary already sitting at 1.499 MB would lose its whole sidecar to it. Retrying without the enrichment makes the worst case equal today's behaviour instead of worse than it.
+
+Do not "fix" the byte-vs-character mismatch: the client measures UTF-8 bytes, the server counts UTF-16 code units, and byte count is always ≥ character count, so the client guard errs on the safe side.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `cli/src/core/JolliMemoryPushOrchestrator.test.ts`. Import `serializeSummaryJson` from the module under test if it is not already imported.
+
+```typescript
+describe("serializeSummaryJson session enrichment", () => {
+	/** A summary whose `recap` alone lands just under the 1.5 MB cap. */
+	function summaryOfRecapSize(chars: number): CommitSummary {
+		return {
+			version: 5,
+			commitHash: "b".repeat(40),
+			commitMessage: "feat: big",
+			commitAuthor: "Dev",
+			commitDate: "2026-08-01T10:00:00.000Z",
+			branch: "feature/x",
+			generatedAt: "2026-08-01T10:05:00.000Z",
+			recap: "x".repeat(chars),
+		} as CommitSummary;
+	}
+
+	it("carries transcriptSessions through when the payload fits", () => {
+		const json = serializeSummaryJson({
+			...summaryOfRecapSize(10),
+			transcriptSessions: [
+				{
+					sessionId: "s1",
+					source: "claude",
+					messageCount: 3,
+					startedAt: "2026-08-01T09:00:00.000Z",
+					endedAt: "2026-08-01T10:10:00.000Z",
+				},
+			],
+		});
+
+		expect(json).toBeDefined();
+		expect(JSON.parse(json as string).transcriptSessions).toEqual([
+			{
+				sessionId: "s1",
+				source: "claude",
+				messageCount: 3,
+				startedAt: "2026-08-01T09:00:00.000Z",
+				endedAt: "2026-08-01T10:10:00.000Z",
+			},
+		]);
+	});
+
+	it("drops only the enrichment when it is what pushes the payload over the cap", () => {
+		// 1.5 MB is 1_572_864 bytes; leave under 400 bytes of headroom so a handful
+		// of session rows is the difference between fitting and not.
+		const base = summaryOfRecapSize(1_572_500);
+		const withoutEnrichment = serializeSummaryJson(base);
+		expect(withoutEnrichment).toBeDefined();
+
+		const json = serializeSummaryJson({
+			...base,
+			transcriptSessions: Array.from({ length: 20 }, (_, i) => ({
+				sessionId: `session-${i}`,
+				source: "claude",
+				messageCount: 10,
+				startedAt: "2026-08-01T09:00:00.000Z",
+				endedAt: "2026-08-01T10:10:00.000Z",
+			})),
+		});
+
+		// The sidecar survives; only the enrichment is gone.
+		expect(json).toBe(withoutEnrichment);
+		expect(JSON.parse(json as string)).not.toHaveProperty("transcriptSessions");
+	});
+
+	it("still returns undefined when the payload is oversized without any enrichment", () => {
+		expect(serializeSummaryJson(summaryOfRecapSize(2_000_000))).toBeUndefined();
+	});
+});
+```
+
+- [ ] **Step 2: Write the implementation**
+
+Add the type next to `MAX_SUMMARY_JSON_BYTES`:
+
+```typescript
+/**
+ * A summary as the PUSH path sees it: the stored record plus the push-time
+ * session enrichment.
+ *
+ * The extra field lives here, not on `CommitSummary`, on purpose — the storage
+ * path cannot name it, so it cannot persist it. That is what keeps this change
+ * clear of the stored-schema lockstep contracts (FolderStorage's hidden layer
+ * and the IntelliJ readers over it).
+ */
+export type EnrichedPushSummary = CommitSummary & {
+	readonly transcriptSessions?: ReadonlyArray<TranscriptSessionMeta>;
+};
+```
+
+Replace the body of `serializeSummaryJson`, keeping its existing docstring and appending the retry paragraph to it:
+
+```typescript
+export function serializeSummaryJson(summary: EnrichedPushSummary): string | undefined {
+	const {
+		jolliDocId: _docId,
+		jolliDocUrl: _docUrl,
+		orphanedDocIds: _orphaned,
+		unresolvedOrphanHashes: _unresolved,
+		...content
+	} = summary;
+	const json = JSON.stringify(content);
+	if (Buffer.byteLength(json, "utf-8") <= MAX_SUMMARY_JSON_BYTES) return json;
+	// The session enrichment is a push-time extra, so shedding it is strictly
+	// better than shedding the whole sidecar — which is what the cap otherwise
+	// does. Worst case becomes the pre-enrichment behavior, never worse.
+	if (content.transcriptSessions !== undefined) {
+		const { transcriptSessions: _sessions, ...withoutSessions } = content;
+		const retry = JSON.stringify(withoutSessions);
+		if (Buffer.byteLength(retry, "utf-8") <= MAX_SUMMARY_JSON_BYTES) {
+			log.warn(
+				`Summary JSON for ${summary.commitHash.substring(0, 8)} exceeds ${MAX_SUMMARY_JSON_BYTES} bytes — pushing without session metadata`,
+			);
+			return retry;
+		}
+	}
+	log.warn(
+		`Summary JSON for ${summary.commitHash.substring(0, 8)} exceeds ${MAX_SUMMARY_JSON_BYTES} bytes — pushing markdown only`,
+	);
+	return;
+}
+```
+
+Add the import: `import type { TranscriptSessionMeta } from "./TranscriptSessionMeta.js";` — type-only for now. Task 3 adds the value import of `collectTranscriptSessionMeta`. Importing the unused function here would trip Biome's `noUnusedImports: error`.
+
+- [ ] **Step 3: Run this task's test file**
+
+From the `cli/` directory:
+
+```bash
+npx vitest run --coverage=false src/core/JolliMemoryPushOrchestrator.test.ts
+```
+
+Expected: all pre-existing cases still pass, plus the 3 new `serializeSummaryJson session enrichment` cases. A pre-existing failure here is a signal that widening the signature broke a caller — fix it rather than skipping the case.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cli/src/core/JolliMemoryPushOrchestrator.ts cli/src/core/JolliMemoryPushOrchestrator.test.ts
+git commit -s -m "feat(cli): shed only the session enrichment when the sidecar cap is hit
+
+The server validates summaryJson with z.string().max(2_000_000), so one
+character over rejects the whole request and the markdown article fails
+with it — which is why the client drops the entire sidecar above its own
+1.5MB guard.
+
+A session row is ~150 bytes, so the enrichment is ~0.3% of the cap, but a
+summary already sitting just under it would lose its whole sidecar to the
+addition. Retrying once without the enrichment makes the worst case equal
+the previous behavior instead of worse than it.
+
+EnrichedPushSummary lives in the push layer rather than on CommitSummary
+so the storage path cannot name the field, and therefore cannot persist
+it."
+```
+
+---
+
+### Task 3: Weave the enrichment into both push paths
+
+**Files:**
+- Modify: `cli/src/core/JolliMemoryPushOrchestrator.ts` — `pushSummary`'s `summaryForMarkdown` at lines 955–960, and `buildOneBatchItem`'s at lines 604–609
+- Test: `cli/src/core/JolliMemoryPushOrchestrator.test.ts`
+
+**Interfaces:**
+- Consumes: `collectTranscriptSessionMeta` (Task 1), `EnrichedPushSummary` (Task 2).
+- Produces: no new exports. Behavioural change only.
+
+**Why both:** they are two independent blocks of weaving code, and `buildOneBatchItem` is the one the pre-push hook actually runs. A change that only lands in `pushSummary` would pass a naive review and ship nothing on the common path.
+
+**The existing test file mocks `./SummaryStore.js` with an enumerating factory** (`getActiveStorage`, `getSummary`, `storeSummary`, …). `collectTranscriptSessionMeta` imports `readTranscript` from that module, so the mock must gain `readTranscript: vi.fn(async () => null)` or the enrichment path throws `readTranscript is not a function`. Tests that want rows back override it per-case with `vi.mocked(readTranscript).mockResolvedValue({ sessions: [...] })`.
+
+- [ ] **Step 1: Extend the existing `./SummaryStore.js` mock**
+
+In `cli/src/core/JolliMemoryPushOrchestrator.test.ts`, add one entry to the existing factory:
+
+```typescript
+vi.mock("./SummaryStore.js", () => ({
+	getActiveStorage: vi.fn(),
+	getIndexEntryMap: vi.fn(async () => new Map()),
+	getSummary: vi.fn(),
+	readNoteFromBranch: vi.fn(),
+	readPlanFromBranch: vi.fn(),
+	// Enrichment path (TranscriptSessionMeta) reads through this. Default: no
+	// artifact, so existing cases keep their pre-enrichment payloads.
+	readTranscript: vi.fn(async () => null),
+	readReferenceFromBranch: vi.fn(),
+	storeSummary: vi.fn(),
+}));
+```
+
+Import it alongside the others so tests can override: add `readTranscript` to the existing `import { … } from "./SummaryStore.js";` list.
+
+- [ ] **Step 2: Write the failing tests**
+
+```typescript
+describe("session enrichment on the push paths", () => {
+	const ONE_SESSION = {
+		sessions: [
+			{
+				sessionId: "s1",
+				source: "claude",
+				entries: [
+					{ role: "human" as const, content: "a", timestamp: "2026-08-01T09:00:00.000Z" },
+					{ role: "assistant" as const, content: "b", timestamp: "2026-08-01T10:10:00.000Z" },
+				],
+			},
+		],
+	};
+
+	/** A v5 root that lists one artifact, plus a child that lists none. */
+	function summaryWithChild(): CommitSummary {
+		return {
+			version: 5,
+			commitHash: "c".repeat(40),
+			commitMessage: "feat: x",
+			commitAuthor: "Dev",
+			commitDate: "2026-08-01T10:00:00.000Z",
+			branch: "feature/x",
+			generatedAt: "2026-08-01T10:05:00.000Z",
+			transcripts: ["t1"],
+			children: [
+				{
+					version: 5,
+					commitHash: "d".repeat(40),
+					commitMessage: "wip",
+					commitAuthor: "Dev",
+					commitDate: "2026-08-01T09:30:00.000Z",
+					branch: "feature/x",
+					generatedAt: "2026-08-01T09:35:00.000Z",
+					transcripts: [],
+				},
+			],
+		} as CommitSummary;
+	}
+
+	it("stamps the rows on the root only, never on a child", async () => {
+		vi.mocked(readTranscript).mockResolvedValue(ONE_SESSION);
+
+		const built = await buildBatchItems([summaryWithChild()], EMPTY_OWNERSHIP, ctx);
+		const pushed = JSON.parse(built[0].item.summary.summaryJson as string);
+
+		expect(pushed.transcriptSessions).toEqual([
+			{
+				sessionId: "s1",
+				source: "claude",
+				messageCount: 2,
+				startedAt: "2026-08-01T09:00:00.000Z",
+				endedAt: "2026-08-01T10:10:00.000Z",
+			},
+		]);
+		// A child copy would activate the server's keep-first merge and truncate.
+		expect(pushed.children[0]).not.toHaveProperty("transcriptSessions");
+	});
+
+	it("weaves the rows on the single-summary path too", async () => {
+		vi.mocked(readTranscript).mockResolvedValue(ONE_SESSION);
+
+		await pushSummary(summaryWithChild(), ctx);
+
+		const payload = vi.mocked(ctx.client.push).mock.calls.at(-1)?.[0] as PushPayload;
+		expect(JSON.parse(payload.summaryJson as string).transcriptSessions).toHaveLength(1);
+	});
+
+	it("omits the key entirely when no session is derivable", async () => {
+		vi.mocked(readTranscript).mockResolvedValue(null);
+
+		const built = await buildBatchItems([summaryWithChild()], EMPTY_OWNERSHIP, ctx);
+
+		// An empty array would read as "measured: zero conversations" and would also
+		// disable the server's bare-transcript-id fallback.
+		expect(JSON.parse(built[0].item.summary.summaryJson as string)).not.toHaveProperty("transcriptSessions");
+	});
+
+	it("never persists the enrichment to the stored summary", async () => {
+		vi.mocked(readTranscript).mockResolvedValue(ONE_SESSION);
+
+		await pushSummary(summaryWithChild(), ctx);
+
+		const stored = vi.mocked(storeSummary).mock.calls.at(-1)?.[0] as CommitSummary;
+		expect(stored).not.toHaveProperty("transcriptSessions");
+	});
+});
+```
+
+**Adapt to the file's existing harness rather than inventing one.** `EMPTY_OWNERSHIP` and `ctx` above are placeholders for whatever the surrounding tests already build (an `OwnedAttachmentMaps` with three empty `Map`s, and a `PushContext` whose `client` is a mocked `JolliMemoryPushClient`). Reuse the file's existing fixtures and `beforeEach` wiring; do not add a second harness. If the existing `pushSummary` cases rely on `getIndexEntryMap` returning an empty map and `storeSummary` resolving, those defaults already hold.
+
+- [ ] **Step 3: Write the implementation**
+
+In `pushSummary`, immediately before the existing `summaryForMarkdown`:
+
+```typescript
+	// Push-time session enrichment. Read from the artifacts this tree references,
+	// stamped on the root only (the server merges duplicate rows keep-first), and
+	// omitted entirely when empty so absence never reads as a measured zero.
+	const transcriptSessions = await collectTranscriptSessionMeta(summary, ctx.cwd, ctx.storage);
+	const summaryForMarkdown: EnrichedPushSummary = {
+		...summary,
+		plans: plansWithUrls,
+		...(notesWithUrls !== summary.notes && { notes: notesWithUrls }),
+		...(referencesWithUrls !== summary.references && { references: referencesWithUrls }),
+		...(transcriptSessions.length > 0 && { transcriptSessions }),
+	};
+```
+
+In `buildOneBatchItem`, the same two changes on its own `summaryForMarkdown`:
+
+```typescript
+	const transcriptSessions = await collectTranscriptSessionMeta(summary, ctx.cwd, ctx.storage);
+	const summaryForMarkdown: EnrichedPushSummary = {
+		...summary,
+		plans: plansWithUrls,
+		...(notesWithUrls !== undefined && { notes: notesWithUrls }),
+		...(referencesWithUrls !== undefined && { references: referencesWithUrls }),
+		...(transcriptSessions.length > 0 && { transcriptSessions }),
+	};
+```
+
+`buildPushMarkdown` takes a `CommitSummary`; `EnrichedPushSummary` is assignable to it, so that call is unchanged and the markdown output is unaffected (the builder does not read the new field).
+
+`updatedSummary` in `pushSummary` (line ~1014) is built from `...summary`, not from `summaryForMarkdown` — leave it that way. That is what makes the "never persisted" invariant structural rather than a convention.
+
+Change the Task 2 type-only import to a value import now that the function is used:
+`import { collectTranscriptSessionMeta, type TranscriptSessionMeta } from "./TranscriptSessionMeta.js";`
+
+- [ ] **Step 4: Run this task's test file**
+
+From the `cli/` directory:
+
+```bash
+npx vitest run --coverage=false src/core/JolliMemoryPushOrchestrator.test.ts
+```
+
+Expected: every pre-existing case still passes, plus the 4 new `session enrichment on the push paths` cases. If a pre-existing `pushSummary` or `buildBatchItems` case fails with `readTranscript is not a function`, Step 1 was skipped.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/core/JolliMemoryPushOrchestrator.ts cli/src/core/JolliMemoryPushOrchestrator.test.ts
+git commit -s -m "feat(cli): stamp per-session transcript bounds onto the pushed summary
+
+Weaves the derived rows into both push paths — the single-summary one and
+the batch one the pre-push hook actually runs. Two independent blocks of
+weaving code, so a change landing in only one would pass review and ship
+nothing on the common path.
+
+The rows go on the root alone. The server merges duplicate rows keep-first,
+so a copy on a squash child would silently truncate both the count and the
+span. An empty result omits the field rather than sending an empty array,
+which would read as a measurement of zero conversations and would disable
+the server's fallback to bare transcript ids.
+
+The write-back copy is still built from the original summary, so the
+enrichment cannot reach storage."
+```
+
+---
+
+### Task 4: The full gate
+
+The one place the whole chain runs, per the Global Constraints. Tasks 1–3 each committed after running their own test file; this task verifies the change as a whole.
+
+**Files:** none — verification only, plus whatever the gate reveals.
+
+- [ ] **Step 1: Run the full gate**
+
+```bash
+npm run all
+```
+
+Expect clean → build → typecheck → lint → test to pass, including the CLI coverage floor (97 / 96 / 97 / 97).
+
+Triage by failure shape, not by re-running blindly:
+- **`Test timed out in NNNNms`** — a load signal, not a regression. Re-run that file alone with the stock timeout; green in isolation is the proof it was CPU contention. Do not raise any timeout.
+- **Assertion or thrown error** — a real failure. Fix it.
+- **`readTranscript is not a function`** — Task 3 Step 1 was skipped; the `./SummaryStore.js` mock in `JolliMemoryPushOrchestrator.test.ts` needs the entry.
+- **Coverage below floor** — add the missing case; never lower the threshold and never edit `cli/vite.config.ts`.
+
+- [ ] **Step 2: Commit any fixes the gate required**
+
+If the gate was clean, there is nothing to commit — Tasks 1–3 already landed their commits, and the branch is done. If the gate required fixes, commit them:
+
+```bash
+git add -u
+git commit -s -m "fix(cli): <what the gate caught>"
+```
+
+Do not squash or rewrite the Task 1–3 commits. Each is a coherent, separately reviewed step, and the history is the record.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec item | Task |
+|---|---|
+| §2 D1 push-time derivation | 3 |
+| §2 D2 type boundary keeps it out of storage | 2 (type), 3 (structural test) |
+| §2 D3 root-stamped, tree-wide | 1 (gathering), 3 (stamping + child test) |
+| §2 D4 aggregate: sum / min / max | 1 |
+| §2 D5 injected reader, fast-tier tests | 1 |
+| §3 emitted shape | 1 |
+| §3.1 rule 1 — no bounds without a timestamp | 1 |
+| §3.1 rule 2 — empty ⇒ key absent | 3 |
+| §3.1 rule 3 — unreadable artifact is skipped | 1 |
+| §3.2 size-cap retry | 2 |
+| §4 both weave points | 3 |
+| §5 invariants 1–9 | 1 (1, 3, 5, 9), 2 (6), 3 (2, 4, 7, 8) |
+| §5 gate, coverage floor | 4 |
+| §6 not-touched list | Global Constraints |
+
+**Deviations from the spec, both narrowing:** the per-run artifact cache in §4 is realised as a per-call `seen` set (Task 1 explains why a cross-summary cache serves no case that arises), and §5 invariant 9 is covered by the repeated-id test rather than a separate sum assertion, since the dedupe guard is the only thing that can break the equality.
+
+**Type consistency:** `collectTranscriptSessionMeta` and `TranscriptSessionMeta` are spelled identically in Tasks 1, 2 and 3. `EnrichedPushSummary` is defined in Task 2 and consumed in Task 3. `readTranscript(id, cwd, storage)` matches the real signature in `SummaryStore.ts`, whose first parameter is named `commitHash` but is interpolated as an opaque id.

--- a/docs/superpowers/plans/2026-08-11-local-agent-concurrency.md
+++ b/docs/superpowers/plans/2026-08-11-local-agent-concurrency.md
@@ -1,0 +1,924 @@
+# Local Agent Concurrency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Record 15-minute activity buckets per agent session so the local dashboard can answer "how many agents was I running at the same time?", data layer only.
+
+**Architecture:** A new `session_activity` table stores one row per (session, 15-minute bucket) in which that session produced a message. `DashboardCollector` derives buckets from per-message timestamps it already reads; `StatsWriter` persists them with the same replace-when-observed contract `session_tool_use` uses; `DashboardQuery` aggregates them into an optional `StatsModel.concurrency` field. No UI.
+
+**Tech Stack:** TypeScript (ESM), `node:sqlite` (STRICT tables), Vitest, Biome.
+
+Spec: [`docs/superpowers/specs/2026-08-11-local-agent-concurrency-design.md`](../specs/2026-08-11-local-agent-concurrency-design.md)
+
+## Global Constraints
+
+- Every commit uses `git commit -s` (DCO). CI rejects PRs without `Signed-off-by:`.
+- **No `Co-Authored-By: Claude …` trailer and no "🤖 Generated with …" footer** in commit messages or PR descriptions.
+- `npm run all` must pass before the final commit (clean → build → typecheck → lint → test).
+- CLI coverage floor: 97% statements / 96% branches / 97% functions / 97% lines. Do not regress it.
+- Biome: tabs, 4-wide indent, 120 column limit. `noExplicitAny: error`, `noUnusedImports/Variables: error`. CI runs `biome check --error-on-warnings` — warnings fail.
+- `MIGRATIONS` in `DashboardDb.ts` is **append-only**. Never edit or reorder an existing entry; never drop a column.
+- **The version number in this plan is not a constant — recompute it.** At writing time this branch declares `DASHBOARD_SCHEMA_VERSION = 5` with five migrations, so `session_activity` is entry 5 and version 6. But branch `pr460` has already appended `TOOL_CALL_TIME_ZERO_SWEEP_DDL` as its own entry 5 and shipped version 6 (verified: `~/.jolli/jollimemory/jollimemory.db` reports `schema_version = 6` today, written by that build). If `pr460` merges first, this becomes entry 6 / version 7. **Read the tail of `MIGRATIONS` on your actual branch point, append after whatever is last, and set `DASHBOARD_SCHEMA_VERSION` to the new array length.**
+- **A dev machine whose shared DB is already at the version you are claiming will silently skip your migration.** The dashboard DB is machine-global (`~/.jolli/jollimemory/jollimemory.db`), shared by every worktree. If it already reads 6 because `pr460` migrated it, a build of this branch that also declares 6 makes `migrateDashboardDb` see `6 >= 6` and run nothing — `session_activity` is never created, and every query against it fails with `no such table`, which reads like a code bug rather than a version collision. Diagnose with the snippet in Task 6 Step 3; recover by pointing tests at a temp `dbPath` (which every test in this plan already does) and, for manual verification, by using a throwaway `dbPath` rather than the shared file.
+- Inner loop is `npm run test:fast`; the dashboard tests are in that tier. Run a single file with
+  `npm run test -w @jolli.ai/cli -- src/dashboard/<File>.test.ts -t "<case>"`.
+
+---
+
+### Task 1: Schema — the `session_activity` table
+
+**Files:**
+- Modify: `cli/src/dashboard/SotSchema.ts` (add `SESSION_ACTIVITY_DDL` after `TOOL_CALL_TIME_DDL`, which ends at line 487)
+- Modify: `cli/src/dashboard/DashboardDb.ts:69` (version) and `cli/src/dashboard/DashboardDb.ts:217-240` (`MIGRATIONS`)
+- Test: `cli/src/dashboard/DashboardDb.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `SESSION_ACTIVITY_DDL: string` exported from `SotSchema.ts`; `DASHBOARD_SCHEMA_VERSION === 6`; table `session_activity(session_event_id TEXT, bucket_ms INTEGER)` with `PRIMARY KEY (session_event_id, bucket_ms)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `cli/src/dashboard/DashboardDb.test.ts`, inside the existing top-level `describe` that already exercises `withDashboardDb` with a temp `dbPath`:
+
+```ts
+	it("creates session_activity, keyed per (session, bucket) and rejecting a REAL bucket", async () => {
+		const rows = await withDashboardDb(
+			(db) =>
+				db
+					.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'session_activity'")
+					.all() as ReadonlyArray<{ name: string }>,
+			{ dbPath },
+		);
+		expect(rows).toHaveLength(1);
+
+		// STRICT is what turns a forgotten Math.floor into a loud failure instead
+		// of a fractional bucket that silently defeats the primary key.
+		await withDashboardDb((db) => {
+			// `enabled_at` is NOT NULL with no default — omitting it fails the insert.
+			db.prepare(
+				"INSERT INTO repos (repo_identity, repo_name, worktree_root, enabled_at) VALUES (?, ?, ?, ?)",
+			).run("repo-1", "repo-1", "/tmp/repo-1", "2026-08-11T00:00:00.000Z");
+			db.prepare(
+				`INSERT INTO sessions (event_id, repo_id, source, session_id, updated_at_ms)
+				 VALUES ('s-evt', 1, 'claude', 's1', 1786425300000)`,
+			).run();
+			db.prepare("INSERT INTO session_activity (session_event_id, bucket_ms) VALUES (?, ?)").run(
+				"s-evt",
+				1786425300000,
+			);
+			expect(() =>
+				db.prepare("INSERT INTO session_activity (session_event_id, bucket_ms) VALUES (?, ?)").run(
+					"s-evt",
+					1786425300000.5,
+				),
+			).toThrow(/REAL/);
+		}, { dbPath });
+	});
+
+	it("is at schema version 6", async () => {
+		const version = await withDashboardDb((db) => readSchemaVersion(db), { dbPath });
+		expect(version).toBe(6);
+	});
+```
+
+Substitute the real number for `6` here and everywhere below in this task — see
+the recompute rule in Global Constraints. It is the length of `MIGRATIONS`
+after your append, on your actual branch point.
+
+This literal assertion is new and worth adding: the file's existing check at
+line 481 compares `readSchemaVersion(db)` against `DASHBOARD_SCHEMA_VERSION`,
+which passes for any value and so cannot catch a migration appended without a
+version bump.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/dashboard/DashboardDb.test.ts -t "session_activity"`
+Expected: FAIL — `expect(received).toHaveLength(1)` got `0` (no such table).
+
+- [ ] **Step 3: Write the DDL constant**
+
+In `cli/src/dashboard/SotSchema.ts`, after `TOOL_CALL_TIME_DDL`:
+
+```ts
+/**
+ * One row per (session, 15-minute bucket) in which that session produced a
+ * message — the input to the concurrency figure.
+ *
+ * `bucket_ms` holds an ABSOLUTE epoch-ms bucket start, not a localised day or
+ * hour key: time zone is a render-time concern that `localDayKey` / `localHour`
+ * already handle in the query layer, and a stored localised copy would be a
+ * second answer to a question that already has one.
+ *
+ * Buckets rather than a stored `(start, end)` interval because a resumed
+ * session is common and its span is not its presence — measured, the longest
+ * session on the author's machine spans 18 hours across 28 messages. A bucket
+ * list occupies only the quarter-hours the session actually spoke in, with no
+ * gap-threshold parameter to tune.
+ *
+ * `INTEGER` under STRICT is load-bearing twice: `node:sqlite` returns these as
+ * JS numbers (epoch ms sits ~5000x below `Number.MAX_SAFE_INTEGER`), and STRICT
+ * REJECTS a REAL here, so a missing `Math.floor` upstream fails at insert
+ * instead of storing a fractional bucket that defeats the primary key.
+ */
+export const SESSION_ACTIVITY_DDL = `
+CREATE TABLE session_activity (
+  session_event_id TEXT NOT NULL REFERENCES sessions(event_id) ON DELETE CASCADE,
+  bucket_ms        INTEGER NOT NULL,
+  PRIMARY KEY (session_event_id, bucket_ms)
+) STRICT;
+CREATE INDEX ix_activity_bucket ON session_activity(bucket_ms);
+`;
+```
+
+- [ ] **Step 4: Append the migration and bump the version**
+
+In `cli/src/dashboard/DashboardDb.ts`, add `SESSION_ACTIVITY_DDL` to the existing import from `./SotSchema.js`, then append it as the **sixth** entry (index 5) of `MIGRATIONS`, after `TOOL_CALL_TIME_DDL`:
+
+```ts
+	TOOL_CALL_TIME_DDL,
+	SESSION_ACTIVITY_DDL,
+];
+```
+
+And at line 69:
+
+```ts
+export const DASHBOARD_SCHEMA_VERSION = 6;
+```
+
+Do not edit entries 0-4. Dev databases are already at 5, and editing an earlier entry reaches only databases created afterwards.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm run test -w @jolli.ai/cli -- src/dashboard/DashboardDb.test.ts`
+Expected: PASS, whole file.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/dashboard/SotSchema.ts cli/src/dashboard/DashboardDb.ts cli/src/dashboard/DashboardDb.test.ts
+git commit -s -m "Add a session_activity table for per-session quarter-hour buckets"
+```
+
+---
+
+### Task 2: `bucketsFrom` — the pure bucketing helper
+
+**Files:**
+- Create: `cli/src/dashboard/ActivityBuckets.ts`
+- Test: `cli/src/dashboard/ActivityBuckets.test.ts`
+
+**Interfaces:**
+- Consumes: `TranscriptEntry` from `../Types.js` (`{ role, content, timestamp?: string }`).
+- Produces:
+  - `ACTIVITY_BUCKET_MS: number` (= 900_000)
+  - `bucketsFrom(entries: ReadonlyArray<TranscriptEntry>): ReadonlyArray<number>` — deduped, ascending bucket starts. Returns `[]` when no entry carries a parseable timestamp.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cli/src/dashboard/ActivityBuckets.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { TranscriptEntry } from "../Types.js";
+import { ACTIVITY_BUCKET_MS, bucketsFrom } from "./ActivityBuckets.js";
+
+const entry = (timestamp?: string): TranscriptEntry => ({ role: "human", content: "x", ...(timestamp ? { timestamp } : {}) });
+
+describe("bucketsFrom", () => {
+	it("floors each timestamp to its quarter-hour start", () => {
+		// 2026-08-11T10:07:23Z falls in the 10:00 bucket.
+		expect(bucketsFrom([entry("2026-08-11T10:07:23.000Z")])).toEqual([Date.parse("2026-08-11T10:00:00.000Z")]);
+		// 10:44:59 falls in the 10:30 bucket, not 10:45.
+		expect(bucketsFrom([entry("2026-08-11T10:44:59.000Z")])).toEqual([Date.parse("2026-08-11T10:30:00.000Z")]);
+	});
+
+	it("dedupes messages sharing a bucket and returns ascending order", () => {
+		const out = bucketsFrom([
+			entry("2026-08-11T10:50:00.000Z"),
+			entry("2026-08-11T10:07:00.000Z"),
+			entry("2026-08-11T10:12:00.000Z"),
+		]);
+		expect(out).toEqual([Date.parse("2026-08-11T10:00:00.000Z"), Date.parse("2026-08-11T10:45:00.000Z")]);
+	});
+
+	it("occupies only the buckets a resumed session spoke in, never the span between", () => {
+		// The measured 18-hour session shape: two messages, a night apart.
+		const out = bucketsFrom([entry("2026-08-10T22:00:00.000Z"), entry("2026-08-11T16:00:00.000Z")]);
+		expect(out).toHaveLength(2);
+	});
+
+	it("skips entries with no timestamp, and unparseable ones, without dropping the rest", () => {
+		expect(bucketsFrom([entry(), entry("not-a-date"), entry("2026-08-11T10:07:00.000Z")])).toEqual([
+			Date.parse("2026-08-11T10:00:00.000Z"),
+		]);
+	});
+
+	it("returns empty when nothing is timestamped — the caller turns that into an ABSENT field", () => {
+		expect(bucketsFrom([entry(), entry()])).toEqual([]);
+		expect(bucketsFrom([])).toEqual([]);
+	});
+
+	it("produces integral buckets, which the STRICT column requires", () => {
+		for (const b of bucketsFrom([entry("2026-08-11T10:07:23.456Z")])) {
+			expect(Number.isInteger(b)).toBe(true);
+			expect(b % ACTIVITY_BUCKET_MS).toBe(0);
+		}
+	});
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/dashboard/ActivityBuckets.test.ts`
+Expected: FAIL — cannot resolve `./ActivityBuckets.js`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `cli/src/dashboard/ActivityBuckets.ts`:
+
+```ts
+/**
+ * Quarter-hour activity bucketing — the one place a transcript's per-message
+ * timestamps become the rows behind the concurrency figure.
+ *
+ * Kept apart from the collector because it is pure and is the only piece of
+ * this feature with arithmetic worth pinning on its own.
+ */
+
+import type { TranscriptEntry } from "../Types.js";
+
+/** Bucket width. 15 minutes: coarse enough that a pause mid-thought does not
+ *  fragment a session, fine enough that "the same bucket" still reads as "at
+ *  the same time" to a person. */
+export const ACTIVITY_BUCKET_MS = 15 * 60 * 1000;
+
+/**
+ * The quarter-hour bucket starts a slice of transcript touched, deduped and
+ * ascending.
+ *
+ * An EMPTY result means no entry carried a parseable timestamp — the caller
+ * must turn that into an ABSENT `activityBuckets` field, never `[]`, so that a
+ * source whose reader emits no timestamps is reported as uncovered rather than
+ * as "used no agents". Entries without a timestamp are skipped individually, so
+ * one malformed line cannot cost the rest of the session its buckets.
+ */
+export function bucketsFrom(entries: ReadonlyArray<TranscriptEntry>): ReadonlyArray<number> {
+	const seen = new Set<number>();
+	for (const e of entries) {
+		if (!e.timestamp) continue;
+		const at = Date.parse(e.timestamp);
+		if (!Number.isFinite(at)) continue;
+		seen.add(Math.floor(at / ACTIVITY_BUCKET_MS) * ACTIVITY_BUCKET_MS);
+	}
+	return [...seen].sort((a, b) => a - b);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -w @jolli.ai/cli -- src/dashboard/ActivityBuckets.test.ts`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cli/src/dashboard/ActivityBuckets.ts cli/src/dashboard/ActivityBuckets.test.ts
+git commit -s -m "Add quarter-hour bucketing for transcript activity"
+```
+
+---
+
+### Task 3: Event field and its projection
+
+**Files:**
+- Modify: `cli/src/dashboard/DashboardModel.ts:44-68` (`SessionUpsertedEvent`)
+- Modify: `cli/src/dashboard/StatsWriter.ts:603-621` (append a block at the end of `projectSession`)
+- Test: `cli/src/dashboard/StatsWriter.test.ts`
+
+**Interfaces:**
+- Consumes: the `session_activity` table from Task 1.
+- Produces: `SessionUpsertedEvent.activityBuckets?: ReadonlyArray<number>`, persisted to `session_activity` keyed on the session's `event_id`.
+
+**Do NOT touch `projectCommitSummary`.** It seeds session rows from `SessionLinkItem`, which carries only `messageCount` and per-model usage — no per-message timestamps exist on that path, so it can never produce buckets and must leave existing rows alone.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `cli/src/dashboard/StatsWriter.test.ts` a new top-level `describe`, next to the existing `describe("session_tool_use projection", …)`:
+
+```ts
+describe("session_activity projection", () => {
+	const readBuckets = (db: DashboardDbHandle) =>
+		(
+			db
+				.prepare("SELECT bucket_ms FROM session_activity ORDER BY bucket_ms")
+				.all() as ReadonlyArray<{ bucket_ms: number }>
+		).map((r) => r.bucket_ms);
+
+	it("stores one row per bucket and replaces them wholesale on re-read", async () => {
+		await applyStatsEvents([envelope(session({ activityBuckets: [1_700_000_000_000, 1_700_000_900_000] }))], {
+			producerKind: "cli",
+			dbPath,
+		});
+		await withDashboardDb((db) => {
+			expect(readBuckets(db)).toEqual([1_700_000_000_000, 1_700_000_900_000]);
+		}, { dbPath });
+
+		// A later full read that saw fewer buckets must not leave the old ones behind.
+		await applyStatsEvents([envelope(session({ activityBuckets: [1_700_000_000_000] }))], {
+			producerKind: "cli",
+			dbPath,
+		});
+		await withDashboardDb((db) => {
+			expect(readBuckets(db)).toEqual([1_700_000_000_000]);
+		}, { dbPath });
+	});
+
+	it("leaves stored buckets alone when the field is ABSENT", async () => {
+		await applyStatsEvents([envelope(session({ activityBuckets: [1_700_000_000_000] }))], {
+			producerKind: "cli",
+			dbPath,
+		});
+		// A producer that cannot see timestamps re-upserts the same session.
+		await applyStatsEvents([envelope(session())], { producerKind: "cli", dbPath });
+		await withDashboardDb((db) => {
+			expect(readBuckets(db)).toEqual([1_700_000_000_000]);
+		}, { dbPath });
+	});
+
+	it("clears stored buckets when an observed read genuinely found none", async () => {
+		await applyStatsEvents([envelope(session({ activityBuckets: [1_700_000_000_000] }))], {
+			producerKind: "cli",
+			dbPath,
+		});
+		await applyStatsEvents([envelope(session({ activityBuckets: [] }))], { producerKind: "cli", dbPath });
+		await withDashboardDb((db) => {
+			expect(readBuckets(db)).toEqual([]);
+		}, { dbPath });
+	});
+});
+```
+
+`DashboardDbHandle` and `withDashboardDb` are already imported at the top of this test file.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/dashboard/StatsWriter.test.ts -t "session_activity projection"`
+Expected: FAIL — TypeScript rejects `activityBuckets` as an unknown property of `SessionUpsertedEvent`.
+
+- [ ] **Step 3: Add the event field**
+
+In `cli/src/dashboard/DashboardModel.ts`, inside `SessionUpsertedEvent`, directly after the `tools` field:
+
+```ts
+	/**
+	 * Quarter-hour buckets in which this session produced a message. REPLACES
+	 * the stored set when present; `undefined` means "this producer could not
+	 * see per-message timestamps" and leaves the rows alone — which is what
+	 * keeps a re-upsert from a source without timestamps from erasing what a
+	 * full read collected.
+	 *
+	 * Producers must send `undefined`, never `[]`, when nothing was timestamped:
+	 * a source whose reader emits no timestamps computes an empty array on every
+	 * read, and emitting it would assert "measured, no activity" about a source
+	 * that was never measurable.
+	 */
+	readonly activityBuckets?: ReadonlyArray<number>;
+```
+
+- [ ] **Step 4: Add the projection**
+
+In `cli/src/dashboard/StatsWriter.ts`, at the very end of `projectSession` (after the closing brace of the `if (event.tools !== undefined)` block, before the function's own closing brace):
+
+```ts
+	// Same replace-when-observed contract as the model split and the tool rows.
+	// Safe as a wholesale replace because the collector reads the WHOLE
+	// transcript, never a cursor-bounded slice — a slice-based producer would
+	// need a merge here instead.
+	if (event.activityBuckets !== undefined) {
+		db.prepare("DELETE FROM session_activity WHERE session_event_id = ?").run(eventId);
+		const insertBucket = db.prepare(
+			"INSERT OR IGNORE INTO session_activity (session_event_id, bucket_ms) VALUES (?, ?)",
+		);
+		for (const bucket of event.activityBuckets) {
+			insertBucket.run(eventId, bucket);
+		}
+	}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm run test -w @jolli.ai/cli -- src/dashboard/StatsWriter.test.ts`
+Expected: PASS, whole file.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/dashboard/DashboardModel.ts cli/src/dashboard/StatsWriter.ts cli/src/dashboard/StatsWriter.test.ts
+git commit -s -m "Persist per-session activity buckets from session.upserted events"
+```
+
+---
+
+### Task 4: Collect buckets from every source
+
+**Files:**
+- Modify: `cli/src/core/TranscriptMessageCounter.ts:122-158` (export the dispatcher)
+- Modify: `cli/src/dashboard/DashboardCollector.ts:196-243` (`sessionEventFromInfo`)
+- Test: `cli/src/dashboard/DashboardCollector.test.ts` (update the existing case at line 108, add new ones)
+
+**Interfaces:**
+- Consumes: `bucketsFrom` from Task 2; `SessionUpsertedEvent.activityBuckets` from Task 3.
+- Produces: `readTranscriptForSource(source: TranscriptSource, transcriptPath: string, cursor: TranscriptCursor | null): Promise<TranscriptReadResult>` exported from `cli/src/core/TranscriptMessageCounter.ts`.
+
+**Why this is not just deleting the early return.** `sessionEventFromInfo` calls `readTranscript(path)` with **no parser argument**, which defaults to `new ClaudeTranscriptParser()`. Letting a Codex transcript through that path yields zero entries — a silent empty result, not an error. The read must be dispatched per source.
+
+- [ ] **Step 1: Export the dispatcher**
+
+In `cli/src/core/TranscriptMessageCounter.ts`, rename the private `readUnreadTranscript` to `readTranscriptForSource`, export it, widen its cursor parameter, and update its two existing call sites in that file:
+
+```ts
+/**
+ * Reads a transcript with the reader its source requires.
+ *
+ * Exported because the dashboard collector needs the same 13-way dispatch: the
+ * bare `readTranscript` defaults to the CLAUDE parser, so calling it for a
+ * Codex or OpenCode path returns zero entries rather than failing.
+ *
+ * Pass `null` for a full read from the start of the file.
+ */
+export async function readTranscriptForSource(
+	source: TranscriptSource,
+	transcriptPath: string,
+	cursor: TranscriptCursor | null,
+): Promise<TranscriptReadResult> {
+	switch (source) {
+		// …body unchanged…
+	}
+}
+```
+
+Keep the `switch` body exactly as it is, including the `cursor ?? undefined` spellings on the `copilot-chat` and `antigravity` branches and the `default` case that treats an unknown source as Claude.
+
+- [ ] **Step 2: Update the test that pins the behaviour being changed**
+
+`cli/src/dashboard/DashboardCollector.test.ts:108` currently reads:
+
+> `it("does not read transcripts for non-Claude sources — no per-turn usage exists there", …)`
+
+That assertion is now wrong by design. Replace it with:
+
+```ts
+	it("reads every source's transcript, but attributes tokens only where per-turn usage exists", async () => {
+		vi.mocked(readTranscriptForSource).mockResolvedValue({
+			entries: [
+				{ role: "human", content: "hi", timestamp: "2026-08-11T10:07:00.000Z" },
+				{ role: "assistant", content: "yo", timestamp: "2026-08-11T10:41:00.000Z" },
+			],
+			newCursor: { lineNumber: 2 },
+			totalLinesRead: 2,
+		} as TranscriptReadResult);
+
+		const event = await sessionEventFromInfo("repo-1", {
+			sessionId: "s1",
+			source: "codex",
+			transcriptPath: "/tmp/s1.jsonl",
+			updatedAt: "2026-08-11T10:41:00.000Z",
+		} as SessionInfo);
+
+		expect(event?.messageCount).toBe(2);
+		expect(event?.activityBuckets).toEqual([
+			Date.parse("2026-08-11T10:00:00.000Z"),
+			Date.parse("2026-08-11T10:30:00.000Z"),
+		]);
+		// Codex carries no per-turn usage, so nothing is attributed.
+		expect(event?.tokenCoverage).toBeUndefined();
+		expect(event?.models).toBeUndefined();
+	});
+
+	it("omits activityBuckets entirely when no entry is timestamped", async () => {
+		vi.mocked(readTranscriptForSource).mockResolvedValue({
+			entries: [{ role: "human", content: "hi" }],
+			newCursor: { lineNumber: 1 },
+			totalLinesRead: 1,
+		} as TranscriptReadResult);
+
+		const event = await sessionEventFromInfo("repo-1", {
+			sessionId: "s2",
+			source: "cursor",
+			transcriptPath: "/tmp/s2.db#c1",
+			updatedAt: "2026-08-11T10:41:00.000Z",
+		} as SessionInfo);
+
+		// ABSENT, not `[]` — "uncovered", not "used no agents".
+		expect(event).not.toHaveProperty("activityBuckets");
+	});
+```
+
+Add `readTranscriptForSource` to the file's mocks alongside the existing `readTranscript` mock, and import `sessionEventFromInfo` if the file does not already.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `npm run test -w @jolli.ai/cli -- src/dashboard/DashboardCollector.test.ts -t "reads every source"`
+Expected: FAIL — `event.messageCount` is `undefined` (the early return still fires for `codex`).
+
+- [ ] **Step 4: Move the early return**
+
+In `cli/src/dashboard/DashboardCollector.ts`, replace the `readTranscript` import with `readTranscriptForSource` from `../core/TranscriptMessageCounter.js`, add `bucketsFrom` from `./ActivityBuckets.js`, and rewrite the body of `sessionEventFromInfo` after `const base = {…}`:
+
+```ts
+	try {
+		// Full read (null cursor): the wholesale replace in `projectSession`
+		// depends on this being the whole session, not a slice.
+		const read = await readUsage(source, s.transcriptPath, null);
+		const buckets = bucketsFrom(read.entries);
+		const models: StatsModelUsage[] = toStatsModelUsage(read.usageByModel ?? []);
+		const first = read.entries[0]?.timestamp;
+		const last = read.entries[read.entries.length - 1]?.timestamp;
+		const startedAtMs = first ? Date.parse(first) : Number.NaN;
+		const endedAtMs = last ? Date.parse(last) : Number.NaN;
+		return {
+			...base,
+			messageCount: read.entries.length,
+			...(Number.isFinite(startedAtMs) ? { startedAtMs } : {}),
+			...(Number.isFinite(startedAtMs) && Number.isFinite(endedAtMs) && endedAtMs > startedAtMs
+				? { durationMs: endedAtMs - startedAtMs }
+				: {}),
+			// ABSENT, never `[]`: a source whose reader emits no timestamps
+			// computes an empty array on every read, and emitting it would
+			// assert "measured, no activity" about a source never measurable.
+			...(buckets.length > 0 ? { activityBuckets: buckets } : {}),
+			...(models.length > 0
+				? { models, tokenCoverage: "full" as const, pricesAsOf: PRICES_AS_OF }
+				: {}),
+			// Forwarded only when the reader actually produced it. An empty array
+			// means "called no tools" and is worth storing; absence means "this
+			// source records none", and the two must not collapse.
+			...(read.toolUse ? { tools: read.toolUse } : {}),
+		};
+	} catch (err) {
+		// A moved or deleted transcript still counts as a session — record it
+		// with what the discoverer knew rather than dropping the row.
+		log.warn("transcript unreadable for %s/%s: %s", source, s.sessionId, errMsg(err));
+		return base;
+	}
+```
+
+Change the injectable third parameter's default accordingly:
+
+```ts
+export async function sessionEventFromInfo(
+	repoIdentity: string,
+	s: SessionInfo,
+	readUsage: typeof readTranscriptForSource = readTranscriptForSource,
+): Promise<SessionUpsertedEvent | null> {
+```
+
+Two things that changed and must stay changed: the `if (source !== "claude") return base;` line is **gone**, and `tokenCoverage: "sessions-only"` is no longer emitted for a model-less read — the field is simply absent, which is what the "omit rather than assert" rule requires and what the test in Step 2 asserts. Verify no other test in the repo depends on the old `"sessions-only"` default from this function; `projectSession` already falls back to `"sessions-only"` when the field is absent.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm run test -w @jolli.ai/cli -- src/dashboard/DashboardCollector.test.ts`
+Expected: PASS, whole file. Then run the neighbours that share these modules:
+`npm run test -w @jolli.ai/cli -- src/core/TranscriptMessageCounter.test.ts src/core/ActiveSessionAggregator.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/core/TranscriptMessageCounter.ts cli/src/dashboard/DashboardCollector.ts cli/src/dashboard/DashboardCollector.test.ts
+git commit -s -m "Collect activity buckets from every agent source, not only Claude"
+```
+
+---
+
+### Task 5: The concurrency query
+
+**Files:**
+- Modify: `cli/src/dashboard/DashboardModel.ts` (add `ConcurrencyModel`, add `StatsModel.concurrency?`)
+- Modify: `cli/src/dashboard/DashboardQuery.ts` (add `buildConcurrency`, wire into the `StatsModel` return at line 969-989)
+- Test: `cli/src/dashboard/DashboardQuery.test.ts`
+
+**Interfaces:**
+- Consumes: the `session_activity` rows written in Task 3.
+- Produces: `StatsModel.concurrency?: ConcurrencyModel`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add this inside the existing `describe("buildDashboardModel", …)` block of
+`cli/src/dashboard/DashboardQuery.test.ts`, so it inherits that block's
+`dir`/`dbPath` lifecycle, its `nowMs` (`Date.parse("2026-07-30T12:00:00Z")`) and
+its `session(over)` envelope helper. Seeding goes through `applyStatsEvents`
+with real events — that is this file's convention, and it exercises Task 3's
+projection end to end rather than reaching into SQL:
+
+```ts
+	describe("concurrency", () => {
+		// Two adjacent quarter-hours inside the default window.
+		const B0 = Math.floor((nowMs - 3_600_000) / 900_000) * 900_000;
+		const B1 = B0 + 900_000;
+
+		const model = async () =>
+			withDashboardDb(
+				(db) => buildDashboardModel(db, { view: "stats", scope: { kind: "all" }, timeZone: "UTC", nowMs }),
+				{ dbPath },
+			);
+
+		it("counts one agent session once even when it touched two repos", async () => {
+			// `sessions` is unique on (repo_id, source, session_id), so the SAME
+			// agent session in two repos is two rows with two event ids. Counting
+			// event ids would report one agent as two — and this figure is
+			// machine-global, which makes that certain rather than latent.
+			await applyStatsEvents(
+				[
+					session({ repoIdentity: "repo-1", source: "cursor", sessionId: "s1", activityBuckets: [B0] }),
+					session({ repoIdentity: "repo-2", source: "cursor", sessionId: "s1", activityBuckets: [B0] }),
+				],
+				{ producerKind: "cli", dbPath },
+			);
+			expect((await model()).stats?.concurrency?.peak).toBe(1);
+		});
+
+		it("reports the peak and the mean over ACTIVE buckets only", async () => {
+			await applyStatsEvents(
+				[
+					session({ source: "claude", sessionId: "s1", activityBuckets: [B0, B1] }),
+					session({ source: "codex", sessionId: "s2", activityBuckets: [B0] }),
+				],
+				{ producerKind: "cli", dbPath },
+			);
+			const stats = (await model()).stats;
+			// B0 holds 2 sessions, B1 holds 1. The mean over the two ACTIVE buckets
+			// is 1.5 — not 3/672, which is what dividing by the window would give.
+			expect(stats?.concurrency?.peak).toBe(2);
+			expect(stats?.concurrency?.meanActive).toBeCloseTo(1.5);
+			expect(stats?.concurrency?.buckets).toHaveLength(2);
+			expect(stats?.concurrency?.bucketMinutes).toBe(15);
+		});
+
+		it("names sources that contributed sessions but no buckets as uncovered", async () => {
+			await applyStatsEvents(
+				[
+					session({ source: "claude", sessionId: "s1", activityBuckets: [B0] }),
+					session({ source: "opencode", sessionId: "s2" }),
+				],
+				{ producerKind: "cli", dbPath },
+			);
+			const stats = (await model()).stats;
+			expect(stats?.concurrency?.measuredSources).toEqual(["claude"]);
+			// Uncovered, NOT "ran zero agents".
+			expect(stats?.concurrency?.uncoveredSources).toEqual(["opencode"]);
+		});
+
+		it("ignores the repo scope — concurrency is a property of the person", async () => {
+			await applyStatsEvents(
+				[
+					session({ repoIdentity: "repo-1", source: "claude", sessionId: "s1", activityBuckets: [B0] }),
+					session({ repoIdentity: "repo-2", source: "codex", sessionId: "s2", activityBuckets: [B0] }),
+				],
+				{ producerKind: "cli", dbPath },
+			);
+			const scoped = await withDashboardDb(
+				(db) =>
+					buildDashboardModel(db, {
+						view: "stats",
+						scope: { kind: "repo", repoIdentity: "repo-1" },
+						timeZone: "UTC",
+						nowMs,
+					}),
+				{ dbPath },
+			);
+			// Both agents still count: filtering here would truncate the number
+			// into something with no actionable meaning.
+			expect(scoped.stats?.concurrency?.peak).toBe(2);
+		});
+
+		it("omits the field entirely when no bucket falls in the window", async () => {
+			await applyStatsEvents([session({ source: "claude", sessionId: "s1" })], {
+				producerKind: "cli",
+				dbPath,
+			});
+			// Absent, not a zero: under forward-only collection this is the normal
+			// state for the first days after deployment.
+			expect((await model()).stats?.concurrency).toBeUndefined();
+		});
+	});
+```
+
+`DashboardScope` is the interface at `DashboardModel.ts:643`; its repo-scoped
+form is `{ kind: "repo", repoIdentity: "<identity>" }`, as used at
+`DashboardServer.ts:651`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -w @jolli.ai/cli -- src/dashboard/DashboardQuery.test.ts -t "concurrency"`
+Expected: FAIL — `concurrency` is not a property of `StatsModel`.
+
+- [ ] **Step 3: Add the model type**
+
+In `cli/src/dashboard/DashboardModel.ts`, next to `HourBucket`:
+
+```ts
+/** One quarter-hour and how many distinct agent sessions were active in it. */
+export interface ConcurrencyBucket {
+	readonly bucketMs: number;
+	readonly sessions: number;
+}
+
+/**
+ * How many agents ran at the same time — machine-global and self-only.
+ *
+ * Deliberately NOT filtered by the page's repo scope: concurrency means "how
+ * many things was this person doing at once", which is a property of the person
+ * and not of a repository. A per-repo figure truncates the number into
+ * something with no actionable meaning.
+ */
+export interface ConcurrencyModel {
+	/** Only buckets with at least one session; ascending. */
+	readonly buckets: ReadonlyArray<ConcurrencyBucket>;
+	/** Bucket width, carried on the wire so a renderer never hardcodes it. */
+	readonly bucketMinutes: number;
+	/**
+	 * Highest session count in any one bucket — an UPPER BOUND on instantaneous
+	 * concurrency, not the thing itself: two sessions active in the same quarter
+	 * hour need not overlap at any instant. Any label must say "agents active
+	 * within the same 15 minutes", never "running simultaneously".
+	 */
+	readonly peak: number;
+	/**
+	 * Mean session count over ACTIVE buckets. The denominator is deliberately
+	 * the buckets with activity, not the buckets in the window: a 7-day window
+	 * holds 672 buckets and dividing by all of them yields ~0.2, a figure with
+	 * no meaning. Any label must state the denominator.
+	 */
+	readonly meanActive: number;
+	/** Sources that contributed at least one bucket in the window. */
+	readonly measuredSources: ReadonlyArray<TranscriptSource>;
+	/** Sources that contributed sessions but no buckets — uncovered, not idle. */
+	readonly uncoveredSources: ReadonlyArray<TranscriptSource>;
+}
+```
+
+And in `StatsModel`, alongside `toolUsage`:
+
+```ts
+	/** Absent when no bucket falls in the window — a consumer shows "no data",
+	 *  never a zero. Under forward-only collection this is the normal state for
+	 *  the first days after deployment. */
+	readonly concurrency?: ConcurrencyModel;
+```
+
+- [ ] **Step 4: Write the query**
+
+In `cli/src/dashboard/DashboardQuery.ts`, next to `buildToolUsage`:
+
+```ts
+/**
+ * The concurrency figure. Takes a window but NOT a scope: it is machine-global
+ * by design (see {@link ConcurrencyModel}).
+ */
+function buildConcurrency(db: DashboardDbHandle, window: ResolvedWindow): ConcurrencyModel | undefined {
+	const rows = db
+		.prepare(
+			// COUNT(DISTINCT session_event_id) would be WRONG: `sessions` is unique
+			// on (repo_id, source, session_id), so one agent session that touched
+			// two repos is two rows with two event ids and would count as two
+			// agents. Machine-global aggregation makes that certain, not latent.
+			`SELECT a.bucket_ms AS bucket_ms,
+			        COUNT(DISTINCT s.source || ':' || s.session_id) AS n
+			   FROM session_activity a
+			   JOIN sessions s ON s.event_id = a.session_event_id
+			  WHERE a.bucket_ms >= ? AND a.bucket_ms < ?
+			  GROUP BY a.bucket_ms
+			  ORDER BY a.bucket_ms`,
+		)
+		.all(window.startMs, window.endMs) as ReadonlyArray<{ bucket_ms: number; n: number }>;
+	if (rows.length === 0) return undefined;
+
+	const buckets = rows.map((r) => ({ bucketMs: r.bucket_ms, sessions: r.n }));
+	const peak = buckets.reduce((max, b) => (b.sessions > max ? b.sessions : max), 0);
+	const total = buckets.reduce((sum, b) => sum + b.sessions, 0);
+
+	// Derived per query, never a declared list: the declarative alternative is
+	// the shape of `PARSER_BACKED_SOURCES`, which omits `kimi` even though
+	// `getParserForSource` accepts it.
+	const measured = new Set(
+		(
+			db
+				.prepare(
+					`SELECT DISTINCT s.source AS source
+					   FROM session_activity a
+					   JOIN sessions s ON s.event_id = a.session_event_id
+					  WHERE a.bucket_ms >= ? AND a.bucket_ms < ?`,
+				)
+				.all(window.startMs, window.endMs) as ReadonlyArray<{ source: string }>
+		).map((r) => r.source),
+	);
+	const seen = (
+		db
+			.prepare("SELECT DISTINCT source FROM sessions WHERE updated_at_ms >= ? AND updated_at_ms < ?")
+			.all(window.startMs, window.endMs) as ReadonlyArray<{ source: string }>
+	).map((r) => r.source);
+
+	return {
+		buckets,
+		bucketMinutes: ACTIVITY_BUCKET_MS / 60_000,
+		peak,
+		meanActive: total / buckets.length,
+		measuredSources: [...measured].sort() as ReadonlyArray<TranscriptSource>,
+		uncoveredSources: seen.filter((s) => !measured.has(s)).sort() as ReadonlyArray<TranscriptSource>,
+	};
+}
+```
+
+Import `ACTIVITY_BUCKET_MS` from `./ActivityBuckets.js` and `ConcurrencyModel` (type-only) from `./DashboardModel.js`. `ResolvedWindow` is the local interface at `DashboardQuery.ts:248`; its bounds are `startMs` (inclusive) and `endMs` (exclusive), the same pair `buildToolUsage` uses at line 1368.
+
+- [ ] **Step 5: Wire it into the model**
+
+In the `StatsModel` return block, after `toolUsage`:
+
+```ts
+		toolUsage: buildToolUsage(db, scope, window),
+		...(concurrency !== undefined ? { concurrency } : {}),
+```
+
+with `const concurrency = buildConcurrency(db, window);` computed just above the return, next to `memoryCards`. Note the deliberate absence of `scope` in that call.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npm run test -w @jolli.ai/cli -- src/dashboard/DashboardQuery.test.ts`
+Expected: PASS, whole file.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cli/src/dashboard/DashboardModel.ts cli/src/dashboard/DashboardQuery.ts cli/src/dashboard/DashboardQuery.test.ts
+git commit -s -m "Report machine-global agent concurrency from activity buckets"
+```
+
+---
+
+### Task 6: Full gate
+
+**Files:** none new.
+
+- [ ] **Step 1: Run the whole gate**
+
+```bash
+npm run all
+```
+
+Expected: clean → build → typecheck → lint → test, all green, CLI coverage at or above 97/96/97/97.
+
+- [ ] **Step 2: Triage any failure by shape, not by name**
+
+A `Test timed out in NNNNms` under the full run is a **load signal**, not a regression — about a dozen CLI files spawn real `git` and get CPU-starved under `--coverage`. Re-run that file alone with the stock timeout; green in isolation is the proof. An assertion or thrown error is a real regression — investigate it.
+
+- [ ] **Step 3: Verify against real data**
+
+```bash
+npm run cli -- dashboard --no-open
+```
+
+Then confirm buckets are actually landing. **First check the shared DB's version
+against your build's** — if `schema_version` already equals the number you
+claimed but `session_activity` is missing, you hit the collision described in
+Global Constraints, and nothing below will work until you point at a fresh
+`dbPath`:
+
+```bash
+node --input-type=module -e '
+import {DatabaseSync} from "node:sqlite";
+const db = new DatabaseSync(process.env.HOME + "/.jolli/jollimemory/jollimemory.db", {readOnly: true});
+const q = (s) => db.prepare(s).all();
+console.log("schema_version:", q("SELECT value FROM schema_meta WHERE key='schema_version'")[0]?.value);
+console.log("has session_activity:", q("SELECT name FROM sqlite_master WHERE name='session_activity'").length === 1);
+console.log("bucket rows:", q("SELECT COUNT(*) c FROM session_activity")[0].c);
+console.table(q(`SELECT s.source, COUNT(DISTINCT a.session_event_id) sessions, COUNT(*) buckets
+                   FROM session_activity a JOIN sessions s ON s.event_id = a.session_event_id
+                  GROUP BY s.source ORDER BY buckets DESC`));
+'
+```
+
+Expected: rows appear for `claude` and `codex` at minimum, since both readers emit per-message timestamps. Sessions collected before this change carry no buckets — forward-only collection is the chosen scope, so an initially small table is correct, not a bug.
+
+- [ ] **Step 4: Commit any fixes**
+
+```bash
+git add -A
+git commit -s -m "Fix <specific issue> found by the full gate"
+```
+
+Skip this step if the gate was green.
+
+---
+
+## Out of scope (do not add)
+
+The spec's §7 lists these deliberately. Do not implement them here, even if they look like small wins:
+
+- **UI.** No change to `cli/src/dashboard/assets/`. The stats page's session-activity card was deliberately removed while its payload stayed live; concurrency enters that same state on purpose, because the card order is authored against a design source not available in this repo.
+- **Backfill** over the transcripts on disk.
+- **OpenCode token/model**, even though its `session` table carries them.
+- **Reader work** for the six sources that emit no per-message timestamps.
+- **The `PARSER_BACKED_SOURCES` omission of `kimi`** — a real pre-existing bug, but unrelated; it belongs in its own change.

--- a/docs/superpowers/specs/2026-08-06-transcript-session-timestamps-design.md
+++ b/docs/superpowers/specs/2026-08-06-transcript-session-timestamps-design.md
@@ -1,0 +1,236 @@
+# Transcript session timestamps on the pushed summary — design
+
+**Date:** 2026-08-06
+**Project:** Manager coaching dashboard (JOLLI-2123 … JOLLI-2127) — this repo's half
+**Status:** draft
+**Scope:** Emit a root-stamped, tree-wide `transcriptSessions[]` array on the pushed `summaryJson`,
+carrying `{sessionId, source, messageCount, startedAt, endedAt}` per conversation. Push-time
+enrichment only — nothing is added to the stored summary schema. This is the *only* deliverable here;
+see [§7](#7-deliberately-out-of-scope) for what was considered and deferred, and why.
+
+The server side of this project lives in the `jolli` repo and is described by three specs there:
+`2026-08-04-manager-coaching-dashboard-design.md` (what the page shows),
+`2026-08-05-coaching-data-axes.md` (where each signal legitimately comes from), and
+`2026-08-06-axis2-review-index-design.md` (the review index). Those documents are authoritative for
+consumer behaviour; this one is authoritative for what this repo emits.
+
+## 1. Why this, and why it is the whole delivery
+
+The dashboard's server side is built: `journey_commit_index`, the indexer, assembly, the query API
+and the Axis 2 review index all exist. What it renders is gated on data this repo has never sent.
+
+`durationMinutes` is the time axis every glyph, the trace total, the feed's hour figures and
+`isFeatureWork`'s 45-minute threshold are drawn against — and it has **no source at all** today. The
+server's `JolliMemoryTranscriptSessionSchema` already carries optional `startedAt` / `endedAt`, and its
+own comment names the missing producer: *"push-time enrichment; see the plugin's
+`collectTranscriptSessionMeta`"*. That function does not exist here. Neither does the field it would
+populate: `CommitSummary` carries only `transcripts?: string[]`.
+
+Establishing that by reading the tree rather than assuming it:
+
+| Signal the dashboard wants | State in this repo |
+|---|---|
+| `transcriptSessions[]` with per-session bounds | **Absent.** No such field, no producer. |
+| Per-commit turn-level `skills` | **Already emitted.** `CommitSummary.skills` rides in `summaryJson` today; the server does not yet model or index it. Nothing to do here. |
+| `prNumber` (Axis 2 join key) | Absent — deferred, see §7. |
+| Session intervals decoupled from commits (Axis 3) | Absent — blocked on a product decision in the axes spec. |
+
+So the one unblocked, unowned, high-leverage gap on this side is the session time axis. Without it
+`isFeatureWork` returns false for everything and the patterns miner mines nothing, which is what the
+08-04 design already records as *"encoded and tested, not hoped for."*
+
+## 2. Decision: derive at push time, never store
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | The enrichment is computed **at push time** from the transcript artifacts, not stored on `CommitSummary`. | Two reasons, and the second is the load-bearing one. It keeps the change clear of the stored-schema lockstep contracts (FolderStorage's hidden layer, the IntelliJ Kotlin readers, the orphan-branch layout). And it is **retroactive**: every already-stored memory gains its time axis on its next push, where a write-time field could only ever cover new commits. |
+| D2 | The field is **not added to `CommitSummary`**. The push layer defines `CommitSummary & { transcriptSessions?: … }` and only the markdown builder and `serializeSummaryJson` accept it. | Makes "push-only, never persisted" a fact the type system enforces rather than a comment. The storage path cannot name the field, so it cannot write it. |
+| D3 | One array, **stamped on the root only**, aggregated across the root and every `children` node. | The server's `mergeSessionStats` documents `transcriptSessions` as *"a push-time, tree-wide enrichment stamped on the root"* and merges duplicate rows **keep-first, never summed**. A per-node stamp would therefore have the server silently truncate `messageCount` and the time bounds for any session appearing on more than one squash child. |
+| D4 | Per session, aggregate: `messageCount` sums, `startedAt` is the min and `endedAt` the max across **all** of that session's transcript slices. | Matches the field's own contract (*"archived message count across all of the session's transcript slices"*). One session legitimately spans several artifacts — an amend delta plus its base — so keep-first on our side would under-report both the count and the span. |
+| D5 | The reader is **injected** (`StorageProvider` / a transcript-reader seam), never reached for directly. | Keeps the new module's tests in the `test:fast` tier. Real-`git` test files are the ones that CPU-starve and time out under a full `--coverage` run, and a timeout is indistinguishable at a glance from a real regression. |
+
+Rejected: computing it in `QueueWorker` at summary-write time. It touches the stored schema (so
+FolderStorage and the Kotlin readers must move in lockstep), it cannot be backfilled, and a new
+stored field has to be landed across the seven git-op paths — amend, squash, the three rebase
+variants — where a missed folding path fails silently.
+
+Also rejected: doing both and letting push-time derivation act as a fallback. Two sources for one
+number drift.
+
+## 3. What is emitted
+
+One array on the root of the pushed `summaryJson`:
+
+```ts
+readonly transcriptSessions?: ReadonlyArray<{
+	readonly sessionId: string;
+	readonly source: string;        // StoredSession.source; absent means "claude" per the existing convention
+	readonly messageCount: number;  // summed across every slice of this session
+	readonly startedAt?: string;    // min parseable entry timestamp
+	readonly endedAt?: string;      // max parseable entry timestamp
+}>;
+```
+
+Derivation, per session key `<source>:<sessionId>`, over the root's and every child's
+`transcripts[]` artifact ids (de-duplicated — squash children repeat ids):
+
+- `messageCount` — sum of `entries.length` across the session's slices.
+- `startedAt` / `endedAt` — min / max of the session's `TranscriptEntry.timestamp` values, counting a
+  value as usable only when `Date.parse` returns a number. An unparseable timestamp is ignored, not
+  coerced.
+
+### 3.1 Three absence rules, each a different lie avoided
+
+`TranscriptEntry.timestamp` is optional, artifacts can be detached, and a commit can have no
+conversation at all. Each case renders as absence, never as a zero:
+
+1. **A session with no parseable timestamp emits neither bound** — not an epoch, not an empty string.
+   A journey of unknown length must never render as an instant one; the 08-04 design's availability
+   rules exist precisely for this.
+2. **An empty result omits the field entirely** rather than sending `transcriptSessions: []`. An empty
+   array reads as *"measured: zero conversations"*, and it would also disable the server's fallback
+   path for bare transcript ids.
+3. **An unreadable artifact is skipped, not fatal.** Its sessions are absent; the rest still emit and
+   the push proceeds. A detached or pruned artifact must not block a push.
+
+### 3.2 The size guard must not become a regression
+
+`serializeSummaryJson` drops the **entire** `summaryJson` above 1.5 MB, because the server caps the
+field at 2,000,000 characters as schema validation — over it, the whole request 400s and the markdown
+article fails with it. The sidecar is optional; the article is not.
+
+A session row is roughly 150 bytes, so a five-session commit adds ~750 B and a thirty-session squash
+tree ~4.5 KB — 0.3 % of the cap. The tail case is nonetheless real: a summary already sitting at
+1.499 MB would lose its whole sidecar to the enrichment. So **on exceeding the cap, retry once
+without the enrichment before giving up.** This is a no-regression guarantee, not a feature: the worst
+case becomes today's behaviour rather than worse than it.
+
+(Note in passing: the client measures UTF-8 **bytes** while the server counts UTF-16 **code units**.
+Byte count is always ≥ character count, so the client guard is conservative in the safe direction.
+Do not "fix" it into a character count.)
+
+## 4. Where it attaches
+
+**Two** weave points. One is `pushSummary` in `cli/src/core/JolliMemoryPushOrchestrator.ts`, async
+with a `PushContext` in hand.
+
+The other is `vscode/src/services/JolliPushOrchestrator.ts`. The VS Code extension does not reuse the
+CLI's orchestrator: it has its own, with its own `serializeSummaryJson` and its own summary weave,
+reached from the sidebar's share action. Omitting it would have been worse than a missing field:
+re-sharing a branch re-pushes the same `jolliDocId` with a sidecar lacking the enrichment, and the
+server re-derives the duration as null, so data already delivered would silently disappear. Both
+halves of the CLI change are mirrored there (the weave and the size-cap retry); the two
+`serializeSummaryJson` copies stay separate.
+
+**The count moved twice, for two different reasons.** This document first said "two", having counted
+only the CLI and missed the extension — that was an error, and finding it is why the VS Code half
+exists. It then said "three": `pushSummary` plus `buildOneBatchItem`, the batch path, plus VS Code.
+It is back to two because the batch path was **deleted**, not because it was never woven: this branch
+was rebased onto main's *"Replace batch push with per-commit async push orchestration"*, which removed
+`buildOneBatchItem` and `buildBatchItems` outright. The weave point went with its host function, and
+`pushSummary` — reached from `PushExecutor`'s per-commit path — is now the only CLI push path.
+Nothing about the enrichment itself changed, but a reader hunting for "the batch path, which is what
+the pre-push hook actually runs" will not find it.
+
+Both build a `summaryForMarkdown` copy and hand it to `serializeSummaryJson`. The enrichment is woven
+into that copy in both places. **Both need a test**: they are two independent blocks of weaving code.
+
+New module: `cli/src/core/TranscriptSessionMeta.ts`, exporting `collectTranscriptSessionMeta`. A
+per-run `Map<transcriptId, StoredTranscript>` cache avoids re-reading the artifacts a squash tree
+references repeatedly.
+
+The derivation does not sit on git's blocking path. Since the same rebase, the pre-push hook pushes
+nothing on its own time: it spawns a detached worker and watches the result file for as long as
+`PRE_PUSH_SYNC_BUDGET_MS = 3_000` allows, and the worker runs to completion whether or not the watch
+is still there. So the artifact reads cost the worker, not the commit. (`INLINE_MIN_HTTP_BUDGET_MS`
+went with the batch path.) Measured cost of the reads themselves: **~115 ms per summary**, dominated
+by the single orphan-branch `git` invocation and near-flat in the number of transcript ids — worth
+knowing before anything moves this derivation back onto a blocking path. No network call may be added
+here regardless (see §7).
+
+## 5. Invariants and their tests
+
+| # | Invariant | What it stops |
+|---|---|---|
+| 1 | A session spanning two artifacts sums its `messageCount` and spans min→max | Keep-first here would under-report, and the server would not complain |
+| 2 | `children` nodes carry no `transcriptSessions` | A child copy activates the server's keep-first merge and silently truncates |
+| 3 | No parseable timestamp ⇒ both bound keys absent | An epoch or empty string would render unknown duration as an instant |
+| 4 | Empty result ⇒ the key is absent from the serialized JSON | `[]` reads as a measurement of zero and kills the bare-id fallback |
+| 5 | One unreadable artifact ⇒ others still emit, push does not throw | A pruned artifact must not block a push |
+| 6 | Over the size cap ⇒ the un-enriched JSON is serialized | No-regression guarantee |
+| 7 | Both `pushSummary` (CLI) and the VS Code orchestrator weave it | Two independent weaving blocks; missing the VS Code one lets a sidebar re-share overwrite delivered bounds with nulls |
+| 8 | The stored summary written by the storage path carries no such field | Proves the push-only boundary behaviourally, not by comment |
+| 9 | Sum of per-session `messageCount` equals the total `entries.length` over the tree's artifacts de-duplicated by transcript id | Keeps this figure and the server's `ConversationStats.messageCount` from disagreeing |
+
+Tests stay in the fast tier by construction (D5): pure derivation over injected reads, no `git`
+subprocess.
+
+**Gate:** one `npm run all` at the end. The CLI coverage floor (97 / 96 / 97 / 97) is not to be
+lowered and `cli/vite.config.ts` is not to be touched.
+
+## 6. Not touched
+
+Stated explicitly so the implementation does not drift into them: `CommitSummary`, `FolderStorage`,
+the IntelliJ `FolderStorageReader` / `KBFolderReader`, the orphan-branch layout, the queue worker, any
+git hook, and the config schema. No new configuration option, no new user-facing surface.
+
+## 6a. Known limitations of what shipped
+
+Found by review after implementation, recorded rather than silently carried.
+
+**The duration measures a span, not activity — and idle time is inside it.** `startedAt`/`endedAt` are
+the first and last archived message of a session, so a session opened at 09:00 and resumed at 17:00
+reports 480 minutes. The server sums those spans, and can only see gaps *between* sessions, so it
+cannot subtract the idle stretch. The practical consequence is that a resumed session clears
+`isFeatureWork`'s 45-minute threshold on idle alone and inflates the feed's hour figures. This follows
+directly from D4, which was chosen deliberately; nothing here bounds it. **Converging it means
+switching from span to active time** — ignoring inter-message gaps above a threshold — which is a
+product decision about what a "duration" should mean on this page, not a defect to patch.
+
+Three smaller ones:
+
+- **The push-only boundary is structural, not type-enforced.** Both write-backs build from the raw
+  summary, so the enrichment cannot currently reach storage — but §2's D2 overstates the guarantee: a
+  spread into a `CommitSummary` would type-check fine, since excess-property checking does not apply to
+  spreads. The code is right; the claim was too strong.
+- **§5's invariant 9 is not literally true.** A session with an empty `sessionId` is skipped, yet its
+  entries do count toward a tree's raw entry total. Harmless, because the server's own merge skips
+  keyless rows identically.
+- **The enrichment counts toward the batch size limits.** It contributes to
+  `BATCH_MAX_TOTAL_CONTENT_CHARS`, so an item sitting just under the limit can now be deferred to the
+  background drain instead of publishing inline. Graceful, but it is a behaviour change §3.2 does not
+  mention.
+
+One wording correction: §4's per-run `Map<transcriptId, StoredTranscript>` cache is implemented as a
+per-call de-duplicated id set. The set covers the case the cache was described for (a squash tree
+referencing one artifact repeatedly); a cache spanning summaries would serve no case that arises.
+
+## 7. Deliberately out of scope
+
+**`prNumber` on the summary (Axis 2's join key).** Considered and deferred, because the acquisition
+moment does not exist. A branch's PR is created *after* its first push, so at pre-push time there is
+no number to read — and post-commit is strictly earlier, not later. Full coverage would require
+re-pushing already-published summaries once the PR appears, and the machinery for that (a `gh` poll,
+a cache, a backfill trigger) is the same machinery the review-timeline reporter needs. Measured cost
+of the poll: `gh pr list` takes **1.07–1.23 s**, which is 36–41 % of the entire 3 s inline pre-push
+budget, so it can never sit on that path. Deferred to be built once, with the review reporter.
+
+Meanwhile the server joins review events by `ticket` and reports `availability.reviewTiming` as
+`"partial"`. Per the Axis 2 spec's own rule — *when the attribution is approximate, the number must
+not claim to be exact* — that is a correct label, not a defect.
+
+**Reporting the PR review timeline (Axis 2's client half).** Blocked, and the blocker is on the
+server: `POST /api/coaching/reviews` is mounted on the browser-session auth chain
+(`authEmailHandler` → `authRefreshHandler` → provisioning → user context), while this client
+authenticates with a `sk-jol-` API key against `apiKeyMiddleware` on `/api/push`. The key cannot open
+that endpoint. The Axis 2 spec anticipated the possibility (*"only if the CLI's auth subject proves
+identical to the dashboard reader's; they are expected to differ"*) but the mount landed on the read
+chain. **This needs a server-side change before any client work starts, and it needs an owner.**
+
+**Session intervals decoupled from commits (Axis 3 presence).** Blocked on the product decision the
+axes spec escalates: it would be the first per-person metric on a page whose spine is *no composite
+score, no ranking of people*.
+
+**Turn-level friction signals** (`redShare`, compaction points, tests-first). These need transcript
+extraction work that no issue owns. Note that the highest-confidence member of that family —
+skill/MCP invocations — is **already emitted** and awaits server-side modelling, not client work.

--- a/docs/superpowers/specs/2026-08-11-local-agent-concurrency-design.md
+++ b/docs/superpowers/specs/2026-08-11-local-agent-concurrency-design.md
@@ -1,0 +1,374 @@
+# Local agent concurrency — design
+
+Date: 2026-08-11
+Status: approved, ready for an implementation plan
+
+## 1. What this is
+
+A local, self-only answer to one question: **how many agents was I running at
+the same time?**
+
+This is the collection half of "Axis 3" from the cloud coaching specs
+(`2026-08-05-coaching-data-axes.md`), which record Axis 3 as "Exists: nothing".
+That is no longer true — the local SQLite dashboard already collects sessions
+from every discovered agent, machine-globally and without the `git push` gate
+the cloud specs assume. What is missing is not a channel; it is the *interval*
+inside each session.
+
+Nothing here uploads anywhere. Cloud upload is a separate, later decision, and
+this design is deliberately shaped so that it cannot drift into one: the figures
+are per-machine and self-only, there is no developer identity, nothing is ranked,
+and no figure is comparable across people.
+
+## 2. Why the data is not already there
+
+Two measurements on this machine's real
+`~/.jolli/jollimemory/jollimemory.db` (1670 sessions):
+
+- **`started_at_ms` is populated on 35 rows — 2.1%.** All 35 are Claude and all
+  are dated 2026-08-08 or later (the rest of the table reaches back to
+  2026-03-27), because the column is this branch's own recent addition.
+- **`duration_ms` is not a working figure.** The longest of those 35 spans
+  1088.6 minutes — 18 hours — across 28 messages. It is a session resumed the
+  next day. Anything built on `last − first` would claim 18 hours of presence.
+
+The root cause of the first is one line,
+[`DashboardCollector.ts:213`](../../../cli/src/dashboard/DashboardCollector.ts):
+
+```ts
+if (source !== "claude") return base;
+```
+
+The early return exists for **token** reasons — only Claude transcripts carry
+per-turn usage — but it also discards `startedAtMs`, `durationMs` and
+`messageCount` for every other source, none of which depend on usage data.
+
+`started_at_ms` is otherwise read by nothing: every existing query
+(`heatmap`, `hours`, the trend series, `recentSessions`) filters and buckets on
+`updated_at_ms` alone, so a three-hour session lands in exactly one hour bucket
+today. The schema anticipated this — its own comment says `started_at_ms`
+"cannot be recovered from `updated_at_ms` and duration", which is why the column
+was kept.
+
+## 3. Decisions
+
+| Decision | Choice | Rejected alternatives |
+|---|---|---|
+| What the view answers | Concurrency — how many agents at once | Presence-hours; a live "what is running now" list |
+| How "at the same time" is defined | 15-minute activity buckets; a session occupies a bucket if it produced a message in it | Interval overlap with a gap threshold (needs a tuning parameter and sweep-line queries); naive `(start, last-activity)` (measurably wrong — see §2) |
+| History | Forward collection only | A one-time backfill over the 2196 Claude + 2152 Codex transcripts still on disk (~7 weeks, oldest 2026-06-23). Feasible, deliberately deferred |
+| Repo scope | Always machine-global; ignores the page's repo filter | Following the filter (truncates the number into something with no actionable meaning); a global figure plus a per-repo share (invites reading the share as a KPI) |
+| Re-read semantics | Insert-only — a bucket is a monotone fact, no read removes one (§4.1) | Wholesale replace like the sibling tables (destroys real presence when a host truncates or Devin regenerates, unrecoverably) |
+| Downstream sync cursor | `recorded_at_ms`, the local insert instant (§4.1) | `bucket_ms` (a backfill inserts old buckets today and a cursor on it would skip them); a monotone rowid/seq (a timestamp is also legible to the consumer) |
+| Non-Claude token/model | Out of scope this round | Wiring OpenCode's token columns (see §7) |
+| UI | None this round — the model field only | A card in the vacated session-activity slot; a split tab on an existing card |
+
+### 3.1 Why buckets rather than intervals
+
+A bucket list needs no threshold parameter, is a single `GROUP BY` to query, and
+handles the 18-hour resumed session correctly by construction: that session
+occupies only the buckets it actually spoke in, not the 72 buckets it spans.
+
+The cost is that `peak` becomes an **upper bound** on instantaneous concurrency
+rather than the thing itself. Two sessions active in the same 15-minute bucket
+need not overlap at any instant. §5 makes that explicit in the label; it must not
+be simplified away.
+
+## 4. Data model
+
+### 4.1 New table
+
+Appended to `MIGRATIONS` in
+[`DashboardDb.ts`](../../../cli/src/dashboard/DashboardDb.ts) as
+`SESSION_ACTIVITY_DDL`, entry 7 (the eighth), bumping
+`DASHBOARD_SCHEMA_VERSION` from 7 to 8. The slot is what this branch's actual
+base yielded — the plan's §"recompute it" warning, honoured — and it is now only
+bookkeeping: identity moved to the entry's NAME, so the number decides nothing.
+Append-only still holds: existing entries are never edited, because a shipped
+entry's DDL is frozen and `MigrationFingerprints.test.ts` fails on a change to
+one.
+
+```sql
+CREATE TABLE session_activity (
+  session_event_id TEXT NOT NULL REFERENCES sessions(event_id) ON DELETE CASCADE,
+  bucket_ms        INTEGER NOT NULL,   -- 15-minute bucket start, absolute epoch ms
+  recorded_at_ms   INTEGER NOT NULL,   -- when this row was first inserted locally
+  PRIMARY KEY (session_event_id, bucket_ms)
+) STRICT;
+CREATE INDEX ix_activity_bucket ON session_activity(bucket_ms);
+CREATE INDEX ix_activity_recorded ON session_activity(recorded_at_ms);
+```
+
+`recorded_at_ms` is `NOT NULL` because it ships inside the `CREATE TABLE` rather
+than arriving as a later `ADD COLUMN`, which takes only a CONSTANT default while
+this value is a wall-clock instant. That is entry 4's `last_call_at_ms` shape,
+whose permanent `NULLIF` handling at every read site is the price of having had
+no choice.
+
+A dev machine that ran an earlier draft of this entry has the table under the
+same name, so the name key reads it as applied rather than replaying it. A
+differing shape is then **drift**, not a missing table: `findDriftedMigrations`
+reports it and `jolli doctor --schema-log` lists it, and the repair is the
+operator's.
+
+#### The table is INSERT-ONLY
+
+`projectSession` replaces `session_model_usage` and `session_tool_use` wholesale
+on every observed read; this table deliberately does not follow that contract.
+Those two restate a **current total**, so a new read supersedes the old. A bucket
+is a **monotone historical fact** — "this session produced a message in this
+quarter-hour" cannot become false — so no read may remove one.
+
+Every case where a re-read returns a non-superset is the evidence going away, not
+the fact: a host rotating its own store, or Devin regenerating onto a different
+`main_chain_id` so the walked chain differs. Wholesale replace destroyed real
+presence there, unrecoverably, because the transcript could no longer prove it.
+
+The cost is the mirror image and is recoverable: a bucket from a **bad read** (a
+parser reading Devin's epoch seconds as ms, a local-time string parsed as UTC)
+now persists rather than being corrected by the next re-read. No repair path
+ships with this — the failure needs a parser bug first, and a wrong row can be
+rebuilt where a deleted one cannot be recovered at all.
+
+`ON DELETE CASCADE` stays. Nothing deletes from `sessions` today; insert-only is
+a rule about re-observation, not about referential cleanup.
+
+#### `recorded_at_ms` is a sync cursor
+
+The instant of first local INSERT — deliberately nothing about the conversation.
+`bucket_ms` cannot serve as a cursor: a backfill over old transcripts inserts old
+buckets today, and a `bucket_ms > lastSync` reader would skip all of them. This
+column answers only "what is new since my last upload", which is the one question
+a downstream sync must ask without knowing what a bucket means.
+
+`INSERT OR IGNORE` keeps a re-observed bucket's **original** stamp, so a 60 s tick
+does not re-present a whole session as new work. Two consumer caveats: the clock
+is `Date.now()` and not monotonic across an NTP correction, so pair the cursor
+with an idempotent upstream upsert and resume at `>= lastSync` (which also
+absorbs the same-millisecond boundary); and it is a local stamp, so two machines
+belonging to one developer stamp independently.
+
+`bucket_ms` holds **absolute epoch ms**, not a localised day/hour key. Time zone
+is a render-time concern that `localDayKey` / `localHour` already handle in the
+query layer; a stored localised copy would be a second answer to a question that
+already has one.
+
+`INTEGER` is the type every epoch-ms column in this schema already uses, and it
+was verified rather than assumed: `node:sqlite` returns these as JS `number`
+(no `readBigInts` anywhere in the repo), current values sit ~5042x below
+`Number.MAX_SAFE_INTEGER`, and a round-trip through a STRICT table is exact.
+STRICT additionally **rejects a REAL value** in this column, so a missing
+`Math.floor` in the bucketing helper fails loudly at insert instead of silently
+storing `…300000.5` and defeating the primary key.
+
+Size: bucket count per session is bounded by its message count, and the whole
+database sums to 8834 messages — a few thousand rows, smaller than `commits`.
+
+### 4.2 Event field
+
+On `SessionUpsertedEvent` in
+[`DashboardModel.ts`](../../../cli/src/dashboard/DashboardModel.ts):
+
+```ts
+/** 15-minute bucket starts, deduped and ascending. ABSENT means this source's
+ *  reader emits no per-message timestamps, and the stored rows are left alone.
+ *  NEVER `[]` — see below. Same contract as `tools`. */
+readonly activityBuckets?: ReadonlyArray<number>;
+```
+
+The ban on `[]` is load-bearing. A source that never stamps timestamps computes
+an empty array on every read; emitting it would assert "measured, no activity"
+for a source that was never measurable. This is the failure mode
+`TranscriptReadResult.toolUse`'s own contract exists to prevent. Emitting the
+field only when `length > 0` makes "uncovered" and "genuinely idle"
+structurally impossible to confuse.
+
+### 4.3 Collection
+
+The early return moves so that every source reads its transcript; only the
+token/model block stays gated on Claude.
+
+Simply deleting the early return is wrong. `sessionEventFromInfo` currently calls
+`readUsage(s.transcriptPath)` with **no parser argument**, which defaults to
+`new ClaudeTranscriptParser()` — letting a Codex transcript through that path
+yields zero entries, a silent empty result rather than an error. The correct
+read is the existing 13-way dispatcher `readUnreadTranscript` in
+[`TranscriptMessageCounter.ts:122`](../../../cli/src/core/TranscriptMessageCounter.ts),
+which is currently module-private and must be extracted and exported (named
+`readTranscriptForSource` below), called with a **null cursor** for a full read:
+
+```ts
+const read = await readTranscriptForSource(source, s.transcriptPath, null);
+const buckets = bucketsFrom(read.entries);   // floor(ts / 900_000) * 900_000, deduped
+return {
+    ...base,
+    messageCount: read.entries.length,
+    ...(buckets.length > 0 ? { activityBuckets: buckets } : {}),
+    ...(source === "claude" ? { models, tokenCoverage, pricesAsOf } : {}),
+};
+```
+
+No declared list of supporting sources is introduced. Capability is inferred
+from whether a read produced buckets, because the declarative alternative is
+exactly the shape of `PARSER_BACKED_SOURCES`, which today omits `kimi` even
+though `getParserForSource` accepts it — making `TOOL_RECORDING_SOURCES`
+permanently unable to include kimi. The six sources that emit no timestamps are
+read anyway; they account for 60 sessions in total, so a list maintained to save
+that is more expensive than the reads it avoids.
+
+### 4.4 Persistence
+
+In `StatsWriter`, mirroring the `session_tool_use` block:
+
+```ts
+if (event.activityBuckets !== undefined) {
+    db.prepare("DELETE FROM session_activity WHERE session_event_id = ?").run(eventId);
+    // then INSERT each bucket
+}
+```
+
+Delete-and-replace is safe **because the collector does a full read**, not a
+cursor-bounded slice. A slice-based producer would need a merge instead.
+
+### 4.5 Coverage this buys
+
+Measured on the real database:
+
+| Sources | Sessions | Reader emits `TranscriptEntry.timestamp` today |
+|---|---|---|
+| claude | 1199 | yes |
+| codex | 376 | yes |
+| copilot, copilot-chat, antigravity, gemini | 35 | yes |
+| opencode | 34 | yes — [`OpenCodeTranscriptReader.ts:254`](../../../cli/src/core/OpenCodeTranscriptReader.ts) derives `time_created` per message |
+| cursor | 14 | yes — [`CursorTranscriptReader.ts:126`](../../../cli/src/core/CursorTranscriptReader.ts) reads `bubble.createdAt` per message |
+| **covered** | **1658 / 1670 = 99.3%** | |
+| cline-cli, devin, cline | 12 = 0.7% | no |
+
+No reader work is therefore in scope: the eight sources that already emit
+timestamps cover 99.3% of sessions.
+
+(An earlier version of this table put `opencode` and `cursor` on the
+uncovered side; both readers already stamp a per-message timestamp, and a
+real-data probe produced buckets for both — 2/2 opencode sessions, 11
+buckets; 1/1 cursor session, 1 bucket — alongside claude and antigravity.
+This was harmless by construction: `measuredSources`/`uncoveredSources` in
+§5 are derived from the data per query rather than from a declared list, so
+a declared list built off this wrong table would have permanently excluded
+both sources — the per-query derivation is what contained the mistake.)
+
+Note for §7: the uncovered three are uncovered because *our readers drop the
+data*, not because the data is absent. Devin's `message_nodes.created_at` is
+populated on every row inspected.
+"Unavailable" here means "not read yet", which is a different claim from
+"unreadable".
+
+## 5. Query
+
+`buildConcurrency(db, opts)` in
+[`DashboardQuery.ts`](../../../cli/src/dashboard/DashboardQuery.ts).
+
+```sql
+SELECT a.bucket_ms,
+       COUNT(DISTINCT s.source || ':' || s.session_id) AS n
+  FROM session_activity a
+  JOIN sessions s ON s.event_id = a.session_event_id
+ WHERE a.bucket_ms >= ? AND a.bucket_ms < ?
+ GROUP BY a.bucket_ms
+```
+
+**`COUNT(DISTINCT session_event_id)` would be wrong.** `sessions` is unique on
+`(repo_id, source, session_id)`, so one agent session that touched two repos is
+two rows with two event ids — measured: three such groups exist for `cursor` on
+this machine. Counting event ids reports one agent as two. This interacts
+directly with the machine-global scope decision: under a per-repo filter the bug
+would be latent, and the decision to aggregate across repos makes it certain.
+
+```ts
+export interface ConcurrencyModel {
+    readonly buckets: ReadonlyArray<{ bucketMs: number; sessions: number }>;  // n > 0 only
+    readonly peak: number;
+    readonly meanActive: number;
+    readonly measuredSources: ReadonlyArray<TranscriptSource>;
+    readonly uncoveredSources: ReadonlyArray<TranscriptSource>;
+}
+```
+
+Carried as an optional `StatsModel.concurrency?`, so an older asset bundle
+served by a newer server ignores it rather than failing.
+
+Three semantics that must reach whatever eventually renders this:
+
+1. **`peak` is an upper bound.** Its label must say "agents active within the
+   same 15 minutes", never "running simultaneously" (§3.1).
+2. **`meanActive`'s denominator is active buckets, not window buckets.** A
+   7-day window holds 672 buckets; dividing by all of them yields ~0.2, a
+   figure with no meaning. Dividing by the buckets with activity answers "when
+   I am working, how many agents do I typically run". The denominator must be
+   stated wherever the number is.
+3. **`measuredSources` / `uncoveredSources` are derived per query**, not
+   declared: measured = contributed ≥1 bucket in the window; uncovered =
+   contributed sessions but no buckets. Same shape as `buildToolUsage`'s
+   existing `uncoveredSources`, for the reason in §4.3.
+
+**Empty window: the whole `concurrency` field is omitted**, so a consumer shows
+"no data" rather than a zero. Under forward-only collection this is the normal
+state for the first days after deployment, not an edge case.
+
+## 6. Scope, testing, failure modes
+
+Delivered: the migration, the collector change, the writer branch, the query,
+and `StatsModel.concurrency?`. **No UI.** The stats page's session-activity card
+(heatmap, hour histogram, records) was deliberately removed while its payload
+stayed live — `stats.heatmap` / `stats.hours` / `stats.fun` are in the model and
+rendered by nothing, with a comment stating that restoring the card is a render
+change only. Concurrency enters that same state deliberately: the card order is
+authored against jolli-design's Dashboard route, which is not available here, so
+placing a card is not a call this design makes. The follow-up is then pure
+front-end with no server change.
+
+Tests, one per deliberate choice above:
+
+| Case | What it prevents |
+|---|---|
+| `bucketsFrom`: floor, dedupe, ascending | A missing floor throws at insert (STRICT), but a missing dedupe silently inflates the table |
+| No timestamps → field absent, not `[]` | Conflating "uncovered" with "idle" (§4.2) |
+| Writer leaves rows alone on `undefined` | Re-upsert from a timestamp-less producer erasing a good read |
+| Cross-repo session counted once | The `source:session_id` key of §5 |
+| `meanActive` denominator | The ~0.2 figure |
+| `measured` / `uncovered` derived from data | The `PARSER_BACKED_SOURCES` omission shape |
+| Empty window omits the field | The first days after deployment |
+
+Failure modes: below the Node 22.13 `node:sqlite` floor, `ProducerHooks`'
+existing contract already skips the write and never blocks git — the new table
+does not change that, and a skipped write degrades to `uncovered`, which is the
+honest label. The migration is append-only.
+
+Coverage floor stays 97/96/97/97.
+
+One-time cost: bootstrap read volume roughly doubles. It reads Claude's 0.8 GB
+today and will additionally read Codex's 0.8 GB. Steady state is unaffected —
+the StopHook and the VS Code 60-second tick each touch one session.
+
+## 7. Deliberately out of scope
+
+- **Cloud upload.** A separate decision. Nothing here is uploadable as designed:
+  no developer identity exists in the local database, and sessions are
+  implicitly "this machine's user".
+- **Backfill.** The transcripts are on disk (2196 Claude + 2152 Codex, oldest
+  2026-06-23) and the existing `Backfill.ts` is a natural host, so this stays
+  cheap to add later.
+- **Non-Claude token/model.** OpenCode's `session` table carries `model` (329 of
+  349 rows), `tokens_input` / `tokens_output` (328), `tokens_cache_read` (230)
+  and `tokens_reasoning` (289). Three findings for whoever picks this up:
+  `model` is a JSON blob (`{"id","providerID","variant"}`) whose ids include
+  values absent from `Pricing.ts` (`big-pickle`, `deepseek-v4-flash-free`), so
+  they belong in the existing unpriced-model set; `cost` is 0 on all 349 rows
+  and must not be read; and `tokens_cache_read` reaches 20.4M on a session whose
+  input is 1.75M, the same cumulative-counter shape that made this repo exclude
+  Claude's `cache_read_input_tokens` from `ConversationTokenBreakdown` — the
+  matching column is `tokens_cache_write`, which is 0 everywhere.
+- **Reader work for the uncovered three (`cline-cli`, `devin`, `cline`).** Worth
+  doing only if the 0.7% matters or a specific user's mix is dominated by one
+  of them.
+- **`PARSER_BACKED_SOURCES` omitting `kimi`.** A pre-existing latent bug found
+  while writing this, unrelated to concurrency. It should be fixed on its own.

--- a/vscode/src/services/JolliPushOrchestrator.test.ts
+++ b/vscode/src/services/JolliPushOrchestrator.test.ts
@@ -5,12 +5,15 @@ const { mockPushToJolli, mockDeleteFromJolli } = vi.hoisted(() => ({
 	mockPushToJolli: vi.fn(),
 	mockDeleteFromJolli: vi.fn(),
 }));
-const { mockReadPlan, mockReadNote, mockReadReference, mockReadSkill } = vi.hoisted(() => ({
-	mockReadPlan: vi.fn(),
-	mockReadNote: vi.fn(),
-	mockReadReference: vi.fn(),
-	mockReadSkill: vi.fn(),
-}));
+const { mockReadPlan, mockReadNote, mockReadReference, mockReadSkill, mockReadTranscriptsBatch } = vi.hoisted(
+	() => ({
+		mockReadPlan: vi.fn(),
+		mockReadNote: vi.fn(),
+		mockReadReference: vi.fn(),
+		mockReadSkill: vi.fn(),
+		mockReadTranscriptsBatch: vi.fn(),
+	}),
+);
 // spec 306: the outbound-push gate. Default allowed; the fail-fast test flips it.
 const { mockIsOutboundPushAllowed } = vi.hoisted(() => ({
 	mockIsOutboundPushAllowed: vi.fn(async () => true),
@@ -29,7 +32,20 @@ vi.mock("../../../cli/src/core/SummaryStore.js", () => ({
 	readNoteFromBranch: mockReadNote,
 	readReferenceFromBranch: mockReadReference,
 	readSkillFromBranch: mockReadSkill,
+	readTranscriptsBatch: mockReadTranscriptsBatch,
 }));
+// Spy-wraps the real `collectTranscriptSessionMeta` (like the panel test wraps
+// `pushSummaryWithAttachments`): every existing test keeps exercising the genuine
+// enrichment, while one test can `mockRejectedValueOnce` to pin that a call-site
+// failure here — not just a `readTranscriptsBatch` failure — still can't abort a push.
+const { mockCollectTranscriptSessionMeta } = vi.hoisted(() => ({
+	mockCollectTranscriptSessionMeta: vi.fn(),
+}));
+vi.mock("../../../cli/src/core/TranscriptSessionMeta.js", async (importActual) => {
+	const actual = await importActual<typeof import("../../../cli/src/core/TranscriptSessionMeta.js")>();
+	mockCollectTranscriptSessionMeta.mockImplementation(actual.collectTranscriptSessionMeta);
+	return { ...actual, collectTranscriptSessionMeta: mockCollectTranscriptSessionMeta };
+});
 vi.mock("../views/SummaryMarkdownBuilder.js", () => ({ buildMarkdown: () => "# markdown" }));
 vi.mock("../../../cli/src/core/Telemetry.js", () => ({ track: vi.fn() }));
 vi.mock("../util/Logger.js", () => ({
@@ -63,6 +79,13 @@ function makeSummary(overrides: Partial<CommitSummary> = {}): CommitSummary {
 	} as unknown as CommitSummary;
 }
 
+/** Makes `readTranscriptsBatch` resolve every requested id to the same value. */
+function mockTranscriptsBatch(value: unknown): void {
+	mockReadTranscriptsBatch.mockImplementation(
+		async (ids: readonly string[]) => new Map(ids.map((id) => [id, value])),
+	);
+}
+
 function makeContext(overrides: Partial<PushContext> = {}): PushContext {
 	return {
 		baseUrl: "https://acme.jolli.ai/",
@@ -81,6 +104,7 @@ beforeEach(() => {
 	mockReadNote.mockResolvedValue("note body");
 	mockReadReference.mockResolvedValue(null);
 	mockReadSkill.mockResolvedValue(null);
+	mockTranscriptsBatch(null);
 	mockIsOutboundPushAllowed.mockResolvedValue(true);
 });
 
@@ -668,6 +692,90 @@ describe("pushSummaryWithAttachments", () => {
 	});
 });
 
+describe("session enrichment on pushSummaryWithAttachments", () => {
+	const ONE_SESSION = {
+		sessions: [
+			{
+				sessionId: "s1",
+				source: "claude" as const,
+				entries: [
+					{ role: "human" as const, content: "a", timestamp: "2026-08-01T09:00:00.000Z" },
+					{ role: "assistant" as const, content: "b", timestamp: "2026-08-01T10:10:00.000Z" },
+				],
+			},
+		],
+	};
+
+	function summaryText(): { calls: unknown[][] } {
+		return { calls: mockPushToJolli.mock.calls };
+	}
+
+	function summaryPayload(): { summaryJson?: string } {
+		const call = summaryText().calls.find((c) => (c[2] as { docType: string }).docType === "summary");
+		return call?.[2] as { summaryJson?: string };
+	}
+
+	it("weaves transcriptSessions into the pushed summaryJson when a transcript is readable", async () => {
+		mockTranscriptsBatch(ONE_SESSION);
+		mockPushToJolli.mockResolvedValue({ docId: 100 });
+		const summary = makeSummary({ transcripts: ["t1"] });
+
+		await pushSummaryWithAttachments(summary, makeContext());
+
+		const parsed = JSON.parse(summaryPayload().summaryJson ?? "{}");
+		expect(parsed.transcriptSessions).toEqual([
+			{
+				sessionId: "s1",
+				source: "claude",
+				messageCount: 2,
+				startedAt: "2026-08-01T09:00:00.000Z",
+				endedAt: "2026-08-01T10:10:00.000Z",
+			},
+		]);
+	});
+
+	it("still pushes without transcriptSessions when the enrichment itself rejects (call-site defense)", async () => {
+		// Regression: `collectTranscriptSessionMeta` used to be awaited unguarded here.
+		// Any throw inside it (not just a `readTranscriptsBatch` failure — e.g. id
+		// resolution over a malformed summary tree) aborted the whole push before
+		// `pushToJolli` was ever reached. The enrichment is an optional extra, so a
+		// rejection here must degrade to "no sessions", never abort the push.
+		mockCollectTranscriptSessionMeta.mockRejectedValueOnce(new Error("enrichment boom"));
+		mockPushToJolli.mockResolvedValue({ docId: 100 });
+		const summary = makeSummary({ transcripts: ["t1"] });
+
+		const result = await pushSummaryWithAttachments(summary, makeContext());
+
+		expect(result.pushedDoc.summaryDocId).toBe(100);
+		expect(mockPushToJolli).toHaveBeenCalled();
+		const parsed = JSON.parse(summaryPayload().summaryJson ?? "{}");
+		expect(parsed).not.toHaveProperty("transcriptSessions");
+	});
+
+	it("omits transcriptSessions entirely when no session is derivable", async () => {
+		mockTranscriptsBatch(null);
+		mockPushToJolli.mockResolvedValue({ docId: 100 });
+		const summary = makeSummary({ transcripts: ["t1"] });
+
+		await pushSummaryWithAttachments(summary, makeContext());
+
+		const parsed = JSON.parse(summaryPayload().summaryJson ?? "{}");
+		expect(parsed).not.toHaveProperty("transcriptSessions");
+	});
+
+	it("never persists the enrichment on the stored summary", async () => {
+		mockTranscriptsBatch(ONE_SESSION);
+		mockPushToJolli.mockResolvedValue({ docId: 100 });
+		const summary = makeSummary({ transcripts: ["t1"] });
+		const ctx = makeContext();
+
+		await pushSummaryWithAttachments(summary, ctx);
+
+		const stored = (ctx.storeSummary as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] as CommitSummary;
+		expect(stored).not.toHaveProperty("transcriptSessions");
+	});
+});
+
 describe("serializeSummaryJson", () => {
 	it("strips jolliDocId/jolliDocUrl/orphanedDocIds and keeps content fields", () => {
 		const json = serializeSummaryJson(
@@ -717,5 +825,60 @@ describe("serializeSummaryJson", () => {
 
 	it("returns undefined for a summary that serializes over the byte cap", () => {
 		expect(serializeSummaryJson(makeSummary({ recap: "x".repeat(1_600_000) }))).toBeUndefined();
+	});
+});
+
+describe("serializeSummaryJson session enrichment", () => {
+	it("carries transcriptSessions through when the payload fits", () => {
+		const json = serializeSummaryJson({
+			...makeSummary({ recap: "x".repeat(10) }),
+			transcriptSessions: [
+				{
+					sessionId: "s1",
+					source: "claude",
+					messageCount: 3,
+					startedAt: "2026-08-01T09:00:00.000Z",
+					endedAt: "2026-08-01T10:10:00.000Z",
+				},
+			],
+		});
+
+		expect(json).toBeDefined();
+		expect(JSON.parse(json as string).transcriptSessions).toEqual([
+			{
+				sessionId: "s1",
+				source: "claude",
+				messageCount: 3,
+				startedAt: "2026-08-01T09:00:00.000Z",
+				endedAt: "2026-08-01T10:10:00.000Z",
+			},
+		]);
+	});
+
+	it("drops only the enrichment when it is what pushes the payload over the cap", () => {
+		// 1.5 MB is 1_572_864 bytes; leave under 400 bytes of headroom so a handful
+		// of session rows is the difference between fitting and not.
+		const base = makeSummary({ recap: "x".repeat(1_572_500) });
+		const withoutEnrichment = serializeSummaryJson(base);
+		expect(withoutEnrichment).toBeDefined();
+
+		const json = serializeSummaryJson({
+			...base,
+			transcriptSessions: Array.from({ length: 20 }, (_, i) => ({
+				sessionId: `session-${i}`,
+				source: "claude",
+				messageCount: 10,
+				startedAt: "2026-08-01T09:00:00.000Z",
+				endedAt: "2026-08-01T10:10:00.000Z",
+			})),
+		});
+
+		// The sidecar survives; only the enrichment is gone.
+		expect(json).toBe(withoutEnrichment);
+		expect(JSON.parse(json as string)).not.toHaveProperty("transcriptSessions");
+	});
+
+	it("still returns undefined when the payload is oversized without any enrichment", () => {
+		expect(serializeSummaryJson(makeSummary({ recap: "x".repeat(2_000_000) }))).toBeUndefined();
 	});
 });

--- a/vscode/src/services/JolliPushOrchestrator.ts
+++ b/vscode/src/services/JolliPushOrchestrator.ts
@@ -28,6 +28,7 @@
  * (per-kind reduced) are pushed — the standalone button's existing behavior.
  */
 
+import { errMsg } from "../../../cli/src/Logger.js";
 import type { CommitSummary, NoteReference, PlanReference, ReferenceCommitRef } from "../../../cli/src/Types.js";
 import { deriveJolliEnvKey, resolveArticleUrl } from "../../../cli/src/core/JolliApiUtils.js";
 import { DocTypeNotAllowedError } from "../../../cli/src/core/JolliMemoryPushClient.js";
@@ -49,6 +50,7 @@ import {
 import { canReuseDocId } from "../../../cli/src/core/push/DocIdReuse.js";
 import { adoptLegacySkillDocIds } from "../../../cli/src/core/push/LegacySkillDocIds.js";
 import { track } from "../../../cli/src/core/Telemetry.js";
+import { collectTranscriptSessionMeta, type TranscriptSessionMeta } from "../../../cli/src/core/TranscriptSessionMeta.js";
 import { log } from "../util/Logger.js";
 import { buildBranchRelativePath, buildPushTitle } from "../views/SummaryUtils.js";
 import { buildMarkdown } from "../views/SummaryMarkdownBuilder.js";
@@ -98,6 +100,18 @@ export class ShareBindingError extends Error {
 const MAX_SUMMARY_JSON_BYTES = 1_572_864;
 
 /**
+ * A summary as the PUSH path sees it: the stored record plus the push-time
+ * session enrichment.
+ *
+ * The extra field lives here, not on `CommitSummary`, on purpose — the storage
+ * path cannot name it, so it cannot persist it. Mirrors
+ * `EnrichedPushSummary` in the CLI's `JolliMemoryPushOrchestrator.ts`.
+ */
+export type EnrichedPushSummary = CommitSummary & {
+	readonly transcriptSessions?: ReadonlyArray<TranscriptSessionMeta>;
+};
+
+/**
  * Serializes a summary for the `summaryJson` push field: the enriched
  * `summaryForMarkdown` copy (plan/note URLs woven in) minus the client push-state
  * fields — `jolliDocId`/`jolliDocUrl` and their skill-article siblings
@@ -108,8 +122,13 @@ const MAX_SUMMARY_JSON_BYTES = 1_572_864;
  * in the same run, so `applyPublishedUrls` has already woven its id/URL onto the
  * summary by the time we serialize. Returns undefined (with a warning) above
  * {@link MAX_SUMMARY_JSON_BYTES}.
+ *
+ * If the payload is over the cap and carries the `transcriptSessions` push-time
+ * enrichment, retries once without it before giving up on the whole sidecar —
+ * the enrichment is a small optional extra, so shedding it alone is strictly
+ * better than losing the entire JSON to it.
  */
-export function serializeSummaryJson(summary: CommitSummary): string | undefined {
+export function serializeSummaryJson(summary: EnrichedPushSummary): string | undefined {
 	const {
 		jolliDocId: _docId,
 		jolliDocUrl: _docUrl,
@@ -119,14 +138,26 @@ export function serializeSummaryJson(summary: CommitSummary): string | undefined
 		...content
 	} = summary;
 	const json = JSON.stringify(content);
-	if (Buffer.byteLength(json, "utf-8") > MAX_SUMMARY_JSON_BYTES) {
-		log.warn(
-			"PushOrchestrator",
-			`Summary JSON for ${summary.commitHash.substring(0, 8)} exceeds ${MAX_SUMMARY_JSON_BYTES} bytes — pushing markdown only`,
-		);
-		return;
+	if (Buffer.byteLength(json, "utf-8") <= MAX_SUMMARY_JSON_BYTES) return json;
+	// The session enrichment is a push-time extra, so shedding it is strictly
+	// better than shedding the whole sidecar — which is what the cap otherwise
+	// does. Worst case becomes the pre-enrichment behavior, never worse.
+	if (content.transcriptSessions !== undefined) {
+		const { transcriptSessions: _sessions, ...withoutSessions } = content;
+		const retry = JSON.stringify(withoutSessions);
+		if (Buffer.byteLength(retry, "utf-8") <= MAX_SUMMARY_JSON_BYTES) {
+			log.warn(
+				"PushOrchestrator",
+				`Summary JSON for ${summary.commitHash.substring(0, 8)} exceeds ${MAX_SUMMARY_JSON_BYTES} bytes — pushing without session metadata`,
+			);
+			return retry;
+		}
 	}
-	return json;
+	log.warn(
+		"PushOrchestrator",
+		`Summary JSON for ${summary.commitHash.substring(0, 8)} exceeds ${MAX_SUMMARY_JSON_BYTES} bytes — pushing markdown only`,
+	);
+	return;
 }
 
 /** Everything the orchestrator needs that isn't on the summary itself. */
@@ -299,7 +330,31 @@ export async function pushSummaryWithAttachments(
 		// article's Context list links to the published docs). `reduceOwnItems`
 		// first — only the reduced set was uploaded (same-named plan snapshots
 		// collapse), so the rendered body must list the same set.
-		const summaryForMarkdown = applyPublishedUrls(reduceOwnItems(summary), published);
+		//
+		// Push-time session enrichment rides along. Read from the artifacts this tree
+		// references, stamped on the root only (the server merges duplicate rows
+		// keep-first), and omitted entirely when empty so absence never reads as a
+		// measured zero. No storage is threaded — this is a read, so the fallback to
+		// the orphan branch (the system of record) inside `resolveStorage` is the
+		// correct source.
+		//
+		// `collectTranscriptSessionMeta` already swallows its own failures and
+		// resolves to `[]`, but this is belt-and-suspenders: the enrichment is an
+		// optional extra, so a defensive catch here too means this call site can
+		// never abort the push, even if that internal guarantee ever regresses.
+		let transcriptSessions: ReadonlyArray<TranscriptSessionMeta> = [];
+		try {
+			transcriptSessions = await collectTranscriptSessionMeta(summary, ctx.workspaceRoot);
+		} catch (err) {
+			log.warn(
+				"PushOrchestrator",
+				`Transcript session enrichment failed for ${summary.commitHash.substring(0, 8)} (non-fatal, pushing without it): ${errMsg(err)}`,
+			);
+		}
+		const summaryForMarkdown: EnrichedPushSummary = {
+			...applyPublishedUrls(reduceOwnItems(summary), published),
+			...(transcriptSessions.length > 0 && { transcriptSessions }),
+		};
 		const markdown = buildMarkdown(summaryForMarkdown);
 		// The structured twin of the markdown article, from the same enriched copy —
 		// the share page renders it directly instead of regex-parsing the markdown.


### PR DESCRIPTION
<!-- jollimemory-summary-start -->
## Quick recap

The developer added machine-wide agent concurrency tracking to the local dashboard. Each coding session's activity is recorded into permanent fifteen-minute buckets that survive every later re-read of the same conversation, and the dashboard now reports how many agent sessions were active within the same quarter hour across every project on the machine, along with the busiest such period and a typical count over periods that saw activity. A session that touched several repositories is counted once, and tools whose histories carry no per-message timing are reported as unmeasured.

Commit summaries now carry a real time axis when they are shared. Each summary records how many messages each working conversation held and the timestamps of its first and last exchange, whether sharing happens from the command line or from the editor extension. Saving a summary now reads all of its conversation records in a single batch, and a summary that outgrows the upload size limit drops only the optional session details while the rest of the structured record uploads intact.

The activity timeline now draws on every supported coding assistant, with sessions from any tool contributing real activity data and message counts. Historical sessions that ran in sibling git worktrees are read during backfill as well, extending the timeline and the concurrency figure to past work done in related checkouts.

The local statistics database verifies its own health on every open. A skipped upgrade step surfaces as a named error spelling out the exact recovery steps, and statistics events stranded after repeated failures are reported and can be revived and reprocessed in a single pass. Recovery guidance now targets a single activity table, leaving the memory records in the same file untouched.

---

## Topics (10)
<details>
<summary><strong>01 · Report how many coding agents ran concurrently across the machine</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The local dashboard could show how much work happened but not how many coding agents a person was running at the same time. The team needed to record when each session was actually active so overlap could be counted, and any recorded working time had to survive later re-reads of the same conversation.

**💡 Decisions Behind the Code**

- **Fifteen-minute activity buckets over session intervals**: sessions are frequently resumed, and the longest measured session covered 18 hours across only 28 messages, so a start-to-end span would wildly overstate presence. Recording only the quarter-hours in which a session actually spoke keeps the figure honest, removes the need for an idle-gap threshold, and still reads as "at the same time" to a person.
- **Insert-only permanent facts over a refreshable snapshot**: the first implementation deleted and rewrote every stored row on each read, but "this session was active during this quarter hour" can never become false. When a host rotates its logs or an agent regenerates an answer, the evidence disappears rather than the activity; a stale row is repairable later, whereas a deleted one is gone forever.
- **Machine-global, ignoring the page's project filter**: concurrency answers "how many things was this person doing at once," which belongs to the person rather than to any repository. Filtering by the selected project would truncate the number into something with no actionable meaning, and counting agent-plus-session identity avoids double counting a session running in two repos.
- **Honest denominators and wording**: the average is taken over active periods only, never every slot in the week, and the peak is documented as an upper bound, since two agents active in the same fifteen minutes need not have overlapped at any instant. The label must say "active within the same fifteen minutes" and never "running simultaneously," the price of a measure that needs no tuning parameter.
- **Absent versus empty must mean different things**: leaving the field out signals a source that cannot see per-message timestamps at all, while an explicit empty set signals a genuine look that found nothing. Missing data is reported as uncovered rather than mistaken for idleness, and the concurrency field is omitted entirely when there is no data, never shown as zero, since activity is only collected going forward.

**✅ What Was Implemented**

- Added a strict activity table keyed on session id and integer fifteen-minute bucket, with an index on the bucket, appended to the migration list and a bumped dashboard schema version; the session stats writer was reworked to be insert-only, dropping the wholesale delete on every read so re-observed rows keep their original timestamp, and the backfill now reads existing activity rows back through a join with a containment-based change check.
- Added an optional activity-buckets field to the session event with an explicit contract: producers send no value, never an empty array, when they cannot observe per-message timestamps. A pure bucketing helper floors each transcript entry's timestamp to its quarter-hour start, dedupes via a set, and returns results sorted ascending, skipping entries that lack or fail to parse a timestamp.
- Added a concurrency model exposing the quarter-hour buckets, bucket width, peak, mean over active buckets, and measured versus uncovered source lists; the query joins activity to sessions over the resolved window and counts distinct source-and-session pairs per bucket so one session spanning two repositories counts once. Uncovered sources are now determined by an unwindowed existence check over each session's own activity rows, so a source whose sessions merely predate the window is no longer labeled unmeasurable.
- Added regression tests covering late-arriving buckets, the shrinking re-read, floor boundaries, dedupe and ordering, the resumed-overnight case, malformed input tolerance, cross-repo dedup, peak and mean, uncovered sources, and scope independence. A one-off backup-and-replay script migrated the existing database, preserving all 106 activity records already collected.
- Added an approved design spec and six-task test-first implementation plan for the data layer, covering the bucket table, the bucketing helper, the event field, and the concurrency aggregation, plus a corrected coverage table (96.4% to 99.3%) with an erratum recording the earlier wrong classification.

**📋 Future Enhancements**

- Reset the ingest cursor so the backfill pass runs again on machines where the buggy build already consumed the generation bump.
- The schema version number must be recomputed at the real merge point once ordering against the other in-flight branch is decided.
- Decide whether the many short (under five message) sessions should be treated differently in the upcoming concurrency charts.
- The UI card rendering the concurrency figure is deliberately not built this round.
- Cloud upload deferred entirely; the local database has no developer identity.
- Historical backfill deferred despite roughly 4,350 transcripts still on disk reaching back about seven weeks.
- Add timestamp reading for three remaining assistants (0.7% of sessions) if it ever matters.
- Pre-existing latent bug: the parser-backed source list omits one assistant, so it can never enter the tool-recording set.

**📁 FILES**
- `cli/src/dashboard/DashboardQuery.ts`
- `cli/src/dashboard/DashboardModel.ts`
- `cli/src/dashboard/StatsWriter.ts`
- `cli/src/dashboard/SotSchema.ts`
- `cli/src/dashboard/DashboardDb.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Backfill and collector read sessions across every git worktree exactly once</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The dashboard's activity timeline was missing historical AI sessions that ran in sibling git worktrees, because the backfill only scanned the main checkout. The user asked that those sibling-worktree sessions also be read during backfill.

**💡 Decisions Behind the Code**

- **Widen the search, not the attribution rule**: the fix expands which checkout directories are queried and leaves the rule deciding whether a conversation belongs to a repository untouched. That rule deliberately excludes a checkout nested inside another one so one workspace never absorbs another's conversations; keeping it intact while covering every linked worktree preserves that protection.
- **Reuse the answer that already existed**: the correct answer to a repository having several checkouts had already been worked out once, in a private helper specific to one source. Promoting that logic to a shared utility means every future source inherits the same proven reasoning instead of re-deriving it.
- **Opt-in spanning declaration**: the flag defaults to false because declaring it wrongly in the opposite direction loses sessions entirely rather than only costing time — a silent correctness risk outweighs one wasted scan, so only sources that genuinely resolve their own worktree set opt in.
- **Union, never substitute**: a missing checkout is silent data loss since nothing else reads that project's per-checkout registry, while a redundant root costs one cheap registry read. Trading a wasted read for guaranteed coverage is the safe side to err on, and the dedupe folds only the comparison path so the caller's original on-disk spelling survives case-sensitive filesystems.
- **Force one rescan so already-recorded sessions are seen**: conversations in sibling worktrees already had rows and read receipts, so the normal "nothing changed, skip it" check would bypass them forever. The session-read version marker was advanced exactly one step, since the current version had never shipped and did not warrant an extra generation.

**✅ What Was Implemented**

- Added a shared worktree-root resolution helper that returns the queried directory plus every linked worktree of the same repository, deduplicated and directory-first, degrading to the directory alone when git is unavailable or the directory is not a checkout; the Antigravity session discoverer now uses it, deleting its private copy.
- The backfill resolves worktree roots once per registered checkout, dedupes across clones, and passes them into the session tier, bumping the session-read generation to force one rescan over the wider scope and correcting the stale comment claiming sessions are recorded per project rather than per directory.
- The dashboard collector now declares an opt-in spanning flag per source: sources that already resolve every worktree themselves are asked once at the current directory while everything else is asked per root, and the current directory is unioned into the root list rather than replaced by it via a dedupe helper. A worktree list that omits or differently spells the current checkout can only add roots, so the checkout's own sessions are always read and a repeated checkout is read only once; a mocked probe pins the spanning source to a single call across three roots.

**📋 Future Enhancements**

- Run the full `npm run all` gate (including the slow tier and VSCode suites) and commit the work — both explicitly deferred by the user.

**📁 FILES**
- `cli/src/dashboard/DashboardCollector.ts`
- `cli/src/core/GitOps.ts`
- `cli/src/dashboard/DbBackfill.ts`
- `cli/src/core/sessions/SessionSourceDefinition.ts`
- `cli/src/core/AntigravitySessionDiscoverer.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Surface and repair statistics events abandoned after repeated failures</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Ten activity events had exhausted their retry budget and been set aside permanently, silently dropping them from every dashboard figure. Nothing in the product reported this, and no existing recovery path would ever bring them back.

**💡 Decisions Behind the Code**

- **Warn without failing**: the underlying memories are safe in the system of record, so an otherwise healthy installation must not report an error state over incomplete dashboard figures.
- **Repair and refresh in one command, not just re-queueing**: re-queueing alone is honest but useless as a fix, because the next refresh happens on the next commit or a periodic tick, and someone not committing right now would read a success message and see the dashboard unchanged. The cost is that the health command now does projection work while holding the write lock, acceptable for an interactive command.
- **Never revive abandoned events automatically**: the reason for failure is not stored, so the only honest trigger is a person who has just fixed the underlying cause. Automatic revival would burn five retries per refresh cycle on a genuinely broken event forever.
- **Count from the table, not by subtraction**: the old revived-minus-projected arithmetic was wrong in both directions — a drain capped at its batch size understates the true remainder, and rows already queued before the un-park could push the derived value negative. The table already knows the answer, so it is asked.

**✅ What Was Implemented**

- Added counting and revival helpers to the stats writer, sharing one predicate scoped to genuine errors and deliberately excluding the unknown-type reason that the normal drain already revives on every pass.
- Added a tenth health check reporting the abandoned count as a warning (never a failure), attaching a repair action only when the count is non-zero; the read path treats every "cannot open the database" case as zero so the health command still completes on old runtimes.
- The repair action revives and drains in one pass, reporting revived and projected counts separately. The leftover count is now taken directly from the drain's pending queue rather than derived by subtraction, so the reported "still queued (will retry)" figure is exact and can never understate or go negative when the drain hits its batch limit or pre-existing queued rows exist.
- Testing against a real database corrected the documented behaviour: one drain spends a single retry, so a still-broken event returns to the queue rather than being immediately abandoned again.

**📁 FILES**
- `cli/src/dashboard/StatsWriter.ts`
- `cli/src/commands/DoctorCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Transcript reads stop triggering false memory-bank warnings on desktop pushes</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A code review found that every push from the desktop app printed a warning meant for writes that were never attempted — a read-only transcript lookup was going through the write-side storage resolver.

**💡 Decisions Behind the Code**

The write-side resolver exists to warn when a write cannot reach both stores, so firing it on a pure read makes a healthy operation look broken; routing reads through the read-side resolver keeps that warning meaningful whenever it does appear. Choosing the wrong direction corrupts no data — it only pollutes logs — which is exactly why the mistake survived unnoticed until review.

**✅ What Was Implemented**

`readTranscriptsBatch` in `cli/src/core/SummaryStore.ts` now resolves storage through the read-only resolver instead of the write-side one, so a pure read no longer trips the write-side fallback warning and desktop-app pushes stop emitting the misleading "The Memory Bank side will miss this write" message on every push.

**📁 FILES**
- `cli/src/core/SummaryStore.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Attach per-conversation timing and message counts to shared commit summaries</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Shared commit summaries listed only which conversations were attached, with no indication of when each working session ran or how much was said. The coaching dashboard measures everything against session duration and had no source for that measurement.

**💡 Decisions Behind the Code**

- **Derive at push time instead of storing the data**: the metadata is computed from transcript artifacts a summary already points at, so every existing memory gains its time axis on its next share with no migration. Storing at write time could only cover new commits and would drag in a coordinated storage-schema change across separate clients.
- **Aggregate across a conversation's slices rather than taking the first match**: one conversation can legitimately be split across several archived pieces, such as an amended change plus its original. Summing counts and spanning earliest-to-latest bounds reflects the real conversation length.
- **Enrichment must never block a share**: session timing is an optional extra, so a failure while reading or resolving conversation artifacts degrades to "no session info" instead of aborting the share; a second guard at the call site protects against future regressions in the collector.
- **Shed the optional extra before sacrificing the whole payload**: when a summary outgrows the upload limit, the session details are the supplementary attachment while the structured summary is the primary artifact consumers depend on. Retrying once without the extra means the worst case is exactly the old markdown-only behaviour, and keeping the enrichment off the stored record's type prevents stale timing data accumulating on disk.
- **Keep both read paths alive rather than requiring batch support**: one storage backend can fetch many files in a single operation while the local-folder backend cannot. The batch helper prefers the fast path when available and quietly loops otherwise, preserving the "one bad record never loses the rest" guarantee for unreadable entries.

**✅ What Was Implemented**

- Added a session-metadata collector that walks the transcript ids a summary references, loads each artifact, and folds every stored session into a per-source accumulator producing a message count plus start and end bounds; bounds compare parsed epoch milliseconds while emitting the original ISO strings, unparseable timestamps are skipped, duplicate ids are guarded, and a missing source defaults to one assistant's format.
- Wove the collector into both command-line push paths and the editor extension's independent push path via a new exported enriched share type that keeps the field off the persisted summary shape; a failed enrichment logs a non-fatal warning and falls through with an empty session list.
- Reworked the JSON serializer so that when the payload exceeds the 1.5 MB upload limit and carries session data, it retries serialization once with that field stripped; the retry is returned if it fits, otherwise it falls back to markdown-only behaviour with a distinct warning message.
- Reads are now batched: a new helper builds transcript paths in one place and calls the storage backend's batch read when it implements one, falling back to a looped read otherwise, preserving a per-entry null for missing or malformed bodies; the collector de-duplicates ids up front and issues a single batch read, replacing the per-id loop.
- Added an approved design spec and four-task implementation plan documenting the root-stamped, tree-wide session array, push-time enrichment, a size-cap retry, three absence rules, and nine test invariants, plus a section headlining the known limitation that reported duration is a first-to-last-message span including idle time.

**📋 Future Enhancements**

- Session length is measured from first to last message, counting idle time as work: a session resumed hours later reports the full span and can clear the feature-work threshold on idle alone. A possible fix is an inactivity threshold that switches to active duration — pending a product decision.
- Pull-request number enrichment remains deferred, to be built together with the review-timeline reporter.
- Server-side blocker needs an owner: the coaching reviews endpoint is mounted on the browser-session authentication chain rather than the API-key chain.

**📁 FILES**
- `cli/src/core/TranscriptSessionMeta.ts`
- `cli/src/core/JolliMemoryPushOrchestrator.ts`
- `cli/src/core/SummaryStore.ts`
- `vscode/src/services/JolliPushOrchestrator.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Dashboard reads session transcripts from every supported coding assistant</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The dashboard's activity timeline only showed work done with one coding assistant, because sessions from all other assistants were skipped before their conversation history was ever opened. Sessions recorded with other tools appeared as bare entries with no message count and no activity over time.

**💡 Decisions Behind the Code**

- **Reuse the existing per-source reader dispatch over a generic default**: the plain transcript reader silently falls back to one assistant's file format, so pointing it at another tool's history returns zero entries instead of an error — a quiet data loss. Routing through the same dispatcher the live conversations sidebar already uses guarantees each source is parsed by the reader it needs, at the cost of exporting a previously internal helper.
- **Omit activity data entirely when no timestamps exist, never an empty list**: some sources record no per-message times, and emitting an empty result would assert "measured, and there was no activity" about something never measurable. Leaving it absent lets the dashboard honestly show it as uncovered.
- **Let the coverage label default downstream instead of stamping it at collection**: the collector leaves the token-coverage value unset and the stats writer applies the fallback, keeping one owner for the default and avoiding two places drifting apart.

**✅ What Was Implemented**

- Promoted the per-source transcript dispatcher to a public export, replacing the private helper, and typed its cursor parameter as nullable so callers can request a full read from the start of the file.
- Rewired the session event collection to call the per-source reader for every source, dropping the single-assistant early bail-out and deriving activity buckets from the read entries for all of them.
- Changed token attribution to leave the token-coverage value unset rather than hardcoding a sessions-only value when no per-turn usage exists, letting the stats writer supply that default.
- Updated the collector tests with a partial module mock keeping the real dispatcher as default behaviour.

**📁 FILES**
- `cli/src/dashboard/DashboardCollector.ts`
- `cli/src/core/TranscriptMessageCounter.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Detect a skipped statistics-database upgrade step and give safe recovery guidance</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Activity statistics stopped recording entirely, with repeated errors about a missing storage table. The upgrade step that should have created it had been skipped without any warning, and the failure surfaced much later as what looked like a plain code bug.

**💡 Decisions Behind the Code**

- **Derive the expected table list from the upgrade steps rather than maintaining one by hand**: a hand-written list is one more place to forget, and forgetting it reintroduces exactly the silent skip the check exists to catch. The parser deliberately errs toward missing things over guessing, since a false alarm takes down the dashboard on a perfectly healthy machine.
- **No automatic self-repair**: replaying the upgrade step would reuse a version number whose meaning already differs between two in-progress branches, which is how the file got broken in the first place. Recovery stays an explicit, operator-visible step.
- **Narrow the recovery, never delete the database**: deletion is unconditionally destructive for anyone who has already completed the storage switchover, because memory records in the same file may have no second copy anywhere. The activity data is disposable and rebuilt from transcript files on disk, so recovery targets only the single activity table. Documentation that asserts safety without stating its precondition was the direct cause of the bad advice, and is now treated as a defect in its own right.

**✅ What Was Implemented**

- Added a helper that derives the expected table set by parsing the migration DDL itself (stripping SQL comments first), plus schema verification and a new named error type spelling out the recovery steps; verification is wired into both arms of the migration path, critically the version early return where a skipped entry can hide, measured at 0.0158 ms per open against the real 147 MB database.
- Made the table-creation pattern tolerate an optional existence clause so it does not capture the literal keyword as a table name and raise a false alarm on every healthy database.
- Replaced the deletion advice with a targeted two-statement recovery that drops only the activity-layer table and rolls the version stamp back one step, safe because activity buckets are re-derived from transcripts on the next collection; the memory records in the same file are never touched.
- Reconciled two directly contradictory comments in the database module — one stating the database must never be deleted because the memory half is the only copy, the other calling deletion safe — with the reconciling condition being the migration state, and refreshed the version constant's documentation.

**📋 Future Enhancements**

- Developers whose local database was upgraded by a pre-rebase build need a two-statement surgical fix, not deletion of the file.
- The safety claim on the schema-ahead error's documentation still lacks its "only before switchover" precondition and should be fixed separately.

**📁 FILES**
- `cli/src/dashboard/DashboardDb.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Diagnose full test gate failures as environment noise, not new regressions</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The full verification run across the whole project failed, and it needed to be established whether the failures came from this batch of work or from pre-existing conditions on the machine.

**💡 Decisions Behind the Code**

- **Judged failures by shape rather than by count**: durations clustering at or just past the global timeout point to machine load contention, while millisecond-level failures point to genuine assertion problems. Splitting on that signal turned an alarming eleven-failure report into two small, separately explainable groups.
- **Required evidence of prior breakage instead of asserting it**: the browse file's last-modified point was shown to predate this work entirely and the current changes shown not to touch it. Suspected-flaky files were re-run in isolation to confirm they pass without competing load.
- **Declined to add defensive code for a version collision found during checks**: a shared local database reported a schema version another unmerged branch had claimed, leaving a required table missing. This is a development-machine artefact, never a released-build condition, and guarding against it would mask the real situation.

**✅ What Was Implemented**

- Separated eleven failures into two shapes by duration: nine ran 60-72 seconds against the 60-second global timeout (heavy real-git and file-lock suites), and two failed in single-digit milliseconds in the browse suite.
- Established the browse failures as pre-existing by showing the file was last modified in a commit predating this work's base and untouched by the current diff, with a known macOS-only cause.
- Traced the run's abrupt death to a coverage writer failing to find a worker's temporary output file, with no test summary printed; a suspected double-run collision was checked and ruled out.

**📋 Future Enhancements**

- The full pre-commit gate still fails on three test files that time out under full-suite load; they remain missing from the slow-test list.

**📁 FILES**
- `cli/src/dashboard/DashboardQuery.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · Recovered corrupted local repository index twice without losing in-progress work</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

On two separate occasions basic repository status and commit commands started failing with unreadable-object errors, blocking finished work from being committed. It was unclear whether any staged or unsaved work was at risk.

**💡 Decisions Behind the Code**

The staging record was treated as a disposable, regenerable artifact while the edited files on disk were treated as the only irreplaceable thing. Diagnosis always came before repair, the staging area was backed up so the whole operation stayed reversible, and the least destructive rebuild option was run on its own. That traded a few minutes of extra work for certainty that no uncommitted content would be destroyed, which mattered because the failure mode resembled both a harmless stale cache and genuine data loss.

**✅ What Was Implemented**

- First incident: confirmed the last good commit was intact and that both edited files still carried the complete in-progress changes, then rebuilt the staging record from the last good commit and verified the resulting change set contained exactly the two expected files. The cause was a background process from a separate repository overwriting the shared bookkeeping file for this working copy.
- Second incident: diagnosed non-destructively first, confirming the file in question was already committed in history and the failure came from a stale staging area referencing a missing object; backed up the staging area, then rebuilt it, after which status returned clean with history intact.

**📁 FILES**
- `cli/src/core/JolliMemoryPushOrchestrator.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · Reformat over-long test helper line to satisfy project formatting check</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The project's code style check was failing on a recently added test file because one line was too long. The problem had been introduced twice: missed during an earlier review, then reintroduced when a later change reverted the formatting.

**💡 Decisions Behind the Code**

The lint failure was traced back to its origin rather than patched blind: the over-long line came from the original task brief, was wrongly cleared by that task's review, and was then reintroduced by a later task that reverted the formatting. Assigning the fix back to the original author of that file kept ownership intact and avoided a second reviewer re-litigating the same line.

**✅ What Was Implemented**

Reformatted the entry helper in the activity-buckets test file from a single 126-character arrow-function expression into a multi-line object literal, bringing it under the 120-column limit enforced by the project's formatter.

**📋 Future Enhancements**

- The lint invocation pipeline swallows the real exit code (reporting success even when checks fail), so failures must be read from the output text — a known trap worth fixing in the tooling.

**📁 FILES**
- `cli/src/dashboard/ActivityBuckets.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 17, 2026 at 2:03 PM · via mixed: Local agent - OpenCode, Local agent - Claude Code*
<!-- jollimemory-summary-end -->