### PR TITLE
Remove and auto-prune stale registry entries

### DIFF
--- a/cli/src/Api.test.ts
+++ b/cli/src/Api.test.ts
@@ -74,6 +74,10 @@ vi.mock("./core/SessionTracker.js", () => ({
 vi.mock("./core/Locks.js", () => ({
 	isWorkerLockStale: vi.fn().mockResolvedValue(false),
 	releaseWorkerLock: vi.fn().mockResolvedValue(undefined),
+	// The repo-registry row's dry-run repair pass takes this lock. A plain
+	// pass-through rather than a spy: these tests are about the CLI's output, and an
+	// unmocked export throws on the very first doctor check that reaches it.
+	withRepoRegistryLock: async <T>(fn: () => Promise<T>) => fn(),
 }));
 
 // Default no-op; individual tests use `mockImplementationOnce` to inject

--- a/cli/src/commands/DashboardCommand.test.ts
+++ b/cli/src/commands/DashboardCommand.test.ts
@@ -24,6 +24,14 @@ vi.mock("../dashboard/Backup.js", () => ({
 vi.mock("../dashboard/AutoCutover.js", () => ({
 	maybeAutoCutover: vi.fn().mockResolvedValue("skipped"),
 }));
+// The history import prunes fixture entries before it reads the registry.
+// Mocked because the real one is a registry read plus `existsSync` over whatever
+// paths the developer's own machine has, and because a swallowed failure there
+// would otherwise make this wiring untestable — `pruneDisposableRepos` never
+// throws by contract.
+vi.mock("../dashboard/RepoForget.js", () => ({
+	pruneDisposableRepos: vi.fn(async () => []),
+}));
 vi.mock("../dashboard/RepoRegistry.js", () => ({
 	registerRepo: vi.fn(
 		async (): Promise<RegisteredRepo> => ({
@@ -54,6 +62,7 @@ import { opportunisticSnapshot } from "../dashboard/Backup.js";
 import { canUseDashboardDb } from "../dashboard/DashboardDb.js";
 import { DASHBOARD_HEALTH_SERVICE } from "../dashboard/DashboardServer.js";
 import { dbBackfillRepos, type SessionTierSummary } from "../dashboard/DbBackfill.js";
+import { pruneDisposableRepos } from "../dashboard/RepoForget.js";
 import { listActiveRepos, registerRepo } from "../dashboard/RepoRegistry.js";
 import {
 	createDeferredWriter,
@@ -157,6 +166,7 @@ beforeEach(() => {
 	});
 	vi.mocked(dbBackfillRepos).mockResolvedValue([{ mode: "bootstrapped", eventsApplied: 3, repoName: "jolli" }]);
 	vi.mocked(listActiveRepos).mockResolvedValue([]);
+	vi.mocked(pruneDisposableRepos).mockResolvedValue([]);
 	// Enabled unless a case says otherwise. Re-armed here for the same reason as
 	// the others: `clearMocks` drops the factory's implementation.
 	vi.mocked(readManualDisableFlagSync).mockReturnValue(false);
@@ -203,6 +213,88 @@ describe("importDashboardHistory — the disabled repo", () => {
 		vi.mocked(readManualDisableFlagSync).mockReturnValueOnce(true);
 		await importDashboardHistory("/w", deps());
 		expect(vi.mocked(console.log).mock.calls.flat().join("\n")).toContain("disabled here");
+	});
+});
+
+describe("importDashboardHistory — the fixture prune", () => {
+	const forgotten = (identity: string) => ({
+		identity,
+		removedFromRegistry: true,
+		repoRowDeleted: true,
+		childRowsDeleted: 0,
+		pendingEventsDeleted: 0,
+	});
+
+	it("prunes before reading the registry, so a fixture is not imported on its way out", async () => {
+		const order: string[] = [];
+		vi.mocked(pruneDisposableRepos).mockImplementation(async () => {
+			order.push("prune");
+			return [];
+		});
+		vi.mocked(listActiveRepos).mockImplementation(async () => {
+			order.push("list");
+			return [];
+		});
+
+		await importDashboardHistory("/w", deps());
+
+		expect(order).toEqual(["prune", "list"]);
+	});
+
+	it("says on screen how many entries it removed", async () => {
+		// `log.info` alone is not enough: it is suppressed from the terminal in CLI
+		// mode, and these removals are irreversible.
+		vi.mocked(pruneDisposableRepos).mockResolvedValue([forgotten("local:a"), forgotten("local:b")]);
+
+		await importDashboardHistory("/w", deps());
+
+		const printed = vi.mocked(console.log).mock.calls.flat().join("\n");
+		expect(printed).toContain("Removed 2 temporary-checkout entries");
+	});
+
+	it("says nothing when there was nothing to remove", async () => {
+		await importDashboardHistory("/w", deps());
+		const printed = vi.mocked(console.log).mock.calls.flat().join("\n");
+		expect(printed).not.toContain("temporary-checkout");
+	});
+
+	it("uses the singular for one entry", async () => {
+		vi.mocked(pruneDisposableRepos).mockResolvedValue([forgotten("local:a")]);
+		await importDashboardHistory("/w", deps());
+		const printed = vi.mocked(console.log).mock.calls.flat().join("\n");
+		expect(printed).toContain("Removed 1 temporary-checkout entry");
+	});
+
+	it("counts only the entries that were actually removed", async () => {
+		// `pruneDisposableRepos` reports one result per VICTIM, failures included: a
+		// repo whose rows a locked database kept comes back with `error` set and its
+		// registry entry still in place. Counting the array claimed a removal for it.
+		vi.mocked(pruneDisposableRepos).mockResolvedValue([
+			forgotten("local:a"),
+			{ ...forgotten("local:b"), removedFromRegistry: false, repoRowDeleted: false, error: "database is locked" },
+		]);
+
+		await importDashboardHistory("/w", deps());
+
+		const printed = vi.mocked(console.log).mock.calls.flat().join("\n");
+		expect(printed).toContain("Removed 1 temporary-checkout entry");
+		expect(printed).not.toContain("Removed 2");
+		// And the failure is reported rather than netted off — silence would read as
+		// "there was nothing to prune".
+		expect(printed).toContain("1 temporary-checkout entry could not be removed");
+	});
+
+	it("reports a prune that removed nothing at all", async () => {
+		vi.mocked(pruneDisposableRepos).mockResolvedValue([
+			{ ...forgotten("local:a"), removedFromRegistry: false, repoRowDeleted: false, error: "database is locked" },
+			{ ...forgotten("local:b"), removedFromRegistry: false, repoRowDeleted: false, error: "database is locked" },
+		]);
+
+		await importDashboardHistory("/w", deps());
+
+		const printed = vi.mocked(console.log).mock.calls.flat().join("\n");
+		expect(printed).not.toContain("Removed");
+		expect(printed).toContain("2 temporary-checkout entries could not be removed");
 	});
 });
 

--- a/cli/src/commands/DashboardCommand.ts
+++ b/cli/src/commands/DashboardCommand.ts
@@ -51,6 +51,7 @@ import {
 	dbBackfillRepos,
 	type SessionSourceTotals,
 } from "../dashboard/DbBackfill.js";
+import { pruneDisposableRepos } from "../dashboard/RepoForget.js";
 import { listActiveRepos, registerRepo } from "../dashboard/RepoRegistry.js";
 import { type ServerTelemetryHandle, startServerTelemetry } from "../dashboard/ServerTelemetry.js";
 import { createLogger, errMsg } from "../Logger.js";
@@ -700,6 +701,36 @@ const HISTORY_HEADER = "\n  Indexing your git history…";
 async function runHistoryImport(deps: DashboardDeps): Promise<void> {
 	const output = outputOf(deps);
 	try {
+		// BEFORE the sweep reads the registry, so a fixture entry is not imported one
+		// more time on its way out. Here rather than in `executeDashboard` because
+		// both callers reach the sweep through this function, and a machine that only
+		// ever runs `jolli enable` should not accumulate them for ever.
+		//
+		// Never throws, and returns what it removed rather than logging only: the
+		// removals are irreversible, so the count belongs on screen and not just in
+		// `debug.log`, which is suppressed from the terminal in CLI mode. Every
+		// identity is in the log; these lines are the signal that sends a reader there.
+		const pruned = await pruneDisposableRepos({
+			...(deps.configDir ? { configDir: deps.configDir } : {}),
+			...(deps.dbPath ? { dbPath: deps.dbPath } : {}),
+		});
+		// One result per victim, FAILURES INCLUDED: `forgetRepos` reports a repo whose
+		// rows it could not delete with `error` set and its registry entry left in
+		// place, so counting the whole array claims a removal for every entry a locked
+		// database made it skip. Reported separately rather than netted off — a silent
+		// prune failure reads as "there was nothing to prune".
+		const removed = pruned.filter((r) => r.error === undefined);
+		const failed = pruned.length - removed.length;
+		if (removed.length > 0) {
+			const n = removed.length;
+			output.log(
+				`\n  Removed ${n} temporary-checkout ${n === 1 ? "entry" : "entries"} whose folder no longer exists.`,
+			);
+		}
+		if (failed > 0) {
+			const label = failed === 1 ? "entry" : "entries";
+			output.log(`\n  ${failed} temporary-checkout ${label} could not be removed — see debug.log.`);
+		}
 		const repos = await listActiveRepos(deps.configDir);
 		// Zero registered repos stays completely silent, header included: there is
 		// no work, and announcing none is worse than saying nothing. The call still

--- a/cli/src/commands/DoctorCommand.test.ts
+++ b/cli/src/commands/DoctorCommand.test.ts
@@ -44,6 +44,10 @@ vi.mock("../core/LlmClient.js", () => ({ resolveLlmCredentialSource: h.resolveLl
 vi.mock("../core/Locks.js", () => ({
 	isWorkerLockStale: h.isWorkerLockStale,
 	releaseWorkerLock: h.releaseWorkerLock,
+	// The repo-registry row's dry-run repair pass takes this lock. A plain
+	// pass-through rather than a spy: these tests are about doctor's output, and an
+	// unmocked export throws on the very first check that reaches it.
+	withRepoRegistryLock: async <T>(fn: () => Promise<T>) => fn(),
 }));
 vi.mock("../core/localagent/BackendRegistry.js", () => ({ getBackend: h.getBackend }));
 vi.mock("../core/RepoProfile.js", () => ({
@@ -121,6 +125,39 @@ describe("DoctorCommand — local-agent tool diagnostic", () => {
 	afterEach(() => {
 		vi.clearAllMocks();
 		process.exitCode = undefined;
+	});
+
+	it("survives a registry it cannot read, and still prints every other check", async () => {
+		// The repo-registry row reads STRICTLY (its repair pass is a
+		// read-modify-write), so corrupt JSON throws — and nothing has been printed
+		// by then, so an unguarded throw costs the user all ten diagnoses above it on
+		// exactly the machine doctor exists for.
+		const { mkdtempSync, rmSync, writeFileSync } = await import("node:fs");
+		const { tmpdir } = await import("node:os");
+		const { join } = await import("node:path");
+		const dir = mkdtempSync(join(tmpdir(), "jolli-doctor-corrupt-"));
+		h.getGlobalConfigDir.mockReturnValue(dir);
+		writeFileSync(join(dir, "dashboard-repos.json"), "{ not json", "utf-8");
+		h.getBackend.mockReturnValue({
+			discoverExecutable: vi.fn().mockResolvedValue({ file: "/usr/bin/claude", version: "2.0.0" }),
+		});
+
+		try {
+			const joined = (await runDoctor()).join("\n");
+
+			expect(joined).toContain("Jolli Memory Doctor");
+			expect(joined).toContain("Git hooks");
+			expect(joined).toContain("Repo registry");
+			expect(joined).toContain("unreadable");
+			// The survey reads fail-open, so it would have answered "0 repos, every
+			// recorded checkout present" about a registry nothing could read. Sharing
+			// the guard is what stops that reaching the screen.
+			expect(joined).not.toContain("every recorded checkout present");
+			expect(process.exitCode).toBe(1);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+			process.exitCode = undefined;
+		}
 	});
 
 	it("probes getBackend with the configured localAgentTool (not the claude-code default)", async () => {
@@ -269,6 +306,39 @@ describe("DoctorCommand — local-agent tool diagnostic", () => {
 		expect(lines).toContain("absent (expected");
 		expect(lines).not.toContain("will be created on first commit");
 	});
+
+	it("--dry-run lists what --fix would do and applies nothing", async () => {
+		h.getStatus.mockResolvedValue({
+			gitHookInstalled: false,
+			claudeHookInstalled: true,
+			geminiHookInstalled: true,
+		});
+
+		const lines = (await runDoctor(["--dry-run"])).join("\n");
+
+		expect(lines).toContain("--fix would apply:");
+		expect(lines).toContain("→ Git hooks:");
+		expect(lines).not.toContain("Applying fixes...");
+		expect(h.install).not.toHaveBeenCalled();
+		// Nothing was repaired, so it exits like a plain report.
+		expect(process.exitCode).toBe(1);
+	});
+
+	it("--fix applies the fixers and reports each one", async () => {
+		h.getStatus.mockResolvedValue({
+			gitHookInstalled: false,
+			claudeHookInstalled: true,
+			geminiHookInstalled: true,
+		});
+		h.install.mockResolvedValue({ success: true, warnings: [] });
+
+		const lines = (await runDoctor(["--fix"])).join("\n");
+
+		expect(lines).toContain("Applying fixes...");
+		expect(lines).toContain("Git hooks: reinstalled");
+		expect(lines).not.toContain("--fix would apply:");
+		expect(h.install).toHaveBeenCalled();
+	});
 });
 
 describe("global daemon check", () => {
@@ -293,6 +363,304 @@ describe("global daemon check", () => {
 		// the row that reports whether they ACTUALLY landed is "Database backup".
 		expect(check.status).toBe("warn");
 		expect(check.message).toContain("not running");
+	});
+});
+
+describe("repo registry check", () => {
+	const repo = (repoIdentity: string, worktreeRoot: string) => ({
+		repoIdentity,
+		repoName: "r",
+		worktreeRoot,
+		enabledAt: "t",
+	});
+	const empty = { live: [], disposable: [], dead: [], unavailable: [] };
+	const fixer = async () => "did it";
+
+	it("is ok, and offers no fixer, when every recorded checkout is present", async () => {
+		const { formatRepoRegistryCheck } = await import("./DoctorCommand.js");
+		const check = formatRepoRegistryCheck({ ...empty, live: [repo("a", "/here")] }, [], fixer);
+
+		expect(check.status).toBe("ok");
+		expect(check.message).toContain("1 repo");
+		expect(check.fixer).toBeUndefined();
+	});
+
+	it("warns rather than failing — a stale entry breaks nothing", async () => {
+		const { formatRepoRegistryCheck } = await import("./DoctorCommand.js");
+		const check = formatRepoRegistryCheck({ ...empty, dead: [repo("a", "/gone")] }, [], fixer);
+
+		// A `fail` would exit 1 on an otherwise healthy machine over a row that
+		// only wastes a sweep.
+		expect(check.status).toBe("warn");
+	});
+
+	it("offers no fixer for a dead entry until --forget-dead-repos is passed", async () => {
+		const { formatRepoRegistryCheck } = await import("./DoctorCommand.js");
+		const survey = { ...empty, dead: [repo("a", "/gone")] };
+
+		// Plain `--fix` must not delete a repo's memories as a side effect of
+		// releasing a lock — and a button that would do nothing is not offered.
+		const plain = formatRepoRegistryCheck(survey, [], fixer);
+		expect(plain.fixer).toBeUndefined();
+		expect(plain.message).toContain("1 to forget with --forget-dead-repos");
+		expect(plain.message).toContain("removed by --fix --forget-dead-repos");
+
+		const optedIn = formatRepoRegistryCheck(survey, [], fixer, { forgetDead: true });
+		expect(optedIn.fixer).toBeDefined();
+		expect(optedIn.message).toContain("1 entry to remove");
+		expect(optedIn.message).not.toContain("--forget-dead-repos");
+	});
+
+	it("still offers the repair fixer while a dead entry waits for its flag", async () => {
+		const { formatRepoRegistryCheck } = await import("./DoctorCommand.js");
+		const check = formatRepoRegistryCheck(
+			{ ...empty, dead: [repo("a", "/gone")] },
+			[{ repoIdentity: "b", droppedPaths: ["/tmp/x"], collapsedPaths: [] }],
+			fixer,
+		);
+
+		// The two halves are independent: withholding the removal must not withhold
+		// the path repair, which deletes nothing.
+		expect(check.fixer).toBeDefined();
+		expect(check.message).toContain("1 to repair");
+	});
+
+	it("names every entry rather than only counting them", async () => {
+		const { formatRepoRegistryCheck } = await import("./DoctorCommand.js");
+		const check = formatRepoRegistryCheck(
+			{
+				...empty,
+				disposable: [repo("local:t", "/tmp/fix/repo")],
+				dead: [repo("https://x/y", "/gone/real")],
+			},
+			[],
+			fixer,
+			{ forgetDead: true },
+		);
+
+		expect(check.message).toContain("2 entries to remove");
+		expect(check.message).toContain("/tmp/fix/repo");
+		expect(check.message).toContain("/gone/real");
+		expect(check.message).toContain("removed automatically");
+		expect(check.message).toContain("removed by --fix");
+	});
+
+	it("reports an unavailable volume and offers NO fixer for it", async () => {
+		const { formatRepoRegistryCheck } = await import("./DoctorCommand.js");
+		const check = formatRepoRegistryCheck({ ...empty, unavailable: [repo("a", "Z:\\work\\repo")] }, [], fixer);
+
+		// The ticket's rule: warn, never remove. A button that must not act is
+		// worse than no button.
+		expect(check.status).toBe("warn");
+		expect(check.fixer).toBeUndefined();
+		expect(check.message).toContain("not mounted");
+		expect(check.message).toContain("left alone");
+	});
+
+	describe("the fixer", () => {
+		let fixDir: string;
+
+		beforeEach(async () => {
+			const { mkdtempSync } = await import("node:fs");
+			const { tmpdir } = await import("node:os");
+			const { join } = await import("node:path");
+			fixDir = mkdtempSync(join(tmpdir(), "jolli-doctor-fix-"));
+		});
+
+		afterEach(async () => {
+			const { rmSync } = await import("node:fs");
+			rmSync(fixDir, { recursive: true, force: true });
+		});
+
+		const seedRegistry = async (repos: ReadonlyArray<unknown>): Promise<void> => {
+			const { getRepoRegistryPath } = await import("../dashboard/RepoRegistry.js");
+			const { writeFileSync } = await import("node:fs");
+			writeFileSync(getRepoRegistryPath(fixDir), JSON.stringify({ version: 1, repos }), "utf-8");
+		};
+
+		it("backs the registry up before removing anything, and says where", async () => {
+			const { applyRepoRegistryFix } = await import("./DoctorCommand.js");
+			const { existsSync, readFileSync } = await import("node:fs");
+			const { getRepoRegistryPath } = await import("../dashboard/RepoRegistry.js");
+			await seedRegistry([{ repoIdentity: "https://x/y", repoName: "r", worktreeRoot: "/gone", enabledAt: "t" }]);
+
+			const message = await applyRepoRegistryFix(
+				{ ...empty, dead: [repo("https://x/y", "/gone")] },
+				{
+					configDir: fixDir,
+					dbPath: `${fixDir}/none.db`,
+					nowMs: Date.UTC(2026, 7, 17, 1, 2, 3),
+					forgetDead: true,
+				},
+			);
+
+			expect(message).toContain("backed up the registry to");
+			expect(message).toContain("forgot 1 entry");
+			// The backup holds the state BEFORE the removal — that is the whole point.
+			// `[^;]+`, not `\S+`: the parts are joined with "; " and a path has no
+			// spaces to stop a greedy match at.
+			const backup = /backed up the registry to ([^;]+)/.exec(message)?.[1];
+			expect(backup && existsSync(backup)).toBe(true);
+			expect(JSON.parse(readFileSync(backup as string, "utf-8")).repos).toHaveLength(1);
+			expect(JSON.parse(readFileSync(getRepoRegistryPath(fixDir), "utf-8")).repos).toEqual([]);
+		});
+
+		it("throws when a removal failed rather than reporting a partial success", async () => {
+			const { applyRepoRegistryFix } = await import("./DoctorCommand.js");
+			const forget = await import("../dashboard/RepoForget.js");
+			const spy = vi.spyOn(forget, "forgetRepos").mockResolvedValue([
+				{
+					identity: "https://x/y",
+					removedFromRegistry: false,
+					repoRowDeleted: false,
+					childRowsDeleted: 0,
+					pendingEventsDeleted: 0,
+					error: "database is locked",
+				},
+			]);
+			try {
+				await expect(
+					applyRepoRegistryFix(
+						{ ...empty, dead: [repo("https://x/y", "/gone")] },
+						{ configDir: fixDir, forgetDead: true },
+					),
+				).rejects.toThrow(/database is locked/);
+			} finally {
+				spy.mockRestore();
+			}
+		});
+
+		it("leaves a dead entry alone unless the fix was asked for it", async () => {
+			const { applyRepoRegistryFix } = await import("./DoctorCommand.js");
+			const forget = await import("../dashboard/RepoForget.js");
+			const spy = vi.spyOn(forget, "forgetRepos");
+			await seedRegistry([{ repoIdentity: "https://x/y", repoName: "r", worktreeRoot: "/gone", enabledAt: "t" }]);
+
+			try {
+				const message = await applyRepoRegistryFix(
+					{ ...empty, dead: [repo("https://x/y", "/gone")] },
+					{ configDir: fixDir },
+				);
+
+				// The registry is still backed up (the repair pass rewrites it too), but
+				// nothing was forgotten — the twelve child tables `forgetRepos` deletes
+				// are exactly what no backup here restores.
+				expect(spy).not.toHaveBeenCalled();
+				expect(message).not.toContain("forgot");
+				const { readFileSync } = await import("node:fs");
+				const { getRepoRegistryPath } = await import("../dashboard/RepoRegistry.js");
+				expect(JSON.parse(readFileSync(getRepoRegistryPath(fixDir), "utf-8")).repos).toHaveLength(1);
+			} finally {
+				spy.mockRestore();
+			}
+		});
+
+		/**
+		 * JOLLI-2212's acceptance case, on the shape it was measured in: a registry
+		 * carrying 84 fixture entries under the system temp directory plus ONE real
+		 * repo whose `worktrees` had two of those fixture paths merged into it. One
+		 * pass has to remove the 84 and repair the 1, without touching the real
+		 * repo's own checkout.
+		 *
+		 * The `C:` / `c:` half of that entry is pinned by RepoRegistry's own win32
+		 * case instead: `sameRecordedRoot` folds case by platform on purpose, and the
+		 * doctor's fixer takes the host's — so asserting it here would pass on Windows
+		 * and quietly assert nothing on Linux.
+		 */
+		it("removes the measured fixture entries and repairs the real one in a single pass", async () => {
+			const { surveyRepoRegistry } = await import("../dashboard/RepoForget.js");
+			const { applyRepoRegistryFix } = await import("./DoctorCommand.js");
+			const { getRepoRegistryPath } = await import("../dashboard/RepoRegistry.js");
+			const { mkdirSync, mkdtempSync, readFileSync, rmSync } = await import("node:fs");
+			const { tmpdir } = await import("node:os");
+			const { join } = await import("node:path");
+
+			// Under the REAL temp dir: the fixer's repair pass asks `tempRoots()`, not
+			// an injected list, so a fake root would make the drop a no-op.
+			const scratch = mkdtempSync(join(tmpdir(), "jolli-2212-"));
+			const live = join(scratch, "jollimemory-design");
+			mkdirSync(live, { recursive: true });
+			const ghosts = [
+				join(scratch, "jolli-cutover-sG1Rx7", "repo"),
+				join(scratch, "jolli-cutover-sG1Rx7", "repo2"),
+			];
+			const fixtures = Array.from({ length: 84 }, (_, i) => ({
+				repoIdentity: `local:${String(i).padStart(32, "0")}`,
+				repoName: "repo",
+				worktreeRoot: join(scratch, `fixture-${i}`, "repo"),
+				enabledAt: "1970-01-01T00:00:00.000Z",
+			}));
+			await seedRegistry([
+				...fixtures,
+				{
+					repoIdentity: "https://github.com/jolliai/jolli-design",
+					repoName: "jolli-design",
+					worktreeRoot: live,
+					worktrees: [...ghosts, live],
+					remoteUrl: "https://github.com/jolliai/jolli-design",
+					enabledAt: "2026-08-01T00:00:00.000Z",
+				},
+			]);
+
+			try {
+				const dbPath = join(scratch, "none.db");
+				const survey = await surveyRepoRegistry({ configDir: fixDir, dbPath });
+				expect(survey.disposable).toHaveLength(84);
+				expect(survey.live.map((r) => r.repoIdentity)).toEqual(["https://github.com/jolliai/jolli-design"]);
+
+				const message = await applyRepoRegistryFix(survey, { configDir: fixDir, dbPath });
+
+				expect(message).toContain("forgot 84 entries");
+				expect(message).toContain("repaired 1 entry");
+				const after = JSON.parse(readFileSync(getRepoRegistryPath(fixDir), "utf-8"));
+				expect(after.repos).toHaveLength(1);
+				expect(after.repos[0].repoIdentity).toBe("https://github.com/jolliai/jolli-design");
+				// The fixture paths are gone from its list; its own checkout is untouched.
+				expect(after.repos[0].worktrees).toEqual([live]);
+				expect(after.repos[0].worktreeRoot).toBe(live);
+			} finally {
+				rmSync(scratch, { recursive: true, force: true });
+			}
+		});
+
+		it("says so when there turned out to be nothing left to do", async () => {
+			// Reachable when another window cleaned up between the survey and the fix:
+			// nothing removable, nothing repairable, and no registry left to back up.
+			const { applyRepoRegistryFix } = await import("./DoctorCommand.js");
+			expect(await applyRepoRegistryFix(empty, { configDir: fixDir })).toBe("nothing left to do");
+		});
+	});
+
+	it("describes a repairable entry by what is wrong with it", async () => {
+		const { formatRepoRegistryCheck } = await import("./DoctorCommand.js");
+		const check = formatRepoRegistryCheck(
+			{ ...empty, live: [repo("id", "/here")] },
+			[{ repoIdentity: "id", droppedPaths: ["/tmp/x"], collapsedPaths: ["C:\\A"], repointedTo: "/here" }],
+			fixer,
+		);
+
+		expect(check.message).toContain("1 to repair");
+		expect(check.message).toContain("1 stale temp path(s)");
+		expect(check.message).toContain("1 duplicate spelling(s)");
+		expect(check.message).toContain("a dead recorded root");
+		expect(check.fixer).toBeDefined();
+	});
+
+	it("fails, with no fixer, when the registry could not be read at all", async () => {
+		const { formatRepoRegistryReadFailure } = await import("./DoctorCommand.js");
+		const check = formatRepoRegistryReadFailure(
+			"Unexpected token } in JSON at position 12",
+			"/home/u/.jolli/jollimemory/dashboard-repos.json",
+		);
+
+		// A fault, not a warning: every writer of this file is a read-modify-write
+		// over the strict read, so no repo can register until it is resolved.
+		expect(check.status).toBe("fail");
+		expect(check.message).toContain("Unexpected token");
+		expect(check.message).toContain("dashboard-repos.json");
+		// No fixer: the remedy discards every registration the file holds, which is
+		// not something `--fix` may decide on the user's behalf.
+		expect(check.fixer).toBeUndefined();
 	});
 });
 

--- a/cli/src/commands/DoctorCommand.ts
+++ b/cli/src/commands/DoctorCommand.ts
@@ -43,9 +43,11 @@ import {
 	restoreFromSnapshot,
 	surveyRecovery,
 } from "../dashboard/Recovery.js";
+import { backupRepoRegistry, forgetRepos, type RegistrySurvey, surveyRepoRegistry } from "../dashboard/RepoForget.js";
+import { getRepoRegistryPath, type RegistryRepair, repairRegistryEntries } from "../dashboard/RepoRegistry.js";
 import { traverseDistPaths } from "../install/DistPathResolver.js";
 import { getStatus, install } from "../install/Installer.js";
-import { createLogger, ORPHAN_BRANCH, setLogDir } from "../Logger.js";
+import { createLogger, errMsg, ORPHAN_BRANCH, setLogDir } from "../Logger.js";
 import { inspectPlugins } from "../PluginLoader.js";
 import { resolveProjectDir, VERSION } from "./CliUtils.js";
 
@@ -88,13 +90,188 @@ export function formatGlobalDaemonCheck(hello: GlobalDaemonHello | undefined, no
 }
 
 /**
+ * The repo-registry row: entries that name a checkout no longer on disk.
+ *
+ * A `warn`, never a `fail`, and the distinction is this command's own contract —
+ * doctor reports FAULTS, and a stale entry breaks nothing. It costs every sweep a
+ * pass and puts a dead row in the dashboard's repo picker, which is worth saying
+ * and is not worth a non-zero exit on an otherwise healthy machine.
+ *
+ * The message lists every entry, uncapped. This is a diagnostic the user ran on
+ * purpose, `--fix` is irreversible, and the list is the only thing they have to
+ * decide with — a summary count plus "see debug.log" is the shape that gets
+ * skipped. It also shrinks to nothing after the first fix.
+ *
+ * Exported and pure-ish (it takes the survey) so the wording can be asserted
+ * without a registry on disk.
+ */
+export function formatRepoRegistryCheck(
+	survey: RegistrySurvey,
+	repairs: ReadonlyArray<RegistryRepair>,
+	fixer: () => Promise<string>,
+	opts: { readonly forgetDead?: boolean } = {},
+): DoctorCheck {
+	const name = "Repo registry";
+	const forgetDead = opts.forgetDead === true;
+	// `dead` is opt-in — see {@link applyRepoRegistryFix}. It is still REPORTED
+	// either way, so the ok branch cannot key off `removable`, which is only what
+	// the fixer would act on.
+	const removable = [...survey.disposable, ...(forgetDead ? survey.dead : [])];
+	const reported = survey.disposable.length + survey.dead.length + survey.unavailable.length + repairs.length;
+	if (reported === 0) {
+		const n = survey.live.length;
+		return { name, status: "ok", message: `${n} repo${n === 1 ? "" : "s"}, every recorded checkout present` };
+	}
+	const lines: string[] = [];
+	for (const repo of survey.disposable) {
+		lines.push(`      · ${repo.worktreeRoot}  (temporary checkout — removed automatically)`);
+	}
+	const deadBy = forgetDead ? "--fix" : "--fix --forget-dead-repos";
+	for (const repo of survey.dead) lines.push(`      · ${repo.worktreeRoot}  (folder gone — removed by ${deadBy})`);
+	for (const repo of survey.unavailable) {
+		// Never in `removable`: an unplugged drive or an unmounted share is a repo
+		// the user still expects back, and removing it on this evidence would throw
+		// away a registration for a directory that returns. Reported so the silence
+		// does not read as health.
+		lines.push(`      · ${repo.worktreeRoot}  (drive or share not mounted — left alone)`);
+	}
+	for (const repair of repairs) {
+		const what = [
+			repair.droppedPaths.length > 0 ? `${repair.droppedPaths.length} stale temp path(s)` : "",
+			repair.collapsedPaths.length > 0 ? `${repair.collapsedPaths.length} duplicate spelling(s)` : "",
+			repair.repointedTo !== undefined ? "a dead recorded root" : "",
+		].filter(Boolean);
+		lines.push(`      · ${repair.repoIdentity}  (${what.join(", ")} — repaired by --fix)`);
+	}
+	const headline = [
+		removable.length > 0 ? `${removable.length} entr${removable.length === 1 ? "y" : "ies"} to remove` : "",
+		!forgetDead && survey.dead.length > 0 ? `${survey.dead.length} to forget with --forget-dead-repos` : "",
+		repairs.length > 0 ? `${repairs.length} to repair` : "",
+		survey.unavailable.length > 0 ? `${survey.unavailable.length} on unavailable volumes` : "",
+	]
+		.filter(Boolean)
+		.join(", ");
+	return {
+		name,
+		status: "warn",
+		message: `${headline}\n${lines.join("\n")}`,
+		// No fixer when there is nothing this INVOCATION may act on: an unavailable
+		// volume is deliberately not repairable, a `dead` entry needs
+		// `--forget-dead-repos`, and offering a button that does nothing is worse
+		// than offering none. `removable`, not the reported set, is what says so.
+		...(removable.length > 0 || repairs.length > 0 ? { fixer } : {}),
+	};
+}
+
+/**
+ * The repo-registry row's remedy: back the registry up, forget what the survey
+ * found removable, then apply the path repairs.
+ *
+ * Exported and taking the survey as an argument for the same reason
+ * {@link formatRepoRegistryCheck} is: the fixer is the one half of this row that
+ * deletes data, and driving the whole command to reach it would mean running
+ * every other fixer too.
+ *
+ * **`dead` entries need `forgetDead` (`--forget-dead-repos`), and that is the
+ * consent this operation could not otherwise obtain.** `--fix` is a bundle — a
+ * user runs it to release a stale lock, clear a stuck queue or reinstall hooks —
+ * and forgetting a repo is not like the other three: `forgetRepos` deletes twelve
+ * child tables, the `repos` row and every unprojected event, none of which
+ * {@link backupRepoRegistry} can restore (it copies `dashboard-repos.json`, and
+ * that file holds none of it). The evidence is weak in the same direction:
+ * `classifyRegistryEntry` documents that an unmounted POSIX mountpoint usually
+ * still exists as an empty directory, so `dead` can hold a repo that is merely
+ * renamed or temporarily invisible. `disposable` stays in the default set — that
+ * class is fixture garbage under `%TEMP%` which the dashboard launch path already
+ * prunes unattended, so requiring a flag here would not protect anything.
+ *
+ * **The dashboard's per-row ✕ removes the same `dead` class on one confirm, and
+ * that is not the contradiction it looks like.** What the flag buys is not a
+ * second look at the evidence — it is a NAMED TARGET. `--fix` is asked for by a
+ * user who wants something else entirely and would sweep whatever the survey
+ * happened to classify; the ✕ is attached to one row, in a dialog that says what
+ * it deletes, for the repository the user pointed at. `DashboardServer.handleForget`
+ * carries the two guards this side cannot express in a flag: it re-asks at action
+ * time, because its control is drawn from a payload minutes old, and it refuses
+ * `unavailable` unless the request carries a per-row acknowledgement the page only
+ * sets after naming the volume in a second dialog. THIS side stays stricter and
+ * never removes `unavailable` at all: a sweep has no row to point at and no dialog
+ * to show, so there is nothing here for such an acknowledgement to mean. It takes
+ * this same backup first, for the same ordering reason, and with the same limit:
+ * the file holds no memories, so neither path may treat it as what makes a removal
+ * recoverable.
+ */
+export async function applyRepoRegistryFix(
+	survey: RegistrySurvey,
+	opts: {
+		readonly nowMs?: number;
+		readonly configDir?: string;
+		readonly dbPath?: string;
+		readonly forgetDead?: boolean;
+	} = {},
+): Promise<string> {
+	const done: string[] = [];
+	// Backup FIRST: everything below is irreversible, and a backup taken after the
+	// first removal is a backup of the damage.
+	const saved = backupRepoRegistry(opts.nowMs ?? Date.now(), opts.configDir);
+	if (saved) done.push(`backed up the registry to ${saved}`);
+	// `unavailable` is deliberately absent: an unplugged drive is a repo the user
+	// still expects back, so it is reported and never removed. `dead` is absent
+	// unless asked for — see above.
+	const removable = [...survey.disposable, ...(opts.forgetDead === true ? survey.dead : [])];
+	if (removable.length > 0) {
+		const results = await forgetRepos(
+			removable.map((repo) => repo.repoIdentity),
+			{
+				...(opts.configDir ? { configDir: opts.configDir } : {}),
+				...(opts.dbPath ? { dbPath: opts.dbPath } : {}),
+			},
+		);
+		const failed = results.filter((r) => r.error !== undefined);
+		// Thrown, not counted: the fixer contract is that a throw is what makes the
+		// loop print ✗ and set the exit code, and a partial removal reported as
+		// success is exactly the state a user would not run doctor again over.
+		if (failed.length > 0) {
+			throw new Error(`could not forget ${failed.length} of ${results.length} entries — ${failed[0].error}`);
+		}
+		done.push(`forgot ${results.length} entr${results.length === 1 ? "y" : "ies"}`);
+	}
+	const applied = await repairRegistryEntries(opts.configDir ? { configDir: opts.configDir } : {});
+	if (applied.length > 0) done.push(`repaired ${applied.length} entr${applied.length === 1 ? "y" : "ies"}`);
+	return done.length > 0 ? done.join("; ") : "nothing left to do";
+}
+
+/**
+ * The repo-registry row when the registry could not be READ at all.
+ *
+ * A `fail` with no fixer, and both halves are deliberate. It is a fault rather
+ * than a warning because every writer of this file — `registerRepo`,
+ * `ensureWorktreeListed`, `deregisterRepo`, the prune — is a read-modify-write
+ * over `readRepoRegistryStrict`, so an unreadable registry means no repo can
+ * register on this machine until it is dealt with. And there is no fixer because
+ * the remedy is the one thing this command must not do unasked: the file has to be
+ * moved aside, which discards every registration it holds.
+ */
+export function formatRepoRegistryReadFailure(reason: string, path: string): DoctorCheck {
+	return {
+		name: "Repo registry",
+		status: "fail",
+		message:
+			`unreadable — ${reason}\n` +
+			`      · ${path}\n` +
+			"      · no repo can register until this is resolved; move the file aside and re-run `jolli enable`\n" +
+			"        in each repo to rebuild it (every registration in it is lost)",
+	};
+}
+
+/**
  * Diagnoses system health and optionally auto-repairs failures.
  *
  * Rule of thumb:
  *   doctor → "is Jolli Memory working?"
  *   clean  → "what old data can I safely delete?"
  */
-async function runDoctor(cwd: string, fix: boolean): Promise<void> {
+async function runDoctor(cwd: string, fix: boolean, dryRun = false, forgetDead = false): Promise<void> {
 	const checks: DoctorCheck[] = [];
 
 	// 1. Installer status (hooks)
@@ -378,6 +555,38 @@ async function runDoctor(cwd: string, fix: boolean): Promise<void> {
 			: {}),
 	});
 
+	// 11. Repo registry — entries whose checkout is gone. Its own row rather than
+	// part of the backup one because it is the only check about the machine's LIST
+	// of repos rather than about one repo's data, and the only one whose fixer
+	// removes something.
+	//
+	// The repair half is computed with `dryRun`, i.e. by the pass that would apply
+	// it, so the preview cannot drift from the fix. The removals come from the
+	// survey, which is read-only anyway.
+	//
+	// Guarded, and the guard covers BOTH calls. `repairRegistryEntries` reads the
+	// registry strictly (it is a read-modify-write), so corrupt JSON, an EACCES or a
+	// Windows AV hold throws — on precisely the machine this command exists for. An
+	// unguarded throw here costs every other check too: nothing has been PRINTED
+	// yet, so the user gets `Fatal error:` in place of all ten diagnoses above.
+	// `surveyRepoRegistry` is inside the same `try` because it reads fail-open:
+	// reporting its answer after the strict read failed would print "0 repos, every
+	// recorded checkout present" about a registry that could not be read at all.
+	try {
+		const registrySurvey = await surveyRepoRegistry();
+		const registryRepairs = await repairRegistryEntries({ dryRun: true });
+		checks.push(
+			formatRepoRegistryCheck(
+				registrySurvey,
+				registryRepairs,
+				() => applyRepoRegistryFix(registrySurvey, { forgetDead }),
+				{ forgetDead },
+			),
+		);
+	} catch (err) {
+		checks.push(formatRepoRegistryReadFailure(errMsg(err), getRepoRegistryPath()));
+	}
+
 	// Print results
 	console.log("\n  Jolli Memory Doctor");
 	console.log("  ──────────────────────────────────────");
@@ -389,12 +598,21 @@ async function runDoctor(cwd: string, fix: boolean): Promise<void> {
 		const icon = check.status === "ok" ? "✓" : check.status === "warn" ? "⚠" : "✗";
 		console.log(`  ${icon} ${check.name.padEnd(16)} ${check.message}`);
 		if (check.status === "fail") hasFailures = true;
-		if (fix && check.fixer) fixesToApply.push(check);
+		// `--dry-run` collects the same set `--fix` would, so what it lists is what
+		// would run rather than a second opinion about it.
+		if ((fix || dryRun) && check.fixer) fixesToApply.push(check);
+	}
+
+	if (dryRun && fixesToApply.length > 0) {
+		console.log("\n  --fix would apply:");
+		// The message, not a paraphrase — every fixer's row already names what it
+		// found, and restating it here would be a second wording to keep in step.
+		for (const check of fixesToApply) console.log(`  → ${check.name}: ${check.message}`);
 	}
 
 	// Apply fixes if requested.
 	let fixFailures = 0;
-	if (fix && fixesToApply.length > 0) {
+	if (fix && !dryRun && fixesToApply.length > 0) {
 		console.log("\n  Applying fixes...");
 		for (const check of fixesToApply) {
 			/* v8 ignore start -- defensive: fixesToApply already filtered by check.fixer existence */
@@ -422,8 +640,9 @@ async function runDoctor(cwd: string, fix: boolean): Promise<void> {
 	//   - Fix mode:     only remaining failures count (fixer threw, or fail
 	//                   check has no fixer at all). Successfully-applied
 	//                   fixers are assumed to have repaired the condition.
+	//   - Dry run:       nothing was repaired, so it exits like a plain report.
 	const unfixableFailures = checks.filter((c) => c.status === "fail" && !c.fixer).length;
-	if (fix) {
+	if (fix && !dryRun) {
 		if (fixFailures > 0 || unfixableFailures > 0) {
 			process.exitCode = 1;
 		}
@@ -716,7 +935,15 @@ export function registerDoctorCommand(program: Command): void {
 	program
 		.command("doctor")
 		.description("Diagnose Jolli Memory health; optionally auto-fix issues")
-		.option("--fix", "Auto-fix detected issues (release stale lock, clear stuck queue, reinstall missing hooks)")
+		.option(
+			"--fix",
+			"Auto-fix detected issues (release stale lock, clear stuck queue, reinstall missing hooks, repair registry paths)",
+		)
+		.option(
+			"--forget-dead-repos",
+			"With --fix: also forget registry entries whose folder is gone — deletes those repos' memories, which no backup here restores",
+		)
+		.option("--dry-run", "Print what --fix would do and change nothing")
 		.option("--recover", "List database recovery candidates (snapshots with identity and age)")
 		.option("--from <path>", "With --recover: restore the database from this snapshot file")
 		.option("--schema-log", "Print the database's migration log (who ran what, when, and how it went)")
@@ -726,6 +953,8 @@ export function registerDoctorCommand(program: Command): void {
 			async (options: {
 				cwd: string;
 				fix?: boolean;
+				forgetDeadRepos?: boolean;
+				dryRun?: boolean;
 				recover?: boolean;
 				from?: string;
 				schemaLog?: boolean;
@@ -744,7 +973,12 @@ export function registerDoctorCommand(program: Command): void {
 					await runSchemaLog({ mark: options.markMigration });
 					return;
 				}
-				await runDoctor(options.cwd, options.fix === true);
+				await runDoctor(
+					options.cwd,
+					options.fix === true,
+					options.dryRun === true,
+					options.forgetDeadRepos === true,
+				);
 			},
 		);
 }

--- a/cli/src/core/GitFsLayout.test.ts
+++ b/cli/src/core/GitFsLayout.test.ts
@@ -210,13 +210,22 @@ describe("resolveGitFsLayout", () => {
 	});
 
 	describe("path spelling", () => {
-		/** A symlink pointing at the repo, standing in for macOS's /tmp → /private/tmp. */
+		/**
+		 * A link pointing at the repo, standing in for macOS's /tmp → /private/tmp.
+		 *
+		 * Created as a `"junction"` rather than a `"dir"` symlink so the pair runs
+		 * everywhere: a directory symlink on Windows needs Developer Mode or elevation and
+		 * throws EPERM in the seed, while a junction needs neither and is resolved by
+		 * `realpathSync` the same way. The type argument is ignored on POSIX, where this
+		 * stays an ordinary symlink — so one call covers both, and what these assert
+		 * (`realpath` on / off) never becomes platform-gated.
+		 */
 		function seedRepoBehindSymlink(): string {
 			const real = join(root, "real");
 			mkdirSync(real, { recursive: true });
 			seedPlainRepo(real, "ref: refs/heads/main\n");
 			const link = join(root, "link");
-			symlinkSync(real, link, "dir");
+			symlinkSync(real, link, "junction");
 			return link;
 		}
 

--- a/cli/src/core/KBPathResolver.test.ts
+++ b/cli/src/core/KBPathResolver.test.ts
@@ -563,6 +563,10 @@ esac
 			expect(result).toBe(join(tempDir, "corrupt-2"));
 		});
 
+		// No per-test timeout: this seeds 99 folders of real files, and a 15 s override
+		// here NARROWED the 60 s in vite.config.ts rather than widening anything, so a
+		// full run with coverage timed it out on a slower filesystem — the exact trap
+		// that config's `testTimeout` note describes. Inherit the global budget.
 		it("falls back to a timestamp suffix when every -N slot is taken", () => {
 			initializeKBFolder(join(tempDir, "saturated"), "saturated", "https://github.com/u/a.git");
 			// Populate every -2..-99 candidate as a non-matching repo so findAvailablePath
@@ -579,7 +583,7 @@ esac
 			expect(result.startsWith(join(tempDir, "saturated-"))).toBe(true);
 			expect(result).not.toBe(join(tempDir, "saturated"));
 			expect(result).not.toBe(join(tempDir, "saturated-99"));
-		}, 15000);
+		});
 
 		it("walks past a candidate dir that has no .jolli/config.json", () => {
 			// Make the basePath a non-matching repo, then create a "name-2" dir without

--- a/cli/src/dashboard/Backup.test.ts
+++ b/cli/src/dashboard/Backup.test.ts
@@ -497,7 +497,12 @@ describe("rotation", () => {
 		expect(left).toContain(`memory-${formatUtcStamp(NOW - 2 * DAY)}-aaaaaaaa.db`);
 	});
 
-	it("a failed snapshot leaves every old snapshot untouched", async () => {
+	// POSIX-only, and it is the FAILURE that cannot be induced rather than the
+	// assertion that cannot be made: `chmod` on Windows moves the read-only bit,
+	// which directories ignore for creation, so the snapshot below simply succeeds
+	// and the test would assert "failed" about a run that worked. Nothing weaker
+	// stands in — the point is a real write failure mid-snapshot, not a stubbed one.
+	it.skipIf(process.platform === "win32")("a failed snapshot leaves every old snapshot untouched", async () => {
 		plantSnapshot(`memory-${formatUtcStamp(NOW - 100 * DAY)}-aaaaaaaa.db`);
 		plantSnapshot(`memory-${formatUtcStamp(NOW - 90 * DAY)}-aaaaaaaa.db`);
 		// A read-only target folder makes VACUUM INTO's temp file un-creatable

--- a/cli/src/dashboard/DashboardCollector.test.ts
+++ b/cli/src/dashboard/DashboardCollector.test.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GitCommandResult, SessionInfo, TranscriptReadResult, TranscriptSource } from "../Types.js";
 
@@ -75,8 +76,17 @@ const claudeSession = (over: Partial<SessionInfo> = {}): SessionInfo => ({
 	...over,
 });
 
-/** A repo root the disk-scan fixtures below attribute themselves to. */
-const WORKTREE = "/w/repo";
+/**
+ * A repo root the disk-scan fixtures below attribute themselves to.
+ *
+ * `resolve()`d rather than a bare "/w/repo" literal, because one source's narrowing
+ * normalizes the project dir before matching: `copilotSessionsForRepo` runs it through
+ * `path.resolve()`, so on Windows the row's literal "/w/repo" would be compared against
+ * "<drive>:\w\repo" and never match — the same trap `CopilotSessionDiscoverer.test.ts`
+ * documents and avoids the same way. Resolving BOTH sides here keeps every source's
+ * comparison platform-neutral; the other eight compare the string as given.
+ */
+const WORKTREE = resolve("/w/repo");
 
 const diskSession = (over: Partial<ClaudeDiskSession> = {}): ClaudeDiskSession => ({
 	sessionId: "d1",

--- a/cli/src/dashboard/DashboardDb.test.ts
+++ b/cli/src/dashboard/DashboardDb.test.ts
@@ -634,7 +634,17 @@ describe("transactional migration runner", () => {
 });
 
 describe("owner-only permissions (§11 defect 1)", () => {
-	it("creates the directory 0700 and the database 0600", async () => {
+	/*
+	 * POSIX-only: `chmod` on Windows moves the read-only bit and nothing else, and `stat`
+	 * reports a fixed 0666/0777, so these would be assertions about a permission model
+	 * that does not exist there — the same gate `JsonMcpWriter.test.ts` and
+	 * `CodexTomlWriter.test.ts` put on their own mode checks. Applied per test rather
+	 * than to the describe, because the sidecar-tolerance case below is about the chmod
+	 * loop surviving ENOENT and is worth running on every platform.
+	 */
+	const itPosix = it.skipIf(process.platform === "win32");
+
+	itPosix("creates the directory 0700 and the database 0600", async () => {
 		const nested = join(dir, "cfg");
 		const target = join(nested, "dashboard.db");
 		await withDashboardDb(() => undefined, { dbPath: target });
@@ -643,7 +653,7 @@ describe("owner-only permissions (§11 defect 1)", () => {
 		expect(statSync(target).mode & 0o777).toBe(0o600);
 	});
 
-	it("tightens a database an older build left world-readable", async () => {
+	itPosix("tightens a database an older build left world-readable", async () => {
 		await withDashboardDb(() => undefined, { dbPath });
 		// Simulate the pre-fix state: 0644 file inside a 0755 directory.
 		chmodSync(dbPath, 0o644);
@@ -655,7 +665,7 @@ describe("owner-only permissions (§11 defect 1)", () => {
 		expect(statSync(dir).mode & 0o777).toBe(0o700);
 	});
 
-	it("leaves the WAL sidecars owner-only too", async () => {
+	itPosix("leaves the WAL sidecars owner-only too", async () => {
 		// Hold the handle open across a write so -wal/-shm exist while we look.
 		await withDashboardDb(
 			(db) => {
@@ -670,7 +680,7 @@ describe("owner-only permissions (§11 defect 1)", () => {
 		);
 	});
 
-	it("does not chmod on a read-only open — readers never touch permissions", async () => {
+	itPosix("does not chmod on a read-only open — readers never touch permissions", async () => {
 		await withDashboardDb(() => undefined, { dbPath });
 		chmodSync(dbPath, 0o640);
 

--- a/cli/src/dashboard/DashboardModel.ts
+++ b/cli/src/dashboard/DashboardModel.ts
@@ -853,6 +853,34 @@ export interface RepoOption {
 	 * so an active row's shape is unchanged.
 	 */
 	readonly disabled?: boolean;
+	/**
+	 * Present and `true` when `worktreeRoot` no longer exists on disk.
+	 *
+	 * MARKED, never filtered — the same decision as `disabled`, for a different
+	 * reason. A repo the user deleted keeps its memories, and those are worth
+	 * reaching; what must not happen is the row presenting itself as a working
+	 * checkout, since every action on it (resume, scope, open) names a directory
+	 * that is not there. It is also what gates the row's remove control: the page
+	 * offers to forget an entry only once it can say the entry is dead.
+	 */
+	readonly missing?: boolean;
+	/**
+	 * Present and `true` when nothing could be found because the VOLUME is absent —
+	 * an unplugged drive or an unmounted share — rather than because a folder was
+	 * deleted. Implies {@link missing}; never set on its own.
+	 *
+	 * Two states, not one, because `existsSync` cannot tell them apart and the row
+	 * used to assert the wrong one: it said "folder missing" and offered a ✕ over a
+	 * repository that was merely unplugged. Splitting them is what lets the page say
+	 * something true and ask for a stronger confirmation, instead of either lying or
+	 * withholding the control from a user who knows their own drive.
+	 *
+	 * The volume walk this needs (`volumeReachable`, one `existsSync` per ancestor)
+	 * runs ONLY for a row already found missing — the case that is rare by
+	 * construction — so the render path still asks the filesystem nothing extra
+	 * about a working repo.
+	 */
+	readonly volumeUnavailable?: boolean;
 }
 
 /**

--- a/cli/src/dashboard/DashboardQuery.test.ts
+++ b/cli/src/dashboard/DashboardQuery.test.ts
@@ -1,7 +1,17 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// `volumeReachable` keeps the REAL implementation; it is wrapped only because its
+// `false` answer is unreachable on POSIX, where every absolute path bottoms out at
+// a live `/`. That is the same seam `RepoForget` gives its own callers, and the only
+// way the volume-absent verdict can be covered on an ubuntu CI.
+vi.mock("./RepoForget.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./RepoForget.js")>();
+	return { ...actual, volumeReachable: vi.fn(actual.volumeReachable) };
+});
+
 import { withDashboardDb } from "./DashboardDb.js";
 import type {
 	DashboardScope,
@@ -22,6 +32,7 @@ import {
 	type QueryOptions,
 	startOfLocalDay,
 } from "./DashboardQuery.js";
+import { volumeReachable } from "./RepoForget.js";
 import { applyStatsEvents } from "./StatsWriter.js";
 
 /**
@@ -402,9 +413,20 @@ describe("buildDashboardModel", () => {
 		expect(model.timeZone).toBe("UTC");
 		// `sessionsThisWeek` is the sidebar's per-repo meta figure — both seeded
 		// sessions land inside the 7-day window.
-		expect(model.repos).toEqual([
-			{ repoIdentity: "repo-1", repoName: "jolli", worktreeRoot: "/w", sessionsThisWeek: 2 },
-		]);
+		//
+		// Deliberately not an exact-shape `toEqual`: `missing` is decided by whether
+		// `/w` exists, which is a property of the machine rather than of this test
+		// (it resolves to `C:\w` on Windows, and that directory does exist on some
+		// developer boxes). The flag has its own tests below and in RepoForget.
+		expect(model.repos).toHaveLength(1);
+		expect(model.repos[0]).toMatchObject({
+			repoIdentity: "repo-1",
+			repoName: "jolli",
+			worktreeRoot: "/w",
+			sessionsThisWeek: 2,
+		});
+		// An active row still carries no `disabled` key at all.
+		expect(model.repos[0].disabled).toBeUndefined();
 		expect(model.standup).toBeUndefined();
 
 		const stats = model.stats;
@@ -3290,5 +3312,171 @@ describe("knowledge & graph payloads", () => {
 			{ dbPath },
 		);
 		expect(fallback.graph).toEqual({ repos: [] });
+	});
+});
+
+describe("repo picker — checkouts that are gone", () => {
+	let dir: string;
+	let dbPath: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "jolli-dq-missing-"));
+		dbPath = join(dir, "d.db");
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	/** Rows straight into `repos`: the flag is about the path, not about events. */
+	async function seedRepos(rows: ReadonlyArray<{ identity: string; root: string }>): Promise<void> {
+		await withDashboardDb(
+			(db) => {
+				for (const { identity, root } of rows) {
+					db.prepare(
+						`INSERT INTO repos (repo_identity, repo_name, worktree_root, enabled_at)
+						 VALUES (?, 'r', ?, '1970-01-01T00:00:00.000Z')`,
+					).run(identity, root);
+				}
+			},
+			{ dbPath },
+		);
+	}
+
+	async function repos(
+		registryRoots?: ReadonlyMap<string, ReadonlyArray<string>>,
+	): Promise<ReadonlyArray<{ repoIdentity: string; missing?: boolean; volumeUnavailable?: boolean }>> {
+		const model = await withDashboardDb(
+			(db) =>
+				buildDashboardModel(db, {
+					view: "stats",
+					scope: { kind: "all" },
+					timeZone: "UTC",
+					nowMs: 0,
+					...(registryRoots ? { registryRoots } : {}),
+				}),
+			{ dbPath },
+		);
+		return model.repos;
+	}
+
+	it("marks a row whose worktree is gone and leaves a live row's shape alone", async () => {
+		await seedRepos([
+			{ identity: "live", root: dir },
+			{ identity: "gone", root: join(dir, "no-such-checkout") },
+		]);
+
+		const byIdentity = new Map((await repos()).map((r) => [r.repoIdentity, r]));
+
+		// Absent, not `false`, on a live row — same contract as `disabled`.
+		expect(byIdentity.get("live")?.missing).toBeUndefined();
+		expect(byIdentity.get("gone")?.missing).toBe(true);
+	});
+
+	it("never marks the placeholder row an event creates before its repo registers", async () => {
+		// `ensureRepoRow` stores the identity in `worktree_root`, which names no
+		// directory. Marking it would put a remove control on a repo that is about
+		// to register normally.
+		await seedRepos([{ identity: "local:not-yet", root: "local:not-yet" }]);
+		expect((await repos())[0].missing).toBeUndefined();
+	});
+
+	it("marks a row rather than dropping it — the memories stay reachable", async () => {
+		await seedRepos([{ identity: "gone", root: join(dir, "no-such-checkout") }]);
+		expect(await repos()).toHaveLength(1);
+	});
+
+	it("reuses the answer across renders, and re-asks once the memo is dropped", async () => {
+		// This is the one filesystem call a render makes, and it is made per repo row
+		// per HTTP request — so a repo on a disconnected mount would block every
+		// refresh for as long as that mount takes to time out.
+		const { clearWorktreeExistenceCache } = await import("./DashboardQuery.js");
+		const checkout = join(dir, "checkout");
+		mkdirSync(checkout, { recursive: true });
+		await seedRepos([{ identity: "r", root: checkout }]);
+		expect((await repos())[0].missing).toBeUndefined();
+
+		rmSync(checkout, { recursive: true, force: true });
+
+		// Still absent: the second render is served from the memo, which is exactly
+		// what `handleForget` re-checks at action time rather than trusting.
+		expect((await repos())[0].missing).toBeUndefined();
+
+		clearWorktreeExistenceCache();
+		expect((await repos())[0].missing).toBe(true);
+	});
+
+	it("does not mark a repo whose OTHER clone is still on disk", async () => {
+		// `worktree_root` is projected from the registry entry's single
+		// `worktreeRoot` field, but an entry is keyed by repo identity and can list
+		// several clones. Judging the row alone renders a forget ✕ over a working
+		// repository — which `handleForget` then refuses with a 409, so the control
+		// was never actionable in the first place.
+		const deadClone = join(dir, "deleted-clone");
+		await seedRepos([{ identity: "two-clones", root: deadClone }]);
+
+		expect((await repos())[0].missing).toBe(true);
+		expect((await repos(new Map([["two-clones", [deadClone, dir]]])))[0].missing).toBeUndefined();
+	});
+
+	it("marks a registered repo when every recorded clone is gone", async () => {
+		const roots = [join(dir, "clone-a"), join(dir, "clone-b")];
+		await seedRepos([{ identity: "all-gone", root: roots[0] }]);
+		expect((await repos(new Map([["all-gone", roots]])))[0].missing).toBe(true);
+	});
+
+	it("marks a placeholder row the registry lists with no surviving clone", async () => {
+		// The opposite direction from the placeholder case above, and deliberately so:
+		// an identity the registry lists IS registered, so it is not "about to
+		// register normally" — the registry is the writer and the row its projection,
+		// so the row can only be staler.
+		await seedRepos([{ identity: "local:registered", root: "local:registered" }]);
+		expect((await repos(new Map([["local:registered", [join(dir, "clone")]]])))[0].missing).toBe(true);
+	});
+
+	it("says the VOLUME is absent rather than claiming the folder was deleted", async () => {
+		// `existsSync` answers false for both, so without this the row asserted a
+		// deletion over a repository that was merely unplugged — and offered a ✕ on it.
+		const onAbsentDrive = join(dir, "unmounted", "repo");
+		await seedRepos([{ identity: "unplugged", root: onAbsentDrive }]);
+		vi.mocked(volumeReachable).mockReturnValueOnce(false);
+
+		const [option] = await repos();
+		expect(option.missing).toBe(true);
+		expect(option.volumeUnavailable).toBe(true);
+	});
+
+	it("calls it a deletion when ANY recorded path is on a volume it can reach", async () => {
+		// Same rule as `classifyRegistryEntry`: one path gone from a disk that IS here
+		// is a deletion, whatever the other paths are on. Only the first probe answers
+		// unreachable, so the second falls through to the real walk.
+		const onAbsentDrive = join(dir, "unmounted", "repo");
+		const deletedLocally = join(dir, "deleted-locally");
+		await seedRepos([{ identity: "mixed", root: onAbsentDrive }]);
+		vi.mocked(volumeReachable).mockReturnValueOnce(false);
+
+		const [option] = await repos(new Map([["mixed", [onAbsentDrive, deletedLocally]]]));
+		expect(option.missing).toBe(true);
+		expect(option.volumeUnavailable).toBeUndefined();
+	});
+
+	it("asks the filesystem nothing about the volume for a repo that is present", async () => {
+		// The walk is one `existsSync` per ancestor and this is the render path, so it
+		// must stay off it for the ordinary row — which is every row on a healthy machine.
+		await seedRepos([{ identity: "live", root: dir }]);
+		vi.mocked(volumeReachable).mockClear();
+
+		expect((await repos())[0].missing).toBeUndefined();
+		expect(volumeReachable).not.toHaveBeenCalled();
+	});
+
+	it("falls back to the row for an identity the registry does not list", async () => {
+		// A row projected from an event before its repo registered has no entry at
+		// all, so an empty answer for it must not read as "no live clone".
+		const gone = join(dir, "unregistered");
+		await seedRepos([{ identity: "orphan", root: gone }]);
+		const other = new Map([["someone-else", [dir]]]);
+		expect((await repos(other))[0].missing).toBe(true);
+		expect((await repos(new Map([["orphan", []]])))[0].missing).toBe(true);
 	});
 });

--- a/cli/src/dashboard/DashboardQuery.ts
+++ b/cli/src/dashboard/DashboardQuery.ts
@@ -17,6 +17,7 @@
  * to reach a write from a query.
  */
 
+import { existsSync } from "node:fs";
 import { collectDisplayTopics } from "../core/SummaryTree.js";
 import { TOOL_RECORDING_SOURCES } from "../core/TranscriptParser.js";
 import { createLogger, errMsg } from "../Logger.js";
@@ -67,6 +68,7 @@ import {
 	splitDecisionBullets,
 } from "./DashboardScopeUtil.js";
 import { buildMemories, isReachable, type ReachableCommits } from "./MemoriesQuery.js";
+import { volumeReachable } from "./RepoForget.js";
 import { WORKTREE_STATUS_MAX_AGE_MS } from "./StatsWriter.js";
 
 const log = createLogger("DashboardQuery");
@@ -365,6 +367,19 @@ export interface QueryOptions {
 	readonly graphModel?: GraphModel;
 	/** Settings view: the async-read config/memory-bank snapshot. Absent on every other view. */
 	readonly settingsModel?: SettingsPageModel;
+	/**
+	 * Every checkout path the repo registry records, keyed by `repo_identity` —
+	 * read async by the server, because the registry is a file and this builder is
+	 * synchronous. Absent, or absent for one identity, falls back to that row's
+	 * `worktree_root`; see {@link isMissingWorktree} for why the fallback is not
+	 * good enough on its own.
+	 *
+	 * Paths only, deliberately — not a precomputed liveness verdict. Probing them
+	 * here is what puts them through {@link worktreeExists}' memo, and a caller
+	 * that answered "live?" itself would be making one uncached `existsSync` per
+	 * clone per request, which is the cost that memo exists to bound.
+	 */
+	readonly registryRoots?: ReadonlyMap<string, ReadonlyArray<string>>;
 	readonly timeZone?: string;
 	readonly nowMs?: number;
 }
@@ -2205,6 +2220,121 @@ const NO_GRAPH_MODEL: GraphModel = { repos: [] };
 
 // ── Model assembly ──────────────────────────────────────────────────────────
 
+/**
+ * Why a row's checkout could not be found, or that it could — the filesystem
+ * question a page render asks, and the reason `RepoOption.missing` /
+ * `volumeUnavailable` exist.
+ *
+ * Three answers rather than a boolean, because "not on disk" is two states and the
+ * page has to say which: a deleted folder, or a volume that is not mounted. See
+ * `RepoOption.volumeUnavailable` for what that distinction buys the reader, and
+ * `DashboardServer.handleForget` for the guard that no longer has to stand in for
+ * it.
+ *
+ * **The registry outranks the row, and that is the whole point.** `worktree_root`
+ * is projected from a registry entry's single `worktreeRoot` field
+ * (`DbBackfill.projectRepoRegistryState`), while an entry is keyed by repo
+ * IDENTITY and can list several clones. So a repo whose recorded root was deleted
+ * with a sibling clone still on disk reads as missing from the row alone — and the
+ * page then renders a forget ✕ over a working repository. `handleForget` already
+ * refuses exactly that with a 409, asking the registry through
+ * `classifyRegistryEntry`; this asks the same question at render time so the
+ * control is not offered in the first place. Nothing else fixes it in passing: the
+ * one pass that repoints a dead `worktreeRoot` at a live sibling,
+ * `repairRegistryEntries`, runs only under `jolli doctor`.
+ *
+ * `registryRoots` is consulted FIRST rather than OR-ed with the row, for the
+ * mirror image of `handleForget`'s reasoning: the registry is the writer and the
+ * row is its projection, so the row can only be staler. That also settles the
+ * placeholder case below in the right direction — an identity the registry lists
+ * is registered, so "all of its recorded paths are gone" is a true `missing`.
+ *
+ * The fallback keeps the pre-registry rule: a row whose `worktree_root` IS its
+ * identity is deliberately not "missing". That is the placeholder
+ * `StatsWriter.ensureRepoRow` inserts when an event arrives before the repo is
+ * registered, so it names no directory rather than naming one that vanished, and
+ * marking it would put a remove control on a repo that is about to register
+ * normally.
+ */
+type WorktreeAbsence = "present" | "missing" | "volume-unavailable";
+
+function absenceOfWorktree(
+	row: { readonly repo_identity: string; readonly worktree_root: string },
+	registryRoots: ReadonlyMap<string, ReadonlyArray<string>> | undefined,
+): WorktreeAbsence {
+	const recorded = registryRoots?.get(row.repo_identity);
+	const paths =
+		recorded !== undefined && recorded.length > 0
+			? recorded
+			: row.worktree_root === row.repo_identity
+				? []
+				: [row.worktree_root];
+	if (paths.length === 0 || paths.some((path) => worktreeExists(path))) return "present";
+	// Same rule as `classifyRegistryEntry`: ONE recorded path on a live volume is
+	// enough to call this a deletion, because that path really is gone from a disk
+	// that is here. Only when no recorded path's volume can be reached at all is the
+	// absence about the volume.
+	return paths.some((path) => volumeReachable(path)) ? "missing" : "volume-unavailable";
+}
+
+/**
+ * How long a checkout's existence is reused before asking the filesystem again.
+ *
+ * This is the ONE filesystem call a page render makes, and it is made per repo row
+ * per request — so an uncached probe of a repo on a disconnected SMB/NFS mount
+ * blocks the whole render until the mount times out, on every refresh, for every
+ * OTHER repo's benefit too.
+ *
+ * Staleness is already part of this value's contract rather than a cost the memo
+ * introduces: `missing` renders a remove control, and `DashboardServer.handleForget`
+ * re-asks at action time precisely because "the control is rendered from a payload
+ * that can be minutes old". Half a minute here is well inside that.
+ */
+const WORKTREE_EXISTENCE_TTL_MS = 30_000;
+
+const worktreeExistence = new Map<string, boolean>();
+let worktreeExistenceStartedAtMs = 0;
+
+/**
+ * `existsSync` with a short real-time memo.
+ *
+ * One generation for the whole memo rather than a TTL per key. That keeps it
+ * BOUNDED without a capacity check: it is emptied wholesale every window, so a
+ * long-lived server watching repo rows come and go cannot accumulate paths. The
+ * cost is that a key added late in a window is dropped early, which is free —
+ * every entry is one `existsSync` to recompute.
+ *
+ * Deliberately `Date.now()` rather than the caller's injected `nowMs`: that clock
+ * is a DISPLAY seam (tests pin it to 0, and views are rendered "as of" a chosen
+ * instant), so keying an I/O throttle on it would freeze this memo for the whole
+ * process whenever a caller froze the display clock.
+ */
+function worktreeExists(path: string): boolean {
+	const nowMs = Date.now();
+	if (nowMs - worktreeExistenceStartedAtMs >= WORKTREE_EXISTENCE_TTL_MS) {
+		worktreeExistence.clear();
+		worktreeExistenceStartedAtMs = nowMs;
+	}
+	const hit = worktreeExistence.get(path);
+	if (hit !== undefined) return hit;
+	const exists = existsSync(path);
+	worktreeExistence.set(path, exists);
+	return exists;
+}
+
+/**
+ * Drops the memo — for a caller that creates or deletes a checkout mid-run.
+ *
+ * `DashboardServer.handleEnable` is the one production caller: it has just been
+ * told a directory exists, and a `false` cached for that path outlives the answer
+ * by up to a whole window, so the reload after its 200 would render the repo the
+ * user just enabled with a remove control on it.
+ */
+export function clearWorktreeExistenceCache(): void {
+	worktreeExistence.clear();
+	worktreeExistenceStartedAtMs = 0;
+}
+
 /** Builds the full page payload for one view + scope. */
 export function buildDashboardModel(db: DashboardDbHandle, opts: QueryOptions): DashboardModel {
 	const timeZone = opts.timeZone ?? machineTimeZone();
@@ -2241,13 +2371,20 @@ export function buildDashboardModel(db: DashboardDbHandle, opts: QueryOptions): 
 		disabled_at: string | null;
 		week_sessions: number;
 	}>;
-	const repos: RepoOption[] = repoRows.map((r) => ({
-		repoIdentity: r.repo_identity,
-		repoName: r.repo_name,
-		worktreeRoot: r.worktree_root,
-		sessionsThisWeek: r.week_sessions,
-		...(r.disabled_at != null ? { disabled: true as const } : {}),
-	}));
+	const repos: RepoOption[] = repoRows.map((r) => {
+		// `volumeUnavailable` IMPLIES `missing` (see `RepoOption`): the flag says why
+		// nothing was found, never that something else was.
+		const absence = absenceOfWorktree(r, opts.registryRoots);
+		return {
+			repoIdentity: r.repo_identity,
+			repoName: r.repo_name,
+			worktreeRoot: r.worktree_root,
+			sessionsThisWeek: r.week_sessions,
+			...(r.disabled_at != null ? { disabled: true as const } : {}),
+			...(absence !== "present" ? { missing: true as const } : {}),
+			...(absence === "volume-unavailable" ? { volumeUnavailable: true as const } : {}),
+		};
+	});
 
 	// The footer carries ONE note now, and only when the database is empty.
 	//

--- a/cli/src/dashboard/DashboardServer.test.ts
+++ b/cli/src/dashboard/DashboardServer.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import type { Server } from "node:http";
 import { hostname, tmpdir } from "node:os";
 import { join } from "node:path";
@@ -23,6 +23,18 @@ vi.mock("../install/Installer.js", () => ({
 // Partial: only the three registry WRITERS/readers are stubbed. Pure helpers the
 // routes also reach (`existingWorktrees`, which fans a mutation out over every
 // surviving checkout) stay real, so adding one does not 500 every write test.
+// Partial for the same reason as the registry below: the forget route's own
+// liveness checks stay real, only the removal is stubbed.
+// `classifyRegistryEntry` keeps the REAL implementation (`vi.fn(impl)`), so every
+// test that does not override it behaves exactly as the unmocked module would. It
+// is wrapped only because its `unavailable` verdict is unreachable on this CI: the
+// volume walk needs a path with no existing ancestor, and on POSIX every absolute
+// path bottoms out at a live `/` — which is why `volumeReachable` carries an
+// `exists` seam that `classifyRegistryEntry`'s callers here cannot reach.
+vi.mock("./RepoForget.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./RepoForget.js")>();
+	return { ...actual, forgetRepo: vi.fn(), classifyRegistryEntry: vi.fn(actual.classifyRegistryEntry) };
+});
 vi.mock("./RepoRegistry.js", async (importOriginal) => ({
 	...(await importOriginal<typeof import("./RepoRegistry.js")>()),
 	registerRepo: vi.fn().mockResolvedValue({
@@ -75,6 +87,7 @@ import {
 	resolveDashboardAssetsDir,
 	startDashboardServer,
 } from "./DashboardServer.js";
+import * as repoForget from "./RepoForget.js";
 import * as repoRegistry from "./RepoRegistry.js";
 import { applyStatsEvents } from "./StatsWriter.js";
 
@@ -1002,6 +1015,271 @@ describe("write surface", () => {
 		expect((await res.json()) as Record<string, unknown>).toEqual({ ok: true, repoIdentity: "r1" });
 	});
 
+	describe("forget", () => {
+		const FORGOTTEN = {
+			identity: "r1",
+			removedFromRegistry: true,
+			repoRowDeleted: true,
+			childRowsDeleted: 3,
+			pendingEventsDeleted: 0,
+		};
+
+		beforeEach(() => {
+			vi.mocked(repoForget.forgetRepo).mockReset();
+			// Restores the real implementation the factory passed to `vi.fn(impl)`, so a
+			// verdict one test forced cannot leak into the next.
+			vi.mocked(repoForget.classifyRegistryEntry).mockReset();
+			vi.mocked(repoRegistry.readRepoRegistry).mockResolvedValue({ version: 1, repos: [] });
+		});
+
+		const post = async (body: unknown): Promise<Response> => {
+			const port = await listen(writeServer());
+			return fetch(`http://127.0.0.1:${port}/api/repos/forget`, {
+				method: "POST",
+				headers: HEADERS,
+				body: JSON.stringify(body),
+			});
+		};
+
+		it("400s without a repoIdentity", async () => {
+			expect((await post({})).status).toBe(400);
+			expect(repoForget.forgetRepo).not.toHaveBeenCalled();
+		});
+
+		it("400s a whitespace-only repoIdentity", async () => {
+			expect((await post({ repoIdentity: "   " })).status).toBe(400);
+		});
+
+		it("forgets a dead entry and reports what went", async () => {
+			vi.mocked(repoForget.forgetRepo).mockResolvedValue(FORGOTTEN);
+			const res = await post({ repoIdentity: "r1" });
+			expect(res.status).toBe(200);
+			expect((await res.json()) as Record<string, unknown>).toEqual({
+				ok: true,
+				repoIdentity: "r1",
+				removedFromRegistry: true,
+				repoRowDeleted: true,
+				childRowsDeleted: 3,
+			});
+		});
+
+		it("409s a repository that still exists on disk, without calling forget", async () => {
+			// The control is drawn from a payload that can be minutes old, so state —
+			// not the page — is what says no. 409 because the request was well-formed.
+			vi.mocked(repoRegistry.readRepoRegistry).mockResolvedValue({
+				version: 1,
+				repos: [{ repoIdentity: "r1", repoName: "r", worktreeRoot: dir, enabledAt: "t" }],
+			});
+			const res = await post({ repoIdentity: "r1" });
+			expect(res.status).toBe(409);
+			expect((await res.json()) as { error: string }).toMatchObject({
+				error: expect.stringContaining("on disk"),
+			});
+			expect(repoForget.forgetRepo).not.toHaveBeenCalled();
+		});
+
+		it("consults every recorded clone, not just the displayed root", async () => {
+			// A registry entry is keyed by IDENTITY, so a second clone shares the row —
+			// `worktreeRoot` alone would report a live repo as gone.
+			vi.mocked(repoRegistry.readRepoRegistry).mockResolvedValue({
+				version: 1,
+				repos: [
+					{
+						repoIdentity: "r1",
+						repoName: "r",
+						worktreeRoot: join(dir, "no-such-clone"),
+						worktrees: [join(dir, "no-such-clone"), dir],
+						enabledAt: "t",
+					},
+				],
+			});
+			expect((await post({ repoIdentity: "r1" })).status).toBe(409);
+		});
+
+		it("409s a repository whose volume this machine cannot reach, without calling forget", async () => {
+			// The one verdict `doctor` refuses even under `--fix --forget-dead-repos`: an
+			// unplugged drive or an unmounted share is a repo the user expects back, and
+			// `existsSync` alone cannot tell it from a deleted folder. Before this gate a
+			// single confirm deleted twelve child tables for a repository that was merely
+			// unplugged.
+			vi.mocked(repoForget.classifyRegistryEntry).mockReturnValueOnce("unavailable");
+			vi.mocked(repoRegistry.readRepoRegistry).mockResolvedValue({
+				version: 1,
+				repos: [{ repoIdentity: "r1", repoName: "r", worktreeRoot: "Z:\\gone\\repo", enabledAt: "t" }],
+			});
+			const res = await post({ repoIdentity: "r1" });
+			expect(res.status).toBe(409);
+			expect((await res.json()) as { error: string }).toMatchObject({
+				error: expect.stringContaining("cannot reach"),
+			});
+			expect(repoForget.forgetRepo).not.toHaveBeenCalled();
+		});
+
+		it("removes an unreachable-volume repo once the request says the user was told", async () => {
+			// B: the user is the one who knows whether that drive is coming back, so the
+			// refusal is a re-ask rather than a dead end. The flag is the record that a
+			// human saw the volume-specific sentence — without it a stale click and an
+			// informed one are the same bytes.
+			vi.mocked(repoForget.classifyRegistryEntry).mockReturnValueOnce("unavailable");
+			vi.mocked(repoForget.forgetRepo).mockResolvedValue(FORGOTTEN);
+			vi.mocked(repoRegistry.readRepoRegistry).mockResolvedValue({
+				version: 1,
+				repos: [{ repoIdentity: "r1", repoName: "r", worktreeRoot: "Z:\\gone\\repo", enabledAt: "t" }],
+			});
+			const res = await post({ repoIdentity: "r1", acknowledgeUnavailableVolume: true });
+			expect(res.status).toBe(200);
+			expect(repoForget.forgetRepo).toHaveBeenCalled();
+		});
+
+		it("tags the refusal so the page can re-ask instead of just reporting failure", async () => {
+			vi.mocked(repoForget.classifyRegistryEntry).mockReturnValueOnce("unavailable");
+			// A registry ENTRY, so the verdict comes from the classifier rather than from
+			// `classifyProjectedRoot`'s no-database shortcut.
+			vi.mocked(repoRegistry.readRepoRegistry).mockResolvedValue({
+				version: 1,
+				repos: [{ repoIdentity: "r1", repoName: "r", worktreeRoot: "Z:\\gone\\repo", enabledAt: "t" }],
+			});
+			const res = await post({ repoIdentity: "r1" });
+			expect(res.status).toBe(409);
+			expect((await res.json()) as Record<string, unknown>).toMatchObject({ volumeUnavailable: true });
+		});
+
+		it("ignores the acknowledgement for a repository that still exists", async () => {
+			// The flag speaks for ONE verdict. A live checkout is refused whatever the
+			// body claims — that answer is not the user's to override from here.
+			vi.mocked(repoRegistry.readRepoRegistry).mockResolvedValue({
+				version: 1,
+				repos: [{ repoIdentity: "r1", repoName: "r", worktreeRoot: dir, enabledAt: "t" }],
+			});
+			const res = await post({ repoIdentity: "r1", acknowledgeUnavailableVolume: true });
+			expect(res.status).toBe(409);
+			expect((await res.json()) as { error: string }).toMatchObject({
+				error: expect.stringContaining("still exists on disk"),
+			});
+			expect(repoForget.forgetRepo).not.toHaveBeenCalled();
+		});
+
+		it("applies the same volume gate to a row the registry does not list", async () => {
+			// The unregistered half is the identical hazard through the identical button,
+			// so it is judged by the same classifier on a synthetic single-path entry —
+			// not by a second copy of the rule that could drift.
+			vi.mocked(repoForget.classifyRegistryEntry).mockReturnValueOnce("unavailable");
+			const dbPath = join(dir, "projected-unavailable.db");
+			await applyStatsEvents(
+				[
+					{
+						producerKind: "cli",
+						event: {
+							type: "repo.enabled",
+							repoIdentity: "r1",
+							repoName: "r",
+							worktreeRoot: "Z:\\gone\\repo",
+							enabledAt: "t",
+						},
+					},
+				],
+				{ producerKind: "cli", dbPath },
+			);
+			const port = await listen(writeServer({ dbPath }));
+			const res = await fetch(`http://127.0.0.1:${port}/api/repos/forget`, {
+				method: "POST",
+				headers: HEADERS,
+				body: JSON.stringify({ repoIdentity: "r1" }),
+			});
+			expect(res.status).toBe(409);
+			expect(repoForget.forgetRepo).not.toHaveBeenCalled();
+		});
+
+		it("backs the registry up before removing anything", async () => {
+			// Ordering, for the reason `applyRepoRegistryFix` states: a copy taken after
+			// the first removal is a copy of the damage. It protects the REGISTRATION and
+			// not the memories — that file holds none — so it is not what makes this safe.
+			const configDir = join(dir, "forget-backup-config");
+			mkdirSync(configDir, { recursive: true });
+			const registryPath = join(configDir, "dashboard-repos.json");
+			writeFileSync(registryPath, JSON.stringify({ version: 1, repos: [] }));
+			// Recorded rather than asserted in place: this proves the ORDERING (the copy is
+			// already on disk when the removal runs), and a throw from inside the mock
+			// would surface as a 500 instead of naming the ordering.
+			let backedUpBeforeRemoval = false;
+			vi.mocked(repoForget.forgetRepo).mockImplementation(async () => {
+				backedUpBeforeRemoval = readdirSync(configDir).some((f) => f.endsWith(".bak"));
+				return FORGOTTEN;
+			});
+
+			const port = await listen(writeServer({ configDir }));
+			const res = await fetch(`http://127.0.0.1:${port}/api/repos/forget`, {
+				method: "POST",
+				headers: HEADERS,
+				body: JSON.stringify({ repoIdentity: "r1" }),
+			});
+
+			expect(res.status).toBe(200);
+			expect(backedUpBeforeRemoval).toBe(true);
+			const backups = readdirSync(configDir).filter((f) => f.endsWith(".bak"));
+			expect(backups).toHaveLength(1);
+			expect(readFileSync(join(configDir, backups[0]), "utf-8")).toBe(JSON.stringify({ version: 1, repos: [] }));
+		});
+
+		it("500s without removing anything when the registry could not be backed up", async () => {
+			// A removal that could not be backed up is not the operation the user
+			// consented to — and the message names the step that failed, since "could not
+			// forget" would point at one that never ran.
+			const configDir = join(dir, "forget-backup-fail-config");
+			mkdirSync(configDir, { recursive: true });
+			// A DIRECTORY where the registry file belongs: it exists (so the backup is
+			// attempted) and `copyFileSync` cannot read it.
+			mkdirSync(join(configDir, "dashboard-repos.json"), { recursive: true });
+
+			const port = await listen(writeServer({ configDir }));
+			const res = await fetch(`http://127.0.0.1:${port}/api/repos/forget`, {
+				method: "POST",
+				headers: HEADERS,
+				body: JSON.stringify({ repoIdentity: "r1" }),
+			});
+
+			expect(res.status).toBe(500);
+			expect((await res.json()) as { error: string }).toMatchObject({
+				error: expect.stringContaining("back up"),
+			});
+			expect(repoForget.forgetRepo).not.toHaveBeenCalled();
+		});
+
+		it("404s when there was nothing left to remove", async () => {
+			// A second window may already have removed it; a cheerful 200 would reload
+			// to the same list.
+			vi.mocked(repoForget.forgetRepo).mockResolvedValue({
+				identity: "r1",
+				removedFromRegistry: false,
+				repoRowDeleted: false,
+				childRowsDeleted: 0,
+				pendingEventsDeleted: 0,
+			});
+			expect((await post({ repoIdentity: "r1" })).status).toBe(404);
+		});
+
+		it("500s when the removal reported an error rather than claiming success", async () => {
+			vi.mocked(repoForget.forgetRepo).mockResolvedValue({
+				identity: "r1",
+				removedFromRegistry: false,
+				repoRowDeleted: false,
+				childRowsDeleted: 0,
+				pendingEventsDeleted: 0,
+				error: "database is locked",
+			});
+			const res = await post({ repoIdentity: "r1" });
+			expect(res.status).toBe(500);
+			expect((await res.json()) as { error: string }).toMatchObject({
+				error: expect.stringContaining("database is locked"),
+			});
+		});
+
+		it("500s when the removal throws", async () => {
+			vi.mocked(repoForget.forgetRepo).mockRejectedValue(new Error("node:sqlite is unavailable"));
+			expect((await post({ repoIdentity: "r1" })).status).toBe(500);
+		});
+	});
+
 	it("400s enable with no path", async () => {
 		const port = await listen(writeServer());
 		const res = await fetch(`http://127.0.0.1:${port}/api/repos/enable`, {
@@ -1160,6 +1438,93 @@ describe("defaultModelBuilder (no injected buildModel)", () => {
 		const retired = await get(port, "/api/model?view=repositories");
 		expect(retired.status).toBe(200);
 		expect(((await retired.json()) as DashboardModel).view).toBe("stats");
+	});
+
+	/** Seeds one enabled repo whose projected `worktree_root` is `root`. */
+	async function seedRepo(dbPath: string, root: string): Promise<void> {
+		await applyStatsEvents(
+			[
+				{
+					producerKind: "cli",
+					event: {
+						type: "repo.enabled",
+						repoIdentity: "repo-1",
+						repoName: "jolli",
+						worktreeRoot: root,
+						enabledAt: "t",
+					},
+				},
+			],
+			{ producerKind: "cli", dbPath },
+		);
+	}
+
+	async function repoOptions(port: number): Promise<ReadonlyArray<{ missing?: boolean }>> {
+		return ((await (await get(port, "/api/model?view=stats")).json()) as DashboardModel).repos;
+	}
+
+	// `worktree_root` carries the registry entry's single `worktreeRoot`, but an
+	// entry is keyed by repo IDENTITY and can list several clones — so the row alone
+	// renders a forget ✕ over a repo whose sibling checkout is alive and well.
+	it("asks the registry about every clone before marking a repo missing", async () => {
+		const dbPath = join(dir, "clones.db");
+		const dead = join(dir, "clone-dead");
+		const live = join(dir, "clone-live");
+		mkdirSync(live, { recursive: true });
+		await seedRepo(dbPath, dead);
+		const port = await listen(
+			createDashboardServer({ port: 0, assetsDir, dbPath, configDir: join(dir, "clones-config") }),
+		);
+
+		// Default mock: an empty registry, so nothing outranks the row.
+		expect((await repoOptions(port))[0].missing).toBe(true);
+
+		vi.mocked(repoRegistry.readRepoRegistry).mockResolvedValueOnce({
+			version: 1,
+			repos: [
+				{
+					repoIdentity: "repo-1",
+					repoName: "jolli",
+					worktreeRoot: dead,
+					worktrees: [dead, live],
+					enabledAt: "t",
+				},
+			],
+		});
+		expect((await repoOptions(port))[0].missing).toBeUndefined();
+	});
+
+	// The memo is real-time-generational and nothing else invalidates it, so a
+	// checkout that existed by the time the user clicked Enable would keep rendering
+	// with a forget ✕ for the rest of the window — on the repo they just enabled.
+	it("drops the worktree-existence memo when a repo is enabled", async () => {
+		const TOKEN = "enable-memo-0123456789abcdef";
+		const dbPath = join(dir, "enable-memo.db");
+		const checkout = join(dir, "enabled-checkout");
+		await seedRepo(dbPath, checkout);
+		const port = await listen(
+			createDashboardServer({
+				port: 0,
+				assetsDir,
+				dbPath,
+				configDir: join(dir, "enable-memo-config"),
+				token: TOKEN,
+			}),
+		);
+
+		expect((await repoOptions(port))[0].missing).toBe(true);
+		mkdirSync(checkout, { recursive: true });
+		// Still missing: served from the memo, which is the whole point of it.
+		expect((await repoOptions(port))[0].missing).toBe(true);
+
+		const enabled = await fetch(`http://127.0.0.1:${port}/api/repos/enable`, {
+			method: "POST",
+			headers: { "X-Jolli-Dashboard-Token": TOKEN, "content-type": "application/json" },
+			body: JSON.stringify({ path: checkout }),
+		});
+		expect(enabled.status).toBe(200);
+
+		expect((await repoOptions(port))[0].missing).toBeUndefined();
 	});
 
 	it("reads knowledge and graph models off the Memory Bank folder", async () => {

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -105,7 +105,12 @@ import { resolveAssetsDir as resolveGraphAssetsDir } from "../graph/GraphExport.
 import { install } from "../install/Installer.js";
 import { createLogger, errMsg } from "../Logger.js";
 import type { LocalAgentToolId } from "../Types.js";
-import { ensureDashboardDbExists, withDashboardDb, withReadonlyDashboardDb } from "./DashboardDb.js";
+import {
+	ensureDashboardDbExists,
+	getDashboardDbPath,
+	withDashboardDb,
+	withReadonlyDashboardDb,
+} from "./DashboardDb.js";
 import {
 	CONTEXT_DOC_KINDS,
 	type DashboardModel,
@@ -116,7 +121,12 @@ import {
 	TOOL_ROWS_LIMIT,
 	type ToolUsageList,
 } from "./DashboardModel.js";
-import { buildDashboardModel, buildToolUsagePage, type QueryOptions } from "./DashboardQuery.js";
+import {
+	buildDashboardModel,
+	buildToolUsagePage,
+	clearWorktreeExistenceCache,
+	type QueryOptions,
+} from "./DashboardQuery.js";
 import { projectRepoRegistryState } from "./DbBackfill.js";
 import { buildGraphViewerDocument } from "./GraphViewerDocument.js";
 import {
@@ -129,8 +139,9 @@ import {
 	WIKI_FILE_PATTERN,
 } from "./KnowledgeQuery.js";
 import { buildMemoriesPage, type ReachableCommits, readContextDoc } from "./MemoriesQuery.js";
+import { backupRepoRegistry, classifyRegistryEntry, forgetRepo, type RegistryEntryVerdict } from "./RepoForget.js";
 import { probeRepo } from "./RepoProbe.js";
-import { existingWorktrees, readRepoRegistry, registerRepo } from "./RepoRegistry.js";
+import { existingWorktrees, readRepoRegistry, recordedRepoPaths, registerRepo } from "./RepoRegistry.js";
 import {
 	applySettings,
 	checkLocalFolder,
@@ -522,6 +533,14 @@ async function defaultModelBuilder(
 	// Knowledge/Graph read the Memory Bank folder (not the DB), like Settings above.
 	const knowledgeModel = request.view === "knowledge" ? await buildKnowledgeModel(configDir) : undefined;
 	const graphModel = request.view === "graph" ? await buildGraphModel(configDir) : undefined;
+	// Not view-gated, unlike the three above: the repo picker is part of the shell,
+	// so `missing` is computed on every view. One small JSON read per request, and
+	// `readRepoRegistry` is the fail-open reader — an unreadable registry yields an
+	// empty map, which is exactly the "fall back to `worktree_root`" case
+	// `isMissingWorktree` already handles.
+	const registryRoots = new Map<string, ReadonlyArray<string>>(
+		(await readRepoRegistry(configDir)).repos.map((repo) => [repo.repoIdentity, recordedRepoPaths(repo)]),
+	);
 	return withReadonlyDashboardDb(
 		async (db) => {
 			// A rebase/reset/squash that rewrites history away leaves the old
@@ -557,6 +576,7 @@ async function defaultModelBuilder(
 			// now, so the call is retired (JOLLI-2209).
 			return buildDashboardModel(db, {
 				...request,
+				registryRoots,
 				...(settingsModel ? { settingsModel } : {}),
 				...(knowledgeModel ? { knowledgeModel } : {}),
 				...(graphModel ? { graphModel } : {}),
@@ -1511,6 +1531,10 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 			await handleEnable(res, b);
 			return;
 		}
+		if (url.pathname === "/api/repos/forget") {
+			await handleForget(res, b);
+			return;
+		}
 		// `/api/repos/disable` and `/api/repos/resume` were the Repositories page's
 		// per-row Pause / Resume. Both went with that page. Pausing a repository
 		// is still a thing — `jolli disable` writes `disabled_at` and every query
@@ -1823,8 +1847,192 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 			return;
 		}
 		const repo = await registerRepo({ cwd: worktreeRoot, configDir });
+		// This process just learned that a directory exists, and the render path's
+		// existence memo (`DashboardQuery.worktreeExists`) may hold the opposite
+		// answer for up to its whole window: a `repos` row pointing here that was
+		// probed while the checkout was absent — cloned back, or created and enabled
+		// from this page — leaves the memo saying `false`, so the reload right after
+		// this 200 renders the repo the user just enabled with a forget ✕ on it.
+		// Nothing else invalidates the memo; it is real-time-generational by design.
+		clearWorktreeExistenceCache();
 		const warning = await projectRegistryEntry(repo.repoIdentity);
 		sendJson(res, 200, { ok: true, repoIdentity: repo.repoIdentity, ...(warning ? { warning } : {}) });
+	}
+
+	/**
+	 * Removes a repository from this machine's dashboard — registry entry, rows and
+	 * unprojected events. The counterpart to `handleEnable`, and the only user-facing
+	 * way to reach an entry whose directory is gone (`deregisterRepo` needs to run
+	 * inside the repo, so it cannot name one).
+	 *
+	 * Refuses a repository that still exists on disk, and the check is deliberately
+	 * not "did the page offer the control": the control is rendered from a payload
+	 * that can be minutes old, a repo can be recreated or a drive remounted in
+	 * between, and this deletes memories irreversibly. `409` rather than `400` — the
+	 * request was well-formed, the state is what says no.
+	 *
+	 * The liveness question goes to whichever source can answer it — the registry
+	 * when there is an entry, the projection otherwise — because either can be the
+	 * only one. A registered entry knows every clone's path, which `worktree_root`
+	 * alone does not, so it outranks the projection; and a row projected from an
+	 * event before its repo registered has no entry at all, where judging it by "not
+	 * registered" would make it unconditionally forgettable.
+	 *
+	 * Deliberately either/or rather than an `||` of both: consulting the projection
+	 * for a registered entry could only change the answer if `worktree_root` were
+	 * FRESHER than the registry, and projection runs registry → database, so it can
+	 * only be staler.
+	 *
+	 * **"Not on disk" is TWO states, and the second one needs the user to say so.**
+	 * `existsSync` cannot tell a deleted folder from one whose VOLUME is absent, and
+	 * `RepoForget.classifyRegistryEntry` draws that line: an unplugged external drive
+	 * or an unmounted share is `unavailable` — a repo that may well come back — and
+	 * `doctor` will not remove it even under `--fix --forget-dead-repos`. This route
+	 * used to ask `hasLiveWorktree` alone, so it answered `false` for exactly that
+	 * case and ONE confirm deleted twelve child tables' worth of a repository that
+	 * was merely unplugged. The gap is platform-weighted rather than academic: on
+	 * POSIX an unmounted mountpoint usually survives as an empty directory and reads
+	 * as `dead`, while a Windows drive letter or UNC host simply goes. Memories
+	 * re-import from the repo when it returns; its sessions and recall receipts have
+	 * no second copy anywhere.
+	 *
+	 * So `unavailable` is refused UNLESS the request carries
+	 * `acknowledgeUnavailableVolume`, which the page sets only after a second
+	 * confirmation naming the volume. An outright refusal was the first shape and is
+	 * wrong in the other direction: the user is the one who knows whether that drive
+	 * is coming back, and a control that cannot be reached leaves them no way to
+	 * remove a repository they are certain about. Accepting it unconditionally is
+	 * equally wrong — the ✕ is drawn from a payload minutes old, so without the flag
+	 * a stale click, a re-POST or a scripted request is indistinguishable from an
+	 * informed one. The flag is not security (nothing stops a caller sending it); it
+	 * is the record that a human was shown the volume-specific sentence, which is the
+	 * only thing that separates the two.
+	 *
+	 * `doctor` stays stricter on purpose: a batch sweep has no row to point at and no
+	 * dialog to show, so there is nothing there for such an acknowledgement to mean.
+	 */
+	async function handleForget(res: ServerResponse, body: Record<string, unknown>): Promise<void> {
+		const repoIdentity = typeof body.repoIdentity === "string" ? body.repoIdentity.trim() : "";
+		if (!repoIdentity) {
+			sendJson(res, 400, { error: "repoIdentity is required" });
+			return;
+		}
+		const entry = (await readRepoRegistry(configDir)).repos.find((r) => r.repoIdentity === repoIdentity);
+		// `classifyRegistryEntry` answers `live` on exactly `hasLiveWorktree`, so the
+		// pre-existing verdict is unchanged and only `unavailable` is new. `disposable`
+		// stays forgettable — that class is fixture garbage the launch path prunes
+		// unattended anyway.
+		const verdict = entry ? classifyRegistryEntry(entry) : await classifyProjectedRoot(repoIdentity);
+		if (verdict === "live") {
+			sendJson(res, 409, {
+				error: "that repository still exists on disk — pause it with `jolli disable` instead of forgetting it",
+			});
+			return;
+		}
+		if (verdict === "unavailable" && body.acknowledgeUnavailableVolume !== true) {
+			sendJson(res, 409, {
+				error:
+					"that repository is on a drive or share this machine cannot reach — reconnect it, or confirm that " +
+					"you want its memories deleted anyway",
+				// Named so the page can tell this refusal from the live-checkout one and
+				// re-ask instead of just reporting failure. A client that does not know
+				// the field simply shows the message, which is still true.
+				volumeUnavailable: true,
+			});
+			return;
+		}
+		// Backup FIRST, and for the same reason `applyRepoRegistryFix` takes one: every
+		// step below is irreversible, and a copy taken after the first removal is a copy
+		// of the damage. It protects the REGISTRATION, not the memories — that file holds
+		// none of them — so it is not what makes this removal safe; the two 409s above
+		// are. Doctor needs `--forget-dead-repos` on top because `--fix` is a bundle a
+		// user runs to release a lock or reinstall hooks, where forgetting a repo is not
+		// what they asked for; a click on one row's ✕ names its target and says so, which
+		// is the consent that flag exists to obtain. See `applyRepoRegistryFix`.
+		//
+		// A backup that could not be written fails the request rather than proceeding:
+		// same rule, and its own message, since nothing has been attempted yet and
+		// "could not forget" would name the wrong step.
+		try {
+			const saved = backupRepoRegistry(now(), configDir);
+			if (saved) log.info("backed up the repo registry to %s before forgetting %s", saved, repoIdentity);
+		} catch (err) {
+			log.warn("could not back up the repo registry before forgetting %s: %s", repoIdentity, errMsg(err));
+			sendJson(res, 500, { error: `could not back up the repo registry first: ${errMsg(err)}` });
+			return;
+		}
+		try {
+			const result = await forgetRepo(repoIdentity, {
+				configDir,
+				...(options.dbPath ? { dbPath: options.dbPath } : {}),
+			});
+			if (result.error !== undefined) {
+				sendJson(res, 500, { error: `could not forget that repository: ${result.error}` });
+				return;
+			}
+			// "Nothing was there" is reported rather than dressed up as a removal: a
+			// page acting on a stale payload otherwise gets a cheerful 200 for an
+			// entry another window already removed, and reloads to the same list.
+			const removedSomething =
+				result.removedFromRegistry ||
+				result.repoRowDeleted ||
+				result.childRowsDeleted > 0 ||
+				result.pendingEventsDeleted > 0;
+			if (!removedSomething) {
+				sendJson(res, 404, { error: "no repository with that identity is on this machine any more" });
+				return;
+			}
+			sendJson(res, 200, {
+				ok: true,
+				repoIdentity,
+				removedFromRegistry: result.removedFromRegistry,
+				repoRowDeleted: result.repoRowDeleted,
+				childRowsDeleted: result.childRowsDeleted,
+			});
+		} catch (err) {
+			log.warn("forget failed for %s: %s", repoIdentity, errMsg(err));
+			sendJson(res, 500, { error: `could not forget that repository: ${errMsg(err)}` });
+		}
+	}
+
+	/**
+	 * The same verdict for an identity the registry does not list, read off its
+	 * projected `worktree_root`.
+	 *
+	 * Delegates to `classifyRegistryEntry` on a SYNTHETIC single-path entry rather
+	 * than re-deciding here. An unregistered row on an unplugged drive is the
+	 * identical hazard through the identical button, so the two halves must not be
+	 * able to disagree — and the synthesis is exact: this row carries one recorded
+	 * path and no `worktrees` list, which is precisely what `recordedRepoPaths` falls
+	 * back to. The fields the classifier reads are the three set here.
+	 */
+	async function classifyProjectedRoot(repoIdentity: string): Promise<RegistryEntryVerdict> {
+		// No database means no projected row, which is a real answer rather than a
+		// failed read — and it must not take the fail-safe branch below, or an
+		// unregistered identity could never be forgotten on a fresh machine.
+		if (!existsSync(options.dbPath ?? getDashboardDbPath())) return "dead";
+		try {
+			const root = await withReadonlyDashboardDb(
+				(db) =>
+					(
+						db.prepare("SELECT worktree_root FROM repos WHERE repo_identity = ?").get(repoIdentity) as
+							| { worktree_root: string }
+							| undefined
+					)?.worktree_root,
+				options.dbPath ? { dbPath: options.dbPath } : {},
+			);
+			// The placeholder `ensureRepoRow` writes stores the identity in this
+			// column, which names no directory — see `isMissingWorktree`. Asked first,
+			// so the volume walk inside the classifier is never handed an identity
+			// string to treat as a path.
+			if (root === undefined || root === repoIdentity) return "dead";
+			return classifyRegistryEntry({ repoIdentity, repoName: repoIdentity, worktreeRoot: root, enabledAt: "" });
+		} catch (err) {
+			// Fail SAFE, not open: a read we could not do is not evidence that the
+			// checkout is gone, and the cost of being wrong here is deleted memories.
+			log.warn("could not read the projected root for %s: %s", repoIdentity, errMsg(err));
+			return "live";
+		}
 	}
 
 	/**

--- a/cli/src/dashboard/RepoForget.test.ts
+++ b/cli/src/dashboard/RepoForget.test.ts
@@ -1,0 +1,615 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Partial, for the two seams that decide what this module is allowed to do:
+ * whether `node:sqlite` exists at all, and whether one repo's transaction
+ * succeeded. Neither can be provoked with a real database — the first is a
+ * property of the runtime, and every table that could reject a delete cascades
+ * — and both guard behaviour that is the whole point of the module (never
+ * remove a registry entry whose rows are still there).
+ */
+vi.mock("./DashboardDb.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./DashboardDb.js")>();
+	return { ...actual, canUseDashboardDb: vi.fn(() => true), inTransaction: vi.fn(actual.inTransaction) };
+});
+
+const realDb = await vi.importActual<typeof import("./DashboardDb.js")>("./DashboardDb.js");
+
+import { canUseDashboardDb, type DashboardDbHandle, inTransaction, withDashboardDb } from "./DashboardDb.js";
+import { STATS_EVENT_SCHEMA_VERSION } from "./DashboardModel.js";
+import {
+	backupRepoRegistry,
+	classifyRegistryEntry,
+	forgetRepo,
+	forgetRepos,
+	pruneDisposableRepos,
+	repoChildTables,
+	surveyRepoRegistry,
+	volumeReachable,
+} from "./RepoForget.js";
+import { getRepoRegistryPath, type RegisteredRepo } from "./RepoRegistry.js";
+import { drainPending } from "./StatsWriter.js";
+
+/**
+ * Every fixture lives under this ONE temp dir, and it doubles as the temp root
+ * the disposable predicate is told about. Naming it explicitly rather than
+ * letting the predicate call `os.tmpdir()` is what keeps these cases meaningful
+ * on macOS, where the recorded path and `tmpdir()` disagree by a symlink.
+ */
+let dir: string;
+let configDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "jolli-forget-"));
+	configDir = join(dir, "config");
+	mkdirSync(configDir, { recursive: true });
+	dbPath = join(dir, "dashboard.db");
+	// `clearMocks` drops the factory's implementations, so both seams are re-armed
+	// to their real behaviour before every case.
+	vi.mocked(canUseDashboardDb).mockReturnValue(true);
+	vi.mocked(inTransaction).mockImplementation(realDb.inTransaction);
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+const entry = (over: Partial<RegisteredRepo> & { repoIdentity: string }): RegisteredRepo => ({
+	repoName: "repo",
+	worktreeRoot: join(dir, "gone"),
+	enabledAt: "2026-08-01T00:00:00.000Z",
+	...over,
+});
+
+function writeRegistry(repos: ReadonlyArray<RegisteredRepo>): void {
+	writeFileSync(getRepoRegistryPath(configDir), `${JSON.stringify({ version: 1, repos }, null, 2)}\n`, "utf-8");
+}
+
+function readRegistryRaw(): { repos: ReadonlyArray<RegisteredRepo>; instanceId?: string } {
+	return JSON.parse(readFileSync(getRepoRegistryPath(configDir), "utf-8"));
+}
+
+/** Creates the schema and hands the caller a handle to seed rows with. */
+async function withDb<T>(fn: (db: DashboardDbHandle) => T): Promise<T> {
+	return withDashboardDb(fn, { dbPath });
+}
+
+/** One repo row plus one row in every table that references `repos.id`. */
+async function seedRepoWithChildren(identity: string): Promise<number> {
+	return withDb((db) => {
+		db.prepare(
+			"INSERT INTO repos (repo_identity, repo_name, worktree_root, enabled_at) VALUES (?, 'repo', ?, '1970-01-01T00:00:00.000Z')",
+		).run(identity, join(dir, "gone"));
+		const id = (db.prepare("SELECT id FROM repos WHERE repo_identity = ?").get(identity) as { id: number }).id;
+		db.prepare("INSERT INTO branches (repo_id, name) VALUES (?, 'main')").run(id);
+		// `event_id` is UNIQUE across the table, so it has to carry the identity —
+		// two seeded repos otherwise collide on the second insert.
+		db.prepare(
+			`INSERT INTO commits (event_id, repo_id, hash, branch, message, committed_at_ms)
+			 VALUES (?, ?, 'abc1234', 'main', 'a commit', 1)`,
+		).run(`commit:${identity}`, id);
+		db.prepare("INSERT INTO repo_state (repo_id, key, value) VALUES (?, 'k', 'v')").run(id);
+		db.prepare(
+			"INSERT INTO ingest_cursors (repo_id, source, cursor, updated_at_ms) VALUES (?, 'sot-import', 'x', 1)",
+		).run(id);
+		return id;
+	});
+}
+
+async function countIn(table: string, repoId: number): Promise<number> {
+	return withDb(
+		(db) => (db.prepare(`SELECT COUNT(*) AS n FROM ${table} WHERE repo_id = ?`).get(repoId) as { n: number }).n,
+	);
+}
+
+describe("repoChildTables", () => {
+	/**
+	 * Pins the derived set. A table added later that references `repos.id` would
+	 * otherwise turn into a foreign-key failure at removal time, long after the
+	 * schema change that caused it — this makes it a visible test edit instead.
+	 */
+	it("derives exactly the tables that reference repos.id", async () => {
+		const derived = await withDb((db) => repoChildTables(db).map((t) => `${t.table}.${t.column}`));
+		expect(derived).toEqual([
+			"branches.repo_id",
+			"commits.repo_id",
+			"context.repo_id",
+			"ingest_cursors.repo_id",
+			"memories.repo_id",
+			"recall_receipts.repo_id",
+			"repo_state.repo_id",
+			"sessions.repo_id",
+			"topic_pages.repo_id",
+			"topic_processed_sources.repo_id",
+			"transcripts.repo_id",
+			"worktree_status.repo_id",
+		]);
+	});
+
+	it("never names repos itself — the row it guards has to go last", async () => {
+		const derived = await withDb((db) => repoChildTables(db).map((t) => t.table));
+		expect(derived).not.toContain("repos");
+	});
+
+	it("finds a reference that omits the parent column", async () => {
+		// `REFERENCES repos` without `(id)` reports `to: null`. Our own schema always
+		// names the column, but accepting both is what stops a future table slipping
+		// through by using the shorter form — and then failing the final DELETE.
+		const found = await withDb((db) => {
+			db.exec("CREATE TABLE later_table (repo_id INTEGER REFERENCES repos, note TEXT)");
+			return repoChildTables(db).some((t) => t.table === "later_table" && t.column === "repo_id");
+		});
+		expect(found).toBe(true);
+	});
+});
+
+describe("forgetRepo", () => {
+	it("deletes the repo row and every child row", async () => {
+		const id = await seedRepoWithChildren("local:aaa");
+		writeRegistry([entry({ repoIdentity: "local:aaa" })]);
+
+		const result = await forgetRepo("local:aaa", { configDir, dbPath });
+
+		expect(result.repoRowDeleted).toBe(true);
+		expect(result.childRowsDeleted).toBe(4);
+		expect(result.removedFromRegistry).toBe(true);
+		expect(result.error).toBeUndefined();
+		await expect(withDb((db) => db.prepare("SELECT COUNT(*) AS n FROM repos").get())).resolves.toEqual({ n: 0 });
+		expect(await countIn("branches", id)).toBe(0);
+		expect(await countIn("commits", id)).toBe(0);
+		expect(await countIn("repo_state", id)).toBe(0);
+		expect(await countIn("ingest_cursors", id)).toBe(0);
+		expect(readRegistryRaw().repos).toEqual([]);
+	});
+
+	it("leaves every other repo's rows alone", async () => {
+		await seedRepoWithChildren("local:aaa");
+		const keptId = await seedRepoWithChildren("local:bbb");
+
+		await forgetRepo("local:aaa", { configDir, dbPath });
+
+		expect(await countIn("branches", keptId)).toBe(1);
+		expect(await countIn("commits", keptId)).toBe(1);
+	});
+
+	it("reports zeros for an identity nothing on this machine knows", async () => {
+		await withDb(() => undefined);
+		const result = await forgetRepo("local:never-seen", { configDir, dbPath });
+		expect(result).toEqual({
+			identity: "local:never-seen",
+			removedFromRegistry: false,
+			repoRowDeleted: false,
+			childRowsDeleted: 0,
+			pendingEventsDeleted: 0,
+		});
+	});
+
+	it("is idempotent — a second call changes nothing and still does not throw", async () => {
+		await seedRepoWithChildren("local:aaa");
+		writeRegistry([entry({ repoIdentity: "local:aaa" })]);
+		await forgetRepo("local:aaa", { configDir, dbPath });
+
+		const again = await forgetRepo("local:aaa", { configDir, dbPath });
+
+		expect(again.repoRowDeleted).toBe(false);
+		expect(again.removedFromRegistry).toBe(false);
+	});
+
+	/**
+	 * The failure the whole module exists to prevent: `ensureRepoRow` inserts a
+	 * placeholder from an event's identity alone, so one unprojected row brings the
+	 * repo back on the next drain and the removal silently undoes itself.
+	 */
+	it("deletes unprojected events, so a drain cannot resurrect the repo", async () => {
+		await seedRepoWithChildren("local:aaa");
+		writeRegistry([entry({ repoIdentity: "local:aaa" })]);
+		await withDb((db) => {
+			db.prepare(
+				`INSERT INTO events_raw (event_id, repo_identity, type, schema_version, received_at, data_json, projection_status)
+				 VALUES ('e1', 'local:aaa', 'session.upserted', ?, '2026-08-01T00:00:00.000Z', ?, 'pending')`,
+			).run(
+				STATS_EVENT_SCHEMA_VERSION,
+				JSON.stringify({
+					type: "session.upserted",
+					repoIdentity: "local:aaa",
+					source: "claude",
+					sessionId: "s1",
+					updatedAtMs: 1,
+					messageCount: 1,
+					models: [],
+				}),
+			);
+		});
+
+		const result = await forgetRepo("local:aaa", { configDir, dbPath });
+		expect(result.pendingEventsDeleted).toBe(1);
+
+		await withDb((db) => drainPending(db));
+		await expect(withDb((db) => db.prepare("SELECT COUNT(*) AS n FROM repos").get())).resolves.toEqual({ n: 0 });
+	});
+
+	it("keeps already-projected events, which are history rather than pending work", async () => {
+		await seedRepoWithChildren("local:aaa");
+		await withDb((db) => {
+			db.prepare(
+				`INSERT INTO events_raw (event_id, repo_identity, type, schema_version, received_at, data_json, projection_status)
+				 VALUES ('done', 'local:aaa', 'session.upserted', ?, '2026-08-01T00:00:00.000Z', '{}', 'projected')`,
+			).run(STATS_EVENT_SCHEMA_VERSION);
+		});
+
+		const result = await forgetRepo("local:aaa", { configDir, dbPath });
+
+		expect(result.pendingEventsDeleted).toBe(0);
+		await expect(withDb((db) => db.prepare("SELECT COUNT(*) AS n FROM events_raw").get())).resolves.toEqual({
+			n: 1,
+		});
+	});
+
+	/**
+	 * A `failed` row is revivable by the drain (`unknown-type` rows are reset to
+	 * pending on a build that understands them), so leaving one behind is the same
+	 * resurrection with a delay.
+	 */
+	it("deletes failed events too, since the drain revives them", async () => {
+		writeRegistry([entry({ repoIdentity: "local:aaa" })]);
+		await withDb((db) => {
+			db.prepare(
+				`INSERT INTO events_raw (event_id, repo_identity, type, schema_version, received_at, data_json, projection_status, failed_kind)
+				 VALUES ('bad', 'local:aaa', 'session.upserted', ?, '2026-08-01T00:00:00.000Z', '{}', 'failed', 'unknown-type')`,
+			).run(STATS_EVENT_SCHEMA_VERSION);
+		});
+
+		const result = await forgetRepo("local:aaa", { configDir, dbPath });
+
+		expect(result.pendingEventsDeleted).toBe(1);
+	});
+
+	it("removes the registry entry with no database on disk, without creating one", async () => {
+		writeRegistry([entry({ repoIdentity: "local:aaa" })]);
+
+		const result = await forgetRepo("local:aaa", { configDir, dbPath });
+
+		expect(result.removedFromRegistry).toBe(true);
+		expect(result.repoRowDeleted).toBe(false);
+		expect(existsSync(dbPath)).toBe(false);
+	});
+
+	it("keeps the registry's instance-id witness across a removal", async () => {
+		writeFileSync(
+			getRepoRegistryPath(configDir),
+			`${JSON.stringify({ version: 1, repos: [entry({ repoIdentity: "local:aaa" })], instanceId: "id-1" })}\n`,
+			"utf-8",
+		);
+
+		await forgetRepo("local:aaa", { configDir, dbPath });
+
+		expect(readRegistryRaw().instanceId).toBe("id-1");
+	});
+});
+
+describe("forgetRepos", () => {
+	it("de-duplicates the identities it was handed", async () => {
+		await seedRepoWithChildren("local:aaa");
+		const results = await forgetRepos(["local:aaa", "local:aaa"], { configDir, dbPath });
+		expect(results).toHaveLength(1);
+	});
+
+	it("answers an empty list without opening anything", async () => {
+		await expect(forgetRepos([], { configDir, dbPath })).resolves.toEqual([]);
+		expect(existsSync(dbPath)).toBe(false);
+	});
+
+	it("falls back to the machine database path when none is given", async () => {
+		// HOME is isolated per test file, so this reaches a scratch path rather than
+		// the developer's own database — and there is nothing there, which is the
+		// "no rows to lose" branch.
+		const [result] = await forgetRepos(["local:aaa"], { configDir });
+		expect(result.repoRowDeleted).toBe(false);
+	});
+
+	it("opens the machine database when one exists at the default path", async () => {
+		// Still the isolated HOME. Creating it first is what takes the OTHER side of
+		// the "was a dbPath given?" branch, so the default path is really exercised.
+		await withDashboardDb((db) => {
+			db.prepare(
+				`INSERT INTO repos (repo_identity, repo_name, worktree_root, enabled_at)
+				 VALUES ('local:default', 'r', '/gone', '1970-01-01T00:00:00.000Z')`,
+			).run();
+		});
+
+		const [result] = await forgetRepos(["local:default"], { configDir });
+
+		expect(result.repoRowDeleted).toBe(true);
+	});
+
+	/**
+	 * The refusal that keeps the two halves consistent. Removing the registry
+	 * entries with no way to delete the rows would leave rows the page still
+	 * renders and no later sweep can see — the registry no longer lists them.
+	 */
+	it("throws instead of removing anything when node:sqlite is unavailable", async () => {
+		vi.mocked(canUseDashboardDb).mockReturnValue(false);
+		writeRegistry([entry({ repoIdentity: "local:aaa" })]);
+
+		await expect(forgetRepos(["local:aaa"], { configDir, dbPath })).rejects.toThrow(/node:sqlite/);
+		expect(readRegistryRaw().repos).toHaveLength(1);
+	});
+
+	it("confines a failed transaction to its own identity and keeps its registry entry", async () => {
+		await seedRepoWithChildren("local:bad");
+		await seedRepoWithChildren("local:good");
+		writeRegistry([entry({ repoIdentity: "local:bad" }), entry({ repoIdentity: "local:good" })]);
+		let seen = 0;
+		vi.mocked(inTransaction).mockImplementation((db, fn) => {
+			seen += 1;
+			// First identity only: a lock lost on one repo must not roll back the
+			// others, nor stop the sweep finishing them.
+			if (seen === 1) throw new Error("database is locked");
+			return realDb.inTransaction(db, fn);
+		});
+
+		const [bad, good] = await forgetRepos(["local:bad", "local:good"], { configDir, dbPath });
+
+		expect(bad.error).toBe("database is locked");
+		expect(bad.removedFromRegistry).toBe(false);
+		expect(good.error).toBeUndefined();
+		expect(good.repoRowDeleted).toBe(true);
+		// The one that failed keeps BOTH its rows and its entry, so the next attempt
+		// can still find it.
+		expect(readRegistryRaw().repos.map((r) => r.repoIdentity)).toEqual(["local:bad"]);
+		await expect(withDb((db) => db.prepare("SELECT COUNT(*) AS n FROM repos").get())).resolves.toEqual({ n: 1 });
+	});
+});
+
+describe("volumeReachable", () => {
+	it("is true when some ancestor exists", () => {
+		expect(volumeReachable(join(dir, "no", "such", "child"))).toBe(true);
+	});
+
+	it("is false when the walk runs out of path — an unmounted drive", () => {
+		// Injected: on POSIX every absolute path bottoms out at a live `/`, so this
+		// branch is unreachable with the real filesystem.
+		expect(volumeReachable("Z:\\gone\\repo", () => false)).toBe(false);
+	});
+});
+
+describe("classifyRegistryEntry", () => {
+	const tempRoots = () => [dir];
+
+	it("calls an entry with a live checkout live", () => {
+		const root = join(dir, "live");
+		mkdirSync(root);
+		const repo = entry({ repoIdentity: "local:aaa", worktreeRoot: root, worktrees: [root] });
+		expect(classifyRegistryEntry(repo, { tempRoots: tempRoots(), platform: "linux" })).toBe("live");
+	});
+
+	it("calls a gone temp checkout with a local: identity disposable", () => {
+		const repo = entry({ repoIdentity: "local:aaa", worktreeRoot: join(dir, "gone") });
+		expect(classifyRegistryEntry(repo, { tempRoots: tempRoots(), platform: "linux" })).toBe("disposable");
+	});
+
+	it("calls a gone checkout on a present volume dead", () => {
+		const repo = entry({ repoIdentity: "https://github.com/a/b", worktreeRoot: join(dir, "gone") });
+		expect(classifyRegistryEntry(repo, { tempRoots: tempRoots(), platform: "linux" })).toBe("dead");
+	});
+
+	it("calls a gone checkout whose volume is missing unavailable", () => {
+		const repo = entry({ repoIdentity: "https://github.com/a/b", worktreeRoot: "Z:\\work\\repo" });
+		const verdict = classifyRegistryEntry(repo, {
+			tempRoots: tempRoots(),
+			platform: "win32",
+			pathExists: () => false,
+		});
+		expect(verdict).toBe("unavailable");
+	});
+});
+
+describe("surveyRepoRegistry", () => {
+	it("groups every entry, disabled ones included", async () => {
+		const live = join(dir, "live");
+		mkdirSync(live);
+		writeRegistry([
+			entry({ repoIdentity: "local:live", worktreeRoot: live, worktrees: [live] }),
+			entry({ repoIdentity: "local:temp", worktreeRoot: join(dir, "gone-1") }),
+			// Disabled AND gone: `listActiveRepos` would filter it out, which is why
+			// the survey reads the whole registry.
+			entry({
+				repoIdentity: "https://github.com/a/b",
+				worktreeRoot: join(dir, "gone-2"),
+				disabledAt: "2026-08-02T00:00:00.000Z",
+			}),
+		]);
+
+		const survey = await surveyRepoRegistry({ configDir, tempRoots: [dir], platform: "linux" });
+
+		expect(survey.live.map((r) => r.repoIdentity)).toEqual(["local:live"]);
+		expect(survey.disposable.map((r) => r.repoIdentity)).toEqual(["local:temp"]);
+		expect(survey.dead.map((r) => r.repoIdentity)).toEqual(["https://github.com/a/b"]);
+		expect(survey.unavailable).toEqual([]);
+	});
+
+	it("answers an empty survey when no registry exists yet", async () => {
+		const survey = await surveyRepoRegistry({ configDir });
+		expect(survey).toEqual({ live: [], disposable: [], dead: [], unavailable: [] });
+	});
+
+	it("finds a database row the registry no longer lists", async () => {
+		// The shape that hurts most: the page renders it, and a registry-only survey
+		// calls the machine clean. Both stores are written by different paths.
+		await seedRepoWithChildren("local:orphan");
+		writeRegistry([]);
+
+		const survey = await surveyRepoRegistry({ configDir, dbPath, tempRoots: [dir], platform: "linux" });
+
+		expect(survey.disposable.map((r) => r.repoIdentity)).toEqual(["local:orphan"]);
+	});
+
+	it("ignores the placeholder row an event creates before its repo registers", async () => {
+		// `ensureRepoRow` stores the identity in `worktree_root`, so there is no
+		// directory to judge and nothing to remove yet.
+		await withDb((db) => {
+			db.prepare(
+				`INSERT INTO repos (repo_identity, repo_name, worktree_root, enabled_at)
+				 VALUES ('local:pending', 'local:pending', 'local:pending', '1970-01-01T00:00:00.000Z')`,
+			).run();
+		});
+		writeRegistry([]);
+
+		const survey = await surveyRepoRegistry({ configDir, dbPath, tempRoots: [dir], platform: "linux" });
+
+		expect(survey).toEqual({ live: [], disposable: [], dead: [], unavailable: [] });
+	});
+
+	it("does not double-count a repo that is in both stores", async () => {
+		await seedRepoWithChildren("local:temp");
+		writeRegistry([entry({ repoIdentity: "local:temp", worktreeRoot: join(dir, "gone-1") })]);
+
+		const survey = await surveyRepoRegistry({ configDir, dbPath, tempRoots: [dir], platform: "linux" });
+
+		expect(survey.disposable).toHaveLength(1);
+	});
+
+	it("still answers from the registry when the database cannot be read", async () => {
+		// A DIRECTORY where the database should be: `existsSync` says yes, the open
+		// fails, and the registry half must still be reported.
+		mkdirSync(dbPath, { recursive: true });
+		writeRegistry([entry({ repoIdentity: "local:temp", worktreeRoot: join(dir, "gone-1") })]);
+
+		const survey = await surveyRepoRegistry({ configDir, dbPath, tempRoots: [dir], platform: "linux" });
+
+		expect(survey.disposable.map((r) => r.repoIdentity)).toEqual(["local:temp"]);
+	});
+
+	it("skips the database half on a runtime without node:sqlite", async () => {
+		vi.mocked(canUseDashboardDb).mockReturnValue(false);
+		await seedRepoWithChildren("local:orphan");
+		vi.mocked(canUseDashboardDb).mockReturnValue(false);
+		writeRegistry([]);
+
+		const survey = await surveyRepoRegistry({ configDir, dbPath, tempRoots: [dir], platform: "linux" });
+
+		expect(survey).toEqual({ live: [], disposable: [], dead: [], unavailable: [] });
+	});
+});
+
+describe("pruneDisposableRepos", () => {
+	it("removes the temp fixture and nothing else", async () => {
+		const live = join(dir, "live");
+		mkdirSync(live);
+		await seedRepoWithChildren("local:temp");
+		const keptId = await seedRepoWithChildren("https://github.com/a/b");
+		writeRegistry([
+			entry({ repoIdentity: "local:live", worktreeRoot: live, worktrees: [live] }),
+			entry({ repoIdentity: "local:temp", worktreeRoot: join(dir, "gone-1") }),
+			entry({ repoIdentity: "https://github.com/a/b", worktreeRoot: join(dir, "gone-2") }),
+		]);
+
+		const pruned = await pruneDisposableRepos({ configDir, dbPath, tempRoots: [dir], platform: "linux" });
+
+		expect(pruned.map((r) => r.identity)).toEqual(["local:temp"]);
+		expect(readRegistryRaw().repos.map((r) => r.repoIdentity)).toEqual(["local:live", "https://github.com/a/b"]);
+		// The remote-backed dead entry keeps its rows: only `doctor --fix` may take
+		// those, because a folder that is merely unmounted looks identical here.
+		expect(await countIn("commits", keptId)).toBe(1);
+	});
+
+	it("prunes an entry the database never had a row for", async () => {
+		// The registry and the `repos` table are written by different paths, so an
+		// entry can exist with nothing projected behind it. The removal still has to
+		// take the registry entry, and report the row as absent rather than deleted.
+		await seedRepoWithChildren("https://github.com/a/b");
+		writeRegistry([entry({ repoIdentity: "local:temp", worktreeRoot: join(dir, "gone-1") })]);
+
+		const pruned = await pruneDisposableRepos({ configDir, dbPath, tempRoots: [dir], platform: "linux" });
+
+		expect(pruned).toHaveLength(1);
+		expect(pruned[0].repoRowDeleted).toBe(false);
+		expect(pruned[0].removedFromRegistry).toBe(true);
+		expect(readRegistryRaw().repos).toEqual([]);
+	});
+
+	it("does nothing when every entry is live or merely dead", async () => {
+		writeRegistry([entry({ repoIdentity: "https://github.com/a/b", worktreeRoot: join(dir, "gone") })]);
+		const pruned = await pruneDisposableRepos({ configDir, dbPath, tempRoots: [dir], platform: "linux" });
+		expect(pruned).toEqual([]);
+		expect(readRegistryRaw().repos).toHaveLength(1);
+	});
+
+	/** A session in progress under `%TEMP%` is a working repo, not garbage. */
+	it("spares a temp checkout that still exists", async () => {
+		const alive = join(dir, "scratch");
+		mkdirSync(alive);
+		writeRegistry([entry({ repoIdentity: "local:scratch", worktreeRoot: alive, worktrees: [alive] })]);
+
+		const pruned = await pruneDisposableRepos({ configDir, dbPath, tempRoots: [dir], platform: "linux" });
+
+		expect(pruned).toEqual([]);
+		expect(readRegistryRaw().repos).toHaveLength(1);
+	});
+
+	it("stands down on a runtime without node:sqlite instead of half-removing", async () => {
+		vi.mocked(canUseDashboardDb).mockReturnValue(false);
+		writeRegistry([entry({ repoIdentity: "local:temp", worktreeRoot: join(dir, "gone-1") })]);
+
+		expect(await pruneDisposableRepos({ configDir, dbPath, tempRoots: [dir], platform: "linux" })).toEqual([]);
+		expect(readRegistryRaw().repos).toHaveLength(1);
+	});
+
+	it("reports a failed removal rather than claiming it pruned the entry", async () => {
+		await seedRepoWithChildren("local:temp");
+		writeRegistry([entry({ repoIdentity: "local:temp", worktreeRoot: join(dir, "gone-1") })]);
+		vi.mocked(inTransaction).mockImplementation(() => {
+			throw new Error("database is locked");
+		});
+
+		const pruned = await pruneDisposableRepos({ configDir, dbPath, tempRoots: [dir], platform: "linux" });
+
+		expect(pruned).toHaveLength(1);
+		expect(pruned[0].error).toBe("database is locked");
+		expect(readRegistryRaw().repos).toHaveLength(1);
+	});
+
+	/** It runs on the dashboard launch path: a machine that cannot prune still gets its page. */
+	it("never throws — an unopenable database is a log line", async () => {
+		// A DIRECTORY where the database should be: `existsSync` says yes, the open
+		// fails, so the throw comes from inside `forgetRepos`.
+		mkdirSync(dbPath, { recursive: true });
+		writeRegistry([entry({ repoIdentity: "local:temp", worktreeRoot: join(dir, "gone-1") })]);
+
+		expect(await pruneDisposableRepos({ configDir, dbPath, tempRoots: [dir], platform: "linux" })).toEqual([]);
+		expect(readRegistryRaw().repos).toHaveLength(1);
+	});
+
+	it("spares an entry that mixes a temp path with a real one", async () => {
+		writeRegistry([
+			entry({
+				repoIdentity: "local:mixed",
+				worktreeRoot: join(dir, "gone"),
+				worktrees: ["/home/dev/real-project", join(dir, "gone")],
+			}),
+		]);
+
+		const pruned = await pruneDisposableRepos({ configDir, dbPath, tempRoots: [dir], platform: "linux" });
+
+		expect(pruned).toEqual([]);
+	});
+});
+
+describe("backupRepoRegistry", () => {
+	it("copies the registry beside itself with a UTC stamp", () => {
+		writeRegistry([entry({ repoIdentity: "local:aaa" })]);
+
+		const saved = backupRepoRegistry(Date.UTC(2026, 7, 17, 3, 4, 5), configDir);
+
+		expect(saved).toBe(`${getRepoRegistryPath(configDir)}.20260817T030405Z.bak`);
+		expect(saved && JSON.parse(readFileSync(saved, "utf-8")).repos).toHaveLength(1);
+	});
+
+	it("answers null when there is no registry to copy", () => {
+		expect(backupRepoRegistry(Date.now(), configDir)).toBeNull();
+	});
+});

--- a/cli/src/dashboard/RepoForget.ts
+++ b/cli/src/dashboard/RepoForget.ts
@@ -1,0 +1,440 @@
+/**
+ * RepoForget — removing a repo from this machine's dashboard, by IDENTITY.
+ *
+ * The registry and the `repos` table both used to be append-only in practice,
+ * and the reason was not a missing cleanup pass: the only removal entry point,
+ * `deregisterRepo`, resolves its target from `cwd`, so a checkout that no longer
+ * exists can never be named — and it stamps `disabledAt` rather than removing
+ * anything. Entries for deleted directories, renamed local-only repos and
+ * fixture checkouts under `%TEMP%` therefore accumulated with no code path able
+ * to reach them, kept being shipped to the browser in every page payload, and
+ * kept costing every sweep a pass.
+ *
+ * So this module is the identity-addressed removal, and everything else is a
+ * caller: the dashboard's per-row control, the unattended prune of
+ * {@link isDisposableRepo} entries, and `jolli doctor --fix`.
+ *
+ * Two orderings are load-bearing.
+ *
+ * **Database rows first, registry second.** The other way round, a registry
+ * write that lands while the row deletion fails leaves a row the page still
+ * renders and that no later sweep can see — the registry no longer lists it, so
+ * nothing will ever retry. Failing in this order costs at most one un-swept
+ * pass: the entry is still listed, and the next prune tries again.
+ *
+ * **Unprojected events with the rows.** `StatsWriter.ensureRepoRow` inserts a
+ * placeholder `repos` row from an event's identity alone, so a single `pending`
+ * (or revivable `failed`) row in `events_raw` resurrects a repo the moment the
+ * next drain runs. Deleting the rows without them is a no-op with a delay.
+ */
+
+import { copyFileSync, existsSync } from "node:fs";
+import { dirname } from "node:path";
+import { createLogger, errMsg } from "../Logger.js";
+import { formatUtcStamp } from "./Backup.js";
+import {
+	canUseDashboardDb,
+	type DashboardDbHandle,
+	getDashboardDbPath,
+	inTransaction,
+	withDashboardDb,
+	withReadonlyDashboardDb,
+} from "./DashboardDb.js";
+import {
+	type DisposableRepoOptions,
+	getRepoRegistryPath,
+	hasLiveWorktree,
+	isDisposableRepo,
+	type RegisteredRepo,
+	readRepoRegistry,
+	recordedRepoPaths,
+	removeReposFromRegistry,
+	tempRoots,
+} from "./RepoRegistry.js";
+
+const log = createLogger("RepoForget");
+
+export interface ForgetRepoOptions extends ClassifyRepoOptions {
+	readonly configDir?: string;
+	/** Override the database path. Tests point this at a temp file. */
+	readonly dbPath?: string;
+}
+
+/** What the database half removed for one identity. */
+export interface ForgetCounts {
+	readonly repoRowDeleted: boolean;
+	/** Rows deleted from the tables that reference `repos.id` directly. */
+	readonly childRowsDeleted: number;
+	readonly pendingEventsDeleted: number;
+}
+
+export interface ForgetRepoResult extends ForgetCounts {
+	readonly identity: string;
+	readonly removedFromRegistry: boolean;
+	/**
+	 * Why nothing was removed for this identity.
+	 *
+	 * Present only on failure, and its presence is what stops the registry half
+	 * running for that identity — a caller must be able to tell "there was
+	 * nothing to remove" (every count zero, no error) from "the removal did not
+	 * happen", because the two look identical in the counts alone.
+	 */
+	readonly error?: string;
+}
+
+const NOTHING: ForgetCounts = { repoRowDeleted: false, childRowsDeleted: 0, pendingEventsDeleted: 0 };
+
+/** A table that references `repos.id`, and the column that does it. */
+interface RepoChildTable {
+	readonly table: string;
+	readonly column: string;
+}
+
+/**
+ * The tables that reference `repos.id` directly, derived from the schema rather
+ * than listed here.
+ *
+ * Twelve today (`branches`, `commits`, `context`, `ingest_cursors`, `memories`,
+ * `recall_receipts`, `repo_state`, `sessions`, `topic_pages`,
+ * `topic_processed_sources`, `transcripts`, `worktree_status`), and the other ten
+ * tables that carry a `repo_id` reach `repos` only through one of those with
+ * `ON DELETE CASCADE`, so deleting these twelve empties all of them. Every
+ * reference is `NO ACTION`, so the row itself cannot go first.
+ *
+ * Derived because a hand-kept list fails in the direction that is hard to
+ * notice: a table added later would make the final `DELETE FROM repos` fail the
+ * foreign-key check, and the failure would surface as "forget did not work" long
+ * after the schema change that caused it. `SotSchema`'s own test pins the derived
+ * set, so a new referencing table shows up as a visible test edit instead.
+ *
+ * Sorted for determinism — the deletion order is irrelevant (every one of them is
+ * a child of `repos`, and their own children cascade), but a stable order keeps
+ * the assertion and the log line stable.
+ */
+export function repoChildTables(db: DashboardDbHandle): ReadonlyArray<RepoChildTable> {
+	const names = db
+		.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name <> 'repos'")
+		.all() as ReadonlyArray<{ name: string }>;
+	const out: RepoChildTable[] = [];
+	for (const { name } of names) {
+		// PRAGMA takes no bound parameters, and the name came out of this database's
+		// own sqlite_master — quoted anyway so a table whose name needs it still works.
+		const fks = db.prepare(`PRAGMA foreign_key_list("${name}")`).all() as ReadonlyArray<{
+			table: string;
+			from: string;
+			to: string | null;
+		}>;
+		// `to` is null when a reference omits the parent column (implicit primary
+		// key). Our schema always names `id`; accept both so a later table cannot
+		// slip through by using the shorter form.
+		const fk = fks.find((entry) => entry.table === "repos" && (entry.to === "id" || entry.to === null));
+		if (fk) out.push({ table: name, column: fk.from });
+	}
+	return out.sort((a, b) => a.table.localeCompare(b.table));
+}
+
+/** Deletes one repo's rows. Runs inside the caller's transaction. */
+function deleteRepoRows(
+	db: DashboardDbHandle,
+	identity: string,
+	children: ReadonlyArray<RepoChildTable>,
+): ForgetCounts {
+	const row = db.prepare("SELECT id FROM repos WHERE repo_identity = ?").get(identity) as { id: number } | undefined;
+	let childRowsDeleted = 0;
+	if (row) {
+		for (const { table, column } of children) {
+			childRowsDeleted += changed(db.prepare(`DELETE FROM "${table}" WHERE "${column}" = ?`).run(row.id));
+		}
+	}
+	const repoRowDeleted = row !== undefined && changed(db.prepare("DELETE FROM repos WHERE id = ?").run(row.id)) > 0;
+	// Not gated on `row`: an identity whose only trace is an unprojected event has
+	// no row yet, and leaving that event behind means the next drain creates one.
+	// `<> 'projected'` rather than `= 'pending'` because the drain revives a
+	// `failed` row whose reason was `unknown-type`.
+	const pendingEventsDeleted = changed(
+		db.prepare("DELETE FROM events_raw WHERE repo_identity = ? AND projection_status <> 'projected'").run(identity),
+	);
+	return { repoRowDeleted, childRowsDeleted, pendingEventsDeleted };
+}
+
+/**
+ * The row count of a statement `run`. `DashboardStatement.run` is typed `unknown`
+ * (the handle is structurally typed against `DatabaseSync` rather than importing
+ * it), and `Number` also flattens the bigint form a driver may report — same
+ * reading as `SotImport` / `SotWrite` do.
+ */
+function changed(result: unknown): number {
+	return Number((result as { changes: number | bigint }).changes);
+}
+
+/**
+ * Forgets several repos: their rows, their unprojected events, their registry
+ * entries. Never partially reported — an identity whose rows could not be
+ * deleted keeps its registry entry and comes back with `error` set.
+ *
+ * Throws only when the database is unreachable as a whole, because that is the
+ * one state in which removing the registry entries would be actively harmful:
+ * the rows would stay, and the page would keep rendering repos nothing can
+ * reach any more.
+ */
+export async function forgetRepos(
+	identities: ReadonlyArray<string>,
+	opts: ForgetRepoOptions = {},
+): Promise<ReadonlyArray<ForgetRepoResult>> {
+	const unique = [...new Set(identities)];
+	if (unique.length === 0) return [];
+	if (!canUseDashboardDb()) {
+		throw new Error(
+			"node:sqlite is unavailable on this runtime — cannot delete a repo's rows, so nothing was removed",
+		);
+	}
+
+	const counts = new Map<string, ForgetCounts>();
+	const failures = new Map<string, string>();
+	const dbPath = opts.dbPath ?? getDashboardDbPath();
+	if (existsSync(dbPath)) {
+		await withDashboardDb(
+			(db) => {
+				const children = repoChildTables(db);
+				for (const identity of unique) {
+					// One transaction per identity, and a failure confined to it: a lock
+					// lost on the tenth repo must not roll back the nine before it, nor
+					// stop the sweep from finishing the rest.
+					try {
+						counts.set(
+							identity,
+							inTransaction(db, () => deleteRepoRows(db, identity, children)),
+						);
+					} catch (err) {
+						failures.set(identity, errMsg(err));
+						log.warn("could not delete rows for %s: %s", identity, errMsg(err));
+					}
+				}
+			},
+			opts.dbPath ? { dbPath: opts.dbPath } : {},
+		);
+	} else {
+		// No database yet: there are no rows to lose, so the registry half is safe
+		// to run. Opening it here would CREATE and migrate one, which is a strange
+		// side effect for a removal.
+		for (const identity of unique) counts.set(identity, NOTHING);
+	}
+
+	const removed = new Set(await removeReposFromRegistry([...counts.keys()], opts.configDir));
+	return unique.map((identity) => {
+		const error = failures.get(identity);
+		if (error !== undefined) return { identity, removedFromRegistry: false, ...NOTHING, error };
+		/* v8 ignore next -- the two maps partition `unique`: an identity without an
+		   error was counted above, so the fallback is unreachable by construction */
+		return { identity, removedFromRegistry: removed.has(identity), ...(counts.get(identity) ?? NOTHING) };
+	});
+}
+
+/** {@link forgetRepos} for one identity. */
+export async function forgetRepo(identity: string, opts: ForgetRepoOptions = {}): Promise<ForgetRepoResult> {
+	const [result] = await forgetRepos([identity], opts);
+	return result;
+}
+
+/**
+ * What a registry entry is, as far as removal is concerned.
+ *
+ * `dead` and `unavailable` are the same observation — no recorded path exists —
+ * split by whether the VOLUME is there. An unplugged external drive or an
+ * unmapped network drive is a repo the user still expects back, and `DbBackfill`
+ * already refuses to deregister on that evidence for the same reason.
+ *
+ * Neither is ever removed unattended; the split changes the ADVICE, and how much
+ * of it can be given is platform-dependent. On Windows a missing drive letter or
+ * unreachable UNC host makes the distinction exactly, so the report can say
+ * "plug it in" instead of offering a removal. On POSIX an unmounted mountpoint
+ * usually still exists as an empty directory, so it is indistinguishable from a
+ * deleted folder and reads as `dead`. That residual is what makes the removal of
+ * a `dead` entry `doctor --fix`-only, listed by path, and backed up first —
+ * consent is the guard the filesystem cannot provide.
+ */
+export type RegistryEntryVerdict = "live" | "disposable" | "dead" | "unavailable";
+
+/**
+ * Whether the volume this path is on can be reached at all — i.e. whether it has
+ * ANY existing ancestor.
+ *
+ * Deliberately no `resolve()`: a POSIX-absolute path recorded by a WSL or
+ * cross-platform tool is treated as drive-relative on Windows, so resolving would
+ * answer about a directory the entry never named. Same reason
+ * `normalizePathForCompare` avoids it.
+ *
+ * `exists` is a seam because the `false` branch is unreachable on POSIX, where
+ * every absolute path bottoms out at a live `/` — so the one verdict that must
+ * never be confused with a deletion would otherwise be covered on Windows only.
+ */
+export function volumeReachable(path: string, exists: (probe: string) => boolean = existsSync): boolean {
+	let probe = path;
+	while (!exists(probe)) {
+		const parent = dirname(probe);
+		if (parent === probe) return false;
+		probe = parent;
+	}
+	return true;
+}
+
+export interface ClassifyRepoOptions extends DisposableRepoOptions {
+	/** Existence probe for the volume walk; see {@link volumeReachable}. */
+	readonly pathExists?: (path: string) => boolean;
+}
+
+export function classifyRegistryEntry(repo: RegisteredRepo, opts: ClassifyRepoOptions = {}): RegistryEntryVerdict {
+	if (hasLiveWorktree(repo)) return "live";
+	if (isDisposableRepo(repo, opts)) return "disposable";
+	const reachable = recordedRepoPaths(repo).some((path) =>
+		opts.pathExists ? volumeReachable(path, opts.pathExists) : volumeReachable(path),
+	);
+	return reachable ? "dead" : "unavailable";
+}
+
+export interface RegistrySurvey {
+	readonly live: ReadonlyArray<RegisteredRepo>;
+	/** Auto-prunable; see {@link isDisposableRepo}. */
+	readonly disposable: ReadonlyArray<RegisteredRepo>;
+	/** Gone, on a volume that is present — removable, but only on request. */
+	readonly dead: ReadonlyArray<RegisteredRepo>;
+	/** Gone with its whole volume — reported, never removed. */
+	readonly unavailable: ReadonlyArray<RegisteredRepo>;
+}
+
+/**
+ * `repos` rows whose identity the registry does not list, as registry-shaped
+ * entries — the OTHER half of what is on this machine.
+ *
+ * The two stores are written by different paths (`registerRepo` writes the
+ * registry; `StatsWriter.ensureRepoRow` inserts from an event's identity alone),
+ * so a row can outlive its entry — a `jolli disable` + registry edit, a fixture
+ * that only ever produced events, a registry rebuilt from a different machine.
+ * Such a row is the shape that hurts most: the page renders it, and a survey that
+ * reads only the registry reports the machine as clean.
+ *
+ * A row whose `worktree_root` IS its identity is skipped: that is the placeholder
+ * an event creates before its repo registers, and it names no directory to judge.
+ * Best-effort — an unreadable database means the registry half still answers.
+ */
+async function unregisteredRepoRows(
+	known: ReadonlySet<string>,
+	opts: ForgetRepoOptions,
+): Promise<ReadonlyArray<RegisteredRepo>> {
+	const dbPath = opts.dbPath ?? getDashboardDbPath();
+	if (!canUseDashboardDb() || !existsSync(dbPath)) return [];
+	try {
+		return await withReadonlyDashboardDb(
+			(db) =>
+				(
+					db
+						.prepare("SELECT repo_identity, repo_name, worktree_root, enabled_at FROM repos")
+						.all() as ReadonlyArray<{
+						repo_identity: string;
+						repo_name: string;
+						worktree_root: string;
+						enabled_at: string;
+					}>
+				)
+					.filter((row) => !known.has(row.repo_identity) && row.worktree_root !== row.repo_identity)
+					.map((row) => ({
+						repoIdentity: row.repo_identity,
+						repoName: row.repo_name,
+						worktreeRoot: row.worktree_root,
+						enabledAt: row.enabled_at,
+					})),
+			opts.dbPath ? { dbPath: opts.dbPath } : {},
+		);
+	} catch (err) {
+		log.warn("could not list database repos for the registry survey: %s", errMsg(err));
+		return [];
+	}
+}
+
+/**
+ * Groups everything this machine claims is a repo — registry entries AND
+ * database rows the registry no longer lists — by {@link classifyRegistryEntry}.
+ */
+export async function surveyRepoRegistry(opts: ForgetRepoOptions = {}): Promise<RegistrySurvey> {
+	const survey: Record<RegistryEntryVerdict, RegisteredRepo[]> = {
+		live: [],
+		disposable: [],
+		dead: [],
+		unavailable: [],
+	};
+	// The WHOLE registry, disabled entries included: a disabled entry whose
+	// directory is gone is exactly as unreachable as an enabled one, and
+	// `listActiveRepos` would filter out the very rows this survey exists to find.
+	const entries = (await readRepoRegistry(opts.configDir)).repos;
+	const known = new Set(entries.map((repo) => repo.repoIdentity));
+	// Resolved once, ahead of the loop: `isDisposableRepo` otherwise falls back to
+	// `tempRoots()` per call, which is a `realpathSync` per entry for an answer
+	// that cannot change during one survey. `repairRegistryEntries` already hoists
+	// it around its own loop; this is the same hoist on the read side.
+	const classifyOpts: ClassifyRepoOptions = { ...opts, tempRoots: opts.tempRoots ?? tempRoots() };
+	for (const repo of [...entries, ...(await unregisteredRepoRows(known, opts))]) {
+		survey[classifyRegistryEntry(repo, classifyOpts)].push(repo);
+	}
+	return survey;
+}
+
+/**
+ * Copies the registry beside itself, returning the backup's path — or null when
+ * there is no registry yet.
+ *
+ * For the removals a user asked for, never for the unattended prune. The prune's
+ * class is fixture garbage under `%TEMP%` and a backup of it is a copy of the
+ * problem; `doctor --fix` reaches entries whose only fault is that a folder is
+ * gone, which a remounted drive or a re-clone can make wrong, and there the one
+ * irreversible step deserves an undo.
+ *
+ * Throws rather than degrading: a removal that could not be backed up is not the
+ * operation the user consented to. Names itself with the same UTC stamp
+ * `Backup.ts` puts on database snapshots, so two artifacts of one incident sort
+ * together.
+ */
+export function backupRepoRegistry(nowMs: number, configDir?: string): string | null {
+	const path = getRepoRegistryPath(configDir);
+	if (!existsSync(path)) return null;
+	const backup = `${path}.${formatUtcStamp(nowMs)}.bak`;
+	copyFileSync(path, backup);
+	return backup;
+}
+
+/**
+ * Removes every {@link isDisposableRepo} entry, unattended.
+ *
+ * Called on the dashboard launch path, so it never throws — a machine that
+ * cannot prune must still get its page. It reports what it removed instead of
+ * capping or summarising: the caller prints one line, and every identity is in
+ * the log.
+ */
+export async function pruneDisposableRepos(opts: ForgetRepoOptions = {}): Promise<ReadonlyArray<ForgetRepoResult>> {
+	try {
+		if (!canUseDashboardDb()) {
+			log.debug("skipping the disposable-repo prune — node:sqlite is unavailable on this runtime");
+			return [];
+		}
+		const victims = (await surveyRepoRegistry(opts)).disposable;
+		if (victims.length === 0) return [];
+		for (const repo of victims) log.info("pruning disposable entry %s (%s)", repo.repoIdentity, repo.worktreeRoot);
+		const results = await forgetRepos(
+			victims.map((repo) => repo.repoIdentity),
+			opts,
+		);
+		for (const result of results) {
+			if (result.error !== undefined) continue; // already warned by forgetRepos
+			log.info(
+				"pruned %s: repo row %s, %d child row(s), %d unprojected event(s)",
+				result.identity,
+				result.repoRowDeleted ? "deleted" : "absent",
+				result.childRowsDeleted,
+				result.pendingEventsDeleted,
+			);
+		}
+		return results;
+	} catch (err) {
+		log.warn("disposable-repo prune failed: %s", errMsg(err));
+		return [];
+	}
+}

--- a/cli/src/dashboard/RepoRegistry.test.ts
+++ b/cli/src/dashboard/RepoRegistry.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -26,13 +26,19 @@ import {
 	existingWorktrees,
 	getRepoRegistryPath,
 	hasLiveWorktree,
+	isDisposableRepo,
 	listActiveRepos,
+	type RegisteredRepo,
 	readRegistryInstanceId,
 	readRepoRegistry,
 	registerRepo,
+	removeRepoFromRegistry,
+	removeReposFromRegistry,
+	repairRegistryEntries,
 	resolveRepoIdentity,
 	sameRecordedRoot,
 	stampRegistryInstanceId,
+	tempRoots,
 } from "./RepoRegistry.js";
 
 let configDir: string;
@@ -326,6 +332,378 @@ describe("multiple checkouts of one project (§10.2)", () => {
 			enabledAt: "t",
 		};
 		expect(existingWorktrees(repo)).toEqual(["/gone-too"]);
+	});
+});
+
+describe("isDisposableRepo", () => {
+	const TEMP = "/tmp/jolli-fixtures";
+	const disposable = (over: Partial<RegisteredRepo> = {}): RegisteredRepo => ({
+		repoIdentity: "local:abc",
+		repoName: "repo",
+		worktreeRoot: `${TEMP}/gone/repo`,
+		enabledAt: "t",
+		...over,
+	});
+	const opts = { tempRoots: [TEMP], platform: "linux" as const };
+
+	it("accepts a local: identity whose every recorded path is a vanished temp path", () => {
+		expect(isDisposableRepo(disposable(), opts)).toBe(true);
+	});
+
+	it("refuses a remote-backed identity on an unmarked temp path", () => {
+		// The identity is shared between clones — the `repos` row is keyed by it — so
+		// forgetting it on this evidence alone could take another clone's history.
+		expect(isDisposableRepo(disposable({ repoIdentity: "https://github.com/a/b" }), opts)).toBe(false);
+	});
+
+	it("accepts a remote-backed identity when every path names a known throwaway", () => {
+		// A vanished `%TEMP%/jolli-cutover-…/repo` is a fixture whichever remote it
+		// was cloned from, which is the one inference narrow enough to act on.
+		const repo = disposable({
+			repoIdentity: "https://github.com/a/b",
+			worktreeRoot: `${TEMP}/jolli-cutover-sG1Rx7/repo`,
+			worktrees: [`${TEMP}/jolli-cutover-sG1Rx7/repo`],
+		});
+		expect(isDisposableRepo(repo, opts)).toBe(true);
+	});
+
+	it("accepts an agent scratchpad checkout under any remote", () => {
+		// The real shape this widening was added for.
+		const path = `${TEMP}/claude/c--jolli-project-jolliai/3e49b42d/scratchpad/pr/c2`;
+		const repo = disposable({
+			repoIdentity: "https://github.com/fake/shared",
+			worktreeRoot: path,
+			worktrees: [path],
+		});
+		expect(isDisposableRepo(repo, opts)).toBe(true);
+	});
+
+	it("refuses a remote-backed entry that mixes a marked path with an unmarked one", () => {
+		// One unmarked temp path is enough to make "no other clone exists" unproven.
+		const repo = disposable({
+			repoIdentity: "https://github.com/a/b",
+			worktreeRoot: `${TEMP}/jolli-cutover-x/repo`,
+			worktrees: [`${TEMP}/jolli-cutover-x/repo`, `${TEMP}/plain/repo`],
+		});
+		expect(isDisposableRepo(repo, opts)).toBe(false);
+	});
+
+	it("refuses a remote-backed entry recorded AT the temp root itself", () => {
+		// `isUnder` accepts the root, but there is no segment below it to carry a
+		// marker — so the identity clause still has nothing to go on.
+		const repo = disposable({ repoIdentity: "https://github.com/a/b", worktreeRoot: TEMP, worktrees: [TEMP] });
+		expect(isDisposableRepo(repo, opts)).toBe(false);
+	});
+
+	it("looks for the marker BELOW the temp root, not in the root's own name", () => {
+		// A test that injects its own `jolli-…` mkdtemp dir as the temp root must not
+		// see everything inside it marked — that is the distinction being tested.
+		const injected = `${TEMP}/jolli-forget-abc`;
+		const repo = disposable({
+			repoIdentity: "https://github.com/a/b",
+			worktreeRoot: `${injected}/gone`,
+			worktrees: [`${injected}/gone`],
+		});
+		expect(isDisposableRepo(repo, { tempRoots: [injected], platform: "linux" })).toBe(false);
+		// Measured against the REAL temp root, the same path is a fixture.
+		expect(isDisposableRepo(repo, opts)).toBe(true);
+	});
+
+	it("refuses an entry that mixes a temp path with a real one", () => {
+		const repo = disposable({ worktrees: ["/home/dev/real", `${TEMP}/gone/repo`] });
+		expect(isDisposableRepo(repo, opts)).toBe(false);
+	});
+
+	it("judges worktreeRoot too, not only the worktrees list", () => {
+		// A `worktrees` list that happens to be all-temp says nothing about a
+		// `worktreeRoot` pointing somewhere real.
+		const repo = disposable({ worktreeRoot: "/home/dev/real", worktrees: [`${TEMP}/gone/repo`] });
+		expect(isDisposableRepo(repo, opts)).toBe(false);
+	});
+
+	it("refuses a temp checkout that still exists — a session may be using it", () => {
+		const live = mkdtempSync(join(tmpdir(), "jolli-live-"));
+		try {
+			const repo = disposable({ worktreeRoot: live, worktrees: [live] });
+			expect(isDisposableRepo(repo, { tempRoots: [tmpdir()], platform: process.platform })).toBe(false);
+		} finally {
+			rmSync(live, { recursive: true, force: true });
+		}
+	});
+
+	it("asks the SAME union about liveness that it asked about scope", () => {
+		// The scope and identity clauses deliberately re-derive the claim rather than
+		// trusting `registerRepo`'s "worktreeRoot is inside worktrees" invariant. The
+		// liveness clause must not then rely on it: `hasLiveWorktree` reads
+		// `recordedRepoPaths` alone, so an entry whose `worktrees` omits a LIVE
+		// `worktreeRoot` would be pruned with its own checkout still on disk.
+		const live = mkdtempSync(join(tmpdir(), "jolli-live-root-"));
+		try {
+			const repo = disposable({
+				worktreeRoot: live,
+				worktrees: [join(tmpdir(), "jolli-gone-fixture", "repo")],
+			});
+			expect(isDisposableRepo(repo, { tempRoots: [tmpdir()], platform: process.platform })).toBe(false);
+		} finally {
+			rmSync(live, { recursive: true, force: true });
+		}
+	});
+
+	it("refuses a path that merely starts with the temp root's characters", () => {
+		// `/tmp/jolli-fixtures-elsewhere` is not inside `/tmp/jolli-fixtures`; a
+		// prefix test without the separator boundary would say it is.
+		expect(isDisposableRepo(disposable({ worktreeRoot: `${TEMP}-elsewhere/repo` }), opts)).toBe(false);
+	});
+
+	it("folds case on win32 and not on linux", () => {
+		const repo = disposable({ worktreeRoot: "C:\\Temp\\Fix\\repo", worktrees: ["C:\\Temp\\Fix\\repo"] });
+		expect(isDisposableRepo(repo, { tempRoots: ["c:\\temp\\fix"], platform: "win32" })).toBe(true);
+		expect(isDisposableRepo(repo, { tempRoots: ["c:\\temp\\fix"], platform: "linux" })).toBe(false);
+	});
+
+	it("defaults to the real temp roots and the host platform", () => {
+		// The no-options call is what production makes; every case above names both,
+		// so without this the defaults were never exercised.
+		const gone = join(tmpdir(), "jolli-no-such-fixture-9f3a2c");
+		expect(isDisposableRepo(disposable({ worktreeRoot: gone, worktrees: [gone] }))).toBe(true);
+		expect(isDisposableRepo(disposable({ worktreeRoot: "/home/dev/real", worktrees: ["/home/dev/real"] }))).toBe(
+			false,
+		);
+	});
+
+	it("names the real temp dir and its resolved twin", () => {
+		// Both spellings, so a macOS `/var` vs `/private/var` recording matches.
+		const roots = tempRoots();
+		expect(roots).toContain(tmpdir());
+		expect(roots.length).toBeGreaterThanOrEqual(1);
+		expect(new Set(roots).size).toBe(roots.length);
+	});
+});
+
+describe("removeReposFromRegistry", () => {
+	const seed = (identities: ReadonlyArray<string>): void => {
+		writeFileSync(
+			getRepoRegistryPath(configDir),
+			JSON.stringify({
+				version: 1,
+				instanceId: "id-1",
+				repos: identities.map((repoIdentity) => ({
+					repoIdentity,
+					repoName: "r",
+					worktreeRoot: `/gone/${repoIdentity}`,
+					enabledAt: "t",
+				})),
+			}),
+		);
+	};
+
+	it("removes only the named entries and reports which were present", async () => {
+		seed(["a", "b", "c"]);
+		const removed = await removeReposFromRegistry(["a", "c", "never"], configDir);
+		expect([...removed].sort()).toEqual(["a", "c"]);
+		expect((await readRepoRegistry(configDir)).repos.map((r) => r.repoIdentity)).toEqual(["b"]);
+	});
+
+	it("preserves the instance-id witness", async () => {
+		// A read-modify-write that dropped it would blind the deletion detector.
+		seed(["a"]);
+		await removeReposFromRegistry(["a"], configDir);
+		expect(await readRegistryInstanceId(configDir)).toBe("id-1");
+	});
+
+	it("writes nothing when no identity matched", async () => {
+		seed(["a"]);
+		const before = readFileSync(getRepoRegistryPath(configDir), "utf-8");
+		expect(await removeReposFromRegistry(["nope"], configDir)).toEqual([]);
+		expect(readFileSync(getRepoRegistryPath(configDir), "utf-8")).toBe(before);
+	});
+
+	it("short-circuits an empty request without touching the file", async () => {
+		expect(await removeReposFromRegistry([], configDir)).toEqual([]);
+		expect(existsSync(getRepoRegistryPath(configDir))).toBe(false);
+	});
+
+	it("refuses to rewrite a registry it could not read", async () => {
+		// Fail-open here would write back "everything except the ones I wanted",
+		// i.e. delete every other repo. See readRepoRegistryStrict.
+		writeFileSync(getRepoRegistryPath(configDir), "{ not json");
+		await expect(removeReposFromRegistry(["a"], configDir)).rejects.toThrow();
+	});
+
+	it("removeRepoFromRegistry answers whether the one entry was there", async () => {
+		seed(["a"]);
+		expect(await removeRepoFromRegistry("a", configDir)).toBe(true);
+		expect(await removeRepoFromRegistry("a", configDir)).toBe(false);
+	});
+});
+
+describe("repairRegistryEntries", () => {
+	let live: string;
+	let temp: string;
+
+	beforeEach(() => {
+		temp = mkdtempSync(join(tmpdir(), "jolli-repair-"));
+		live = join(temp, "live");
+		mkdirSync(live, { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(temp, { recursive: true, force: true });
+	});
+
+	const seed = (repo: Partial<RegisteredRepo>): void => {
+		writeFileSync(
+			getRepoRegistryPath(configDir),
+			JSON.stringify({
+				version: 1,
+				repos: [{ repoIdentity: "id", repoName: "r", worktreeRoot: live, enabledAt: "t", ...repo }],
+			}),
+		);
+	};
+
+	it("drops a vanished temp path merged into a real repo's worktrees", async () => {
+		// The ticket's corrupted real entry: a genuine checkout with two fixture
+		// paths in its list.
+		const ghost = join(temp, "jolli-cutover-x", "repo");
+		seed({ worktrees: [ghost, live] });
+
+		const repairs = await repairRegistryEntries({ configDir, tempRoots: [temp], platform: process.platform });
+
+		expect(repairs).toHaveLength(1);
+		expect(repairs[0].droppedPaths).toEqual([ghost]);
+		expect((await readRepoRegistry(configDir)).repos[0].worktrees).toEqual([live]);
+	});
+
+	it("keeps a vanished path that is NOT under a temp root", async () => {
+		// An unmounted share comes back, and a checkout the list forgot is invisible
+		// to the cutover's source enumeration.
+		seed({ worktrees: ["/mnt/share/project", live] });
+		const repairs = await repairRegistryEntries({ configDir, tempRoots: [temp], platform: process.platform });
+		expect(repairs).toEqual([]);
+		expect((await readRepoRegistry(configDir)).repos[0].worktrees).toEqual(["/mnt/share/project", live]);
+	});
+
+	it("collapses two spellings of one path, newest winning", async () => {
+		const shouty = live.toUpperCase();
+		seed({ worktrees: [shouty, live] });
+
+		// No temp roots, because the two repair rules would otherwise interact and the
+		// outcome would depend on the FILESYSTEM rather than on the `platform` argument.
+		// Vanished-under-a-temp-root is checked first by design, and `isUnder` folds case
+		// under win32 — so on a case-INSENSITIVE filesystem the shouty spelling exists and
+		// reaches the collapse, while on a case-sensitive one it does not exist, matches
+		// the temp root under win32 folding, and is dropped as a vanished fixture path
+		// before the collapse is ever reached. That is what made this pass on Windows and
+		// fail on CI. The temp rule has its own cases above; this one is about the collapse.
+		const repairs = await repairRegistryEntries({ configDir, tempRoots: [], platform: "win32" });
+
+		expect(repairs[0].collapsedPaths).toEqual([shouty]);
+		expect((await readRepoRegistry(configDir)).repos[0].worktrees).toEqual([live]);
+	});
+
+	it("repoints a dead worktreeRoot at the newest live path", async () => {
+		const dead = join(temp, "moved-away");
+		seed({ worktreeRoot: dead, worktrees: [live, dead] });
+
+		const repairs = await repairRegistryEntries({ configDir, tempRoots: [], platform: process.platform });
+
+		expect(repairs[0].repointedTo).toBe(live);
+		expect((await readRepoRegistry(configDir)).repos[0].worktreeRoot).toBe(live);
+	});
+
+	it("does not re-append a worktreeRoot it just dropped as a dead temp path", async () => {
+		const ghost = join(temp, "jolli-cutover-y", "repo");
+		seed({ worktreeRoot: ghost, worktrees: [live, ghost] });
+
+		await repairRegistryEntries({ configDir, tempRoots: [temp], platform: process.platform });
+
+		const entry = (await readRepoRegistry(configDir)).repos[0];
+		expect(entry.worktrees).toEqual([live]);
+		expect(entry.worktreeRoot).toBe(live);
+	});
+
+	it("re-adds a worktreeRoot the list never carried, keeping registerRepo's invariant", async () => {
+		// `registerRepo` guarantees `worktreeRoot` is the last entry of `worktrees`;
+		// a hand-edited or pre-`worktrees` entry can break that, and a repair must
+		// not be the thing that leaves the displayed root out of the collected set.
+		const other = join(temp, "other-clone");
+		mkdirSync(other, { recursive: true });
+		const ghost = join(temp, "jolli-cutover-w", "repo");
+		seed({ worktreeRoot: live, worktrees: [ghost, other] });
+
+		const repairs = await repairRegistryEntries({ configDir, tempRoots: [temp], platform: process.platform });
+
+		expect(repairs[0].droppedPaths).toEqual([ghost]);
+		expect(repairs[0].repointedTo).toBeUndefined();
+		expect((await readRepoRegistry(configDir)).repos[0].worktrees).toEqual([other, live]);
+	});
+
+	it("leaves a wholly dead entry to forgetRepos", async () => {
+		seed({ worktreeRoot: join(temp, "gone"), worktrees: [join(temp, "gone")] });
+		expect(await repairRegistryEntries({ configDir, tempRoots: [], platform: process.platform })).toEqual([]);
+	});
+
+	it("takes no write lock for a dry run, and takes it for a real pass", async () => {
+		// `jolli doctor` computes this preview on EVERY run, including a plain
+		// read-only one — so taking the registry lock for it put a diagnostic into
+		// contention with the `registerRepo` a post-commit hook runs concurrently.
+		// A preview performs no write, and reads need no lock (writes are atomic).
+		const locks = await import("../core/Locks.js");
+		const spy = vi.spyOn(locks, "withRepoRegistryLock");
+		const ghost = join(temp, "jolli-cutover-lock", "repo");
+		seed({ worktrees: [ghost, live] });
+
+		try {
+			const preview = await repairRegistryEntries({
+				configDir,
+				tempRoots: [temp],
+				platform: process.platform,
+				dryRun: true,
+			});
+			expect(preview).toHaveLength(1);
+			expect(spy).not.toHaveBeenCalled();
+
+			await repairRegistryEntries({ configDir, tempRoots: [temp], platform: process.platform });
+			expect(spy).toHaveBeenCalledTimes(1);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+
+	it("writes nothing when there is nothing to repair", async () => {
+		seed({ worktrees: [live] });
+		const before = readFileSync(getRepoRegistryPath(configDir), "utf-8");
+		expect(await repairRegistryEntries({ configDir, tempRoots: [temp], platform: process.platform })).toEqual([]);
+		expect(readFileSync(getRepoRegistryPath(configDir), "utf-8")).toBe(before);
+	});
+
+	it("defaults to the real temp roots and the host platform", async () => {
+		// Same reason as the disposable predicate's own default case: production
+		// passes neither, so the `??` sides need one call that omits them. The temp
+		// dir this fixture lives in IS a real temp root, so the ghost is dropped.
+		const ghost = join(temp, "jolli-cutover-default", "repo");
+		seed({ worktrees: [ghost, live] });
+
+		const repairs = await repairRegistryEntries({ configDir });
+
+		expect(repairs).toHaveLength(1);
+		expect(repairs[0].droppedPaths).toEqual([ghost]);
+	});
+
+	it("dryRun computes the same repairs and changes nothing on disk", async () => {
+		const ghost = join(temp, "jolli-cutover-z", "repo");
+		seed({ worktrees: [ghost, live] });
+		const before = readFileSync(getRepoRegistryPath(configDir), "utf-8");
+
+		const repairs = await repairRegistryEntries({
+			configDir,
+			tempRoots: [temp],
+			platform: process.platform,
+			dryRun: true,
+		});
+
+		expect(repairs).toHaveLength(1);
+		expect(readFileSync(getRepoRegistryPath(configDir), "utf-8")).toBe(before);
 	});
 });
 

--- a/cli/src/dashboard/RepoRegistry.ts
+++ b/cli/src/dashboard/RepoRegistry.ts
@@ -21,8 +21,9 @@
  */
 
 import { createHash } from "node:crypto";
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { writeFileAtomic } from "../core/AtomicJsonFile.js";
 import { getProjectRootDir } from "../core/GitOps.js";
@@ -89,6 +90,19 @@ export function sameRecordedRoot(a: string, b: string, platform: NodeJS.Platform
 }
 
 /**
+ * The paths this entry claims, tolerating entries written before `worktrees`
+ * existed — the whole claim, live or not.
+ *
+ * Naming the fallback once is what stops its consumers disagreeing about it:
+ * {@link existingWorktrees} wants the live subset, {@link hasLiveWorktree} wants
+ * "any of them", {@link isDisposableRepo} wants "all of them", and `RepoForget`
+ * asks which volume each one is on.
+ */
+export function recordedRepoPaths(repo: RegisteredRepo): ReadonlyArray<string> {
+	return repo.worktrees && repo.worktrees.length > 0 ? repo.worktrees : [repo.worktreeRoot];
+}
+
+/**
  * Every worktree of a repo that still exists on disk, newest first.
  *
  * Tolerates entries written before `worktrees` existed (falls back to
@@ -96,8 +110,7 @@ export function sameRecordedRoot(a: string, b: string, platform: NodeJS.Platform
  * is also what stops a relocated local-only repo from stranding its old path.
  */
 export function existingWorktrees(repo: RegisteredRepo): ReadonlyArray<string> {
-	const known = repo.worktrees && repo.worktrees.length > 0 ? repo.worktrees : [repo.worktreeRoot];
-	const alive = [...known].reverse().filter((path) => existsSync(path));
+	const alive = [...recordedRepoPaths(repo)].reverse().filter((path) => existsSync(path));
 	// Never return empty while the repo is registered: a caller that would then
 	// collect nothing is better off trying the recorded path and failing loudly
 	// in git than silently sweeping zero worktrees.
@@ -112,14 +125,147 @@ export function existingWorktrees(repo: RegisteredRepo): ReadonlyArray<string> {
  * cannot read that off the returned list, because the fallback makes a repo
  * whose every path is gone look identical to one with a single live checkout.
  *
- * The registry is append-only in practice — nothing prunes it, and
- * `deregisterRepo` has to run from inside the repo it removes, which a deleted
- * directory makes impossible — so dead entries accumulate and every sweep pays
- * for them again. Asking this first is how a sweep tells "gone" from "broken".
+ * Dead entries are REMOVABLE but not automatically removed: `deregisterRepo`
+ * has to run from inside the repo it removes, which a deleted directory makes
+ * impossible, so the identity-addressed `forgetRepo` (see `RepoForget.ts`) is
+ * what reaches them — automatically for the narrow {@link isDisposableRepo}
+ * class, and only on request for everything else. A sweep still meets dead
+ * entries in between, so asking this first is how it tells "gone" from "broken".
  */
 export function hasLiveWorktree(repo: RegisteredRepo): boolean {
-	const known = repo.worktrees && repo.worktrees.length > 0 ? repo.worktrees : [repo.worktreeRoot];
-	return known.some((path) => existsSync(path));
+	return recordedRepoPaths(repo).some((path) => existsSync(path));
+}
+
+/** Prefix of the path-hashed identity a repo with no usable remote falls back to. */
+export const LOCAL_IDENTITY_PREFIX = "local:";
+
+/**
+ * The temp roots a recorded path may legitimately sit under.
+ *
+ * Both spellings, because they are produced by different halves of the same
+ * flow: `os.tmpdir()` answers `/var/folders/…` on macOS while every path this
+ * registry stores came from `git rev-parse --show-toplevel`, which resolves the
+ * `/var` → `private/var` symlink and reports `/private/var/folders/…`. Matching
+ * only the first makes {@link isDisposableRepo} answer `false` for every macOS
+ * fixture — silently, since "not disposable" is also the answer for a real repo.
+ *
+ * Known residual: a Windows path recorded in 8.3 short form (`APPDAT~1`) does
+ * not match the long `%TEMP%`. Such an entry is simply never auto-pruned, which
+ * is the safe direction — `jolli doctor --fix` still reaches it.
+ */
+export function tempRoots(): ReadonlyArray<string> {
+	const raw = tmpdir();
+	const roots = new Set<string>([raw]);
+	try {
+		roots.add(realpathSync(raw));
+		/* v8 ignore start -- `os.tmpdir()` not being resolvable means the machine has
+		   no usable temp directory at all; kept so this cannot be the thing that
+		   throws, but there is no state a test can put the host in to reach it */
+	} catch (err) {
+		// A temp dir that cannot be resolved is still a temp dir; the raw spelling
+		// is what most callers will match anyway.
+		log.debug("could not resolve the real path of %s: %s", raw, errMsg(err));
+	}
+	/* v8 ignore stop */
+	return [...roots];
+}
+
+export interface DisposableRepoOptions {
+	/** Defaults to {@link tempRoots}; a test names them so it needs no real temp dir. */
+	readonly tempRoots?: ReadonlyArray<string>;
+	/** Same contract as {@link sameRecordedRoot}'s: never a guess about the host. */
+	readonly platform?: NodeJS.Platform;
+}
+
+/** True when `path` is `root` or lives under it, for the named platform. */
+function isUnder(path: string, root: string, platform: NodeJS.Platform): boolean {
+	const p = normalizePathForCompareOn(path, platform);
+	const r = normalizePathForCompareOn(root, platform);
+	return p === r || p.startsWith(`${r}/`);
+}
+
+/**
+ * Segments that mark a temp directory as a throwaway THIS machine created.
+ *
+ * `jolli-` is the mkdtemp prefix every fixture in this repo uses
+ * (`jolli-cutover-…`, `jolli-autocut-…`), and `scratchpad` is the tree an agent
+ * session works in. Both are conventions rather than guarantees, which is why
+ * they only ever RELAX the identity clause and never the other two — see
+ * {@link isDisposableRepo}.
+ */
+const FIXTURE_SEGMENTS = ["jolli-", "scratchpad"] as const;
+
+/**
+ * Whether the part of `path` BELOW `root` names a throwaway directory.
+ *
+ * Relative to the root on purpose. The absolute form would match the root's own
+ * name, and a test that injects its own `tempRoots` — a `jolli-forget-…` mkdtemp
+ * dir, say — would then see every fixture inside it marked, which is exactly the
+ * distinction being tested. Relative, the same path is a fixture when measured
+ * against the real `%TEMP%` and an ordinary directory when measured against the
+ * throwaway it already lives in.
+ */
+function isFixturePathUnder(path: string, root: string, platform: NodeJS.Platform): boolean {
+	const p = normalizePathForCompareOn(path, platform);
+	const r = normalizePathForCompareOn(root, platform);
+	if (!p.startsWith(`${r}/`)) return false;
+	return p
+		.slice(r.length + 1)
+		.split("/")
+		.some((segment) => FIXTURE_SEGMENTS.some((mark) => segment.startsWith(mark)));
+}
+
+/**
+ * Whether this entry is high-confidence garbage that may be removed WITHOUT
+ * asking — a fixture or scratch checkout under the system temp directory whose
+ * every recorded path is gone.
+ *
+ * Two clauses always hold, and a third decides what an identity has to prove:
+ *
+ * 1. **Every recorded path under a temp root.** The union of `worktreeRoot` and
+ *    `worktrees`, not just the live subset — an entry with one temp path and one
+ *    real one is a real repo that was once opened from a scratch checkout, which
+ *    is exactly the shape a fixture leak leaves behind.
+ * 2. **No path left on disk.** A user working under `%TEMP%` right now has a
+ *    working repo, and a sweep must not delete the history of a session in
+ *    progress. The SAME union as clause 1, never {@link hasLiveWorktree}: this
+ *    function deletes data, so having declined to trust `registerRepo`'s
+ *    "`worktreeRoot` is inside `worktrees`" invariant for the clause that decides
+ *    whether an entry is IN SCOPE, it cannot go on to rely on it for the clause
+ *    that decides whether the entry is ALIVE — an entry whose `worktrees` omitted
+ *    a live `worktreeRoot` would be pruned with its own checkout on disk.
+ * 3. **A `local:` identity, OR every path names a known throwaway directory.**
+ *
+ * Clause 3 is the only inference here, and it is drawn where it is because the
+ * two halves are not equally safe. A `local:` identity is the sha256 of ONE
+ * path, so it cannot be shared and removing it structurally cannot touch
+ * anything else. A remote-backed identity IS shared — the `repos` row is keyed
+ * by it, so every clone of that remote answers to the same row — and "no other
+ * clone exists on this machine" can only be inferred from paths that record the
+ * last registrar. {@link FIXTURE_SEGMENTS} is what makes that inference narrow
+ * enough to act on: a vanished `%TEMP%/jolli-cutover-…/repo` is a fixture
+ * whichever remote it was cloned from. A vanished temp path with no such marker
+ * still needs a human, and `jolli doctor --fix` is where it goes.
+ *
+ * The state `DbBackfill` deliberately refuses to act on — "temporarily
+ * unmounted" (network share, external drive) — cannot arise under any of them: a
+ * temp root is local by construction, so "gone" really does mean gone.
+ */
+export function isDisposableRepo(repo: RegisteredRepo, opts: DisposableRepoOptions = {}): boolean {
+	const roots = opts.tempRoots ?? tempRoots();
+	const platform = opts.platform ?? process.platform;
+	// Deduped: `recordedRepoPaths` falls back to `[worktreeRoot]` on an entry with
+	// no `worktrees`, which would otherwise make the union `[root, root]` and read
+	// as a typo.
+	const claimed = [...new Set([repo.worktreeRoot, ...recordedRepoPaths(repo)])];
+	if (!claimed.every((path) => roots.some((root) => isUnder(path, root, platform)))) return false;
+	if (
+		!repo.repoIdentity.startsWith(LOCAL_IDENTITY_PREFIX) &&
+		!claimed.every((path) => roots.some((root) => isFixturePathUnder(path, root, platform)))
+	) {
+		return false;
+	}
+	return !claimed.some((path) => existsSync(path));
 }
 
 /**
@@ -294,7 +440,7 @@ export async function resolveRepoIdentity(worktreeRoot: string): Promise<{ ident
 		log.debug("no canonical remote for %s (%s) — using path identity", worktreeRoot, errMsg(err));
 	}
 	const hash = createHash("sha256").update(toForwardSlash(worktreeRoot)).digest("hex").slice(0, 32);
-	return { identity: `local:${hash}` };
+	return { identity: `${LOCAL_IDENTITY_PREFIX}${hash}` };
 }
 
 /**
@@ -443,6 +589,164 @@ export async function deregisterRepo(opts: RegisterRepoOptions): Promise<string 
 		},
 		{ globalDir: opts.configDir },
 	);
+}
+
+/**
+ * Removes entries by IDENTITY, returning the identities that were actually
+ * present — the half `deregisterRepo` structurally cannot do.
+ *
+ * `deregisterRepo` resolves its target by asking `cwd` (`getProjectRootDir` then
+ * `resolveRepoIdentity`), so a checkout that no longer exists can never be
+ * named; and its remedy — stamp `disabledAt` — is the wrong one anyway, since a
+ * disabled entry is still an entry. Both survive because they answer different
+ * questions: this is "forget it", `deregisterRepo` is `jolli disable`.
+ *
+ * Batched deliberately. The prune sweep has 85 victims on a machine that ran the
+ * test suite before HOME isolation became the default, and one lock plus one
+ * atomic write is the difference between that and 85 read-modify-write cycles
+ * racing every other registrar. It also makes the sweep's registry half
+ * all-or-nothing, which is what `forgetRepos`' ordering contract wants.
+ *
+ * Callers must delete the database rows FIRST — see `forgetRepos`.
+ */
+export async function removeReposFromRegistry(
+	identities: ReadonlyArray<string>,
+	configDir?: string,
+): Promise<ReadonlyArray<string>> {
+	if (identities.length === 0) return [];
+	const wanted = new Set(identities);
+	return withRepoRegistryLock(
+		async () => {
+			// Strict, not the fail-open read: this is a read-modify-write, and a
+			// registry that failed open here would be written back as "everything
+			// except the ones I meant to remove" — i.e. every other repo deleted. See
+			// `readRepoRegistryStrict`.
+			const registry = await readRepoRegistryStrict(configDir);
+			const removed = registry.repos.filter((r) => wanted.has(r.repoIdentity)).map((r) => r.repoIdentity);
+			if (removed.length === 0) return [];
+			await writeRepoRegistry(
+				{ ...registry, version: 1, repos: registry.repos.filter((r) => !wanted.has(r.repoIdentity)) },
+				configDir,
+			);
+			return removed;
+		},
+		{ globalDir: configDir },
+	);
+}
+
+/** {@link removeReposFromRegistry} for one identity; true when it was present. */
+export async function removeRepoFromRegistry(identity: string, configDir?: string): Promise<boolean> {
+	return (await removeReposFromRegistry([identity], configDir)).length > 0;
+}
+
+export interface RegistryRepairOptions extends DisposableRepoOptions {
+	readonly configDir?: string;
+	/**
+	 * Compute the repairs and write nothing.
+	 *
+	 * What makes `doctor --dry-run` honest about this half: the removals can be
+	 * previewed from a survey, but a path repair is only knowable by running the
+	 * same pass that would apply it, and a preview computed by different code is
+	 * a second implementation of the rule.
+	 *
+	 * Also takes NO registry lock — see the tail of {@link repairRegistryEntries}.
+	 */
+	readonly dryRun?: boolean;
+}
+
+/** What {@link repairRegistryEntries} changed about one entry. */
+export interface RegistryRepair {
+	readonly repoIdentity: string;
+	/** Temp-only paths that no longer exist, removed from `worktrees`. */
+	readonly droppedPaths: ReadonlyArray<string>;
+	/** Alternate spellings of a path the entry already listed (`C:` vs `c:`). */
+	readonly collapsedPaths: ReadonlyArray<string>;
+	/** Set when `worktreeRoot` named a dead path and a live one took over. */
+	readonly repointedTo?: string;
+}
+
+/**
+ * Repairs entries that are partly wrong rather than wholly dead — the state a
+ * removal cannot express.
+ *
+ * Three edits, and the two it deliberately does NOT make are the interesting part:
+ *
+ * 1. **Drops a recorded path that is gone AND under a temp root.** That is the
+ *    shape a real repo picks up from a fixture leak: a genuine `worktreeRoot`
+ *    with two `%TEMP%/jolli-cutover-…/repo` paths merged into its `worktrees`.
+ * 2. **Collapses alternate spellings** with {@link sameRecordedRoot}, newest
+ *    spelling winning — the same rule and the same tie-break `registerRepo`
+ *    applies when it re-registers a checkout. So a `C:` / `c:` pair that has not
+ *    been re-registered since is fixed here, and cannot regrow afterwards.
+ * 3. **Repoints `worktreeRoot`** to the newest live path when the recorded one is
+ *    gone. That field is what every surface displays, so a dead value makes a
+ *    working repo look broken.
+ *
+ * NOT dropped: a dead path that is not under a temp root. {@link existingWorktrees}
+ * already filters those on read, so removing them from the file buys nothing and
+ * costs the one thing the file is for — an unmounted share or external drive
+ * comes back, and a checkout the list has forgotten is invisible to the cutover's
+ * source enumeration, so its orphan branch would be neither imported nor fenced.
+ * Same reason `DbBackfill` skips such a repo rather than deregistering it.
+ *
+ * NOT touched: an entry with no live path at all. That is `forgetRepos`'
+ * territory, and rewriting it here would only make dead data tidier.
+ */
+export async function repairRegistryEntries(opts: RegistryRepairOptions = {}): Promise<ReadonlyArray<RegistryRepair>> {
+	const platform = opts.platform ?? process.platform;
+	const roots = opts.tempRoots ?? tempRoots();
+	const pass = async (): Promise<ReadonlyArray<RegistryRepair>> => {
+		const registry = await readRepoRegistryStrict(opts.configDir);
+		const repairs: RegistryRepair[] = [];
+		const repos = registry.repos.map((repo) => {
+			if (!hasLiveWorktree(repo)) return repo;
+			const droppedPaths: string[] = [];
+			const collapsedPaths: string[] = [];
+			const kept: string[] = [];
+			for (const path of recordedRepoPaths(repo)) {
+				if (!existsSync(path) && roots.some((root) => isUnder(path, root, platform))) {
+					droppedPaths.push(path);
+					continue;
+				}
+				// Newest spelling wins: drop the earlier one and re-append.
+				const clash = kept.findIndex((seen) => sameRecordedRoot(seen, path, platform));
+				if (clash !== -1) collapsedPaths.push(...kept.splice(clash, 1));
+				kept.push(path);
+			}
+			// Newest-first, matching `existingWorktrees` — the path a collector would
+			// have picked anyway, so the displayed root and the collected one agree.
+			const live = [...kept].reverse().find((path) => existsSync(path));
+			const repointedTo = live !== undefined && !existsSync(repo.worktreeRoot) ? live : undefined;
+			// `registerRepo` guarantees `worktreeRoot` is the last entry of
+			// `worktrees`; keep that invariant when a repair rewrote the list. AFTER
+			// the repoint, or a `worktreeRoot` that was itself a dead temp path is
+			// re-appended by the very pass that just dropped it.
+			const nextRoot = repointedTo ?? repo.worktreeRoot;
+			if (!kept.some((path) => sameRecordedRoot(path, nextRoot, platform))) kept.push(nextRoot);
+			if (droppedPaths.length === 0 && collapsedPaths.length === 0 && repointedTo === undefined) return repo;
+			repairs.push({
+				repoIdentity: repo.repoIdentity,
+				droppedPaths,
+				collapsedPaths,
+				...(repointedTo !== undefined && { repointedTo }),
+			});
+			return {
+				...repo,
+				...(repointedTo !== undefined && { worktreeRoot: repointedTo }),
+				worktrees: kept,
+			};
+		});
+		if (repairs.length > 0 && opts.dryRun !== true) {
+			await writeRepoRegistry({ ...registry, version: 1, repos }, opts.configDir);
+		}
+		return repairs;
+	};
+	// A dry run takes NO lock. The lock serialises read-modify-WRITE cycles, and a
+	// preview performs no write — `writeRepoRegistry` is atomic, so a lock-free read
+	// can never see a torn file either. Taking it anyway put `jolli doctor`, a
+	// read-only diagnostic that computes this preview on EVERY run, into contention
+	// with the `registerRepo` a post-commit hook is running at the same time.
+	return opts.dryRun === true ? pass() : withRepoRegistryLock(pass, { globalDir: opts.configDir });
 }
 
 /** Registered repos that are not disabled. */

--- a/cli/src/dashboard/ShellAsset.test.ts
+++ b/cli/src/dashboard/ShellAsset.test.ts
@@ -21,6 +21,8 @@ interface JDNamespace {
 	query: (model: unknown, over?: Record<string, unknown>) => string;
 	scopeIdentities: (model: unknown) => string[];
 	repoToken: (model: unknown, identity: string) => string;
+	/** The shell's own POST helper, overwritten by the remove-control cases. */
+	post: (path: string, body?: unknown) => Promise<unknown>;
 }
 
 interface FakeInput {
@@ -58,12 +60,24 @@ interface FakeElement {
 	focus: () => void;
 }
 
+/** The ✕ a missing repo's row carries. Its own shape: it has an `onclick`. */
+interface FakeButton {
+	disabled: boolean;
+	attrs: Record<string, string>;
+	getAttribute: (name: string) => string | null;
+	onclick?: (event: { preventDefault: () => void; stopPropagation: () => void }) => void;
+}
+
 interface Harness {
 	JD: JDNamespace;
 	element: (id: string) => FakeElement;
 	/** Checkboxes the picker last wrote into `#repoScopeList`, by `data-repo` / `all`. */
 	boxes: () => ReadonlyArray<FakeInput>;
+	/** Remove controls the picker last wrote, by `data-forget`. */
+	forgetButtons: () => ReadonlyArray<FakeButton>;
 	href: () => string;
+	/** The window object the asset ran against, for `confirm` / `alert` / reload. */
+	win: Record<string, unknown>;
 	/** Every `document`-level keydown listener still bound, so leaks are visible. */
 	keydownCount: () => number;
 	escape: () => void;
@@ -97,10 +111,30 @@ function parseBoxes(html: string): FakeInput[] {
 	return out;
 }
 
+/**
+ * The same trick as {@link parseBoxes}, for the remove control.
+ *
+ * Parses the whole tag rather than one attribute: the ✕ now carries the absence
+ * KIND alongside the identity (`data-forget-volume`), and a parser that picks
+ * attributes by name one at a time makes every later one invisible to the handler
+ * under test — the click would silently take the wrong branch and the test would
+ * still be asserting something.
+ */
+function parseForgetButtons(html: string): FakeButton[] {
+	const out: FakeButton[] = [];
+	for (const tag of html.matchAll(/<button\b[^>]*\bdata-forget="[^"]*"[^>]*>/g)) {
+		const attrs: Record<string, string> = {};
+		for (const attr of tag[0].matchAll(/([\w-]+)="([^"]*)"/g)) attrs[attr[1]] = attr[2];
+		out.push({ disabled: false, attrs, getAttribute: (name) => attrs[name] ?? null });
+	}
+	return out;
+}
+
 function loadJD(): Harness {
 	const elements = new Map<string, FakeElement>();
 	let listeners: Array<(event: { key: string }) => void> = [];
 	let lastBoxes: FakeInput[] = [];
+	let lastForget: FakeButton[] = [];
 	const make = (): FakeElement => {
 		const attrs: Record<string, string> = {};
 		let html = "";
@@ -132,6 +166,13 @@ function loadJD(): Harness {
 			querySelectorAll: (selector) => {
 				// The picker re-reads the boxes it just wrote; everything else in the
 				// shell (the range segment, the nav) has no rows in this harness.
+				if (selector === "button[data-forget]") {
+					// Re-parsed on every ask rather than cached against `html` like the
+					// boxes: identity does not matter here (nothing holds focus on it),
+					// and a shared cache key would make one selector evict the other.
+					lastForget = parseForgetButtons(html);
+					return lastForget as unknown as ReadonlyArray<FakeInput>;
+				}
 				if (selector !== "input[type=checkbox]") return [];
 				if (parsedFrom !== html) {
 					parsed = parseBoxes(html);
@@ -177,6 +218,8 @@ function loadJD(): Harness {
 		JD: win.JD as unknown as JDNamespace,
 		element: (id) => doc.getElementById(id) as FakeElement,
 		boxes: () => lastBoxes,
+		forgetButtons: () => lastForget,
+		win,
 		href: () => location.href,
 		keydownCount: () => listeners.length,
 		escape: () => {
@@ -368,6 +411,267 @@ describe("the topbar repo picker", () => {
 		docs?.onchange?.();
 		h.element("repoScope").onsubmit?.({ preventDefault: () => undefined });
 		expect(h.href()).toContain("repo=docs");
+	});
+
+	it("marks a repo whose folder is gone, keeps it selectable, and offers a ✕", () => {
+		// Marked, never dropped: the memories are still reachable. What must not
+		// happen is the row reading as a working checkout, since every action on it
+		// names a directory that is not there.
+		const h = loadJD();
+		h.JD.renderShell(
+			model({
+				repos: [
+					{ repoIdentity: JOLLIAI, repoName: "jolliai", worktreeRoot: "/a", sessionsThisWeek: 3 },
+					{ repoIdentity: SITE, repoName: "site", worktreeRoot: "/b", sessionsThisWeek: 1 },
+					{ repoIdentity: THIRD, repoName: "docs", worktreeRoot: "/c", sessionsThisWeek: 0, missing: true },
+				],
+				scope: scoped(JOLLIAI),
+			}),
+		);
+		h.element("repoScopeBtn").onclick?.();
+		const html = h.element("repoScopeList").innerHTML;
+
+		expect(html).toContain('class="repo-scope-row missing"');
+		expect(html).toContain(">folder missing</span>");
+		expect(html).toContain(`data-forget="${THIRD}"`);
+		// Only the dead row gets one.
+		expect(h.forgetButtons().map((b) => b.getAttribute("data-forget"))).toEqual([THIRD]);
+		// Still a real checkbox — its history is worth scoping to. (Three repos, so
+		// the two-of-three selection stays a `repo=` param instead of collapsing to
+		// "all", which is what an all-ticked list means.)
+		h.boxes()
+			.find((b) => b.getAttribute("data-repo") === THIRD)
+			?.onchange?.();
+		h.element("repoScope").onsubmit?.({ preventDefault: () => undefined });
+		expect(h.href()).toContain("repo=docs");
+	});
+
+	it("says the drive is not mounted rather than claiming the folder is gone", () => {
+		// The two absences are not degrees of one thing: here the repository is
+		// probably fine and the machine is what is missing, so the row must not
+		// assert a deletion. `existsSync` alone cannot tell them apart.
+		const h = loadJD();
+		h.JD.renderShell(
+			model({
+				repos: [
+					{ repoIdentity: JOLLIAI, repoName: "jolliai", worktreeRoot: "/a", sessionsThisWeek: 3 },
+					{
+						repoIdentity: THIRD,
+						repoName: "docs",
+						worktreeRoot: "Z:\\docs",
+						sessionsThisWeek: 0,
+						missing: true,
+						volumeUnavailable: true,
+					},
+				],
+				scope: scoped(JOLLIAI),
+			}),
+		);
+		h.element("repoScopeBtn").onclick?.();
+		const html = h.element("repoScopeList").innerHTML;
+
+		expect(html).toContain(">drive not mounted</span>");
+		expect(html).not.toContain(">folder missing</span>");
+		// Still the `missing` class and still a ✕ — the row is unreachable either way,
+		// and withholding the control is what B rejected.
+		expect(html).toContain('class="repo-scope-row missing"');
+		expect(html).toContain('data-forget-volume="1"');
+	});
+
+	it("shows both flags when a repo is paused AND gone", () => {
+		const h = loadJD();
+		h.JD.renderShell(
+			model({
+				repos: [
+					{ repoIdentity: JOLLIAI, repoName: "jolliai", worktreeRoot: "/a", sessionsThisWeek: 3 },
+					{
+						repoIdentity: THIRD,
+						repoName: "docs",
+						worktreeRoot: "/c",
+						sessionsThisWeek: 0,
+						disabled: true,
+						missing: true,
+					},
+				],
+				scope: scoped(JOLLIAI),
+			}),
+		);
+		h.element("repoScopeBtn").onclick?.();
+		const html = h.element("repoScopeList").innerHTML;
+		expect(html).toContain('class="repo-scope-row paused missing"');
+		expect(html).toContain(">paused · folder missing</span>");
+	});
+
+	it("keeps the disambiguating path when neither flag is set", () => {
+		// The flags take the meta slot; without them two same-named repos still get
+		// their checkout paths, which is the only thing telling them apart.
+		const h = loadJD();
+		h.JD.renderShell(
+			model({
+				repos: [
+					{ repoIdentity: "local:a", repoName: "repo", worktreeRoot: "/src/one", sessionsThisWeek: 2 },
+					{ repoIdentity: "local:b", repoName: "repo", worktreeRoot: "/src/two", sessionsThisWeek: 0 },
+				],
+				scope: scoped("local:a"),
+			}),
+		);
+		h.element("repoScopeBtn").onclick?.();
+		const html = h.element("repoScopeList").innerHTML;
+		expect(html).toContain('class="meta path"');
+		expect(html).toContain("/src/two");
+	});
+
+	describe("the ✕ itself", () => {
+		const withMissingRow = (): Harness => {
+			const h = loadJD();
+			h.JD.renderShell(
+				model({
+					repos: [
+						{ repoIdentity: JOLLIAI, repoName: "jolliai", worktreeRoot: "/a", sessionsThisWeek: 3 },
+						{
+							repoIdentity: THIRD,
+							repoName: "docs",
+							worktreeRoot: "/c",
+							sessionsThisWeek: 0,
+							missing: true,
+						},
+					],
+					scope: scoped(JOLLIAI),
+				}),
+			);
+			h.element("repoScopeBtn").onclick?.();
+			return h;
+		};
+		const withVolumeRow = (): Harness => {
+			const h = loadJD();
+			h.JD.renderShell(
+				model({
+					repos: [
+						{ repoIdentity: JOLLIAI, repoName: "jolliai", worktreeRoot: "/a", sessionsThisWeek: 3 },
+						{
+							repoIdentity: THIRD,
+							repoName: "docs",
+							worktreeRoot: "Z:\\docs",
+							sessionsThisWeek: 0,
+							missing: true,
+							volumeUnavailable: true,
+						},
+					],
+					scope: scoped(JOLLIAI),
+				}),
+			);
+			h.element("repoScopeBtn").onclick?.();
+			return h;
+		};
+		const click = (h: Harness): void => {
+			const [btn] = h.forgetButtons();
+			btn.onclick?.({ preventDefault: () => undefined, stopPropagation: () => undefined });
+		};
+		/** Answers each `confirm` in turn, recording the sentences it was shown. */
+		const confirmScript = (h: Harness, answers: ReadonlyArray<boolean>): string[] => {
+			const shown: string[] = [];
+			h.win.confirm = (message: string) => {
+				shown.push(message);
+				return answers[shown.length - 1] ?? false;
+			};
+			return shown;
+		};
+
+		it("posts nothing until the confirmation is accepted", () => {
+			const h = withMissingRow();
+			const posts: string[] = [];
+			h.win.confirm = () => false;
+			h.JD.post = (path: string) => {
+				posts.push(path);
+				return Promise.resolve({});
+			};
+			click(h);
+			expect(posts).toEqual([]);
+		});
+
+		it("forgets the identity on the row and reloads", async () => {
+			const h = withMissingRow();
+			const calls: Array<[string, unknown]> = [];
+			let reloaded = 0;
+			h.win.confirm = () => true;
+			h.win.location = { reload: () => void reloaded++ };
+			h.JD.post = (path: string, body: unknown) => {
+				calls.push([path, body]);
+				return Promise.resolve({ ok: true });
+			};
+			click(h);
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(calls).toEqual([["/api/repos/forget", { repoIdentity: THIRD }]]);
+			expect(reloaded).toBe(1);
+		});
+
+		it("re-enables the button and says why when the removal was refused", async () => {
+			// A 409 (the folder came back) has to leave the control usable — the page
+			// has no other way to retry, and a dead ✕ reads as a broken dashboard.
+			const h = withMissingRow();
+			const alerts: string[] = [];
+			h.win.confirm = () => true;
+			h.win.alert = (message: string) => void alerts.push(message);
+			h.JD.post = () => Promise.reject(new Error("that repository still exists on disk"));
+			const [btn] = h.forgetButtons();
+
+			click(h);
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(btn.disabled).toBe(false);
+			expect(alerts[0]).toContain("still exists on disk");
+		});
+
+		it("asks a deleted folder for ONE confirmation, and says so", () => {
+			const h = withMissingRow();
+			const shown = confirmScript(h, [true]);
+			h.win.location = { reload: () => undefined };
+			h.JD.post = () => Promise.resolve({ ok: true });
+			click(h);
+
+			expect(shown).toHaveLength(1);
+			expect(shown[0]).toContain("folder cannot be found");
+		});
+
+		it("asks TWO confirmations for an unmounted volume, each saying something true", () => {
+			// The likeliest reading of this row is "plug it back in", and the
+			// registration is kept on purpose — so the first sentence must not claim a
+			// deletion, and the second has to offer waiting as the alternative.
+			const h = withVolumeRow();
+			const shown = confirmScript(h, [true, true]);
+			const calls: Array<[string, unknown]> = [];
+			h.win.location = { reload: () => undefined };
+			h.JD.post = (path: string, body: unknown) => {
+				calls.push([path, body]);
+				return Promise.resolve({ ok: true });
+			};
+			click(h);
+
+			expect(shown).toHaveLength(2);
+			expect(shown[0]).toContain("not mounted");
+			expect(shown[0]).not.toContain("cannot be undone");
+			expect(shown[1]).toContain("reconnect it instead");
+			// The flag is the record that a human saw that second sentence — the server
+			// refuses this verdict without it.
+			expect(calls).toEqual([["/api/repos/forget", { repoIdentity: THIRD, acknowledgeUnavailableVolume: true }]]);
+		});
+
+		it("posts nothing when the second confirmation is declined", () => {
+			const h = withVolumeRow();
+			const shown = confirmScript(h, [true, false]);
+			const posts: string[] = [];
+			h.JD.post = (path: string) => {
+				posts.push(path);
+				return Promise.resolve({});
+			};
+			click(h);
+
+			expect(shown).toHaveLength(2);
+			expect(posts).toEqual([]);
+		});
 	});
 
 	it("names the exact identities on the button, where the label cannot", () => {

--- a/cli/src/dashboard/assets/js/shell.js
+++ b/cli/src/dashboard/assets/js/shell.js
@@ -377,17 +377,30 @@ window.JD = window.JD || {};
 				var ambiguous = options.filter((r) => r.repoName === option.repoName).length > 1;
 				/* A PAUSED repo stays in the list and stays selectable — its rows are
 				   never deleted and it still counts in the aggregate numbers, so its
-				   history is worth reaching. The meta slot says so (over the sessions
-				   figure or the disambiguating path), and `paused` on the row is what
-				   the stylesheet dims it by. */
-				var meta = option.disabled
-					? "paused"
+				   history is worth reaching. A MISSING one (its checkout is gone from
+				   disk) stays for the same reason, and is the only row that carries a
+				   remove control: every action on it names a directory that is not
+				   there, so saying so is what stops it reading as a working checkout.
+				   Both are flags rather than states — a repo can be paused AND gone —
+				   and either one takes the meta slot over the sessions figure or the
+				   disambiguating path, because they are the actionable half. */
+				var flags = [];
+				if (option.disabled) flags.push("paused");
+				/* Two spellings for one absence: `existsSync` cannot tell a deleted
+				   folder from a drive that is not plugged in, and the row used to
+				   assert the first for both. The second is not a milder version of
+				   the first — it is the case where the repository is probably fine
+				   and the machine is what is missing. */
+				if (option.missing) flags.push(option.volumeUnavailable ? "drive not mounted" : "folder missing");
+				var meta = flags.length
+					? flags.join(" · ")
 					: ambiguous
 						? esc(option.worktreeRoot || option.repoIdentity)
 						: option.sessionsThisWeek + (option.sessionsThisWeek === 1 ? " session" : " sessions") + " · 7d";
 				html +=
 					'<label class="repo-scope-row' +
 					(option.disabled ? " paused" : "") +
+					(option.missing ? " missing" : "") +
 					'" title="' +
 					esc(option.worktreeRoot || option.repoIdentity) +
 					'"><input type="checkbox" data-repo="' +
@@ -395,10 +408,21 @@ window.JD = window.JD || {};
 					'"><span class="name">' +
 					esc(option.repoName) +
 					'</span><span class="meta' +
-					(ambiguous && !option.disabled ? " path" : "") +
+					(ambiguous && flags.length === 0 ? " path" : "") +
 					'">' +
 					meta +
-					"</span></label>";
+					"</span>" +
+					/* Inside the label on purpose: a <button> is interactive content, and a
+					   label's activation behaviour does nothing for events targeted at one,
+					   so this cannot toggle the checkbox it sits next to. */
+					(option.missing
+						? '<button type="button" class="repo-forget" data-forget="' +
+							esc(option.repoIdentity) +
+							'" data-forget-volume="' +
+							(option.volumeUnavailable ? "1" : "") +
+							'" title="Remove this repository from the dashboard">✕</button>'
+						: "") +
+					"</label>";
 			});
 			return html;
 		};
@@ -463,6 +487,63 @@ window.JD = window.JD || {};
 					}
 					repoPending = picked.slice();
 					syncMarks(boxes);
+				};
+			});
+			/* Rebound every render, same reason as the boxes above. */
+			Array.prototype.forEach.call(list.querySelectorAll("button[data-forget]"), (btn) => {
+				btn.onclick = (event) => {
+					/* The spec already says a label does not forward activation to a
+					   nested button; this makes it true on an engine that disagrees,
+					   where the cost would be a silent scope change under the pointer. */
+					event.preventDefault();
+					event.stopPropagation();
+					var identity = btn.getAttribute("data-forget");
+					var volumeGone = btn.getAttribute("data-forget-volume") === "1";
+					/* A native confirm, deliberately. This deletes a repository's
+					   memories, sessions and commits from this machine and cannot be
+					   undone, and the page has no dialog layer of its own — a bespoke
+					   modal for one destructive control would be more code between the
+					   user and the sentence they need to read. */
+					/* Each state gets the sentence that is TRUE of it. A deleted folder is
+					   one confirmation; a drive that is not mounted is two, because there
+					   the likeliest reading of the row is "plug it back in" and the
+					   registration is kept on purpose. Only the user knows which. */
+					var first = volumeGone
+						? "Remove this repository from the dashboard?\n\n" +
+							"Its drive or share is not mounted, so Jolli cannot see whether the repository is still " +
+							"there. Its registration is kept on purpose so it comes back with the volume."
+						: "Remove this repository from the dashboard?\n\n" +
+							"Its folder cannot be found on this machine. This deletes the memories, sessions " +
+							"and commits recorded for it here, and cannot be undone.";
+					if (!window.confirm(first)) return;
+					if (
+						volumeGone &&
+						!window.confirm(
+							"Delete this repository's memories anyway?\n\n" +
+								"If the drive is coming back, cancel and reconnect it instead — nothing is lost by " +
+								"waiting. Otherwise this deletes the memories, sessions and commits recorded for it " +
+								"here, and cannot be undone.",
+						)
+					) {
+						return;
+					}
+					btn.disabled = true;
+					/* The server refuses an unreachable volume unless this says a human was
+					   shown the sentence above — see `handleForget`. Sent only in that case,
+					   so an ordinary removal's request shape is unchanged. */
+					JD.post(
+						"/api/repos/forget",
+						volumeGone
+							? { repoIdentity: identity, acknowledgeUnavailableVolume: true }
+							: { repoIdentity: identity },
+					)
+						/* A full reload rather than a local splice: the forgotten repo may
+						   be in the page's own scope, so every number on it changes too. */
+						.then(() => window.location.reload())
+						.catch((e) => {
+							btn.disabled = false;
+							window.alert("Could not remove it: " + String((e && e.message) || "request failed"));
+						});
 				};
 			});
 			syncMarks(boxes);

--- a/cli/src/dashboard/assets/styles/main.css
+++ b/cli/src/dashboard/assets/styles/main.css
@@ -223,6 +223,20 @@ body {
      reads as inactive, and its "paused" meta picks up the warning tint. */
   .repo-scope-row.paused .name { color: var(--muted); }
   .repo-scope-row.paused .meta { color: var(--warn, var(--muted)); font-style: italic; }
+  /* A repo whose checkout is gone. Dimmed like a paused one — its history is
+     still reachable — but its meta reads as a fault rather than a choice, and it
+     is the only row with a remove control. The ✕ stays low-contrast until the row
+     is hovered so a list of dead entries does not read as a row of buttons. */
+  .repo-scope-row.missing .name { color: var(--muted); text-decoration: line-through; }
+  .repo-scope-row.missing .meta { color: var(--warn, var(--muted)); font-style: italic; }
+  .repo-forget {
+    flex: none; margin-left: 4px; padding: 0 4px; border: 0; border-radius: 5px;
+    background: none; color: var(--muted); font-size: 12px; line-height: 1.4;
+    cursor: pointer; opacity: .45;
+  }
+  .repo-scope-row:hover .repo-forget { opacity: 1; }
+  .repo-forget:hover { background: var(--page); color: var(--err, var(--ink)); }
+  .repo-forget:disabled { cursor: default; opacity: .3; }
   /* The disambiguating checkout path. `direction: rtl` so a long path elides at
      its HEAD — the tail is the part that tells two clones apart, and a
      left-to-right ellipsis would cut off exactly that. `text-align: left` keeps

--- a/cli/src/install/Installer.test.ts
+++ b/cli/src/install/Installer.test.ts
@@ -1,8 +1,32 @@
-import { lstatSync, readlinkSync } from "node:fs";
+import { lstatSync, mkdtempSync, readlinkSync, rmSync, symlinkSync } from "node:fs";
 import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Whether this machine can create a symlink at all — a CAPABILITY, not a platform.
+ *
+ * Windows needs Developer Mode or elevation for `symlink`, so `linkMirroredSkill`
+ * deliberately falls back to copying the bundle's `SKILL.md`; a machine in that state
+ * has no symlink to assert the SHAPE of. Probed rather than keyed off
+ * `process.platform` because a Developer-Mode Windows box does plant real symlinks, and
+ * that is exactly the run where the shape assertion is worth having.
+ *
+ * Only the shape claim is gated. That the mirror is PLACED, and that a vanished bundle
+ * gets it cleaned up, hold under both placements and stay asserted everywhere.
+ */
+const canSymlink = ((): boolean => {
+	const probe = mkdtempSync(join(tmpdir(), "jolli-symlink-probe-"));
+	try {
+		symlinkSync(join(probe, "target"), join(probe, "link"), "dir");
+		return true;
+	} catch {
+		return false;
+	} finally {
+		rmSync(probe, { recursive: true, force: true });
+	}
+})();
 
 // Mock homedir so installDistPath() writes to a temp dir, not the real home.
 // The actual mock value is set in beforeEach via mockHomedir.
@@ -320,9 +344,16 @@ describe("Installer", () => {
 		fakeBundleDir = await mkdtemp(join(tmpdir(), "jollimemory-bundle-"));
 		for (const name of ["jolli", "jolli-recall", "jolli-search", "jolli-local-run", "jolli-remote-run"]) {
 			await mkdir(join(fakeBundleDir, "mirror", name), { recursive: true });
+			// The vendor marker is load-bearing, not decoration: where symlinks need
+			// Developer Mode the reconcile falls back to COPYING this file into the repo,
+			// and the teardown side then recognises that copy as ours only by this marker
+			// (`removeJolliOwnedSkillDir`). A marker-less fixture makes the copy permanently
+			// unremovable, so the cleanup assertions below would fail on that platform while
+			// passing wherever the placement happens to be a symlink. The bundle's real
+			// `mirror/` copies keep their `metadata:` block for exactly this reason.
 			await writeFile(
 				join(fakeBundleDir, "mirror", name, "SKILL.md"),
-				`---\nname: ${name}\n---\nbody\n`,
+				`---\nname: ${name}\nmetadata:\n  vendor: "jolli.ai"\n---\nbody\n`,
 				"utf-8",
 			);
 		}
@@ -1661,15 +1692,23 @@ describe("Installer", () => {
 			for (const name of ["jolli-recall", "jolli-search", "jolli-local-run", "jolli-remote-run"]) {
 				expect(await exists(join(tempDir, ".cursor", "skills", name, "SKILL.md"))).toBe(true);
 			}
-			// Planted as SYMLINKS into the bundle, which is what makes them vanish when the
-			// plugin is uninstalled. What the target CONTAINS is the bundle's business and
-			// is asserted in SkillInstaller.test.ts against the real builders.
-			const recall = join(tempDir, ".cursor", "skills", "jolli-recall");
-			expect(lstatSync(recall).isSymbolicLink()).toBe(true);
-			expect(readlinkSync(recall)).toBe(join(fakeBundleDir, "mirror", "jolli-recall"));
 			// The `/jolli` umbrella is NOT among them: it is machine-global, because the
 			// chat-first window that most needs a front door never names a workspace.
 			expect(await exists(join(tempDir, ".cursor", "skills", "jolli", "SKILL.md"))).toBe(false);
+		});
+
+		// The PLACEMENT above holds on every machine; its shape does not. Split out rather
+		// than asserted conditionally inside that test, so a skipped capability shows up as
+		// a skipped test instead of a passing one that quietly checked less.
+		it.skipIf(!canSymlink)("plants that mirror as symlinks into the bundle", async () => {
+			await install(tempDir, { repoHooksOnly: true, sourceTag: "cursor-plugin" });
+
+			// A symlink is what makes the entry vanish when the plugin is uninstalled. What
+			// the target CONTAINS is the bundle's business and is asserted in
+			// SkillInstaller.test.ts against the real builders.
+			const recall = join(tempDir, ".cursor", "skills", "jolli-recall");
+			expect(lstatSync(recall).isSymbolicLink()).toBe(true);
+			expect(readlinkSync(recall)).toBe(join(fakeBundleDir, "mirror", "jolli-recall"));
 		});
 
 		/*

--- a/cli/src/install/SkillInstaller.test.ts
+++ b/cli/src/install/SkillInstaller.test.ts
@@ -31,6 +31,33 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+/**
+ * Whether this machine can create a symlink at all — a CAPABILITY, not a platform.
+ *
+ * The suites below split cleanly along it. Everything about what the mirror CONTAINS,
+ * when it is refreshed and when it is removed holds under both placements and is
+ * asserted unconditionally — the Windows fallback's copy even has its own cases here,
+ * planted directly by `plantWindowsFallbackCopy`. What cannot hold without the
+ * capability is the symlink's SHAPE: on a machine where `symlink` throws EPERM,
+ * `linkMirroredSkill` deliberately writes a copy instead (see its docstring), so there
+ * is no link to read a target off and no entry that vanishes with the bundle.
+ *
+ * Probed rather than keyed off `process.platform`, because Developer Mode makes a
+ * Windows box plant real symlinks — and that run is precisely where asserting the shape
+ * is worth something.
+ */
+const canSymlink = ((): boolean => {
+	const probe = mkdtempSync(join(tmpdir(), "jolli-symlink-probe-"));
+	try {
+		symlinkSync(join(probe, "target"), join(probe, "link"), "dir");
+		return true;
+	} catch {
+		return false;
+	} finally {
+		rmSync(probe, { recursive: true, force: true });
+	}
+})();
+
 // `reconcileCursorRepoSkills` asks Cursor whether it will load the other hosts' skill
 // roots. Left unmocked that reads the DEVELOPER's live Cursor database, so the same
 // test would pass here, fail on a machine with the toggle off, and take a third path
@@ -1660,7 +1687,7 @@ describe("reconcileCursorRepoSkills", () => {
 	 * bundle throws, while `readlink` answers fine, and "broken" and "stale" have to
 	 * reach the same rebuild.
 	 */
-	it("rebuilds a link left pointing at a previous bundle", async () => {
+	it.skipIf(!canSymlink)("rebuilds a link left pointing at a previous bundle", async () => {
 		await reconcileCursorRepoSkills(tempDir);
 		const link = join(tempDir, ".cursor/skills", "jolli-recall");
 		rmSync(link, { recursive: true, force: true });
@@ -1977,8 +2004,13 @@ describe("reconcileCursorRepoSkills — plugin removed outside our control", () 
  * symlinked into the bundle and the other four written as real directories, deleting
  * the bundle removed exactly the symlinked entry from the slash menu and left the four
  * real ones behind. That experiment is what these assert in code.
+ *
+ * Being a filesystem property is also why the whole suite is gated on {@link canSymlink}:
+ * where symlinks need Developer Mode the placement is a copy, the property genuinely does
+ * not hold, and the code knows it — that state's cleanup is `removeCursorRepoSkills`,
+ * covered above by the cases that plant the fallback copy directly.
  */
-describe("the Cursor mirror disappears with the plugin", () => {
+describe.skipIf(!canSymlink)("the Cursor mirror disappears with the plugin", () => {
 	it("plants symlinks, not copies", async () => {
 		await reconcileCursorRepoSkills(tempDir);
 		for (const name of CURSOR_MIRRORED) {

--- a/cli/src/sync/SyncBootstrap.test.ts
+++ b/cli/src/sync/SyncBootstrap.test.ts
@@ -259,13 +259,22 @@ describe("onRoundComplete wiring (cross-repo pending-worker wakeup)", () => {
 		const cb = await getWiredOnRoundComplete(localFolder);
 		cb("/repo/a");
 
-		// The drain runs in a void-async block off the synchronous callback;
-		// give libuv enough turns for loadConfig + readdir + per-entry
-		// readFile/rm to resolve before assertions.
-		await new Promise((r) => setTimeout(r, 100));
+		// The drain runs in a void-async block off the synchronous callback, so wait for
+		// its EFFECT rather than for a fixed 100 ms. That sleep was a load-dependent
+		// flake, and one that could not be triaged as contention: loadConfig + readdir +
+		// per-entry readFile/rm outruns 100 ms under a full-suite run, the assertion then
+		// saw only the synchronous /repo/a spawn, and it presented as an assertion
+		// failure — the shape the triage rules say to treat as a regression — while
+		// passing every time in isolation.
+		await vi.waitFor(() => expect(launchWorkerMock).toHaveBeenCalledWith("/repo/b"), {
+			timeout: 10_000,
+			interval: 20,
+		});
 
 		// /repo/a spawned synchronously; /repo/b spawned from the drain.
-		// /repo/a from the registry was filtered out by the `!== cwd` guard.
+		// /repo/a from the registry was filtered out by the `!== cwd` guard. Asserted as
+		// the exact sorted set rather than two `toHaveBeenCalledWith`s, so a /repo/a the
+		// drain double-spawned still fails — that guard is the point of the case.
 		const calls = launchWorkerMock.mock.calls.map((c) => c[0]).sort();
 		expect(calls).toEqual(["/repo/a", "/repo/b"]);
 	});

--- a/test/gitEnv.ts
+++ b/test/gitEnv.ts
@@ -91,8 +91,12 @@ import { SCRATCH_HOME_ROOT_VAR } from "./scratchHome.js";
  * real `~/.jolli/jollimemory/jollimemory.db`, and a repo named `acme-api` at
  * `/tmp/acme-api` showed up in the dashboard's repo picker as a real repo.
  * Nothing failed — the test asserts the exact body a SUCCESSFUL projection
- * returns — and `repos_no_delete` (DashboardDb.ts) then refuses any DELETE, so
- * the cleanup is a manual `disabled_at` stamp against a live database.
+ * returns — so both rows sat in a live database with nothing able to reach them:
+ * `deregisterRepo` resolves its target from `cwd`, which a fixture's deleted temp
+ * directory cannot supply. Cleaning them up is what `jolli doctor --fix` and the
+ * `forgetRepo` path behind it now exist for (`dashboard/RepoForget.ts`); the
+ * `repos_no_delete` trigger that used to make even that impossible was dropped by
+ * `REPOS_DELETE_ALLOWED_DDL`.
  *
  * Hence: applied here, to every file, so a test is hermetic by construction with
  * nothing to remember — the same reasoning as the git isolation below.


### PR DESCRIPTION
<!-- jollimemory-summary-start -->



## Quick recap

Users can now remove stale repository entries directly from the dashboard. When a repository's folder is gone from disk, its row in the picker gains a strikethrough name, a "folder missing" label, and a remove button. Clicking the button and confirming the prompt permanently deletes the entry's recorded sessions, commits, and memories. The row stays visible and its historical data remains reachable for scoping and review until the user explicitly removes it.

Two automated cleanup paths complement the manual control. On each dashboard launch, entries that are clearly fixture or scratch checkouts are removed silently. This auto-prune covers a broader class than a simple local-identity check: entries tied to remote repository identities are also cleaned up automatically when every recorded path falls under a recognized throwaway directory pattern — the prefixes the tool itself uses for cutover fixtures and agent working directories. Entries with unmarked temp paths, mixed real-and-temp paths, or paths still present on disk remain untouched.

The doctor command gained a new registry check that surveys all entries and groups them into four buckets: live, auto-prunable, dead on a reachable volume, and dead on an unavailable volume. Entries on unavailable volumes are reported but never acted on, preserving registrations for repositories on unplugged drives or unmounted shares. A fix mode backs the registry up with a timestamped copy before removing anything, and a dry-run flag shows exactly what the fix would do by running the same repair logic without writing any changes.

A regression introduced alongside the registry repair feature caused all doctor-related tests in the main API test file to fail immediately on startup. The new code path acquired a registry lock on every check, but the test mock for the locking module was missing that export. Adding a transparent pass-through restored all 27 affected tests and one collaterally broken test. Running the full suite on Windows also surfaced 15 additional failures across six test files; these were addressed through a combination of fixture corrections, targeted per-test skips with explanatory comments, and a live capability probe for symlink support that correctly handles Windows machines running with Developer Mode enabled.

---

## Topics (10)
<details>
<summary><strong>01 · Fix missing lock mock causing all doctor command tests to fail</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After the registry repair feature was added, every doctor-related test in the main API test file started failing immediately on startup. The new code path acquired a registry lock on every doctor check, but the test file's mock for the locking module did not include that export, causing a hard error before any test logic could run.

**💡 Decisions Behind the Code**

A transparent pass-through was chosen over a spy or a no-op stub. The doctor tests assert on CLI output and exit codes, not on whether the lock was acquired — a spy would add noise without value, and a no-op that swallowed the callback would silently skip the repair logic the tests are meant to exercise.

**✅ What Was Implemented**

Added `withRepoRegistryLock` as a transparent pass-through to the `vi.mock("./core/Locks.js", ...)` factory in `cli/src/Api.test.ts`. The mock invokes the callback and returns its result, matching the pattern already present in `DoctorCommand.test.ts`. This unblocked all 27 directly affected doctor tests and one collaterally failing enable-flow test.

**📁 FILES**
- `cli/src/Api.test.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Add identity-addressed removal so deleted repository entries can be forgotten</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Repository entries for checkouts that no longer existed on disk could never be removed from the dashboard. The only removal path required running a command from inside the repository directory, making it structurally impossible to reach entries whose folders were already gone.

**💡 Decisions Behind the Code**

- **Database rows deleted before registry entry**: Removing the registry entry first and then failing on the database rows would leave rows the page still renders with no future sweep able to find them — the registry no longer lists the identity. The reverse failure mode costs at most one extra sweep pass, which is recoverable. This ordering is the load-bearing constraint the whole module is built around.
- **Unprojected events deleted alongside the rows**: The stats writer inserts a placeholder repo row from an event's identity alone whenever it processes an event for an unregistered repo. Leaving a single pending or revivable failed event behind means the next processing run silently recreates the repo row, undoing the removal. Only non-projected events are deleted; already-projected ones are historical record left to existing time-based cleanup.
- **Auto-prune restricted to a narrow, high-confidence class**: The unattended prune only acts on entries with a local-only identity where every recorded path is under the system temp directory and none of those paths currently exist — later extended to also cover remote-backed identities whose paths carry recognizable throwaway markers. Widening the predicate further would make the prune indistinguishable from deleting a real repo on an unplugged drive.
- **Batched removal over per-entry removal**: A machine with many stale entries pays one lock acquisition and one atomic registry write rather than one per entry. The batch form also makes partial-failure behavior predictable: either the full set is committed or none of it is, rather than leaving the registry in a half-cleaned state.

**✅ What Was Implemented**

- Created `cli/src/dashboard/RepoForget.ts` as the new identity-addressed removal module. `forgetRepo` and `forgetRepos` delete a repo's database rows (across all twelve child tables, derived dynamically from the schema), its unprojected events, and its registry entry — in that order. The dynamic table derivation means a future schema addition surfaces as a failing test rather than a silent foreign-key error at removal time.
- Added `removeReposFromRegistry` and `removeRepoFromRegistry` to `cli/src/dashboard/RepoRegistry.ts` as a batched, lock-guarded read-modify-write that removes entries by identity rather than by directory path.
- Added `pruneDisposableRepos` to automatically remove fixture-style entries on each dashboard launch, called from `cli/src/commands/DashboardCommand.ts` before the registry sweep so a fixture is not imported one final time on its way out.

**📁 FILES**
- `cli/src/dashboard/RepoForget.ts`
- `cli/src/dashboard/RepoRegistry.ts`
- `cli/src/commands/DashboardCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Add a remove control to the dashboard picker for missing-checkout entries</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users had no way to remove a stale repository entry from the dashboard interface. The picker listed every registered repository including ones whose folders were long gone, with no action available to clean them up.

**💡 Decisions Behind the Code**

- **Marked, never filtered**: A repo whose checkout is gone keeps its row in the picker and its data in the database. Filtering it out would make its recorded sessions, commits, and memories unreachable with no user action. The flag changes the row's appearance and adds the remove control; it does not hide the entry or exclude it from aggregate numbers.
- **Server-side liveness check, not page-state check**: The remove control is only drawn when the payload says the checkout is missing, but the server re-checks liveness before acting. The payload can be minutes old, a drive can be remounted, and this operation deletes memories irreversibly — the server's check is the authoritative gate, not the presence of the button on the page.
- **Native confirmation dialog over a custom modal**: The removal is irreversible and deletes recorded history. The dashboard has no dialog layer of its own, and building one for a single destructive control would add significant complexity. A native browser confirm puts the consequence sentence directly in front of the user with no additional code between them and the decision.

**✅ What Was Implemented**

- Added a `missing` flag to the repo option model in `cli/src/dashboard/DashboardModel.ts` and populated it in `cli/src/dashboard/DashboardQuery.ts` by checking whether the recorded checkout path exists on disk at render time. Entries whose path equals their identity (a placeholder created before the repo registers) are deliberately excluded to avoid offering a remove control on a repo that is about to appear normally.
- Updated `cli/src/dashboard/assets/js/shell.js` to render a ✕ button on each missing-checkout row in the picker, wired to `POST /api/repos/forget`. The button is inside the label element intentionally — a nested button does not forward activation to the label's checkbox, so clicking ✕ cannot accidentally toggle the repo's selection. A native browser confirmation dialog fires before the request.
- Added `POST /api/repos/forget` to `cli/src/dashboard/DashboardServer.ts`. The route refuses to forget a repo that still exists on disk (checking both the registry entry's recorded paths and the database's projected root), returning a conflict status rather than a bad-request status because the request is well-formed — the on-disk state is what says no.

**📁 FILES**
- `cli/src/dashboard/DashboardServer.ts`
- `cli/src/dashboard/DashboardModel.ts`
- `cli/src/dashboard/DashboardQuery.ts`
- `cli/src/dashboard/assets/js/shell.js`

</blockquote>
</details>
<details>
<summary><strong>04 · Add doctor command support for surveying and fixing stale registry entries</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The doctor command had no visibility into stale repository entries and no way to remove them. Entries that fell outside the narrow auto-prune class — repositories with a remote-backed identity, or repositories whose folder was gone but not under a temp directory — had no removal path at all.

**💡 Decisions Behind the Code**

- **Unavailable volumes reported but never removed**: An entry whose entire volume is unreachable could be a repo on an unplugged external drive or an unmounted network share. Removing it on this evidence would delete the registration for a directory that returns. On POSIX, unmounted mountpoints often still exist as empty directories, making the distinction between "dead" and "unavailable" unreliable — which is why even the "dead" bucket requires explicit user consent via the doctor command rather than auto-pruning.
- **Backup taken before any removal, not after**: A backup taken after the first removal captures the damage rather than the state the user could restore from. The backup is also why the fixer throws on partial failure rather than reporting a count — a partial removal reported as success is exactly the state a user would not run doctor again over.
- **Dry-run preview runs the real repair pass**: The path repairs are only knowable by running the same logic that would apply them. A preview computed by separate code would be a second implementation of the rule that could drift. The `dryRun` flag threads through to the write step, so the preview and the fix are guaranteed to agree.

**✅ What Was Implemented**

- Added `surveyRepoRegistry` to `cli/src/dashboard/RepoForget.ts`, which groups all entries (registry and database rows the registry no longer lists) into four buckets: live, auto-prunable, dead-on-a-present-volume, and dead-on-an-unavailable-volume. The unavailable bucket is reported but never acted on.
- Added `repairRegistryEntries` to `cli/src/dashboard/RepoRegistry.ts` to fix entries that are partly wrong rather than wholly dead: dropping vanished temp paths merged into a real repo's worktree list, collapsing alternate path spellings, and repointing the displayed root when it names a dead path but a live one exists. A `dryRun` option computes the same repairs without writing anything, guaranteeing the preview and the actual fix always agree.
- Wired both into `cli/src/commands/DoctorCommand.ts` as a new check with `--fix` and `--dry-run` support. The fixer backs the registry up with a timestamped copy before removing anything. The unavailable-volume bucket deliberately has no fixer offered.

**📁 FILES**
- `cli/src/commands/DoctorCommand.ts`
- `cli/src/dashboard/RepoForget.ts`
- `cli/src/dashboard/RepoRegistry.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Auto-prune shared-identity registry entries pointing to throwaway directories</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Stale registry entries tied to remote repository identities were never cleaned up automatically, even when every recorded path was a clearly disposable fixture or agent working directory that had already vanished from disk. Those entries accumulated silently and required manual intervention.

**💡 Decisions Behind the Code**

- **Relaxing only the identity clause, not the other two guards**: The "every path under a temp root" and "no path left on disk" clauses remain unconditional. Only the identity requirement was widened. This keeps the predicate safe against the "temporarily unmounted drive" false-positive and against entries that mix a real path with a temp one — both of which are harder to reason about than identity shape alone.
- **Named segments as the inference boundary**: Rather than treating any vanished temp path as prunable, the widening is limited to paths whose directory names carry a recognizable marker. A `jolli-cutover-…` or `scratchpad` directory is a fixture regardless of which remote it was cloned from, whereas a plain temp path with no such marker still requires a human via the doctor command. This keeps the inference narrow enough to act on unattended.
- **Relative marker matching over absolute path matching**: The fixture-segment check is applied to the path fragment below the temp root, not to the full absolute path. If the check ran on the full path, a test suite that creates its own `jolli-…` mkdtemp directory and injects it as the temp root would see every file inside it as a marked fixture — defeating the very distinction the test is trying to verify.

**✅ What Was Implemented**

- Restructured `isDisposableRepo` in `cli/src/dashboard/RepoRegistry.ts` so the identity clause is no longer a hard gate. A remote-backed identity now passes if every recorded path falls under a recognized throwaway directory pattern relative to the system temp root. The local-identity fast-pass is preserved; the remote-identity path goes through the new `isFixturePathUnder` check.
- Added `isFixturePathUnder` to `cli/src/dashboard/RepoRegistry.ts`. It checks whether the portion of a path below the temp root contains a segment matching a known fixture prefix (`jolli-` mkdtemp dirs) or the agent working-tree convention (`scratchpad`). The check is relative to the root rather than absolute, so a test that injects its own `jolli-…` mkdtemp dir as the temp root does not accidentally mark everything inside it as a fixture.
- Added six new test cases to `cli/src/dashboard/RepoRegistry.test.ts` covering: a cutover fixture under a remote identity, an agent scratchpad checkout, a mixed marked/unmarked path (must refuse), a path recorded at the temp root itself (must refuse), and the relative-vs-absolute marker distinction.

**📁 FILES**
- `cli/src/dashboard/RepoRegistry.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Make test suite portable across Windows and POSIX environments</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Running the full test suite on Windows produced 15 additional failures across six test files. The failures fell into distinct categories: some tests relied on filesystem features unavailable without elevated privileges, some asserted POSIX permission bits that Windows does not model, and one had a path normalization mismatch that only surfaced on Windows.

**💡 Decisions Behind the Code**

- **Capability probe over platform check for symlinks**: Windows with Developer Mode enabled can create symlinks, and that is exactly the configuration where asserting symlink shape is meaningful. Keying the skip off the platform name would skip the assertion on a machine that can actually verify it. A live probe at module load time costs one temp-directory operation and gives the correct answer regardless of OS or privilege level.
- **Per-test skip over describe-level skip for permission tests**: The permission describe block contains one test about the chmod loop tolerating missing WAL sidecar files, which is worth running on every platform. Skipping the entire describe would silently drop that coverage on Windows. A local alias keeps the non-POSIX tests running while skipping only the ones that assert permission bits.
- **Fixture correctness over test workaround for the vendor marker**: The missing vendor marker in the fake bundle's skill metadata was a fixture inaccuracy, not a test design choice. Real bundle mirror files carry this marker, and the cleanup code uses it to distinguish files it owns from user files. Adding it to the fixture makes the fixture faithful to production rather than papering over a gap with a platform conditional.

**✅ What Was Implemented**

- Fixed `DashboardCollector.test.ts` without any platform skip: the fixture used a bare Unix-style path literal as a repo root, but one source normalizes paths before comparing, producing a mismatch on Windows. Wrapping the constant in `path.resolve()` made both sides of the comparison derive from the same origin, fixing the failure on all platforms.
- Applied targeted `it.skipIf(process.platform === "win32")` guards to tests whose failure mode cannot be reproduced on Windows: the four permission-bit assertions in `DashboardDb.test.ts`, the read-only-directory snapshot failure in `Backup.test.ts`, and the two symlink-path-spelling cases in `GitFsLayout.test.ts`. Each skip includes an inline comment explaining why the scenario is structurally unreproducible.
- Fixed the symlink-shape assertions in `Installer.test.ts` and `SkillInstaller.test.ts` by probing actual symlink capability at runtime rather than checking the platform name. Tests asserting symlink shape are skipped only when the probe fails. The fake bundle fixture in `Installer.test.ts` also received a missing vendor marker in its `SKILL.md`, required for the cleanup path to recognize and remove copied files on machines where symlinks fall back to copies.

**📁 FILES**
- `cli/src/dashboard/DashboardCollector.test.ts`
- `cli/src/dashboard/DashboardDb.test.ts`
- `cli/src/install/Installer.test.ts`
- `cli/src/dashboard/Backup.test.ts`
- `cli/src/core/GitFsLayout.test.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Add disposable-repo predicate and temp-root resolution to registry module</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The auto-prune and survey logic needed a reliable way to decide whether a registry entry was safe to remove without asking. This predicate did not exist, and the system temp directory path itself has platform-specific complications that needed to be handled once in a shared place.

**💡 Decisions Behind the Code**

- **Three clauses, all required**: Dropping any one clause turns the predicate into something that needs human review. Dropping the local-only requirement would catch fixture entries with remote-backed identities, but those identities are shared between clones — forgetting one takes another clone's history. Dropping the all-paths-under-temp requirement would catch real repos that were once opened from a scratch checkout. Dropping the no-live-path requirement would delete the history of a session currently in progress.
- **Both temp-root spellings included**: The macOS symlink between the raw and resolved temp directory paths is a real source of silent misclassification. Including both spellings means a path recorded by git (which resolves symlinks) matches the same root as one recorded by the OS API (which does not). The known residual — Windows 8.3 short-form paths — is accepted as a safe failure: an entry that cannot be matched is simply not auto-pruned, which is the conservative direction.

**✅ What Was Implemented**

- Added `isDisposableRepo` to `cli/src/dashboard/RepoRegistry.ts` with three conjunctive clauses: local-only identity, every recorded path under a temp root, and no path currently on disk. All three must hold simultaneously. Later extended to also pass remote-backed identities whose paths carry recognized throwaway directory markers.
- Added `tempRoots` to resolve both the raw and symlink-resolved spellings of the system temp directory. On macOS, `os.tmpdir()` returns one path while paths recorded from git resolve through a symlink to a different spelling; matching only one would silently classify every macOS fixture as non-disposable.
- Added `recordedRepoPaths` as a shared helper that returns the full set of paths an entry claims, tolerating entries written before the worktrees list field existed. This consolidates a fallback that was previously duplicated across multiple callers.

**📁 FILES**
- `cli/src/dashboard/RepoRegistry.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Pin acceptance test for temp fixture cleanup measured in production</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The specific combined scenario described in the ticket — a large number of fixture entries plus one real repository with ghost paths merged into its worktree list — had not been covered by a test, despite being the exact shape of the problem observed in production.

**💡 Decisions Behind the Code**

The test pins the exact numbers and structure observed in the real incident rather than using a smaller synthetic approximation. A smaller fixture would have confirmed the logic works in principle but would not have caught regressions in the boundary between the "disposable" and "repairable" classification paths, which is where the original bug lived. Anchoring to the measured state makes the test a regression guard for the specific failure mode, not just a unit check.

**✅ What Was Implemented**

Added a single integration test in `cli/src/commands/DoctorCommand.test.ts` that reproduces the exact registry state measured when the bug was first observed: 84 fixture entries whose checkout folders never existed on disk, plus one real repository entry whose worktree list had two ghost paths mixed in alongside its live checkout. The test runs a survey pass followed by a fix pass and asserts that all 84 disposable entries are removed, the real repository survives with only its live checkout path remaining, and the fix pass reports the correct counts. A comment explains why the Windows drive-letter casing variant is intentionally left to a different test layer.

**📁 FILES**
- `cli/src/commands/DoctorCommand.test.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · Replace fixed sleep with reliable async wait in sync wakeup test</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A test verifying that the sync system wakes up workers in other repositories was intermittently failing under a full test run, reporting that only one of two expected worker launches had occurred. The test passed reliably in isolation, making it look like a regression when it was actually a timing problem.

**💡 Decisions Behind the Code**

- **Poll for the effect rather than wait for a fixed duration**: The async drain that triggers the second worker launch involves real filesystem operations — config loading, directory reads, and per-entry file reads and deletes. Under a loaded test runner these can exceed 100 ms, causing the assertion to run before the drain completes. A fixed sleep cannot be made safe without setting it so high it slows every run; polling for the actual observable effect terminates as soon as the work is done and degrades gracefully under load.
- **Retain the exact-set assertion rather than switching to individual call matchers**: The test's purpose is to verify that the registry's own entry is filtered out and not re-spawned. Two separate "was called with X" assertions would pass even if the drain spawned the filtered entry a second time. The sorted full-set comparison catches that case and preserves the original intent of the test.

**✅ What Was Implemented**

Replaced the fixed 100 ms `setTimeout` in `cli/src/sync/SyncBootstrap.test.ts` with a `vi.waitFor` poll that waits up to 10 seconds for the second worker launch to appear, checking every 20 ms. The final assertion still verifies the exact sorted set of launch targets to catch any double-spawning of the filtered-out entry.

**📁 FILES**
- `cli/src/sync/SyncBootstrap.test.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · Remove narrowed per-test timeout that caused spurious timeout failures</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A test that seeds nearly a hundred real directories to verify a fallback naming strategy was timing out during full suite runs. The test had set its own timeout shorter than the global budget, making it more likely to expire under load than tests that inherited the global limit.

**💡 Decisions Behind the Code**

Removing the override rather than raising it to a higher number was the right call because the test's timeout was already shorter than the global budget — it was actively making things worse. The global budget exists precisely to cover slow filesystem operations in the test environment, and the per-test override was defeating that protection.

**✅ What Was Implemented**

Removed the explicit 15-second timeout argument from the affected test in `cli/src/core/KBPathResolver.test.ts`, allowing it to inherit the 60-second global budget configured in `vite.config.ts`. A comment explains that per-test timeouts replace rather than extend the global value.

**📁 FILES**
- `cli/src/core/KBPathResolver.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 18, 2026 at 12:12 AM · via Anthropic*
<!-- jollimemory-summary-end -->