### PR TITLE
Heal stale storage after an unwitnessed cutover

### DIFF
--- a/cli/src/commands/GlobalDaemonCommand.test.ts
+++ b/cli/src/commands/GlobalDaemonCommand.test.ts
@@ -1,0 +1,65 @@
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runGlobalDaemonMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const ensureGlobalDaemonMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("../daemon/GlobalDaemon.js", () => ({
+	GLOBAL_DAEMON_COMMAND: "global-daemon",
+	runGlobalDaemon: runGlobalDaemonMock,
+}));
+
+vi.mock("../daemon/EnsureGlobalDaemon.js", () => ({
+	GLOBAL_DAEMON_ENSURE_COMMAND: "global-daemon-ensure",
+	ensureGlobalDaemon: ensureGlobalDaemonMock,
+}));
+
+import { registerGlobalDaemonCommand } from "./GlobalDaemonCommand.js";
+
+function makeProgram(): Command {
+	const program = new Command();
+	program.exitOverride();
+	registerGlobalDaemonCommand(program);
+	return program;
+}
+
+beforeEach(() => {
+	runGlobalDaemonMock.mockClear();
+	ensureGlobalDaemonMock.mockClear();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("registerGlobalDaemonCommand", () => {
+	it("registers both hidden commands with stable descriptions", () => {
+		const program = makeProgram();
+		const daemon = program.commands.find((c) => c.name() === "global-daemon");
+		const ensure = program.commands.find((c) => c.name() === "global-daemon-ensure");
+		expect(daemon?.description()).toMatch(/machine-global resident process/i);
+		expect(ensure?.description()).toMatch(/ensures the machine-global daemon exists/i);
+	});
+
+	it("runs the daemon with a --socket override", async () => {
+		await makeProgram().parseAsync(["global-daemon", "--socket", "/tmp/jolli.sock"], { from: "user" });
+		expect(runGlobalDaemonMock).toHaveBeenCalledWith({ socketPath: "/tmp/jolli.sock" });
+		expect(ensureGlobalDaemonMock).not.toHaveBeenCalled();
+	});
+
+	it("runs the daemon with no --socket (derived path)", async () => {
+		await makeProgram().parseAsync(["global-daemon"], { from: "user" });
+		expect(runGlobalDaemonMock).toHaveBeenCalledWith({ socketPath: undefined });
+	});
+
+	it("runs the ensure helper with a --socket override", async () => {
+		await makeProgram().parseAsync(["global-daemon-ensure", "--socket", "/tmp/e.sock"], { from: "user" });
+		expect(ensureGlobalDaemonMock).toHaveBeenCalledWith({ socketPath: "/tmp/e.sock" });
+		expect(runGlobalDaemonMock).not.toHaveBeenCalled();
+	});
+
+	it("runs the ensure helper with no --socket (derived path)", async () => {
+		await makeProgram().parseAsync(["global-daemon-ensure"], { from: "user" });
+		expect(ensureGlobalDaemonMock).toHaveBeenCalledWith({ socketPath: undefined });
+	});
+});

--- a/cli/src/core/ActiveStorageHeal.test.ts
+++ b/cli/src/core/ActiveStorageHeal.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CutoverRoute } from "../dashboard/CutoverRouter.js";
+import { DualWriteStorage } from "./DualWriteStorage.js";
+import type { StorageProvider } from "./StorageProvider.js";
+
+// getActiveStorage / setActiveStorage are backed by a closure var so a heal that
+// swaps the override is observable across calls, exactly as the process global is.
+const { store } = vi.hoisted(() => ({ store: { current: undefined as StorageProvider | undefined } }));
+vi.mock("./SummaryStore.js", () => ({
+	getActiveStorage: () => store.current,
+	setActiveStorage: (s: StorageProvider | undefined) => {
+		store.current = s;
+	},
+}));
+
+const { createStorageMock } = vi.hoisted(() => ({ createStorageMock: vi.fn() }));
+vi.mock("./StorageFactory.js", () => ({ createStorage: createStorageMock }));
+
+const { resolveRouteMock } = vi.hoisted(() => ({ resolveRouteMock: vi.fn() }));
+// Keep the REAL `routeMovesOffOrphanBranch` (a pure classifier the heal shares
+// with the VS Code bridge) so these cases exercise the shipped predicate, and
+// stub only the DB-touching `resolveCutoverRoute`.
+vi.mock("../dashboard/CutoverRouter.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../dashboard/CutoverRouter.js")>()),
+	resolveCutoverRoute: resolveRouteMock,
+}));
+
+import {
+	clearActiveStorageHealThrottle,
+	ensureActiveStorageMatchesRoute,
+	ROUTE_PROBE_THROTTLE_MS,
+	resetActiveStorageHealThrottle,
+} from "./ActiveStorageHeal.js";
+
+/** A storage that reads off the orphan branch — the pre-cutover shape. */
+const orphan = { kind: "orphan-branch" } as unknown as StorageProvider;
+const orphanPrimary = { kind: "orphan-branch" } as unknown as StorageProvider;
+const sqlitePrimary = { kind: "sqlite" } as unknown as StorageProvider;
+const folderShadow = { kind: "folder" } as unknown as StorageProvider;
+// REAL DualWriteStorage instances, not `{kind:"dual-write"}` literals: the heal
+// now unwraps the primary through `instanceof DualWriteStorage`, so a structural
+// double would fail the check and silently make the default (dual-write) storage
+// mode un-healable — the exact regression this shape guards against.
+/** A pre-cutover dual-write: reads come from its orphan primary. */
+const dualOrphan = new DualWriteStorage(orphanPrimary, folderShadow);
+/** What createStorage returns post-cutover: dual-write over a SQLite primary. */
+const dualSqlite = new DualWriteStorage(sqlitePrimary, folderShadow);
+
+function route(state: CutoverRoute["state"]): CutoverRoute {
+	if (state === "cutover") {
+		return { state, record: { tips: {}, cutoverVersion: 1, committedAt: "", schemaVersion: 1 } };
+	}
+	if (state === "blocked") return { state, reason: "db down" };
+	return { state } as CutoverRoute;
+}
+
+beforeEach(() => {
+	store.current = undefined;
+	resetActiveStorageHealThrottle();
+	createStorageMock.mockReset().mockResolvedValue(dualSqlite);
+	resolveRouteMock.mockReset().mockResolvedValue(route("uncutover"));
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("ensureActiveStorageMatchesRoute", () => {
+	it("does nothing when there is no active storage", async () => {
+		await ensureActiveStorageMatchesRoute("/repo");
+		expect(resolveRouteMock).not.toHaveBeenCalled();
+		expect(createStorageMock).not.toHaveBeenCalled();
+	});
+
+	it("fast-paths without a route lookup when the active storage already reads SQLite", async () => {
+		store.current = dualSqlite;
+		await ensureActiveStorageMatchesRoute("/repo");
+		expect(resolveRouteMock).not.toHaveBeenCalled();
+		expect(store.current).toBe(dualSqlite);
+	});
+
+	it("fast-paths for a bare SQLite storage (a non-claimable cut-over project)", async () => {
+		store.current = { kind: "sqlite" } as unknown as StorageProvider;
+		await ensureActiveStorageMatchesRoute("/repo");
+		expect(resolveRouteMock).not.toHaveBeenCalled();
+	});
+
+	it("leaves an orphan-backed storage alone while the repo is uncutover", async () => {
+		store.current = orphan;
+		resolveRouteMock.mockResolvedValue(route("uncutover"));
+		await ensureActiveStorageMatchesRoute("/repo");
+		expect(resolveRouteMock).toHaveBeenCalledWith("/repo");
+		expect(createStorageMock).not.toHaveBeenCalled();
+		expect(store.current).toBe(orphan);
+	});
+
+	it("leaves an orphan-backed storage alone when the DB is blocked (readable-but-stale beats a hard throw)", async () => {
+		store.current = orphan;
+		resolveRouteMock.mockResolvedValue(route("blocked"));
+		await ensureActiveStorageMatchesRoute("/repo");
+		expect(createStorageMock).not.toHaveBeenCalled();
+		expect(store.current).toBe(orphan);
+	});
+
+	it("rebuilds the storage once the repo is cut over", async () => {
+		store.current = orphan;
+		resolveRouteMock.mockResolvedValue(route("cutover"));
+		await ensureActiveStorageMatchesRoute("/repo");
+		expect(createStorageMock).toHaveBeenCalledWith("/repo", "/repo");
+		expect(store.current).toBe(dualSqlite);
+	});
+
+	it("rebuilds the storage while the repo is fenced but not yet committed", async () => {
+		store.current = orphan;
+		resolveRouteMock.mockResolvedValue(route("legacy-fenced"));
+		await ensureActiveStorageMatchesRoute("/repo");
+		expect(createStorageMock).toHaveBeenCalledTimes(1);
+		expect(store.current).toBe(dualSqlite);
+	});
+
+	it("rebuilds a pre-cutover dual-write object (orphan primary)", async () => {
+		store.current = dualOrphan;
+		resolveRouteMock.mockResolvedValue(route("cutover"));
+		await ensureActiveStorageMatchesRoute("/repo");
+		expect(createStorageMock).toHaveBeenCalledTimes(1);
+		expect(store.current).toBe(dualSqlite);
+	});
+
+	it("stops checking on later calls once rebuilt (cutover is one-way)", async () => {
+		store.current = orphan;
+		resolveRouteMock.mockResolvedValue(route("cutover"));
+		await ensureActiveStorageMatchesRoute("/repo");
+		await ensureActiveStorageMatchesRoute("/repo");
+		expect(resolveRouteMock).toHaveBeenCalledTimes(1);
+		expect(createStorageMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("yields to a heal that swapped the storage while the route was being probed", async () => {
+		store.current = orphan;
+		resolveRouteMock.mockImplementation(async () => {
+			// Something else installed the post-cutover storage while we probed.
+			store.current = dualSqlite;
+			return route("cutover");
+		});
+		await ensureActiveStorageMatchesRoute("/repo");
+		expect(createStorageMock).not.toHaveBeenCalled();
+		expect(store.current).toBe(dualSqlite);
+	});
+
+	it("swallows a route-resolution failure and leaves the storage as-is", async () => {
+		store.current = orphan;
+		resolveRouteMock.mockRejectedValue(new Error("boom"));
+		await ensureActiveStorageMatchesRoute("/repo");
+		expect(createStorageMock).not.toHaveBeenCalled();
+		expect(store.current).toBe(orphan);
+	});
+
+	it("coalesces concurrent heals into a single rebuild", async () => {
+		store.current = orphan;
+		resolveRouteMock.mockResolvedValue(route("cutover"));
+		await Promise.all([ensureActiveStorageMatchesRoute("/repo"), ensureActiveStorageMatchesRoute("/repo")]);
+		expect(createStorageMock).toHaveBeenCalledTimes(1);
+		expect(store.current).toBe(dualSqlite);
+	});
+
+	it("throttles the route probe for a still-uncutover repo within the window", async () => {
+		store.current = orphan;
+		resolveRouteMock.mockResolvedValue(route("uncutover"));
+		await ensureActiveStorageMatchesRoute("/repo");
+		await ensureActiveStorageMatchesRoute("/repo");
+		expect(resolveRouteMock).toHaveBeenCalledTimes(1);
+		expect(store.current).toBe(orphan);
+	});
+
+	it("re-probes the route once the throttle window has elapsed", async () => {
+		vi.useFakeTimers();
+		store.current = orphan;
+		resolveRouteMock.mockResolvedValue(route("uncutover"));
+		await ensureActiveStorageMatchesRoute("/repo");
+		await ensureActiveStorageMatchesRoute("/repo");
+		expect(resolveRouteMock).toHaveBeenCalledTimes(1);
+		vi.advanceTimersByTime(ROUTE_PROBE_THROTTLE_MS + 1);
+		await ensureActiveStorageMatchesRoute("/repo");
+		expect(resolveRouteMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("throttles the next probe after a probe failure too", async () => {
+		store.current = orphan;
+		resolveRouteMock.mockRejectedValue(new Error("boom"));
+		await ensureActiveStorageMatchesRoute("/repo");
+		await ensureActiveStorageMatchesRoute("/repo");
+		expect(resolveRouteMock).toHaveBeenCalledTimes(1);
+		expect(store.current).toBe(orphan);
+	});
+
+	it("does not throw and leaves the storage as-is when createStorage fails after a cutover", async () => {
+		store.current = orphan;
+		resolveRouteMock.mockResolvedValue(route("cutover"));
+		createStorageMock.mockRejectedValue(new Error("sqlite locked"));
+		await expect(ensureActiveStorageMatchesRoute("/repo")).resolves.toBeUndefined();
+		expect(store.current).toBe(orphan);
+	});
+
+	it("retries the rebuild on a later call after a transient createStorage failure", async () => {
+		vi.useFakeTimers();
+		store.current = orphan;
+		resolveRouteMock.mockResolvedValue(route("cutover"));
+		createStorageMock.mockRejectedValueOnce(new Error("sqlite locked")).mockResolvedValue(dualSqlite);
+		await ensureActiveStorageMatchesRoute("/repo");
+		expect(store.current).toBe(orphan);
+		vi.advanceTimersByTime(ROUTE_PROBE_THROTTLE_MS + 1);
+		await ensureActiveStorageMatchesRoute("/repo");
+		expect(store.current).toBe(dualSqlite);
+	});
+
+	it("clearActiveStorageHealThrottle forces an immediate re-probe inside the window", async () => {
+		store.current = orphan;
+		resolveRouteMock.mockResolvedValue(route("uncutover"));
+		await ensureActiveStorageMatchesRoute("/repo");
+		await ensureActiveStorageMatchesRoute("/repo");
+		expect(resolveRouteMock).toHaveBeenCalledTimes(1); // throttled
+
+		// A frozen-error caller clears the back-off so the next call re-probes without
+		// waiting out the window; now the route reads cut over and the storage rebuilds.
+		clearActiveStorageHealThrottle("/repo");
+		resolveRouteMock.mockResolvedValue(route("cutover"));
+		await ensureActiveStorageMatchesRoute("/repo");
+		expect(resolveRouteMock).toHaveBeenCalledTimes(2);
+		expect(store.current).toBe(dualSqlite);
+	});
+
+	it("clearActiveStorageHealThrottle is scoped to one cwd", async () => {
+		store.current = orphan;
+		resolveRouteMock.mockResolvedValue(route("uncutover"));
+		await ensureActiveStorageMatchesRoute("/repo-a");
+		await ensureActiveStorageMatchesRoute("/repo-b");
+		expect(resolveRouteMock).toHaveBeenCalledTimes(2);
+
+		clearActiveStorageHealThrottle("/repo-a");
+		await ensureActiveStorageMatchesRoute("/repo-a"); // re-probes
+		await ensureActiveStorageMatchesRoute("/repo-b"); // still throttled
+		expect(resolveRouteMock).toHaveBeenCalledTimes(3);
+	});
+});

--- a/cli/src/core/ActiveStorageHeal.ts
+++ b/cli/src/core/ActiveStorageHeal.ts
@@ -1,0 +1,133 @@
+/**
+ * ActiveStorageHeal — keeps a long-lived process's process-global storage
+ * override honest across a cutover it did not witness.
+ *
+ * `createStorage` routing only decides which backend a NEWLY created storage
+ * object binds to. A long-lived process (the per-worktree MCP daemon; the VS
+ * Code host) calls `setActiveStorage` ONCE at startup and then holds that object
+ * for its whole life. If the repo cuts over afterwards, the override is a
+ * pre-cutover `DualWriteStorage(orphan, folder)` — and because the override
+ * short-circuits `resolveStorage` / `resolveReadStorage` (SummaryStore), the
+ * `sotFallback` that would otherwise resolve the current system of record never
+ * runs. Two failures follow, and the second is the worse one:
+ *
+ *   1. A write (e.g. the lazy catalog rebuild `getCatalogWithLazyBuild` runs on
+ *      the `search` / `recall` read path) reaches `OrphanBranchStorage.writeFiles`,
+ *      which re-reads the fence and throws "orphan branch is frozen". Loud, but a
+ *      restart is the only cure.
+ *   2. Reads come off the FROZEN orphan branch — silently missing every memory
+ *      written to SQLite since the cutover. Stale-but-successful, which the
+ *      cutover contract names as worse than no data at all.
+ *
+ * The heal closes both: before a repo-scoped tool runs, swap the override back
+ * to whatever `createStorage` builds for the CURRENT route. The throttle,
+ * coalescing and one-way latch all live in the shared {@link CutoverHealGate};
+ * this module only wires that gate to THIS host's apply step (swap the process
+ * global) and its fast-path predicate ({@link readsFromOrphanBranch}). The VS
+ * Code host wires the same gate to its own apply step (drop cached storage).
+ */
+
+import { createLogger, errMsg } from "../Logger.js";
+import { CutoverHealGate, ROUTE_PROBE_THROTTLE_MS } from "./CutoverHealGate.js";
+import { DualWriteStorage } from "./DualWriteStorage.js";
+import { createStorage } from "./StorageFactory.js";
+import type { StorageProvider } from "./StorageProvider.js";
+import { getActiveStorage, setActiveStorage } from "./SummaryStore.js";
+
+const log = createLogger("ActiveStorageHeal");
+
+// Re-exported so the VS Code bridge and the daemon tests keep importing the
+// throttle constant from here; the value itself is owned by CutoverHealGate.
+export { ROUTE_PROBE_THROTTLE_MS };
+
+/**
+ * True when reads from this provider come off the (freezable) orphan branch —
+ * i.e. it is a pre-cutover object. `DualWriteStorage` reports `kind:"dual-write"`
+ * both before and after a cutover, so the primary's kind is the only thing that
+ * distinguishes an orphan-backed one from a SQLite-backed one.
+ *
+ * The dual-write case reaches `.primary` through an `instanceof` narrow, NOT a
+ * structural cast: `dual-write` is the DEFAULT storage mode, so a rename of the
+ * `primary` field under a structural probe would make this return `false` for
+ * every real dual-write object — the whole heal silently no-ops on the common
+ * path — and tsc would not catch it. `instanceof` makes that rename a compile
+ * error here.
+ */
+function readsFromOrphanBranch(storage: StorageProvider | undefined): boolean {
+	if (!storage) return false;
+	if (storage.kind === "orphan-branch") return true;
+	if (storage instanceof DualWriteStorage) {
+		return storage.primary.kind === "orphan-branch";
+	}
+	return false;
+}
+
+/**
+ * One {@link CutoverHealGate} per cwd. A daemon only ever has one, but the key
+ * keeps the module general and lets a test isolate cwds. Dropping the whole entry
+ * (rather than resetting a field) is what makes {@link resetActiveStorageHealThrottle}
+ * clear the throttle AND any in-flight probe together.
+ */
+const gates = new Map<string, CutoverHealGate>();
+
+function gateFor(cwd: string): CutoverHealGate {
+	let gate = gates.get(cwd);
+	if (!gate) {
+		gate = new CutoverHealGate({
+			cwd,
+			// The override reads the system of record once it is no longer
+			// orphan-backed; that is both the fast path and the racing re-check.
+			isHealed: () => !readsFromOrphanBranch(getActiveStorage()),
+			applyHeal: async (route) => {
+				setActiveStorage(await createStorage(cwd, cwd));
+				log.info(
+					"Rebuilt active storage after cutover (route=%s); reads/writes now route to the database. cwd=%s",
+					route.state,
+					cwd,
+				);
+			},
+			onProbeError: (err) =>
+				log.debug("cutover-route probe failed during storage heal (%s) — leaving storage as-is", String(err)),
+			onApplyError: (err) =>
+				log.warn(
+					"rebuild after cutover failed (%s) — leaving storage as-is, will retry. cwd=%s",
+					errMsg(err),
+					cwd,
+				),
+		});
+		gates.set(cwd, gate);
+	}
+	return gate;
+}
+
+/**
+ * Rebuilds the process-global active storage if the repo has cut over since it
+ * was set. A no-op on the fast path (override already reads the system of record,
+ * or there is none). Never throws — see {@link CutoverHealGate.ensure}.
+ */
+export function ensureActiveStorageMatchesRoute(cwd: string): Promise<void> {
+	// Fast path: skip creating a gate at all when there is nothing orphan-backed
+	// to heal (no active storage, or it already reads SQLite).
+	if (!readsFromOrphanBranch(getActiveStorage())) return Promise.resolve();
+	return gateFor(cwd).ensure();
+}
+
+/**
+ * Test seam: drops every gate so a case reusing a cwd starts clean. Dropping the
+ * gate clears both its throttle back-off and any in-flight probe (a lingering
+ * in-flight promise from a prior case would otherwise be coalesced onto).
+ */
+export function resetActiveStorageHealThrottle(): void {
+	gates.clear();
+}
+
+/**
+ * Forget the throttle back-off for ONE cwd so the very next
+ * {@link ensureActiveStorageMatchesRoute} re-probes the route instead of trusting
+ * the window. Called when a tool hit "orphan branch is frozen": that throw proves
+ * a cutover landed inside the current back-off window, so waiting out the wall
+ * clock would let a self-retrying agent strike the frozen branch twice.
+ */
+export function clearActiveStorageHealThrottle(cwd: string): void {
+	gates.get(cwd)?.forgetBackOff();
+}

--- a/cli/src/core/ArchivedConversations.test.ts
+++ b/cli/src/core/ArchivedConversations.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import type { StoredSession, StoredTranscript, TranscriptEntry } from "../Types.js";
+import { archivedSessionKey, groupArchivedSessions, sliceStartTime } from "./ArchivedConversations.js";
+
+function entry(role: "human" | "assistant", content: string, timestamp?: string): TranscriptEntry {
+	return { role, content, timestamp };
+}
+
+function session(overrides: Partial<StoredSession> & Pick<StoredSession, "sessionId">): StoredSession {
+	return { entries: [], ...overrides };
+}
+
+function transcript(sessions: StoredSession[]): StoredTranscript {
+	return { sessions };
+}
+
+describe("sliceStartTime", () => {
+	it("returns the epoch ms of the first parseable timestamp", () => {
+		const entries = [
+			entry("human", "hi", "2026-08-19T10:00:00.000Z"),
+			entry("assistant", "yo", "2026-08-19T10:05:00.000Z"),
+		];
+		expect(sliceStartTime(entries)).toBe(Date.parse("2026-08-19T10:00:00.000Z"));
+	});
+
+	it("skips entries with no timestamp and uses the next parseable one", () => {
+		const entries = [entry("human", "hi"), entry("assistant", "yo", "2026-08-19T10:05:00.000Z")];
+		expect(sliceStartTime(entries)).toBe(Date.parse("2026-08-19T10:05:00.000Z"));
+	});
+
+	it("skips an unparseable timestamp and falls through to undefined", () => {
+		expect(sliceStartTime([entry("human", "hi", "not-a-date")])).toBeUndefined();
+	});
+
+	it("returns undefined for an empty slice", () => {
+		expect(sliceStartTime([])).toBeUndefined();
+	});
+});
+
+describe("archivedSessionKey", () => {
+	it("joins source and sessionId", () => {
+		expect(archivedSessionKey({ sessionId: "abc", source: "codex" })).toBe("codex:abc");
+	});
+
+	it("defaults a source-less session to 'claude'", () => {
+		expect(archivedSessionKey({ sessionId: "abc", source: undefined })).toBe("claude:abc");
+	});
+});
+
+describe("groupArchivedSessions", () => {
+	it("collapses one session in one commit into a single row", () => {
+		const t = transcript([
+			session({ sessionId: "s1", source: "claude", entries: [entry("human", "hi", "2026-08-19T10:00:00.000Z")] }),
+		]);
+		const result = groupArchivedSessions([["c1", t]]);
+		expect(result.order).toEqual(["claude:s1"]);
+		const g = result.grouped.get("claude:s1");
+		expect(g?.hash).toBe("c1");
+		expect(g?.entries).toHaveLength(1);
+	});
+
+	it("merges a session split across commits and orders slices by first timestamp", () => {
+		// Later commit carries the EARLIER slice — sorting must reorder them.
+		const early = session({
+			sessionId: "s1",
+			source: "claude",
+			entries: [entry("human", "first", "2026-08-19T09:00:00.000Z")],
+		});
+		const late = session({
+			sessionId: "s1",
+			source: "claude",
+			entries: [entry("assistant", "second", "2026-08-19T11:00:00.000Z")],
+		});
+		// First-seen commit "c1" carries the LATE slice, "c2" carries the early one.
+		const result = groupArchivedSessions([
+			["c1", transcript([late])],
+			["c2", transcript([early])],
+		]);
+		const g = result.grouped.get("claude:s1");
+		// First-seen hash is preserved (c1), but entries are chronological.
+		expect(g?.hash).toBe("c1");
+		expect(g?.entries.map((e) => e.content)).toEqual(["first", "second"]);
+	});
+
+	it("keeps first-seen slice order when a slice has no parseable timestamp", () => {
+		const withTime = session({
+			sessionId: "s1",
+			source: "claude",
+			entries: [entry("human", "timed", "2026-08-19T10:00:00.000Z")],
+		});
+		const noTime = session({ sessionId: "s1", source: "claude", entries: [entry("assistant", "untimed")] });
+		const result = groupArchivedSessions([
+			["c1", transcript([withTime])],
+			["c2", transcript([noTime])],
+		]);
+		// Comparator returns 0 (tb undefined), so first-seen order holds.
+		expect(result.grouped.get("claude:s1")?.entries.map((e) => e.content)).toEqual(["timed", "untimed"]);
+	});
+
+	it("hides a usage-only carrier (empty entries + recorded usage)", () => {
+		const carrier = session({
+			sessionId: "s1",
+			source: "claude",
+			entries: [],
+			usage: { input: 100, output: 50, cached: 0 },
+		});
+		const result = groupArchivedSessions([["c1", transcript([carrier])]]);
+		expect(result.order).toEqual([]);
+		expect(result.grouped.has("claude:s1")).toBe(false);
+	});
+
+	it("keeps a real empty conversation (empty entries, no usage)", () => {
+		const empty = session({ sessionId: "s1", source: "claude", entries: [] });
+		const result = groupArchivedSessions([["c1", transcript([empty])]]);
+		expect(result.order).toEqual(["claude:s1"]);
+		expect(result.grouped.get("claude:s1")?.entries).toEqual([]);
+	});
+
+	it("shows a conversation entry-less in one commit but real in another, even with usage", () => {
+		const carrierSlice = session({
+			sessionId: "s1",
+			source: "claude",
+			entries: [],
+			usage: { input: 10, output: 5, cached: 0 },
+		});
+		const realSlice = session({
+			sessionId: "s1",
+			source: "claude",
+			entries: [entry("human", "real", "2026-08-19T10:00:00.000Z")],
+		});
+		const result = groupArchivedSessions([
+			["c1", transcript([carrierSlice])],
+			["c2", transcript([realSlice])],
+		]);
+		// Merged entries are non-empty, so the carrier predicate does not fire.
+		expect(result.grouped.get("claude:s1")?.entries.map((e) => e.content)).toEqual(["real"]);
+	});
+
+	it("treats an absent entries field as an empty slice", () => {
+		// Legacy/malformed stored session with `entries` omitted (cast around the
+		// required field to mimic on-disk data the reader tolerates).
+		const legacy = { sessionId: "s1", source: "claude" } as unknown as StoredSession;
+		const result = groupArchivedSessions([["c1", transcript([legacy])]]);
+		// No usage recorded, so it stays as a real (empty) conversation.
+		expect(result.grouped.get("claude:s1")?.entries).toEqual([]);
+	});
+});

--- a/cli/src/core/CutoverHealGate.test.ts
+++ b/cli/src/core/CutoverHealGate.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CutoverRoute } from "../dashboard/CutoverRouter.js";
+import { CutoverHealGate, type CutoverHealGateOptions, ROUTE_PROBE_THROTTLE_MS } from "./CutoverHealGate.js";
+
+const { resolveRouteMock } = vi.hoisted(() => ({ resolveRouteMock: vi.fn() }));
+// Keep the REAL `routeMovesOffOrphanBranch` classifier (the shared product rule)
+// and stub only the DB-touching `resolveCutoverRoute`.
+vi.mock("../dashboard/CutoverRouter.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../dashboard/CutoverRouter.js")>()),
+	resolveCutoverRoute: resolveRouteMock,
+}));
+
+function route(state: CutoverRoute["state"]): CutoverRoute {
+	if (state === "cutover") {
+		return { state, record: { tips: {}, cutoverVersion: 1, committedAt: "", schemaVersion: 1 } };
+	}
+	if (state === "blocked") return { state, reason: "db down" };
+	return { state } as CutoverRoute;
+}
+
+/** A gate with spy-able callbacks and a mutable `healed` fact. */
+function makeGate(overrides: Partial<CutoverHealGateOptions> = {}) {
+	const state = { healed: false };
+	const applyHeal = vi.fn(() => {
+		state.healed = true;
+	});
+	const onProbeError = vi.fn();
+	const onApplyError = vi.fn();
+	const gate = new CutoverHealGate({
+		cwd: "/repo",
+		isHealed: () => state.healed,
+		applyHeal,
+		onProbeError,
+		onApplyError,
+		...overrides,
+	});
+	return { gate, state, applyHeal, onProbeError, onApplyError };
+}
+
+beforeEach(() => {
+	resolveRouteMock.mockReset().mockResolvedValue(route("uncutover"));
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("CutoverHealGate", () => {
+	it("fast-paths without a route probe when already healed", async () => {
+		const { gate, state, applyHeal } = makeGate();
+		state.healed = true;
+		await gate.ensure();
+		expect(resolveRouteMock).not.toHaveBeenCalled();
+		expect(applyHeal).not.toHaveBeenCalled();
+	});
+
+	it("leaves storage as-is while the repo is uncutover", async () => {
+		const { gate, applyHeal } = makeGate();
+		resolveRouteMock.mockResolvedValue(route("uncutover"));
+		await gate.ensure();
+		expect(resolveRouteMock).toHaveBeenCalledWith("/repo");
+		expect(applyHeal).not.toHaveBeenCalled();
+	});
+
+	it("leaves storage as-is when the DB is blocked (readable-but-stale beats a throw)", async () => {
+		const { gate, applyHeal } = makeGate();
+		resolveRouteMock.mockResolvedValue(route("blocked"));
+		await gate.ensure();
+		expect(applyHeal).not.toHaveBeenCalled();
+	});
+
+	it("applies the heal once the repo is cut over", async () => {
+		const { gate, applyHeal } = makeGate();
+		resolveRouteMock.mockResolvedValue(route("cutover"));
+		await gate.ensure();
+		expect(applyHeal).toHaveBeenCalledTimes(1);
+		expect(applyHeal).toHaveBeenCalledWith(route("cutover"));
+	});
+
+	it("applies the heal while the repo is fenced but not yet committed", async () => {
+		const { gate, applyHeal } = makeGate();
+		resolveRouteMock.mockResolvedValue(route("legacy-fenced"));
+		await gate.ensure();
+		expect(applyHeal).toHaveBeenCalledTimes(1);
+	});
+
+	it("stops probing on later calls once healed (cutover is one-way)", async () => {
+		const { gate, applyHeal } = makeGate();
+		resolveRouteMock.mockResolvedValue(route("cutover"));
+		await gate.ensure();
+		await gate.ensure();
+		expect(resolveRouteMock).toHaveBeenCalledTimes(1);
+		expect(applyHeal).toHaveBeenCalledTimes(1);
+	});
+
+	it("yields to a heal that landed while the route was being probed", async () => {
+		const { gate, state, applyHeal } = makeGate();
+		resolveRouteMock.mockImplementation(async () => {
+			// A concurrent heal flipped the healed fact while we probed.
+			state.healed = true;
+			return route("cutover");
+		});
+		await gate.ensure();
+		expect(applyHeal).not.toHaveBeenCalled();
+	});
+
+	it("coalesces concurrent ensure() calls into a single probe + apply", async () => {
+		const { gate, applyHeal } = makeGate();
+		resolveRouteMock.mockResolvedValue(route("cutover"));
+		await Promise.all([gate.ensure(), gate.ensure()]);
+		expect(resolveRouteMock).toHaveBeenCalledTimes(1);
+		expect(applyHeal).toHaveBeenCalledTimes(1);
+	});
+
+	it("throttles the probe for a still-uncutover repo within the window", async () => {
+		const { gate } = makeGate();
+		resolveRouteMock.mockResolvedValue(route("uncutover"));
+		await gate.ensure();
+		await gate.ensure();
+		expect(resolveRouteMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("re-probes once the throttle window has elapsed", async () => {
+		vi.useFakeTimers();
+		const { gate } = makeGate();
+		resolveRouteMock.mockResolvedValue(route("uncutover"));
+		await gate.ensure();
+		await gate.ensure();
+		expect(resolveRouteMock).toHaveBeenCalledTimes(1);
+		vi.advanceTimersByTime(ROUTE_PROBE_THROTTLE_MS + 1);
+		await gate.ensure();
+		expect(resolveRouteMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("honours a custom throttle window", async () => {
+		vi.useFakeTimers();
+		const { gate } = makeGate({ throttleMs: 100 });
+		resolveRouteMock.mockResolvedValue(route("uncutover"));
+		await gate.ensure();
+		vi.advanceTimersByTime(50);
+		await gate.ensure();
+		expect(resolveRouteMock).toHaveBeenCalledTimes(1); // still inside 100ms
+		vi.advanceTimersByTime(60);
+		await gate.ensure();
+		expect(resolveRouteMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("reports and swallows a route-probe failure, then backs off", async () => {
+		const { gate, onProbeError, applyHeal } = makeGate();
+		resolveRouteMock.mockRejectedValue(new Error("probe boom"));
+		await expect(gate.ensure()).resolves.toBeUndefined();
+		expect(onProbeError).toHaveBeenCalledTimes(1);
+		expect(applyHeal).not.toHaveBeenCalled();
+		// backed off — a second immediate call does not re-probe
+		await gate.ensure();
+		expect(resolveRouteMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("reports and swallows an applyHeal failure, then backs off and retries later", async () => {
+		vi.useFakeTimers();
+		const applyHeal = vi
+			.fn<(route: CutoverRoute) => void>()
+			.mockImplementationOnce(() => {
+				throw new Error("sqlite locked");
+			})
+			.mockImplementationOnce(() => {});
+		const onApplyError = vi.fn();
+		const gate = new CutoverHealGate({
+			cwd: "/repo",
+			isHealed: () => false,
+			applyHeal,
+			onApplyError,
+		});
+		resolveRouteMock.mockResolvedValue(route("cutover"));
+
+		await expect(gate.ensure()).resolves.toBeUndefined();
+		expect(onApplyError).toHaveBeenCalledTimes(1);
+		expect(applyHeal).toHaveBeenCalledTimes(1);
+
+		vi.advanceTimersByTime(ROUTE_PROBE_THROTTLE_MS + 1);
+		await gate.ensure();
+		expect(applyHeal).toHaveBeenCalledTimes(2);
+	});
+
+	it("forgetBackOff re-probes immediately inside the throttle window", async () => {
+		const { gate, applyHeal } = makeGate();
+		resolveRouteMock.mockResolvedValue(route("uncutover"));
+		await gate.ensure();
+		await gate.ensure();
+		expect(resolveRouteMock).toHaveBeenCalledTimes(1); // throttled
+
+		gate.forgetBackOff();
+		resolveRouteMock.mockResolvedValue(route("cutover"));
+		await gate.ensure();
+		expect(resolveRouteMock).toHaveBeenCalledTimes(2);
+		expect(applyHeal).toHaveBeenCalledTimes(1);
+	});
+
+	it("tolerates absent onProbeError / onApplyError hooks", async () => {
+		const gate = new CutoverHealGate({
+			cwd: "/repo",
+			isHealed: () => false,
+			applyHeal: () => {
+				throw new Error("apply boom");
+			},
+		});
+		resolveRouteMock.mockRejectedValueOnce(new Error("probe boom"));
+		await expect(gate.ensure()).resolves.toBeUndefined();
+		resolveRouteMock.mockResolvedValue(route("cutover"));
+		gate.forgetBackOff();
+		await expect(gate.ensure()).resolves.toBeUndefined();
+	});
+});

--- a/cli/src/core/CutoverHealGate.ts
+++ b/cli/src/core/CutoverHealGate.ts
@@ -1,0 +1,121 @@
+/**
+ * CutoverHealGate — the shared state machine that keeps a long-lived process's
+ * cached storage honest across a cutover it did not witness.
+ *
+ * Two hosts need the identical scaffolding around an unwitnessed cutover: the
+ * per-worktree MCP daemon ({@link ../core/ActiveStorageHeal.ts}) and the VS Code
+ * extension host ({@link ../../../vscode/src/JolliMemoryBridge.ts}). Both must
+ * probe the repo's cutover route lazily, coalesce the concurrent probes a burst
+ * of tool calls would otherwise fire, latch off once the repo is seen cut over
+ * (cutover is one-way), and back off between probes while the repo is still
+ * uncutover so the common path stays near-free. Only the APPLY step differs — the
+ * daemon swaps the process-global `setActiveStorage`, the bridge drops its cached
+ * storage promises — and that difference is the `applyHeal` callback. Everything
+ * else (the throttle window, the in-flight promise, the racing re-check) is this
+ * class, so a change to the heal contract is made once instead of drifting across
+ * two hand-rolled copies.
+ *
+ * The route CLASSIFIER ({@link routeMovesOffOrphanBranch}) is the genuinely
+ * shared product rule and already lived in `cli/src`; this gate is the generic
+ * async plumbing around it, parameterized so no host specifics leak in.
+ */
+
+import { type CutoverRoute, resolveCutoverRoute, routeMovesOffOrphanBranch } from "../dashboard/CutoverRouter.js";
+
+/**
+ * How long a repo that probed as still-orphan-backed (uncutover / blocked, or a
+ * probe that failed) is trusted before the route is probed again. Bounds the
+ * per-call cost of the pre-cutover common path at the cost of an at-most-one-window
+ * read-staleness gap after an unwitnessed cutover — a write re-reads the fence at
+ * the plumbing layer regardless, so the gap is reads only, never a data gap.
+ */
+export const ROUTE_PROBE_THROTTLE_MS = 5_000;
+
+export interface CutoverHealGateOptions {
+	/** The repo / worktree root this gate probes for. */
+	cwd: string;
+	/**
+	 * Fast path AND racing re-check: `true` when the host's storage already reads
+	 * the current source of truth, so no heal is needed. Consulted BEFORE probing
+	 * (skip the whole probe) and again AFTER probing but before {@link applyHeal}
+	 * (yield to a heal that landed while this one was probing).
+	 */
+	isHealed: () => boolean;
+	/**
+	 * Apply the heal for a route that has moved off the orphan branch. May throw:
+	 * a transient failure (a momentary SQLite lock, a git probe error) must not
+	 * fail the tool call that triggered the heal, so on a throw the gate backs off
+	 * and a later {@link ensure} retries. Reached only when {@link isHealed} is
+	 * still `false` after the route probe.
+	 */
+	applyHeal: (route: CutoverRoute) => void | Promise<void>;
+	/** Host hook for logging a route-probe failure (the route is left as-is). */
+	onProbeError?: (err: unknown) => void;
+	/** Host hook for logging an {@link applyHeal} failure (the gate backs off). */
+	onApplyError?: (err: unknown) => void;
+	/** Throttle override; defaults to {@link ROUTE_PROBE_THROTTLE_MS}. */
+	throttleMs?: number;
+}
+
+export class CutoverHealGate {
+	private inFlight: Promise<void> | null = null;
+	private nextProbeAt = 0;
+
+	constructor(private readonly opts: CutoverHealGateOptions) {}
+
+	/**
+	 * Rebuilds the host's storage if the repo has cut over since it was cached.
+	 * A no-op on the fast path (already reads the source of truth, or throttled).
+	 * Never throws — see {@link CutoverHealGateOptions.applyHeal}.
+	 */
+	ensure(): Promise<void> {
+		// Fast path: storage that already reads the system of record never regresses
+		// (cutover is one-way), so skip the route lookup entirely.
+		if (this.opts.isHealed()) return Promise.resolve();
+		if (this.inFlight) return this.inFlight;
+		// Throttle: a still-uncutover repo stays orphan-backed for a daemon's whole
+		// life, so probing on every call is wasted work. Cutover is rare and one-way.
+		if (Date.now() < this.nextProbeAt) return Promise.resolve();
+		this.inFlight = this.run().finally(() => {
+			this.inFlight = null;
+		});
+		return this.inFlight;
+	}
+
+	/**
+	 * Forget the back-off so the very next {@link ensure} re-probes instead of
+	 * trusting the window. Called when a write hit "orphan branch is frozen": that
+	 * throw proves a cutover landed INSIDE the current window, so waiting it out
+	 * would let a self-retrying caller strike the frozen branch twice.
+	 */
+	forgetBackOff(): void {
+		this.nextProbeAt = 0;
+	}
+
+	private async run(): Promise<void> {
+		const route = await resolveCutoverRoute(this.opts.cwd).catch((err) => {
+			this.opts.onProbeError?.(err);
+			return null;
+		});
+		// Only a committed cutover or a pending fence moves the source of truth off
+		// the orphan branch. `uncutover` keeps it authoritative; `blocked` means the
+		// DB is unreachable, where rebuilding would only turn a readable-but-stale
+		// read into a hard throw — back off and leave the storage as-is.
+		if (!routeMovesOffOrphanBranch(route)) {
+			this.backOff();
+			return;
+		}
+		// A racing heal may already have applied while we probed.
+		if (this.opts.isHealed()) return;
+		try {
+			await this.opts.applyHeal(route as CutoverRoute);
+		} catch (err) {
+			this.opts.onApplyError?.(err);
+			this.backOff();
+		}
+	}
+
+	private backOff(): void {
+		this.nextProbeAt = Date.now() + (this.opts.throttleMs ?? ROUTE_PROBE_THROTTLE_MS);
+	}
+}

--- a/cli/src/core/OrphanBranchStorage.test.ts
+++ b/cli/src/core/OrphanBranchStorage.test.ts
@@ -26,7 +26,7 @@ import {
 	readFileFromBranch,
 	writeMultipleFilesToBranch,
 } from "./GitOps.js";
-import { OrphanBranchStorage } from "./OrphanBranchStorage.js";
+import { OrphanBranchFrozenError, OrphanBranchStorage } from "./OrphanBranchStorage.js";
 
 const mockedReadFile = vi.mocked(readFileFromBranch);
 const mockedBatchReadFiles = vi.mocked(batchReadFilesFromBranch);
@@ -147,8 +147,10 @@ describe("cutover fence at write time", () => {
 		fenceState.fence = { reason: "cutover", at: "t" };
 		try {
 			const storage = new OrphanBranchStorage("/repo");
-			await expect(storage.writeFiles([{ path: "summaries/x.json", content: "{}" }], "m")).rejects.toThrow(
-				/frozen/,
+			// Typed, not a bare Error: the MCP dispatcher and the VS Code bridge both
+			// key their self-heal retry on `instanceof OrphanBranchFrozenError`.
+			await expect(storage.writeFiles([{ path: "summaries/x.json", content: "{}" }], "m")).rejects.toBeInstanceOf(
+				OrphanBranchFrozenError,
 			);
 			expect(writeMultipleFilesToBranch).not.toHaveBeenCalled();
 			expect(ensureOrphanBranch).not.toHaveBeenCalled();

--- a/cli/src/core/OrphanBranchStorage.ts
+++ b/cli/src/core/OrphanBranchStorage.ts
@@ -11,6 +11,24 @@ import {
 import { readCutoverFence } from "./RepoProfile.js";
 import type { StorageKind, StorageProvider } from "./StorageProvider.js";
 
+/**
+ * Thrown by {@link OrphanBranchStorage.writeFiles} when the branch it holds has
+ * been frozen (or retired) by a cutover this long-lived object did not witness.
+ *
+ * Typed rather than a bare `Error` so a tool dispatcher can recognise it WITHOUT
+ * matching on message text: seeing it proves a cutover landed since the storage
+ * override was built, so the caller should forget its route-probe back-off and
+ * heal immediately rather than wait out the throttle window (JOLLI-2231). Two
+ * throw sites raise it — the per-clone fence and the shared-identity CAS row —
+ * because both mean the same thing to the caller: rebuild against the database.
+ */
+export class OrphanBranchFrozenError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "OrphanBranchFrozenError";
+	}
+}
+
 export class OrphanBranchStorage implements StorageProvider {
 	readonly kind: StorageKind = "orphan-branch";
 
@@ -37,7 +55,7 @@ export class OrphanBranchStorage implements StorageProvider {
 		// onto the frozen branch after commit.
 		const fence = await readCutoverFence(this.cwd ?? process.cwd()).catch(() => null);
 		if (fence !== null) {
-			throw new Error(
+			throw new OrphanBranchFrozenError(
 				"orphan branch is frozen (cutover fence in place) — this process holds a pre-cutover storage " +
 					"object; restart it so writes route to the database",
 			);
@@ -51,7 +69,7 @@ export class OrphanBranchStorage implements StorageProvider {
 		// unfenced repo must never be blocked by a missing or broken database.
 		const { hasCutoverRow } = await import("../dashboard/CutoverRouter.js");
 		if (await hasCutoverRow(this.cwd ?? process.cwd()).catch(() => false)) {
-			throw new Error(
+			throw new OrphanBranchFrozenError(
 				"orphan branch is retired for this repository (cutover committed) — writes route to the " +
 					"database; re-run the operation from an up-to-date surface",
 			);

--- a/cli/src/dashboard/CutoverRouter.ts
+++ b/cli/src/dashboard/CutoverRouter.ts
@@ -95,6 +95,26 @@ export type CutoverRoute =
 	| { readonly state: "cutover"; readonly record: CutoverRecord }
 	| { readonly state: "blocked"; readonly reason: string };
 
+/**
+ * True when this route has moved the system of record OFF the (freezable) orphan
+ * branch — i.e. a long-lived process holding a pre-cutover storage object must
+ * rebuild it against SQLite. Only a committed `cutover` or a pending
+ * `legacy-fenced` do so: `uncutover` keeps the orphan branch authoritative, and
+ * `blocked` means the database is unreachable, where rebuilding would only turn
+ * readable-but-stale reads into a hard throw.
+ *
+ * This is a PRODUCT rule (AGENTS.md: rules live in `cli/src`, hosts are adapters),
+ * so both the daemon's `ActiveStorageHeal` and the VS Code bridge route through
+ * it rather than each restating the state set — the two had drifted to opposite
+ * polarities of the same condition, which a fifth route state would silently
+ * break in whichever place forgot to update.
+ */
+export function routeMovesOffOrphanBranch(
+	route: CutoverRoute | null | undefined,
+): route is Extract<CutoverRoute, { state: "cutover" | "legacy-fenced" }> {
+	return route?.state === "cutover" || route?.state === "legacy-fenced";
+}
+
 /** What the database said, with "no row" and "cannot ask" kept distinct. */
 type DbAnswer =
 	| { readonly kind: "row"; readonly record: CutoverRecord }

--- a/cli/src/mcp/McpServer.test.ts
+++ b/cli/src/mcp/McpServer.test.ts
@@ -24,6 +24,16 @@ vi.mock("../core/GitOps.js", () => ({ probeWorktree: probeWorktreeMock }));
 const { mockStorage } = vi.hoisted(() => ({ mockStorage: { kind: "mock-storage" } }));
 vi.mock("../core/StorageFactory.js", () => ({ createStorage: vi.fn().mockResolvedValue(mockStorage) }));
 vi.mock("../core/SummaryStore.js", () => ({ setActiveStorage: vi.fn() }));
+// The CallTool handler re-checks the cutover state before a repo-scoped built-in;
+// stub it so these tests don't need real storage, and so ordering can be asserted.
+const { ensureHealMock, clearThrottleMock } = vi.hoisted(() => ({
+	ensureHealMock: vi.fn().mockResolvedValue(undefined),
+	clearThrottleMock: vi.fn(),
+}));
+vi.mock("../core/ActiveStorageHeal.js", () => ({
+	ensureActiveStorageMatchesRoute: ensureHealMock,
+	clearActiveStorageHealThrottle: clearThrottleMock,
+}));
 // The CallTool handler emits per-tool telemetry; spy on track().
 vi.mock("../core/Telemetry.js", () => ({ track: vi.fn() }));
 
@@ -93,6 +103,7 @@ vi.mock("../core/JolliMemoryPushClient.js", () => ({
 
 import { VERSION } from "../commands/CliUtils.js";
 import type { PlatformToolManifestEntry } from "../core/JolliMemoryPushClient.js";
+import { OrphanBranchFrozenError } from "../core/OrphanBranchStorage.js";
 import { createStorage } from "../core/StorageFactory.js";
 import { setActiveStorage } from "../core/SummaryStore.js";
 import { track } from "../core/Telemetry.js";
@@ -220,6 +231,8 @@ describe("startMcpServer", () => {
 		fetchManifestMock.mockReset();
 		invokePlatformToolMock.mockReset();
 		vi.mocked(track).mockClear();
+		ensureHealMock.mockClear();
+		clearThrottleMock.mockClear();
 		// Clean baseline for the log-dir anchoring assertions below.
 		resetLogDir();
 	});
@@ -305,6 +318,24 @@ describe("startMcpServer", () => {
 		expect(JSON.parse(result.content[0].text)).toEqual({ hits: [] });
 	});
 
+	it("CallTool re-checks the cutover state before a repo-scoped built-in, and before dispatch", async () => {
+		let healedBeforeDispatch = false;
+		vi.mocked(runSearch).mockImplementationOnce(async () => {
+			healedBeforeDispatch = ensureHealMock.mock.calls.length > 0;
+			return { hits: [] };
+		});
+		await startMcpServer("/repo");
+		await capturedHandlers[1]({ params: { name: "search", arguments: { query: "x" } } });
+		expect(ensureHealMock).toHaveBeenCalledWith("/repo");
+		expect(healedBeforeDispatch).toBe(true);
+	});
+
+	it("CallTool does NOT re-check the cutover state for a built-in that needs no repo (list_spaces)", async () => {
+		await startMcpServer("/repo");
+		await capturedHandlers[1]({ params: { name: "list_spaces", arguments: {} } });
+		expect(ensureHealMock).not.toHaveBeenCalled();
+	});
+
 	it("CallTool handler returns an isError response when the handler throws", async () => {
 		vi.mocked(runSearch).mockRejectedValueOnce(new Error("boom"));
 		await startMcpServer("/repo");
@@ -315,6 +346,51 @@ describe("startMcpServer", () => {
 		};
 		expect(result.isError).toBe(true);
 		expect(JSON.parse(result.content[0].text)).toEqual({ error: "boom" });
+	});
+
+	it("CallTool self-heals and retries once when a repo-scoped tool hits the frozen branch", async () => {
+		// A cutover that landed inside the heal's throttle window leaves the tool
+		// dispatching against the frozen orphan branch. The typed error clears the
+		// back-off, re-heals (now unthrottled), and retries so the caller sees success.
+		vi.mocked(runSearch)
+			.mockRejectedValueOnce(new OrphanBranchFrozenError("orphan branch is frozen"))
+			.mockResolvedValueOnce({ hits: [] });
+		await startMcpServer("/repo");
+		const result = (await capturedHandlers[1]({ params: { name: "search", arguments: { query: "x" } } })) as {
+			content: { type: string; text: string }[];
+			isError?: boolean;
+		};
+		expect(clearThrottleMock).toHaveBeenCalledWith("/repo");
+		// Healed once before the first attempt, once more before the retry.
+		expect(ensureHealMock).toHaveBeenCalledTimes(2);
+		expect(runSearch).toHaveBeenCalledTimes(2);
+		expect(result.isError).toBeUndefined();
+		expect(JSON.parse(result.content[0].text)).toEqual({ hits: [] });
+	});
+
+	it("CallTool surfaces the frozen error when the single retry also fails", async () => {
+		// Two `Once`s, not a persistent reject: the retry consumes the second, and
+		// nothing leaks into the next test's runSearch.
+		vi.mocked(runSearch)
+			.mockRejectedValueOnce(new OrphanBranchFrozenError("orphan branch is frozen"))
+			.mockRejectedValueOnce(new OrphanBranchFrozenError("orphan branch is frozen"));
+		await startMcpServer("/repo");
+		const result = (await capturedHandlers[1]({ params: { name: "search", arguments: { query: "x" } } })) as {
+			content: { type: string; text: string }[];
+			isError?: boolean;
+		};
+		expect(clearThrottleMock).toHaveBeenCalledTimes(1);
+		expect(runSearch).toHaveBeenCalledTimes(2); // one retry, then give up
+		expect(result.isError).toBe(true);
+		expect(JSON.parse(result.content[0].text)).toEqual({ error: "orphan branch is frozen" });
+	});
+
+	it("CallTool does NOT clear the throttle or retry for a non-frozen error", async () => {
+		vi.mocked(runSearch).mockRejectedValueOnce(new Error("boom"));
+		await startMcpServer("/repo");
+		await capturedHandlers[1]({ params: { name: "search", arguments: { query: "x" } } });
+		expect(clearThrottleMock).not.toHaveBeenCalled();
+		expect(runSearch).toHaveBeenCalledTimes(1);
 	});
 
 	it("CallTool handler flags a structured {type:'error'} result as isError (push_memory contract parity)", async () => {

--- a/cli/src/mcp/McpServer.ts
+++ b/cli/src/mcp/McpServer.ts
@@ -30,9 +30,11 @@ import {
 	type Prompt,
 } from "@modelcontextprotocol/sdk/types.js";
 import { VERSION } from "../commands/CliUtils.js";
+import { clearActiveStorageHealThrottle, ensureActiveStorageMatchesRoute } from "../core/ActiveStorageHeal.js";
 import { isLocalAgentChild } from "../core/AgentReentry.js";
 import { probeWorktree } from "../core/GitOps.js";
 import { JolliMemoryPushClient, type PlatformToolManifestEntry } from "../core/JolliMemoryPushClient.js";
+import { OrphanBranchFrozenError } from "../core/OrphanBranchStorage.js";
 import { loadConfig } from "../core/SessionTracker.js";
 import { createStorage } from "../core/StorageFactory.js";
 import { setActiveStorage } from "../core/SummaryStore.js";
@@ -683,10 +685,42 @@ export function createMcpServer(runtime: McpRuntime): Server {
 			// Route backend-defined tools through the generic executor; everything
 			// else is a built-in handled by the local dispatch table.
 			const platformTool = platformByName.get(name);
-			const result =
-				platformClient && platformTool
-					? await platformClient.invokePlatformTool(platformTool, args ?? {})
-					: await dispatchTool(cwd, name, args ?? {});
+			// Repo-scoped built-ins get the storage heal (platform tools take nothing
+			// from cwd, so they can neither go stale nor throw the frozen error).
+			const repoScopedBuiltin =
+				!platformTool && TOOL_DEFINITIONS.find((t) => t.name === name)?.requiresRepo === true;
+			if (repoScopedBuiltin) {
+				// Before a repo-scoped built-in reads or writes, re-check that this
+				// long-lived process's storage still matches the repo's cutover state.
+				// A daemon (or the stdio fallback) that outlived a cutover holds a
+				// pre-cutover object bound to the now-FROZEN orphan branch: reads come
+				// back stale and the lazy catalog rebuild on the search/recall path
+				// throws "orphan branch is frozen". This heals it in place — no restart,
+				// no reconnect — and no-ops on the fast path once storage reads SQLite.
+				// Per-call, not per-connection: the reproduction is one MCP connection
+				// that spans the cutover, so an attach-time check would never fire.
+				await ensureActiveStorageMatchesRoute(cwd);
+			}
+			let result: unknown;
+			if (platformClient && platformTool) {
+				result = await platformClient.invokePlatformTool(platformTool, args ?? {});
+			} else {
+				try {
+					result = await dispatchTool(cwd, name, args ?? {});
+				} catch (err) {
+					// The heal above is throttled, so a cutover that landed INSIDE the
+					// current back-off window is invisible to it: the pre-cutover override
+					// survives and the lazy catalog write throws frozen. That throw is the
+					// proof the window is stale — forget the back-off, re-heal (now
+					// unthrottled it rebuilds against SQLite), and retry once so the caller
+					// never sees the frozen error. Only this typed error retries; anything
+					// else propagates unchanged.
+					if (!(err instanceof OrphanBranchFrozenError)) throw err;
+					clearActiveStorageHealThrottle(cwd);
+					await ensureActiveStorageMatchesRoute(cwd);
+					result = await dispatchTool(cwd, name, args ?? {});
+				}
+			}
 			// Unify the error contract across tools. `push_memory` (and any backend
 			// platform tool) reports failure as a structured `{ type: "error" }`
 			// result rather than throwing, so flag it `isError` here to match the

--- a/vscode/src/JolliMemoryBridge.test.ts
+++ b/vscode/src/JolliMemoryBridge.test.ts
@@ -244,11 +244,26 @@ vi.mock("../../cli/src/core/KBRepoDiscoverer.js", () => ({
 
 // createStorage now routes by cutover state; pin these tests to the
 // pre-cutover default so they exercise the dual-write path they always did.
-vi.mock("../../cli/src/dashboard/CutoverRouter.js", () => ({
-	// A plain function, not vi.fn(): this suite resets mock implementations
-	// between tests, which would strip a mockResolvedValue and make the route
-	// resolve to undefined.
-	resolveCutoverRoute: async () => ({ state: "uncutover" }),
+// The route is read from a mutable holder so a test can flip it to `cutover`
+// (see the storage-cutover-heal suite) — a plain function, not vi.fn(), because
+// this suite resets mock implementations between tests, which would strip a
+// mockResolvedValue and make the route resolve to undefined. `beforeEach` resets
+// the holder to the pre-cutover default.
+const { cutoverRouteHolder } = vi.hoisted(() => ({
+	cutoverRouteHolder: {
+		current: { state: "uncutover" } as { state: string; reason?: string },
+		// When set, the mock rejects — exercises the heal's route-probe-failure path.
+		throwErr: null as Error | null,
+	},
+}));
+vi.mock("../../cli/src/dashboard/CutoverRouter.js", async (importOriginal) => ({
+	// Keep the real `routeMovesOffOrphanBranch` classifier (shared with the daemon's
+	// heal); stub only the DB-touching `resolveCutoverRoute`.
+	...(await importOriginal<typeof import("../../cli/src/dashboard/CutoverRouter.js")>()),
+	resolveCutoverRoute: async () => {
+		if (cutoverRouteHolder.throwErr) throw cutoverRouteHolder.throwErr;
+		return cutoverRouteHolder.current;
+	},
 }));
 
 vi.mock("../../cli/src/core/KBPathResolver.js", async (importOriginal) => {
@@ -432,6 +447,7 @@ vi.mock("node:fs/promises", () => ({
 // ── Import under test (after mocks) ─────────────────────────────────────────
 
 import { getAggregateWikiFreshness } from "../../cli/src/core/WikiFreshness.js";
+import { OrphanBranchFrozenError } from "../../cli/src/core/OrphanBranchStorage.js";
 import { JolliMemoryBridge } from "./JolliMemoryBridge.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -498,6 +514,9 @@ function mockExecFileError(message: string, stderr?: string): void {
 describe("JolliMemoryBridge", () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
+		// Pre-cutover default; the storage-cutover-heal suite flips this per test.
+		cutoverRouteHolder.current = { state: "uncutover" };
+		cutoverRouteHolder.throwErr = null;
 		mockHomedir.mockReturnValue("/mock/home");
 		resolveGitHooksDir.mockResolvedValue("/mock/hooks");
 		loadGlobalConfig.mockResolvedValue({
@@ -562,6 +581,94 @@ describe("JolliMemoryBridge", () => {
 		it("stores cwd and exposes it as a public property", () => {
 			const bridge = makeBridge();
 			expect(bridge.cwd).toBe(TEST_CWD);
+		});
+	});
+
+	// ── storage cutover heal (JOLLI-2231) ────────────────────────────────
+	//
+	// The extension host caches its storage backends for its whole lifetime. If
+	// the repo cuts over while a window is open, the caches must be dropped so the
+	// next read/write rebuilds against SQLite instead of the frozen orphan branch.
+	// getStatus() is the probe: it calls getStorage(), and swallows any rebuild
+	// error internally, so these tests can assert the heal TRIGGER (reloadStorage)
+	// without depending on the SQLite rebuild succeeding on a synthetic cwd.
+	describe("storage cutover heal", () => {
+		it("does not drop the storage caches while the repo is uncutover", async () => {
+			const bridge = makeBridge();
+			const reloadSpy = vi.spyOn(bridge, "reloadStorage");
+			await bridge.getStatus();
+			expect(reloadSpy).not.toHaveBeenCalled();
+		});
+
+		it("drops the storage caches once the repo has cut over", async () => {
+			const bridge = makeBridge();
+			const reloadSpy = vi.spyOn(bridge, "reloadStorage");
+			cutoverRouteHolder.current = { state: "cutover" };
+			await bridge.getStatus();
+			expect(reloadSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it("drops the caches while the repo is fenced but not yet committed", async () => {
+			const bridge = makeBridge();
+			const reloadSpy = vi.spyOn(bridge, "reloadStorage");
+			cutoverRouteHolder.current = { state: "legacy-fenced" };
+			await bridge.getStatus();
+			expect(reloadSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it("stops probing the route once the repo is seen cut over (one-way latch)", async () => {
+			const bridge = makeBridge();
+			cutoverRouteHolder.current = { state: "cutover" };
+			const reloadSpy = vi.spyOn(bridge, "reloadStorage");
+			await bridge.getStatus();
+			await bridge.getStatus();
+			expect(reloadSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it("leaves the caches in place when the DB is blocked (stale-but-working beats a throw)", async () => {
+			const bridge = makeBridge();
+			const reloadSpy = vi.spyOn(bridge, "reloadStorage");
+			cutoverRouteHolder.current = { state: "blocked", reason: "db down" };
+			await bridge.getStatus();
+			expect(reloadSpy).not.toHaveBeenCalled();
+		});
+
+		it("leaves the caches in place when the route probe fails (retries next time)", async () => {
+			const bridge = makeBridge();
+			const reloadSpy = vi.spyOn(bridge, "reloadStorage");
+			cutoverRouteHolder.throwErr = new Error("route probe boom");
+			await bridge.getStatus();
+			expect(reloadSpy).not.toHaveBeenCalled();
+		});
+
+		it("coalesces concurrent reads into a single route probe + reload", async () => {
+			const bridge = makeBridge();
+			cutoverRouteHolder.current = { state: "cutover" };
+			const reloadSpy = vi.spyOn(bridge, "reloadStorage");
+			await Promise.all([bridge.getStatus(), bridge.getStatus()]);
+			expect(reloadSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it("retries a store write once when it hits the frozen branch", async () => {
+			const bridge = makeBridge();
+			// The cached pre-cutover write throws frozen; healOnFrozen clears the
+			// back-off, re-probes, and retries once so the caller sees success. Route is
+			// left uncutover here so the retry's getStorage() succeeds in this synthetic
+			// env — the reload-on-cutover path itself is covered by the suite above.
+			storePlans
+				.mockRejectedValueOnce(new OrphanBranchFrozenError("orphan branch is frozen"))
+				.mockResolvedValueOnce(undefined);
+			await expect(bridge.storePlans([{ slug: "p", content: "x" }], "msg")).resolves.toBeUndefined();
+			expect(storePlans).toHaveBeenCalledTimes(2);
+		});
+
+		it("does not swallow a non-frozen write error (no heal, no retry)", async () => {
+			const bridge = makeBridge();
+			const reloadSpy = vi.spyOn(bridge, "reloadStorage");
+			storePlans.mockRejectedValueOnce(new Error("disk full"));
+			await expect(bridge.storePlans([{ slug: "p", content: "x" }], "msg")).rejects.toThrow("disk full");
+			expect(storePlans).toHaveBeenCalledTimes(1);
+			expect(reloadSpy).not.toHaveBeenCalled();
 		});
 	});
 
@@ -4360,6 +4467,81 @@ describe("JolliMemoryBridge", () => {
 					"Tree hash aliases found — panel refresh recommended",
 				);
 			});
+		});
+
+		it("logs (does not throw) when the background scanTreeHashAliases fails with a non-frozen error", async () => {
+			mockExecFileSuccess("feature/test\n"); // getCurrentBranch
+			mockExecFileSuccess("abc\n"); // resolveHistoryBaseRef: refExists
+			mockExecFileSuccess("headhash123\n"); // getHEADHash
+			mockExecFileSuccess("mergebase456\n"); // merge-base
+			mockExecFileSuccess("\n"); // resolveOwnCommitsBase → empty reflog
+			mockExecFileSuccess(
+				`commitHash1\x00fix: test\x00John\x00john@example.com\x002025-03-15T10:00:00Z\x00\x00\n`,
+			); // git log
+			mockExecFileSuccess("origin/feature/test\n"); // resolvePushBaseRef
+			mockExecFileSuccess("def\n"); // refExists for upstream
+			mockExecFileSuccess("\n"); // rev-list (unpushed)
+
+			getIndexEntryMap.mockResolvedValue(new Map()); // commitHash1 unmatched
+			scanTreeHashAliases.mockRejectedValue(new Error("disk full"));
+			getDiffStats.mockResolvedValueOnce({ filesChanged: 1, insertions: 1, deletions: 0 });
+
+			const bridge = makeBridge();
+			const reloadSpy = vi.spyOn(bridge, "reloadStorage");
+			// The panel read itself must succeed even though its background alias write fails.
+			await expect(bridge.listBranchCommits("main")).resolves.toBeDefined();
+
+			await vi.waitFor(() => {
+				expect(warn).toHaveBeenCalledWith(
+					"commits",
+					"background tree-hash alias scan failed: %s",
+					expect.stringContaining("disk full"),
+				);
+			});
+			// A generic failure is logged, not treated as a cutover — no heal.
+			expect(reloadSpy).not.toHaveBeenCalled();
+		});
+
+		it("heals (does not log) when the background scanTreeHashAliases hits the frozen orphan branch", async () => {
+			mockExecFileSuccess("feature/test\n"); // getCurrentBranch
+			mockExecFileSuccess("abc\n"); // resolveHistoryBaseRef: refExists
+			mockExecFileSuccess("headhash123\n"); // getHEADHash
+			mockExecFileSuccess("mergebase456\n"); // merge-base
+			mockExecFileSuccess("\n"); // resolveOwnCommitsBase → empty reflog
+			mockExecFileSuccess(
+				`commitHash1\x00fix: test\x00John\x00john@example.com\x002025-03-15T10:00:00Z\x00\x00\n`,
+			); // git log
+			mockExecFileSuccess("origin/feature/test\n"); // resolvePushBaseRef
+			mockExecFileSuccess("def\n"); // refExists for upstream
+			mockExecFileSuccess("\n"); // rev-list (unpushed)
+
+			getIndexEntryMap.mockResolvedValue(new Map()); // commitHash1 unmatched
+			getDiffStats.mockResolvedValueOnce({ filesChanged: 1, insertions: 1, deletions: 0 });
+
+			// The panel read runs while the repo still looks uncutover (so its own
+			// getStorage() does not heal); the background write is what discovers the
+			// freeze. Flipping the route as the write fails models the cutover having
+			// landed inside the throttle window: the catch clears the back-off,
+			// re-probes (now cutover) and heals.
+			cutoverRouteHolder.current = { state: "uncutover" };
+			scanTreeHashAliases.mockImplementation(async () => {
+				cutoverRouteHolder.current = { state: "cutover" };
+				throw new OrphanBranchFrozenError("orphan branch is frozen");
+			});
+
+			const bridge = makeBridge();
+			const reloadSpy = vi.spyOn(bridge, "reloadStorage");
+			await expect(bridge.listBranchCommits("main")).resolves.toBeDefined();
+
+			// The frozen error triggers the heal (drops the caches), never the warn log.
+			await vi.waitFor(() => {
+				expect(reloadSpy).toHaveBeenCalledTimes(1);
+			});
+			expect(warn).not.toHaveBeenCalledWith(
+				"commits",
+				"background tree-hash alias scan failed: %s",
+				expect.anything(),
+			);
 		});
 
 		it("resolvePushBaseRef uses origin/<branch> fallback when upstream ref does not resolve", async () => {

--- a/vscode/src/JolliMemoryBridge.ts
+++ b/vscode/src/JolliMemoryBridge.ts
@@ -39,6 +39,8 @@ import {
 	savePluginSource,
 	saveSquashPending,
 } from "../../cli/src/core/SessionTracker.js";
+import { CutoverHealGate } from "../../cli/src/core/CutoverHealGate.js";
+import { OrphanBranchFrozenError } from "../../cli/src/core/OrphanBranchStorage.js";
 import { invalidateSotRouteCache } from "../../cli/src/core/SotStorageResolver.js";
 import { createStorage } from "../../cli/src/core/StorageFactory.js";
 import { recordMemoryEdit } from "../../cli/src/dashboard/ProducerHooks.js";
@@ -243,6 +245,25 @@ export class JolliMemoryBridge {
 	private readStoragePromise: Promise<StorageProvider> | null = null;
 
 	/**
+	 * One-way latch driving {@link ensureStorageMatchesCutover}: flips once the
+	 * repo is observed cut over, after which the shared {@link cutoverHealGate}
+	 * never re-probes (cutover never reverts). Held here rather than inside the
+	 * gate because this host's "already healed" fact is a plain boolean, unlike the
+	 * daemon's, which reads it off the process-global storage.
+	 */
+	private cutoverHealed = false;
+
+	/**
+	 * The shared cutover-heal state machine (throttle + in-flight coalescing +
+	 * one-way latch), wired to THIS host's apply step: drop the cached storage
+	 * promises so the next {@link getStorage} / {@link getReadStorage} rebuilds
+	 * against the current source of truth. The daemon wires the same gate to
+	 * `setActiveStorage` instead; see {@link CutoverHealGate}. Lazily built so it
+	 * can close over {@link cwd}, which the constructor sets.
+	 */
+	private cutoverHealGateInstance: CutoverHealGate | null = null;
+
+	/**
 	 * Short-lived cache for the {@link loadConfig} + {@link discoverRepos}
 	 * pair that {@link findRepoForAbsPath} hits per `.md` URI shown by the
 	 * file-decoration provider. Without this, VS Code's per-URI
@@ -291,7 +312,8 @@ export class JolliMemoryBridge {
 	}
 
 	/** Lazy-resolved write storage. See {@link storagePromise}. */
-	private getStorage(): Promise<StorageProvider> {
+	private async getStorage(): Promise<StorageProvider> {
+		await this.ensureStorageMatchesCutover();
 		if (!this.storagePromise) {
 			// Reset on rejection so the next caller gets a fresh attempt
 			// instead of awaiting the cached rejected promise forever.
@@ -304,7 +326,8 @@ export class JolliMemoryBridge {
 	}
 
 	/** Lazy-resolved read storage. See {@link readStoragePromise}. */
-	private getReadStorage(): Promise<StorageProvider> {
+	private async getReadStorage(): Promise<StorageProvider> {
+		await this.ensureStorageMatchesCutover();
 		if (!this.readStoragePromise) {
 			this.readStoragePromise = this.createReadStorage().catch((err) => {
 				this.readStoragePromise = null;
@@ -312,6 +335,90 @@ export class JolliMemoryBridge {
 			});
 		}
 		return this.readStoragePromise;
+	}
+
+	/**
+	 * Drops the storage caches when the repo cut over since they were built.
+	 *
+	 * The extension host is the product's longest-lived process, and it caches
+	 * BOTH storage backends ({@link storagePromise} / {@link readStoragePromise})
+	 * plus the system-of-record route memo for its whole lifetime. A cutover
+	 * committed by another surface (a CLI run, the dashboard auto-cutover) freezes
+	 * the orphan branch, but nothing here noticed: {@link reloadStorage} was wired
+	 * ONLY to the settings-save callback, so a window left open across a cutover
+	 * kept reading the now-frozen orphan branch (stale — silently missing every
+	 * memory written to SQLite since) and threw "orphan branch is frozen" on the
+	 * lazy catalog write behind a search/recall. That is JOLLI-2231's MCP-daemon
+	 * failure one surface over; this is its fix for this host.
+	 *
+	 * Mirrors the daemon's `ensureActiveStorageMatchesRoute`
+	 * ([ActiveStorageHeal.ts](../../cli/src/core/ActiveStorageHeal.ts)) — both wire
+	 * the shared {@link CutoverHealGate} (throttle + coalescing + one-way latch)
+	 * to their own apply step. The apply differs only because this host threads
+	 * storage explicitly rather than through `setActiveStorage`, so it drops the
+	 * caches (letting the next {@link getStorage} / {@link getReadStorage} rebuild
+	 * against SQLite) instead of swapping a process global. One-way, coalesced and
+	 * throttled: once the repo is seen cut over the latch makes every later call a
+	 * no-op, and while it is still uncutover the route probe (a read-only SQLite
+	 * open + fence read) runs at most once per window rather than on every call — a
+	 * method that awaits both {@link getReadStorage} and {@link getStorage} would
+	 * probe twice per operation otherwise.
+	 */
+	private ensureStorageMatchesCutover(): Promise<void> {
+		return this.cutoverHealGate().ensure();
+	}
+
+	/**
+	 * Lazily builds the {@link CutoverHealGate} for this bridge. Lazy so it can
+	 * close over {@link cwd} (set by the constructor) and so it is only allocated
+	 * for a bridge that actually performs a repo-scoped operation. The gate's
+	 * "already healed" fact is this host's {@link cutoverHealed} boolean, and its
+	 * apply step drops the caches; a route-probe failure or a `blocked` DB leaves
+	 * the caches in place (readable-but-stale beats a hard throw) and a later call
+	 * retries — all of which is the shared gate's contract, not restated here.
+	 */
+	private cutoverHealGate(): CutoverHealGate {
+		if (!this.cutoverHealGateInstance) {
+			this.cutoverHealGateInstance = new CutoverHealGate({
+				cwd: this.cwd,
+				isHealed: () => this.cutoverHealed,
+				applyHeal: () => {
+					this.cutoverHealed = true;
+					this.reloadStorage();
+				},
+			});
+		}
+		return this.cutoverHealGateInstance;
+	}
+
+	/**
+	 * Runs a storage-writing op, healing once if it hits the cutover fence.
+	 *
+	 * {@link ensureStorageMatchesCutover} is throttled, so a cutover that landed
+	 * INSIDE the current back-off window is invisible to it: `getStorage()` hands
+	 * back the cached pre-cutover `DualWriteStorage`, and its orphan primary throws
+	 * {@link OrphanBranchFrozenError} on the write. That throw is the proof the
+	 * window is stale — forget the back-off, re-probe (now unthrottled it latches
+	 * `cutoverHealed` and drops the caches), and retry the op once against the
+	 * SQLite-backed storage, so the caller never sees the frozen error. Only that
+	 * typed error retries; anything else propagates unchanged.
+	 *
+	 * Unlike the daemon, this host only reaches the fence on WRITE ops (its reads
+	 * are index + file reads that never trigger the lazy catalog writeback the MCP
+	 * search/recall path does). Every writer that reaches the orphan branch —
+	 * `store*`, `archivePlanForCommit` / `archiveNoteForCommit`, and the v1→v3
+	 * index migration — wraps itself here; a read that only touches the index +
+	 * files does not.
+	 */
+	private async healOnFrozen<T>(op: () => Promise<T>): Promise<T> {
+		try {
+			return await op();
+		} catch (err) {
+			if (!(err instanceof OrphanBranchFrozenError)) throw err;
+			this.cutoverHealGate().forgetBackOff();
+			await this.ensureStorageMatchesCutover();
+			return op();
+		}
 	}
 
 	private async createReadStorage(): Promise<StorageProvider> {
@@ -1223,14 +1330,34 @@ export class JolliMemoryBridge {
 				this.cwd,
 				writeStorage,
 				readStorage,
-			).then((anyFound) => {
-				if (anyFound) {
-					log.info(
+			)
+				.then((anyFound) => {
+					if (anyFound) {
+						log.info(
+							"commits",
+							"Tree hash aliases found — panel refresh recommended",
+						);
+					}
+				})
+				.catch((err) => {
+					// This is a fire-and-forget background WRITE (aliases dual-write via
+					// `writeStorage`), so its rejection has no caller to surface it — a
+					// bare `void` would leave it as an unhandled promise rejection. A
+					// cutover that froze the orphan branch is the expected failure: the
+					// alias write cannot land, so trigger the heal (subsequent ops rebuild
+					// against SQLite) and swallow — a best-effort cross-branch match is not
+					// worth failing the panel over. Anything else is logged, not thrown.
+					if (err instanceof OrphanBranchFrozenError) {
+						this.cutoverHealGate().forgetBackOff();
+						void this.ensureStorageMatchesCutover();
+						return;
+					}
+					log.warn(
 						"commits",
-						"Tree hash aliases found — panel refresh recommended",
+						"background tree-hash alias scan failed: %s",
+						String(err),
 					);
-				}
-			});
+				});
 		}
 
 		const cachedCount = commits.filter(
@@ -2532,15 +2659,17 @@ export class JolliMemoryBridge {
 			readonly planProgress?: ReadonlyArray<PlanProgressArtifact>;
 		},
 	): Promise<void> {
-		const storage = await this.getStorage();
-		const readStorage = await this.getReadStorage();
-		await storeSummary(summary, this.cwd, force, artifacts, storage, readStorage);
-		// The dashboard's `memories` rows are a projection of these files that
-		// only the post-commit worker refreshes; a webview edit (detach a
-		// conversation, remove a plan, delete a topic, regenerate) would otherwise
-		// keep serving the pre-edit memory on the local dashboard forever.
-		// Never throws — see `recordMemoryEdit`.
-		await recordMemoryEdit(this.cwd, [summary.commitHash]);
+		return this.healOnFrozen(async () => {
+			const storage = await this.getStorage();
+			const readStorage = await this.getReadStorage();
+			await storeSummary(summary, this.cwd, force, artifacts, storage, readStorage);
+			// The dashboard's `memories` rows are a projection of these files that
+			// only the post-commit worker refreshes; a webview edit (detach a
+			// conversation, remove a plan, delete a topic, regenerate) would otherwise
+			// keep serving the pre-edit memory on the local dashboard forever.
+			// Never throws — see `recordMemoryEdit`.
+			await recordMemoryEdit(this.cwd, [summary.commitHash]);
+		});
 	}
 
 	/**
@@ -2584,8 +2713,10 @@ export class JolliMemoryBridge {
 		commitMessage: string,
 		branch?: string,
 	): Promise<void> {
-		const storage = await this.getStorage();
-		await storePlans(planFiles, commitMessage, this.cwd, branch, storage);
+		return this.healOnFrozen(async () => {
+			const storage = await this.getStorage();
+			await storePlans(planFiles, commitMessage, this.cwd, branch, storage);
+		});
 	}
 
 	/** Writes note files (orphan-branch + Memory Bank visible MD). */
@@ -2594,8 +2725,10 @@ export class JolliMemoryBridge {
 		commitMessage: string,
 		branch?: string,
 	): Promise<void> {
-		const storage = await this.getStorage();
-		await storeNotes(noteFiles, commitMessage, this.cwd, branch, storage);
+		return this.healOnFrozen(async () => {
+			const storage = await this.getStorage();
+			await storeNotes(noteFiles, commitMessage, this.cwd, branch, storage);
+		});
 	}
 
 	/**
@@ -2613,14 +2746,16 @@ export class JolliMemoryBridge {
 		commitMessage: string,
 		branch?: string,
 	): Promise<void> {
-		const storage = await this.getStorage();
-		await storeReferences(
-			referenceFiles,
-			commitMessage,
-			this.cwd,
-			branch,
-			storage,
-		);
+		return this.healOnFrozen(async () => {
+			const storage = await this.getStorage();
+			await storeReferences(
+				referenceFiles,
+				commitMessage,
+				this.cwd,
+				branch,
+				storage,
+			);
+		});
 	}
 
 	/** Batched transcript write+delete. */
@@ -2631,8 +2766,10 @@ export class JolliMemoryBridge {
 		}>,
 		deletes: ReadonlyArray<string>,
 	): Promise<void> {
-		const storage = await this.getStorage();
-		await saveTranscriptsBatch(writes, deletes, this.cwd, storage);
+		return this.healOnFrozen(async () => {
+			const storage = await this.getStorage();
+			await saveTranscriptsBatch(writes, deletes, this.cwd, storage);
+		});
 	}
 
 	/** Returns the set of commit hashes that have transcript files. */
@@ -2663,8 +2800,10 @@ export class JolliMemoryBridge {
 
 	/** Migrates a v1 index to v3 flat format. */
 	async migrateIndexToV3(): Promise<{ migrated: number; skipped: number }> {
-		const storage = await this.getStorage();
-		return migrateIndexToV3(this.cwd, storage);
+		return this.healOnFrozen(async () => {
+			const storage = await this.getStorage();
+			return migrateIndexToV3(this.cwd, storage);
+		});
 	}
 
 	/** Archives a plan and associates it with a commit. */
@@ -2672,8 +2811,10 @@ export class JolliMemoryBridge {
 		slug: string,
 		commitHash: string,
 	): Promise<PlanReference | null> {
-		const storage = await this.getStorage();
-		return archivePlanForCommit(slug, commitHash, this.cwd, storage);
+		return this.healOnFrozen(async () => {
+			const storage = await this.getStorage();
+			return archivePlanForCommit(slug, commitHash, this.cwd, storage);
+		});
 	}
 
 	/** Archives a note and associates it with a commit. */
@@ -2681,8 +2822,10 @@ export class JolliMemoryBridge {
 		id: string,
 		commitHash: string,
 	): Promise<NoteReference | null> {
-		const storage = await this.getStorage();
-		return archiveNoteForCommit(id, commitHash, this.cwd, storage);
+		return this.healOnFrozen(async () => {
+			const storage = await this.getStorage();
+			return archiveNoteForCommit(id, commitHash, this.cwd, storage);
+		});
 	}
 
 	// ── Git utility methods ───────────────────────────────────────────────


### PR DESCRIPTION
## Problem

A long-lived process — the per-worktree MCP daemon, and the VS Code extension host — resolves its storage backend once at startup and holds it for its whole life. When another surface commits a cutover (a CLI run, or the dashboard auto-cutover), the orphan branch freezes, but the long-lived process keeps its pre-cutover object:

- reads come off the now-frozen orphan branch — silently missing every memory written to SQLite since the cutover (stale-but-successful, which the cutover contract names as worse than no data);
- the lazy catalog rebuild behind search/recall reaches `OrphanBranchStorage.writeFiles` and throws "orphan branch is frozen".

A restart was the only cure (JOLLI-2231).

## Fix

Re-check the repo's cutover route before a repo-scoped operation runs and rebuild against the current source of truth in place:

- **MCP server** — `ActiveStorageHeal.ensureActiveStorageMatchesRoute` swaps the process-global active storage before a repo-scoped built-in dispatches. Per-call, not per-connection: the reproduction is one connection that spans the cutover, so an attach-time check would never fire.
- **VS Code host** — `JolliMemoryBridge` drops its cached read/write storage on the same signal, since it threads storage explicitly rather than through `setActiveStorage`.

Both paths are **one-way, coalesced, and throttled**:

- Once the repo is seen cut over the check latches off (cutover is one-way), so a cut-over repo stops probing entirely.
- While the repo is still uncutover — the common case for a daemon's whole life, where the `.kind` fast path can never short-circuit — the route probe (a read-only SQLite open + fence read) is throttled to at most once per `ROUTE_PROBE_THROTTLE_MS` (5s), shared by both surfaces. This trades an at-most-one-window read-staleness gap after an unwitnessed cutover for a near-free hot path; a write re-reads the fence at the plumbing layer and throws on a frozen branch regardless, so it is never a data gap.
- A blocked DB, a failed route probe, or a transient `createStorage` failure leaves the stale-but-readable storage in place and backs off rather than turning a working read into a hard throw. The heal never throws out of the tool call.

## Testing

- `ActiveStorageHeal.ts` — 100% coverage (stmt/branch/func/line), covering throttle-skip, window expiry, probe failure, and the never-throw contract on a failed rebuild.
- `McpServer` + VS Code bridge (unit + integration) green.
- `npm run test:fast` green (472 files / 12793 tests, coverage thresholds met); typecheck + lint clean.
