### PR TITLE
Add Advanced toggles for Knowledge and Graph dashboard menus

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -1813,6 +1813,26 @@ export interface JolliMemoryConfig {
 	 */
 	readonly wikiRebuild?: "manual" | "auto";
 	/**
+	 * Whether `jolli dashboard`'s sidebar shows the **Knowledge** menu row (the
+	 * Memory Bank `_wiki` browser). Absent means HIDDEN — the polarity is
+	 * deliberately `=== true`, so every existing install upgrades into the
+	 * default-off state with no migration.
+	 *
+	 * Scoped to the sidebar row ALONE. `/knowledge`, `/wiki-viewer` and
+	 * `/api/wiki/*` stay routed and `jolli compile` still builds the wiki, so a
+	 * bookmark, the Knowledge → Graph jump and the iframe preview keep working
+	 * while the row is hidden. Anything about whether the wiki is BUILT lives in
+	 * `wikiRebuild` above, not here.
+	 */
+	readonly dashboardKnowledgeMenuEnabled?: boolean;
+	/**
+	 * Whether `jolli dashboard`'s sidebar shows the **Graph** menu row (the
+	 * per-repo knowledge graph). Same polarity and the same row-only scope as
+	 * {@link dashboardKnowledgeMenuEnabled} — `/graph` and `/graph-viewer` stay
+	 * routed either way.
+	 */
+	readonly dashboardGraphMenuEnabled?: boolean;
+	/**
 	 * Whether the post-commit hook prints live memory-capture progress to stdout
 	 * (so a `git commit` driven from a terminal or AI-agent session shows the
 	 * capture lifecycle inline, and blocks until it drains).

--- a/cli/src/dashboard/DashboardModel.ts
+++ b/cli/src/dashboard/DashboardModel.ts
@@ -1700,6 +1700,24 @@ export interface CoverageNote {
 	readonly message: string;
 }
 
+/**
+ * Which OPTIONAL sidebar menu rows this machine shows — Settings → Advanced.
+ *
+ * Lives at the top of {@link DashboardModel}, not inside {@link SettingsPageModel},
+ * for two reasons that pull the same way. The sidebar is part of the SHELL, so it
+ * is rendered on every view and needs these booleans in every payload; and the
+ * Settings modal fetches a whole `DashboardModel` (`/api/model?view=settings`), so
+ * it reads them here too. One fact, one place — a copy under `settings` would be a
+ * second owner with no tie-breaker.
+ *
+ * `false` hides the ROW only. Both views stay routed (see `VIEW_PATHS` in
+ * `DashboardServer`), so a bookmark and the Knowledge → Graph jump keep working.
+ */
+export interface DashboardMenus {
+	readonly knowledge: boolean;
+	readonly graph: boolean;
+}
+
 /** Everything one page render needs. Injected inline, then refreshed over HTTP. */
 export interface DashboardModel {
 	readonly schemaVersion: number;
@@ -1711,6 +1729,8 @@ export interface DashboardModel {
 	readonly scope: DashboardScope;
 	readonly repos: ReadonlyArray<RepoOption>;
 	readonly coverage: ReadonlyArray<CoverageNote>;
+	/** Optional sidebar rows the user has switched on. Present on every view. */
+	readonly menus: DashboardMenus;
 	readonly stats?: StatsModel;
 	readonly standup?: StandupModel;
 	/** Present on the memories view only. */

--- a/cli/src/dashboard/DashboardQuery.test.ts
+++ b/cli/src/dashboard/DashboardQuery.test.ts
@@ -364,6 +364,35 @@ describe("buildDashboardModel", () => {
 		}
 	});
 
+	// The optional sidebar rows. This builder is synchronous and the flags live in
+	// a file, so the server reads them and passes them in — which makes the DEFAULT
+	// the interesting case: an omitted slice must land on hidden, or a caller that
+	// has never heard of the flags switches a row on by saying nothing.
+	it("defaults both optional menu rows to hidden when the caller passes none", async () => {
+		await seed();
+		const model = await withDashboardDb(
+			(db) => buildDashboardModel(db, { view: "stats", scope: { kind: "all" }, timeZone: "UTC", nowMs }),
+			{ dbPath },
+		);
+		expect(model.menus).toEqual({ knowledge: false, graph: false });
+	});
+
+	it("passes a caller's menu flags through unchanged", async () => {
+		await seed();
+		const model = await withDashboardDb(
+			(db) =>
+				buildDashboardModel(db, {
+					view: "stats",
+					scope: { kind: "all" },
+					timeZone: "UTC",
+					nowMs,
+					menus: { knowledge: true, graph: false },
+				}),
+			{ dbPath },
+		);
+		expect(model.menus).toEqual({ knowledge: true, graph: false });
+	});
+
 	it("exposes the price-table date", async () => {
 		await seed();
 		const model = await withDashboardDb(

--- a/cli/src/dashboard/DashboardQuery.ts
+++ b/cli/src/dashboard/DashboardQuery.ts
@@ -27,6 +27,7 @@ import type {
 	AdoptionTier,
 	CommitInsightKind,
 	CoverageNote,
+	DashboardMenus,
 	DashboardModel,
 	DashboardRange,
 	DashboardScope,
@@ -368,6 +369,13 @@ export interface QueryOptions {
 	readonly graphModel?: GraphModel;
 	/** Settings view: the async-read config/memory-bank snapshot. Absent on every other view. */
 	readonly settingsModel?: SettingsPageModel;
+	/**
+	 * Which optional sidebar rows to show, read from config by the server (this
+	 * builder is synchronous and the flags live in a file). Absent means BOTH
+	 * hidden — the same polarity `config.json` has, so a caller that does not
+	 * know about them cannot switch one on by omission.
+	 */
+	readonly menus?: DashboardMenus;
 	/**
 	 * Every checkout path the repo registry records, keyed by `repo_identity` —
 	 * read async by the server, because the registry is a file and this builder is
@@ -2535,6 +2543,10 @@ export function buildDashboardModel(db: DashboardDbHandle, opts: QueryOptions): 
 		scope: options.scope,
 		repos,
 		coverage,
+		// Default-off rather than default-on: see `QueryOptions.menus`. Always
+		// present in the payload, so `shell.js` never has to guess what an absent
+		// slice meant.
+		menus: options.menus ?? { knowledge: false, graph: false },
 		...payload(),
 	};
 }

--- a/cli/src/dashboard/DashboardServer.test.ts
+++ b/cli/src/dashboard/DashboardServer.test.ts
@@ -75,6 +75,7 @@ import { readTelemetryEvents } from "../core/TelemetryBuffer.js";
 import { TRANSCRIPT_SOURCE_LABELS } from "../core/TranscriptSourceLabel.js";
 import { getAggregateWikiFreshness } from "../core/WikiFreshness.js";
 import * as installer from "../install/Installer.js";
+import { withIsolatedHome } from "../testUtils/isolatedHome.js";
 import { withDashboardDb } from "./DashboardDb.js";
 import { type DashboardModel, type DashboardScope, type DashboardView, TOOL_ROWS_LIMIT } from "./DashboardModel.js";
 import {
@@ -177,6 +178,7 @@ const model = (view: DashboardView): DashboardModel => ({
 	scope: { kind: "all" },
 	repos: [],
 	coverage: [],
+	menus: { knowledge: false, graph: false },
 });
 
 async function listen(server: Server): Promise<number> {
@@ -1451,6 +1453,79 @@ describe("defaultModelBuilder (no injected buildModel)", () => {
 		const retired = await get(port, "/api/model?view=repositories");
 		expect(retired.status).toBe(200);
 		expect(((await retired.json()) as DashboardModel).view).toBe("stats");
+	});
+
+	// The optional sidebar rows come from config, and they are read on EVERY view
+	// rather than only on settings — the sidebar is shell furniture, so a flag that
+	// arrived on one view only would leave the nav guessing everywhere else. Both
+	// halves are asserted here because only this block runs the real builder.
+	it("reads the optional menu flags from config, on every view", async () => {
+		const dbPath = join(dir, "menus.db");
+		const configDir = join(dir, "menus-config");
+		mkdirSync(configDir, { recursive: true });
+		writeFileSync(
+			join(configDir, "config.json"),
+			JSON.stringify({ dashboardKnowledgeMenuEnabled: true, dashboardGraphMenuEnabled: false }),
+		);
+		await withDashboardDb(() => {}, { dbPath });
+		const port = await listen(createDashboardServer({ port: 0, assetsDir, dbPath, configDir }));
+
+		for (const view of ["stats", "standup", "memories", "knowledge", "graph"] as const) {
+			const res = await get(port, `/api/model?view=${view}`);
+			expect(((await res.json()) as DashboardModel).menus, view).toEqual({ knowledge: true, graph: false });
+		}
+	});
+
+	// A config with neither key — every install before this shipped — must read as
+	// both hidden. `=== true` gives that; the test is what stops a later `!== false`
+	// from quietly reversing the default for everyone.
+	it("defaults both optional menu flags to hidden when config says nothing", async () => {
+		const dbPath = join(dir, "menus-default.db");
+		await withDashboardDb(() => {}, { dbPath });
+		const port = await listen(
+			createDashboardServer({ port: 0, assetsDir, dbPath, configDir: join(dir, "menus-default-config") }),
+		);
+		const res = await get(port, "/api/model?view=stats");
+		expect(((await res.json()) as DashboardModel).menus).toEqual({ knowledge: false, graph: false });
+	});
+
+	// `configDir` is optional on this builder, and every caller in production
+	// resolves it before getting here — so the machine-global fallback is only
+	// reachable through a hand-built server. It still has to read the same file the
+	// resolved path would, which is what this pins: HOME is redirected, a config is
+	// written where `getGlobalConfigDir()` will look, and the flags come back.
+	it("falls back to the machine-global config dir when none is given", async () => {
+		// `withIsolatedHome`, never a hand-rolled `process.env.HOME = …`: that is
+		// isolation on POSIX and a NO-OP on Windows, where `os.homedir()` reads
+		// USERPROFILE — so the hand-rolled form writes into the developer's real
+		// `~/.jolli/jollimemory/`. The helper's own docstring records that damage.
+		const home = join(dir, "fallback-home");
+		mkdirSync(join(home, ".jolli", "jollimemory"), { recursive: true });
+		writeFileSync(
+			join(home, ".jolli", "jollimemory", "config.json"),
+			JSON.stringify({ dashboardGraphMenuEnabled: true }),
+		);
+		await withIsolatedHome(home, async () => {
+			const dbPath = join(dir, "menus-global.db");
+			await withDashboardDb(() => {}, { dbPath });
+			const port = await listen(createDashboardServer({ port: 0, assetsDir, dbPath }));
+			const res = await get(port, "/api/model?view=stats");
+			expect(((await res.json()) as DashboardModel).menus).toEqual({ knowledge: false, graph: true });
+		});
+	});
+
+	// Hiding a row does NOT close its route: only the sidebar entry is gated, so a
+	// bookmark still opens the page rather than being redirected somewhere the
+	// reader did not ask for. A gate added here later would break this.
+	it("keeps /knowledge and /graph routed while both menu flags are off", async () => {
+		const dbPath = join(dir, "menus-routes.db");
+		await withDashboardDb(() => {}, { dbPath });
+		const port = await listen(
+			createDashboardServer({ port: 0, assetsDir, dbPath, configDir: join(dir, "menus-routes-config") }),
+		);
+		for (const path of ["/knowledge", "/graph"]) {
+			expect((await get(port, path)).status, path).toBe(200);
+		}
 	});
 
 	/** Seeds one enabled repo whose projected `worktree_root` is `root`. */

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -666,6 +666,17 @@ async function defaultModelBuilder(
 	const registryRoots = new Map<string, ReadonlyArray<string>>(
 		(await readRepoRegistry(configDir)).repos.map((repo) => [repo.repoIdentity, recordedRepoPaths(repo)]),
 	);
+	// Optional sidebar rows. Not view-gated either, and for the same reason the
+	// registry read above is not: the sidebar is shell furniture rendered on EVERY
+	// view, so a flag read only on the settings view would leave the nav guessing
+	// everywhere else. One small JSON read per request, on the same order as the
+	// registry's; `loadConfigFromDir` is fail-open (an unreadable config reads as
+	// an empty one), which lands on the default-hidden state rather than throwing.
+	const menuConfig = await loadConfigFromDir(configDir ?? getGlobalConfigDir());
+	const menus = {
+		knowledge: menuConfig.dashboardKnowledgeMenuEnabled === true,
+		graph: menuConfig.dashboardGraphMenuEnabled === true,
+	};
 	return withReadonlyDashboardDb(
 		async (db) => {
 			// A rebase/reset/squash that rewrites history away leaves the old
@@ -702,6 +713,7 @@ async function defaultModelBuilder(
 			return buildDashboardModel(db, {
 				...request,
 				registryRoots,
+				menus,
 				...(settingsModel ? { settingsModel } : {}),
 				...(knowledgeModel ? { knowledgeModel } : {}),
 				...(graphModel ? { graphModel } : {}),

--- a/cli/src/dashboard/SettingsAsset.test.ts
+++ b/cli/src/dashboard/SettingsAsset.test.ts
@@ -4,7 +4,7 @@
  * `assets/js/*.js` is plain JavaScript, never type-checked by tsc, so a typo in
  * a field name or a broken template renders silently in the browser. This
  * evaluates the real IIFE against a stub window/document and asserts each of the
- * five section renderers, following the pattern of `FeedCardAsset.test.ts`.
+ * six section renderers, following the pattern of `FeedCardAsset.test.ts`.
  */
 
 import { readFileSync } from "node:fs";
@@ -22,11 +22,12 @@ interface FakeElement {
 	insertAdjacentHTML: (pos: string, html: string) => void;
 }
 
-const SECTION_IDS = ["agents", "summary", "sync", "bank", "others"];
+const SECTION_IDS = ["agents", "summary", "sync", "bank", "others", "advanced"];
 
 /**
  * Loads format.js → settings.js against a stub window/document. The document's
- * `querySelectorAll(".set-rail-item")` returns five persistent fake buttons so
+ * `querySelectorAll(".set-rail-item")` returns one persistent fake button per
+ * section so
  * the test can drive section switches; every other selector returns []. The
  * async `JD` helpers are stubbed to never-resolving promises so the lazy loads
  * that fire on the sync/bank sections make no real request.
@@ -105,7 +106,7 @@ describe("settings.js renderSettings", () => {
 	it("renders the section rail and the default AI Agents section", () => {
 		const { renderSettings, app } = loadJD();
 		renderSettings(MODEL);
-		for (const label of ["AI Agents", "AI Summary", "Sync to Jolli", "Memory Bank", "Others"]) {
+		for (const label of ["AI Agents", "AI Summary", "Sync to Jolli", "Memory Bank", "Others", "Advanced"]) {
 			expect(app.innerHTML).toContain(label);
 		}
 		expect(app.innerHTML).toContain("Claude Code");
@@ -113,7 +114,7 @@ describe("settings.js renderSettings", () => {
 		expect(app.innerHTML).toContain("Apply Changes");
 	});
 
-	it("renders each of the five section renderers with its distinctive content", () => {
+	it("renders each of the six section renderers with its distinctive content", () => {
 		const { renderSettings, app, rail } = loadJD();
 		renderSettings(MODEL);
 		const go = (id: string) => rail.get(id)?.onclick?.();
@@ -134,6 +135,10 @@ describe("settings.js renderSettings", () => {
 		go("others");
 		expect(app.innerHTML).toContain("Exclude Patterns");
 		expect(app.innerHTML).toContain("Sign commits with DCO");
+
+		go("advanced");
+		expect(app.innerHTML).toContain("Show Knowledge");
+		expect(app.innerHTML).toContain("Show Graph");
 	});
 
 	it("survives a settings payload missing optional sections, still rendering each section's own content", () => {
@@ -148,6 +153,7 @@ describe("settings.js renderSettings", () => {
 			sync: "Outbound push per repo",
 			bank: "Folder Path",
 			others: "Exclude Patterns",
+			advanced: "Show Knowledge",
 		};
 		for (const id of SECTION_IDS) {
 			rail.get(id)?.onclick?.();
@@ -170,12 +176,30 @@ interface FieldStub {
 	oninput?: () => void;
 }
 
-function loadFormJD(): {
+function loadFormJD(
+	model: unknown = MODEL,
+	extraFields: ReadonlyArray<readonly [string, string]> = [],
+	/**
+	 * `window.__JOLLI_DASHBOARD__.menus` — what the SIDEBAR is currently showing,
+	 * which is what `doApply` compares against. Defaults to the settings payload's
+	 * own slice, the normal case where page and modal agree; pass it explicitly to
+	 * model two tabs that have drifted apart.
+	 */
+	pageMenus: unknown = (model as { menus?: unknown }).menus,
+): {
 	fields: Map<string, FieldStub>;
 	applyBtn: { onclick?: () => void };
 	posts: { path: string; body: Record<string, unknown> }[];
+	/** How many times doApply asked the PAGE to repaint (the sidebar refresh). */
+	pageRefreshes: () => number;
+	/** The callbacks doApply handed to `JD.refreshNow`, for an identity check. */
+	refreshArgs: () => ReadonlyArray<unknown>;
+	/** The stub the page render must be driven through. */
+	renderPage: unknown;
 } {
 	const posts: { path: string; body: Record<string, unknown> }[] = [];
+	let pageRefreshes = 0;
+	const refreshArgs: unknown[] = [];
 	const app = { innerHTML: "", insertAdjacentHTML: () => undefined };
 	const applyBtn: { onclick?: () => void } = {};
 	const field = (name: string, type: string): FieldStub => ({
@@ -188,6 +212,7 @@ function loadFormJD(): {
 		["globalInstructions", field("globalInstructions", "checkbox")],
 		["codexEnabled", field("codexEnabled", "checkbox")],
 		["maxTokens", field("maxTokens", "number")],
+		...extraFields.map(([name, type]): [string, FieldStub] => [name, field(name, type)]),
 	]);
 	const doc = {
 		getElementById: (id: string) =>
@@ -205,11 +230,17 @@ function loadFormJD(): {
 				posts.push({ path, body });
 				return Promise.resolve({ ok: true, hookFailures: [] });
 			},
-			refreshNow: () => undefined,
+			refreshNow: (render: unknown) => {
+				pageRefreshes += 1;
+				refreshArgs.push(render);
+			},
 			renderPage: () => undefined,
 		},
 		document: doc,
 		addEventListener: () => undefined,
+		// The page payload the sidebar was rendered from. `doApply` reads its
+		// `menus` to decide whether the sidebar needs repainting.
+		__JOLLI_DASHBOARD__: { menus: pageMenus },
 	} as Record<string, unknown>;
 	for (const f of ["format.js", "settings.js"]) {
 		new Function("window", "document", readFileSync(new URL(`./assets/js/${f}`, import.meta.url), "utf8"))(
@@ -218,8 +249,15 @@ function loadFormJD(): {
 		);
 	}
 	// render() → wire() assigns applyBtn.onclick and the fields' on* handlers.
-	(win.JD as { renderSettings: (m: unknown) => void }).renderSettings(MODEL);
-	return { fields, applyBtn, posts };
+	(win.JD as { renderSettings: (m: unknown) => void }).renderSettings(model);
+	return {
+		fields,
+		applyBtn,
+		posts,
+		pageRefreshes: () => pageRefreshes,
+		refreshArgs: () => refreshArgs,
+		renderPage: (win.JD as { renderPage: unknown }).renderPage,
+	};
 }
 
 describe("settings.js form wiring", () => {
@@ -248,6 +286,203 @@ describe("settings.js form wiring", () => {
 		expect(body.codexEnabled).toBe(false); // seeded from MODEL, untouched
 		expect(body.aiProvider).toBe("anthropic"); // seeded, untouched
 		expect(body.dcoSignoff).toBe(true); // seeded from MODEL.others
+	});
+});
+
+/**
+ * The Advanced section — the two optional sidebar rows.
+ *
+ * Its state does NOT come from `model.settings`: the flags live at the top of the
+ * payload as `model.menus`, because the sidebar reads them on every view (see
+ * `DashboardMenus`). So this suite is what pins that `initForm` reads the whole
+ * model rather than the settings slice — a mistake tsc cannot see, and one whose
+ * symptom is a checkbox that is silently always off while the row it controls is
+ * showing.
+ */
+describe("settings.js Advanced section", () => {
+	function advancedHtml(menus?: Record<string, boolean>): string {
+		const { renderSettings, app, rail } = loadJD();
+		renderSettings(menus ? { ...MODEL, menus } : MODEL);
+		rail.get("advanced")?.onclick?.();
+		return app.innerHTML;
+	}
+
+	it("seeds each switch from model.menus, not from the settings slice", () => {
+		const html = advancedHtml({ knowledge: true, graph: false });
+		expect(html).toMatch(/data-field="dashboardKnowledgeMenuEnabled" checked/);
+		expect(html).toContain('data-field="dashboardGraphMenuEnabled"/>');
+	});
+
+	it("renders both switches off when the payload carries no menus slice", () => {
+		const html = advancedHtml();
+		expect(html).toContain('data-field="dashboardKnowledgeMenuEnabled"/>');
+		expect(html).toContain('data-field="dashboardGraphMenuEnabled"/>');
+	});
+
+	// The rows are hidden by default, so this section is where a reader learns the
+	// pages exist — and that switching one off neither stops the content being built
+	// nor closes the route. Both halves are load-bearing product text, not phrasing:
+	// without the first a user reads the switch as "stop compiling", and without the
+	// second a bookmark that still works looks like a bug.
+	it("says that switching a row off stops nothing and closes no route", () => {
+		const html = advancedHtml();
+		expect(html).toContain("nothing stops being generated");
+		expect(html).toContain("reachable by URL");
+	});
+
+	// Two names are deliberately absent. "Memory Bank" belongs to the VS Code
+	// panel's folder settings and means nothing on this surface; `jolli compile` is
+	// how the pages are produced, which a reader choosing menu rows does not need
+	// (the pages' own empty states name it). Pinned because both are the obvious
+	// thing to reach for when describing these two pages.
+	it("describes the pages without naming Memory Bank or the compile command", () => {
+		const html = advancedHtml();
+		expect(html).toContain("Show Knowledge");
+		expect(html).toContain("Show Graph");
+		const advanced = html.slice(html.indexOf("Sidebar menu"));
+		expect(advanced).not.toContain("Memory Bank");
+		expect(advanced).not.toContain("jolli compile");
+	});
+});
+
+describe("settings.js Advanced apply", () => {
+	const FIELDS = [["dashboardKnowledgeMenuEnabled", "checkbox"] as const];
+
+	it("carries both flags in the Apply payload, seeded from model.menus", () => {
+		const { applyBtn, posts } = loadFormJD({ ...MODEL, menus: { knowledge: false, graph: true } });
+		applyBtn.onclick?.();
+		const body = posts.find((post) => post.path === "/api/settings/apply")?.body;
+		expect(body?.dashboardKnowledgeMenuEnabled).toBe(false);
+		expect(body?.dashboardGraphMenuEnabled).toBe(true);
+	});
+
+	it("submits a toggled flag and repaints the page so the sidebar row appears", async () => {
+		const { fields, applyBtn, posts, pageRefreshes } = loadFormJD(
+			{ ...MODEL, menus: { knowledge: false, graph: false } },
+			FIELDS,
+		);
+		const box = fields.get("dashboardKnowledgeMenuEnabled");
+		if (box) {
+			box.checked = true;
+			box.onchange?.();
+		}
+		applyBtn.onclick?.();
+		const body = posts.find((post) => post.path === "/api/settings/apply")?.body;
+		expect(body?.dashboardKnowledgeMenuEnabled).toBe(true);
+		// The POST resolves on a microtask, so the refresh is queued behind it.
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(pageRefreshes()).toBe(1);
+	});
+
+	// The page repaint is not free — it redraws the whole view under the modal — so
+	// it must fire only for a change the sidebar can actually show. A save that
+	// moves an unrelated field must leave the page alone.
+	it("does not repaint the page when no sidebar flag moved", async () => {
+		const { fields, applyBtn, pageRefreshes } = loadFormJD({ ...MODEL, menus: { knowledge: true, graph: true } });
+		const gi = fields.get("globalInstructions");
+		if (gi) {
+			gi.checked = true;
+			gi.onchange?.();
+		}
+		applyBtn.onclick?.();
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(pageRefreshes()).toBe(0);
+	});
+
+	// Each flag needs its own case. With only the Knowledge one covered, deleting
+	// the Graph half of the comparison outright still passed — a Graph-only save
+	// would then leave the sidebar stale until a reload.
+	it("repaints the page for a Graph-only change", async () => {
+		const { fields, applyBtn, pageRefreshes } = loadFormJD(
+			{ ...MODEL, menus: { knowledge: false, graph: false } },
+			[["dashboardGraphMenuEnabled", "checkbox"]],
+		);
+		const box = fields.get("dashboardGraphMenuEnabled");
+		if (box) {
+			box.checked = true;
+			box.onchange?.();
+		}
+		applyBtn.onclick?.();
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(pageRefreshes()).toBe(1);
+	});
+
+	// Both flags moving in OPPOSITE directions in one save. Nothing else here
+	// distinguishes the two comparisons, so swapping them read as "unchanged" and
+	// skipped the repaint while both rows were wrong.
+	it("repaints the page when the two flags move in opposite directions at once", async () => {
+		const { fields, applyBtn, posts, pageRefreshes } = loadFormJD(
+			{ ...MODEL, menus: { knowledge: true, graph: false } },
+			[
+				["dashboardKnowledgeMenuEnabled", "checkbox"],
+				["dashboardGraphMenuEnabled", "checkbox"],
+			],
+		);
+		const knowledge = fields.get("dashboardKnowledgeMenuEnabled");
+		if (knowledge) {
+			knowledge.checked = false;
+			knowledge.onchange?.();
+		}
+		const graph = fields.get("dashboardGraphMenuEnabled");
+		if (graph) {
+			graph.checked = true;
+			graph.onchange?.();
+		}
+		applyBtn.onclick?.();
+		const body = posts.find((post) => post.path === "/api/settings/apply")?.body;
+		expect(body?.dashboardKnowledgeMenuEnabled).toBe(false);
+		expect(body?.dashboardGraphMenuEnabled).toBe(true);
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(pageRefreshes()).toBe(1);
+	});
+
+	// The comparison is against what the SIDEBAR is showing, not against the
+	// modal's own payload. Here another tab already switched Knowledge off, so the
+	// page model has moved while this modal still holds `true`: re-saving `true`
+	// looks unchanged to the modal and IS a change to the sidebar. Comparing the
+	// wrong one skipped the repaint exactly when it was needed most.
+	it("repaints the page when the sidebar has drifted from the open modal", async () => {
+		const { fields, applyBtn, pageRefreshes } = loadFormJD(
+			{ ...MODEL, menus: { knowledge: true, graph: false } },
+			[],
+			{
+				knowledge: false,
+				graph: false,
+			},
+		);
+		const gi = fields.get("globalInstructions");
+		if (gi) {
+			gi.checked = true;
+			gi.onchange?.();
+		}
+		applyBtn.onclick?.();
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(pageRefreshes()).toBe(1);
+	});
+
+	// The page must be repainted through main.js's renderPage. Handing
+	// `refreshNow` this module's own `render` instead type-checks, passes a
+	// call-count assertion, and repaints the MODAL from a page payload — whose
+	// `settings` slice is undefined, so the whole form comes back empty.
+	it("drives the repaint through JD.renderPage, not the modal renderer", async () => {
+		const { fields, applyBtn, refreshArgs, renderPage } = loadFormJD(
+			{ ...MODEL, menus: { knowledge: false, graph: false } },
+			[["dashboardKnowledgeMenuEnabled", "checkbox"]],
+		);
+		const box = fields.get("dashboardKnowledgeMenuEnabled");
+		if (box) {
+			box.checked = true;
+			box.onchange?.();
+		}
+		applyBtn.onclick?.();
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(refreshArgs()).toEqual([renderPage]);
 	});
 });
 

--- a/cli/src/dashboard/SettingsEndpoints.test.ts
+++ b/cli/src/dashboard/SettingsEndpoints.test.ts
@@ -36,6 +36,7 @@ function baseModel(view: DashboardView): DashboardModel {
 		scope: { kind: "all" },
 		repos: [],
 		coverage: [],
+		menus: { knowledge: false, graph: false },
 	};
 }
 

--- a/cli/src/dashboard/SettingsMutations.test.ts
+++ b/cli/src/dashboard/SettingsMutations.test.ts
@@ -53,6 +53,8 @@ function baseInput(over: Partial<SettingsApplyInput> = {}): SettingsApplyInput {
 		syncTranscripts: false,
 		dcoSignoff: false,
 		excludePatterns: "",
+		dashboardKnowledgeMenuEnabled: false,
+		dashboardGraphMenuEnabled: false,
 		...over,
 	};
 }
@@ -141,6 +143,38 @@ describe("parseSettingsApplyInput", () => {
 		expect(parseSettingsApplyInput(rawBody({ localAgentModel: "haiku" })).localAgentModel).toBe("haiku");
 	});
 
+	// The two sidebar flags are the only TRI-STATE booleans here: an absent field
+	// must stay absent, so `applySettings` leaves the stored row alone. Reading it
+	// as `false` — which every other boolean here does — let a page that predates
+	// the fields switch both rows off on a save that touched neither.
+	it("leaves an absent sidebar-menu flag undefined rather than reading it as off", () => {
+		const body = rawBody();
+		delete body.dashboardKnowledgeMenuEnabled;
+		delete body.dashboardGraphMenuEnabled;
+		const parsed = parseSettingsApplyInput(body);
+		expect(parsed.dashboardKnowledgeMenuEnabled).toBeUndefined();
+		expect(parsed.dashboardGraphMenuEnabled).toBeUndefined();
+	});
+
+	// A submitted `false` is a real answer and must survive as one, or unticking a
+	// row would be indistinguishable from not mentioning it.
+	it("carries each sidebar-menu flag independently, false included", () => {
+		const parsed = parseSettingsApplyInput(
+			rawBody({ dashboardKnowledgeMenuEnabled: true, dashboardGraphMenuEnabled: false }),
+		);
+		expect(parsed.dashboardKnowledgeMenuEnabled).toBe(true);
+		expect(parsed.dashboardGraphMenuEnabled).toBe(false);
+	});
+
+	// A non-boolean is a submission we cannot read, so it is treated as absent (keep
+	// the stored value) rather than as the `false` a truthy/`=== true` test would
+	// give it. `"on"` is the string an HTML form would send.
+	it("treats a non-boolean sidebar-menu flag as absent, not as off", () => {
+		expect(
+			parseSettingsApplyInput(rawBody({ dashboardGraphMenuEnabled: "on" })).dashboardGraphMenuEnabled,
+		).toBeUndefined();
+	});
+
 	it("rejects a submission with every agent disabled", () => {
 		const allOff = Object.fromEntries(
 			[
@@ -181,6 +215,35 @@ describe("applySettings", () => {
 		expect(config.compileExcludeFolders).toEqual(["archive", "tmp-*"]);
 		expect(config.excludePatterns).toEqual(["*.lock"]);
 		expect(config.dcoSignoff).toBe(true);
+	});
+
+	// An explicit `false` must reach disk, or unticking a row would silently keep
+	// the row — the cost of making these two fields conditional.
+	it("persists both sidebar-menu flags, including a switch back off", async () => {
+		const d = configDirWith({});
+		await applySettings(baseInput({ dashboardKnowledgeMenuEnabled: true, dashboardGraphMenuEnabled: true }), d);
+		expect(readConfig(d).dashboardKnowledgeMenuEnabled).toBe(true);
+		expect(readConfig(d).dashboardGraphMenuEnabled).toBe(true);
+
+		await applySettings(baseInput({ dashboardKnowledgeMenuEnabled: false, dashboardGraphMenuEnabled: true }), d);
+		expect(readConfig(d).dashboardKnowledgeMenuEnabled).toBe(false);
+		expect(readConfig(d).dashboardGraphMenuEnabled).toBe(true);
+	});
+
+	// The whole point of the tri-state. A submission with neither field — what a tab
+	// left open across a CLI upgrade sends, since `settings.js` is inlined into the
+	// page at load — must leave both stored rows exactly as they were. Reading them
+	// as `false` switched both off on a save the user made about something else.
+	it("leaves stored sidebar-menu flags untouched when the submission omits them", async () => {
+		const d = configDirWith({ dashboardKnowledgeMenuEnabled: true, dashboardGraphMenuEnabled: true });
+		const input = baseInput({ dcoSignoff: true });
+		delete (input as { dashboardKnowledgeMenuEnabled?: boolean }).dashboardKnowledgeMenuEnabled;
+		delete (input as { dashboardGraphMenuEnabled?: boolean }).dashboardGraphMenuEnabled;
+		await applySettings(input, d);
+		const config = readConfig(d);
+		expect(config.dcoSignoff).toBe(true);
+		expect(config.dashboardKnowledgeMenuEnabled).toBe(true);
+		expect(config.dashboardGraphMenuEnabled).toBe(true);
 	});
 
 	it("stores localAgentModel only when it differs from the default", async () => {

--- a/cli/src/dashboard/SettingsMutations.ts
+++ b/cli/src/dashboard/SettingsMutations.ts
@@ -78,6 +78,25 @@ export interface SettingsApplyInput {
 	readonly syncTranscripts: boolean;
 	readonly dcoSignoff: boolean;
 	readonly excludePatterns: string;
+	/**
+	 * Optional sidebar rows (Advanced). TRI-STATE, unlike every other boolean
+	 * here: `undefined` means "leave the stored value alone".
+	 *
+	 * The others can safely be two-state because a page always submits the value
+	 * it was rendered with, so overwriting one needs a genuinely concurrent edit.
+	 * These two are different in kind — a page that PREDATES them submits nothing,
+	 * and a two-state read would then have the server invent `false` and switch
+	 * both rows off on a save that touched neither. That is reachable without any
+	 * concurrency: `settings.js` is inlined into the page at load, so any tab left
+	 * open across a CLI upgrade is such a page, and Settings is a modal it can
+	 * open without navigating. Same reasoning, and the same conditional spread, as
+	 * `jolliUrl` in `applySettings`.
+	 *
+	 * Unticking a row still persists `false`, because the page always submits an
+	 * explicit boolean for both (see `collect()` in `assets/js/settings.js`).
+	 */
+	readonly dashboardKnowledgeMenuEnabled?: boolean;
+	readonly dashboardGraphMenuEnabled?: boolean;
 }
 
 export interface SettingsApplyResult {
@@ -100,6 +119,16 @@ const AGENT_FIELDS = [
 
 function asBool(v: unknown): boolean {
 	return v === true;
+}
+
+/**
+ * `undefined` for anything that is not a boolean, so a caller can tell "absent"
+ * from "present and false". A malformed value (the string `"on"` an HTML form
+ * would send, say) is treated as absent rather than as `false`: keeping what is
+ * stored is the safe answer to a submission we cannot read.
+ */
+function asOptionalBool(v: unknown): boolean | undefined {
+	return typeof v === "boolean" ? v : undefined;
 }
 
 function asString(v: unknown): string {
@@ -150,6 +179,8 @@ export function parseSettingsApplyInput(body: Record<string, unknown>): Settings
 	if (!AGENT_FIELDS.some((f) => agents[f])) {
 		throw new SettingsValidationError("At least one AI agent must be enabled");
 	}
+	const knowledgeMenu = asOptionalBool(body.dashboardKnowledgeMenuEnabled);
+	const graphMenu = asOptionalBool(body.dashboardGraphMenuEnabled);
 	const maxTokensRaw = body.maxTokens;
 	const maxTokens =
 		typeof maxTokensRaw === "number" && Number.isFinite(maxTokensRaw) && maxTokensRaw > 0
@@ -170,6 +201,10 @@ export function parseSettingsApplyInput(body: Record<string, unknown>): Settings
 		syncTranscripts: asBool(body.syncTranscripts),
 		dcoSignoff: asBool(body.dcoSignoff),
 		excludePatterns: asString(body.excludePatterns),
+		// `asOptionalBool`, never `asBool` — see `SettingsApplyInput` for why these
+		// two must be able to say "the submission did not mention me".
+		...(knowledgeMenu !== undefined ? { dashboardKnowledgeMenuEnabled: knowledgeMenu } : {}),
+		...(graphMenu !== undefined ? { dashboardGraphMenuEnabled: graphMenu } : {}),
 	};
 }
 
@@ -296,6 +331,15 @@ export async function applySettings(
 			compileExcludeFolders: splitCsv(input.compileExcludeFolders),
 			syncTranscripts: input.syncTranscripts,
 			dcoSignoff: input.dcoSignoff,
+			// Conditional, unlike every other boolean above — an absent field must
+			// leave the stored row alone rather than switch it off. See
+			// `SettingsApplyInput` for the failure this closes.
+			...(input.dashboardKnowledgeMenuEnabled !== undefined
+				? { dashboardKnowledgeMenuEnabled: input.dashboardKnowledgeMenuEnabled }
+				: {}),
+			...(input.dashboardGraphMenuEnabled !== undefined
+				? { dashboardGraphMenuEnabled: input.dashboardGraphMenuEnabled }
+				: {}),
 			excludePatterns: splitCsv(input.excludePatterns),
 			...giUpdate,
 			// Conditional spread — writing `jolliUrl: undefined` would DELETE a URL a

--- a/cli/src/dashboard/ShellAsset.test.ts
+++ b/cli/src/dashboard/ShellAsset.test.ts
@@ -15,6 +15,7 @@
 
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import type { DashboardMenus } from "./DashboardModel.js";
 
 interface JDNamespace {
 	renderShell: (model: unknown) => void;
@@ -1027,5 +1028,123 @@ describe("the topbar repo picker", () => {
 			[JOLLIAI, true],
 			[SITE, false],
 		]);
+	});
+});
+
+/**
+ * The sidebar's two OPTIONAL rows (Settings → Advanced).
+ *
+ * Worth its own suite for the same reason the scope cases above are: the rows are
+ * built by string concatenation into `#sbNav`, so tsc never sees them, and the
+ * failure mode is silent in both directions — a row that never appears however it
+ * is configured looks exactly like "the user left it off", and a row that ignores
+ * the flag looks exactly like the feature was never built.
+ *
+ * `data-nav-view` rather than the visible label: the label is also what the
+ * DASHBOARDS title table carries, so matching on it would pass on a page title
+ * while the row was missing.
+ */
+describe("JD.renderShell — optional nav rows", () => {
+	const navViews = (h: Harness): string[] =>
+		[...h.element("sbNav").innerHTML.matchAll(/data-nav-view="([^"]*)"/g)].map((m) => m[1]);
+
+	/**
+	 * Every `menus` literal below is typed, and that is the only thing holding the
+	 * two halves of this feature in lockstep. `shell.js` indexes `model.menus` by a
+	 * plain string (`optional: "knowledge"`), so renaming a `DashboardMenus` field
+	 * is a change tsc propagates through every TypeScript caller while leaving the
+	 * asset silently reading a key nobody sends — both rows then never appear again,
+	 * with every test still green. Typing the literal makes the rename fail HERE
+	 * first, and the assertions below fail if only the test is updated.
+	 */
+	const menus = (knowledge: boolean, graph: boolean): DashboardMenus => ({ knowledge, graph });
+
+	/** How many icons a row rendered, keyed by view — a per-row count, not a page total. */
+	const iconsPerRow = (h: Harness): Record<string, number> => {
+		const out: Record<string, number> = {};
+		for (const row of h
+			.element("sbNav")
+			.innerHTML.matchAll(/<button[^>]*data-nav-view="([^"]*)"[\s\S]*?<\/button>/g)) {
+			out[row[1]] = (row[0].match(/<svg /g) ?? []).length;
+		}
+		return out;
+	};
+
+	it("hides Knowledge and Graph when both flags are off", () => {
+		const h = loadJD();
+		h.JD.renderShell(model({ menus: menus(false, false) }));
+		expect(navViews(h)).toEqual(["stats", "standup", "memories"]);
+	});
+
+	it("shows each row only when its own flag is on, keeping NAV_MIDDLE's order", () => {
+		const h = loadJD();
+		h.JD.renderShell(model({ menus: menus(true, false) }));
+		expect(navViews(h)).toEqual(["stats", "standup", "memories", "knowledge"]);
+
+		h.JD.renderShell(model({ menus: menus(false, true) }));
+		expect(navViews(h)).toEqual(["stats", "standup", "memories", "graph"]);
+
+		h.JD.renderShell(model({ menus: menus(true, true) }));
+		expect(navViews(h)).toEqual(["stats", "standup", "memories", "knowledge", "graph"]);
+	});
+
+	// The rows carry their icon and path from the same tables the always-on rows
+	// use, so a flag that only controlled visibility of a half-built row would be
+	// worse than no flag at all.
+	it("renders a revealed row with the same path and icon markup as an always-on row", () => {
+		const h = loadJD();
+		h.JD.renderShell(model({ menus: menus(true, true) }));
+		const html = h.element("sbNav").innerHTML;
+		expect(html).toContain('data-nav-path="/knowledge"');
+		expect(html).toContain('data-nav-path="/graph"');
+		// Per ROW, not per page: the two Dashboard children are `child` rows and carry
+		// no icon of their own (the group label above them has two), so a page total
+		// cannot tell a row that lost its icon from a label that grew one.
+		expect(iconsPerRow(h)).toEqual({ stats: 0, standup: 0, memories: 1, knowledge: 1, graph: 1 });
+	});
+
+	// A payload with no `menus` at all is what a tab left open across an upgrade
+	// polls its way into, and what a hand-built model in another suite passes. It
+	// must read as HIDDEN — the same polarity config has — rather than throwing or
+	// revealing a row nobody switched on.
+	it("treats an absent menus slice as both rows hidden", () => {
+		const h = loadJD();
+		h.JD.renderShell(model());
+		expect(navViews(h)).toEqual(["stats", "standup", "memories"]);
+	});
+
+	// A slice naming only one row, or holding a non-boolean, must degrade the same
+	// way — the predicate is `=== true`, so anything unreadable is "not switched on"
+	// rather than a row appearing off the back of a truthy string.
+	it("treats a partial or non-boolean menus slice as hidden", () => {
+		const h = loadJD();
+		h.JD.renderShell(model({ menus: { knowledge: true } }));
+		expect(navViews(h)).toEqual(["stats", "standup", "memories", "knowledge"]);
+
+		h.JD.renderShell(model({ menus: { knowledge: "yes", graph: 1 } }));
+		expect(navViews(h)).toEqual(["stats", "standup", "memories"]);
+	});
+
+	// Only the ROW is gated. Landing on /graph with the flag off still renders the
+	// page's identity, because the route is deliberately left live (a bookmark is
+	// not answered with a redirect) — and a hidden row must not take the title with
+	// it.
+	it("keeps the page title of a hidden view when the page is opened directly", () => {
+		const h = loadJD();
+		h.JD.renderShell(model({ view: "graph", menus: menus(false, false) }));
+		expect(h.element("pageTitle").textContent).toBe("Graph");
+		expect(navViews(h)).toEqual(["stats", "standup", "memories"]);
+	});
+
+	// Settings is built from NAV_BOTTOM, outside the filtered loop, so no change to
+	// the predicate itself can reach it. What this does catch is the refactor that
+	// would: folding NAV_BOTTOM into NAV_MIDDLE to share the filter, which empties
+	// the pinned slot and hides its own container.
+	it("leaves the pinned Settings row outside the filtered list", () => {
+		const h = loadJD();
+		h.JD.renderShell(model({ menus: menus(false, false) }));
+		expect(h.element("sbBottom").innerHTML).toContain('data-nav-view="settings"');
+		expect(h.element("sbBottom").hidden).toBe(false);
+		expect(navViews(h)).not.toContain("settings");
 	});
 });

--- a/cli/src/dashboard/assets/js/settings.js
+++ b/cli/src/dashboard/assets/js/settings.js
@@ -5,9 +5,11 @@ window.JD = window.JD || {};
 	 * Settings — opened as a MODAL over any page (like the Claude settings dialog),
 	 * not a routed page. `JD.openSettings()` fetches the settings model via
 	 * `/api/model?view=settings`, then renders a left section rail + content into
-	 * the modal body. Five sections mirror the VS Code settings panel's tabs, and
-	 * every label / hint / placeholder / button text is aligned to that panel
-	 * verbatim (SettingsHtmlBuilder.ts) so the two surfaces read identically.
+	 * the modal body. Five of the six sections mirror the VS Code settings panel's
+	 * tabs, and every label / hint / placeholder / button text in those five is
+	 * aligned to that panel verbatim (SettingsHtmlBuilder.ts) so the two surfaces
+	 * read identically. `advanced` is the exception and has NO VS Code counterpart:
+	 * it configures this dashboard's own sidebar, which that panel does not render.
 	 *
 	 * Editable fields are a CONTROLLED FORM: every value lives in `state.form`
 	 * (seeded once from the payload), the renderers read from it, and every edit
@@ -24,6 +26,7 @@ window.JD = window.JD || {};
 		{ id: "sync", label: "Sync to Jolli" },
 		{ id: "bank", label: "Memory Bank" },
 		{ id: "others", label: "Others" },
+		{ id: "advanced", label: "Advanced" },
 	];
 
 	// Per-section leading glyphs — the same compact Lucide-style outlines the
@@ -36,6 +39,7 @@ window.JD = window.JD || {};
 		sync: '<path d="M12 13v8"/><path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242"/><path d="m8 17 4-4 4 4"/>',
 		bank: '<ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5V19A9 3 0 0 0 21 19V5"/><path d="M3 12A9 3 0 0 0 21 12"/>',
 		others: '<path d="M20 7h-9"/><path d="M14 17H5"/><circle cx="17" cy="17" r="3"/><circle cx="7" cy="7" r="3"/>',
+		advanced: '<path d="m12 14 4-4"/><path d="M3.34 19a10 10 0 1 1 17.32 0"/>',
 	};
 
 	function sectionIcon(id) {
@@ -107,7 +111,12 @@ window.JD = window.JD || {};
 		return JD.esc(String(s == null ? "" : s));
 	}
 
-	function initForm(s) {
+	// Takes the WHOLE model, not just `model.settings`: the Advanced rows are
+	// driven by `model.menus`, which lives at the top of the payload because the
+	// sidebar reads it on every view (see `DashboardMenus`). One fact, one place.
+	function initForm(model) {
+		var s = model.settings || {};
+		var menus = model.menus || {};
 		var a = s.agents || {};
 		var sum = s.summary || {};
 		var mb = s.memoryBank || {};
@@ -130,6 +139,10 @@ window.JD = window.JD || {};
 			syncTranscripts: mb.syncTranscripts === true,
 			dcoSignoff: others.dcoSignoff === true,
 			excludePatterns: others.excludePatterns || "",
+			// `=== true`, matching the config polarity: an absent flag is HIDDEN, so
+			// a payload without `menus` cannot render a row as switched on.
+			dashboardKnowledgeMenuEnabled: menus.knowledge === true,
+			dashboardGraphMenuEnabled: menus.graph === true,
 		};
 		AGENTS.forEach((pair) => {
 			form[pair[0]] = a[pair[0]] !== false;
@@ -237,7 +250,7 @@ window.JD = window.JD || {};
 	function render(model) {
 		var s = model.settings || {};
 		if (!state.form) {
-			state.form = initForm(s);
+			state.form = initForm(model);
 			// Baseline for dirty-tracking: Apply stays disabled until the form diverges.
 			state.initialForm = JSON.stringify(state.form);
 			state.folderStatus = null;
@@ -328,6 +341,7 @@ window.JD = window.JD || {};
 		if (section === "sync") return syncSection(s.summary || {});
 		if (section === "bank") return bankSection(s.memoryBank || {}, f);
 		if (section === "others") return othersSection(f);
+		if (section === "advanced") return advancedSection(f);
 		return "";
 	}
 
@@ -732,6 +746,41 @@ window.JD = window.JD || {};
 		);
 	}
 
+	// The sidebar's two optional rows. Hidden by default, so this section is the
+	// only place a reader finds out those pages exist at all — which is why each
+	// hint describes what the page IS and what it is for, rather than how it is
+	// produced. Three things are deliberately absent from this copy. "Memory Bank"
+	// is the VS Code panel's name for the folder and means nothing on this surface,
+	// so Knowledge is described by what it shows. `jolli compile` is the command
+	// that builds both, and a reader deciding whether to show a menu row does not
+	// need it (the pages' own empty states name it, which is where it matters). And
+	// the row-only scope stays in the section hint rather than being repeated per
+	// row: it is one fact about both switches.
+	function advancedSection(f) {
+		return block(
+			"Sidebar menu",
+			'<p class="section-hint">Extra pages for the left menu, off by default. Switching one off just hides its row — nothing stops being generated, and the page stays reachable by URL.</p>' +
+				'<div class="set-group">' +
+				toggleRow(
+					"dashboardKnowledgeMenuEnabled",
+					"Show Knowledge",
+					f.dashboardKnowledgeMenuEnabled === true,
+					// "Source Commits" is the literal heading `WikiMarkdownBuilder` writes
+					// at the foot of every topic page, and those links are the ones the
+					// wiki viewer rewrites into memory jumps — so this names the real
+					// affordance rather than implying every sentence is a link.
+					"A reading view over the knowledge distilled from your commits. Search topic pages across your repositories, open one in the side pane, and follow its <strong>Source Commits</strong> list back to the memories it was built from.",
+				) +
+				toggleRow(
+					"dashboardGraphMenuEnabled",
+					"Show Graph",
+					f.dashboardGraphMenuEnabled === true,
+					"The visual companion to Knowledge: the same distilled decisions and gotchas drawn as a graph, so you can follow the relationships between them — and spot the clusters a list never shows.",
+				) +
+				"</div>",
+		);
+	}
+
 	function opt(value, label, current) {
 		return '<option value="' + esc(value) + '"' + (value === current ? " selected" : "") + ">" + esc(label) + "</option>";
 	}
@@ -762,6 +811,8 @@ window.JD = window.JD || {};
 			syncTranscripts: f.syncTranscripts === true,
 			dcoSignoff: f.dcoSignoff === true,
 			excludePatterns: f.excludePatterns,
+			dashboardKnowledgeMenuEnabled: f.dashboardKnowledgeMenuEnabled === true,
+			dashboardGraphMenuEnabled: f.dashboardGraphMenuEnabled === true,
 		};
 		AGENTS.forEach((pair) => {
 			out[pair[0]] = f[pair[0]] === true;
@@ -847,6 +898,26 @@ window.JD = window.JD || {};
 		state.error = null;
 		state.notice = null;
 		var payload = collect();
+		// Whether the SIDEBAR now needs repainting. `refreshSettings` refetches the
+		// settings payload into the modal, which cannot touch the sidebar — that is
+		// rendered from `window.__JOLLI_DASHBOARD__` by the page — so an Advanced
+		// change needs a page-level refresh too, or the row the user just switched on
+		// stays absent until they reload. Conditional because that refresh repaints
+		// the whole page under the modal (on /graph that rebuilds the iframe and
+		// loses its pan/zoom): worth it when the nav moved, gratuitous on every
+		// other save.
+		//
+		// Compared against the PAGE's model, never the modal's own: the question is
+		// "does what the sidebar is showing still match what we just saved?", and the
+		// sidebar was rendered from that payload. Asking the modal's copy instead got
+		// it exactly backwards whenever the two had drifted — another tab switching a
+		// row off moves the page model (the 30 s poll on My Dashboard picks it up)
+		// while the open modal still holds the old value, so re-saving from here
+		// would look unchanged and skip the repaint that was now most needed.
+		var menus = (window.__JOLLI_DASHBOARD__ || {}).menus || {};
+		var menusChanged =
+			payload.dashboardKnowledgeMenuEnabled !== (menus.knowledge === true) ||
+			payload.dashboardGraphMenuEnabled !== (menus.graph === true);
 		render(model);
 		JD.post("/api/settings/apply", payload)
 			.then((data) => {
@@ -856,6 +927,14 @@ window.JD = window.JD || {};
 					? "Settings saved. " + failures.length + " repo hook(s) could not be synced — see the server log."
 					: "Settings saved";
 				refreshSettings();
+				// Two independent refetches, and the order they LAND in does not matter:
+				// this one rewrites the sidebar, the topbar and `#app`, while
+				// refreshSettings rewrites `#settingsModalBody` — a sibling of `#app`,
+				// not a child (see index.html), so neither can overwrite the other.
+				// `JD.renderPage` is assigned by main.js, which loads after this module —
+				// guarded for the same load-order reason `window.JD` itself is, not
+				// because it is expected to be missing at click time.
+				if (menusChanged && JD.refreshNow && JD.renderPage) JD.refreshNow(JD.renderPage);
 			})
 			.catch((err) => {
 				state.busy = null;

--- a/cli/src/dashboard/assets/js/shell.js
+++ b/cli/src/dashboard/assets/js/shell.js
@@ -139,8 +139,10 @@ window.JD = window.JD || {};
 	   rather than behind an expand/collapse toggle — that interaction is a later
 	   polish pass, not a routing concern.
 
-	   NOTHING IS GATED any more. These rows used to disable themselves until a
-	   repo was enabled, mirroring DashboardServer's GATED_PATHS so a dead row and
+	   NO ROW IS GATED BY REPO COUNT any more (the two optional rows below are a
+	   different question — they are hidden by preference, and their routes stay
+	   open). These rows used to disable themselves until a repo was enabled,
+	   mirroring DashboardServer's GATED_PATHS so a dead row and
 	   a 302 could not disagree, and Repositories sat below them as the never-gated
 	   row that opened the gate. Repositories is gone, so the gate has nowhere to
 	   send anyone — a disabled row leading nowhere is worse than a live one that
@@ -148,8 +150,15 @@ window.JD = window.JD || {};
 	   page used to.
 
 	   Knowledge and Graph ARE routed (VIEW_PATHS has /knowledge, /graph) and sit
-	   below Memories. Settings alone has no scrollable nav row
-	   and no page path — it is a modal pinned to the bottom slot (NAV_BOTTOM),
+	   below Memories, but their ROWS are OPTIONAL and hidden by default: each
+	   carries an `optional` key naming its `model.menus` flag, and the user turns
+	   it on in Settings → Advanced. They stay in this one table so the order
+	   cannot drift from the enabled case, and only the row is gated — the routes,
+	   the /wiki-viewer and /graph-viewer iframes and the Knowledge page's own
+	   "open graph" link all keep working while a row is hidden, so a bookmark is
+	   never answered with a redirect to somewhere the reader did not ask for.
+	   Settings alone has no scrollable nav row and no page path — it is a
+	   modal pinned to the bottom slot (NAV_BOTTOM),
 	   opened via JD.openSettings, so a direct visit to /settings 404s. Adding a
 	   new page needs its server route, view token and model payload too — a nav
 	   row on its own is not enough. */
@@ -164,9 +173,15 @@ window.JD = window.JD || {};
 		{ view: "memories", path: "/memories", label: "Memories" },
 		/* Knowledge / Graph browse the Memory Bank FOLDER, whose repo set differs
 		   from the enabled dashboard repos — they carry their own empty state. */
-		{ view: "knowledge", path: "/knowledge", label: "Knowledge" },
-		{ view: "graph", path: "/graph", label: "Graph" },
+		{ view: "knowledge", path: "/knowledge", label: "Knowledge", optional: "knowledge" },
+		{ view: "graph", path: "/graph", label: "Graph", optional: "graph" },
 	];
+
+	/* Whether an optional nav row is switched on. Absent `menus` — a payload from a
+	   server that predates the flags, or one that failed to read config — reads as
+	   HIDDEN, matching the config polarity (`=== true`) rather than revealing a row
+	   the user never asked for. */
+	var navRowVisible = (item, model) => !item.optional || (model.menus || {})[item.optional] === true;
 	/* Settings is pinned to the sidebar's bottom edge (its reserved slot), not in
 	   the scrollable menu list — a persistent destination rather than the last
 	   nav row. */
@@ -612,9 +627,12 @@ window.JD = window.JD || {};
 		document.getElementById("pageTitle").textContent = current.label;
 		document.getElementById("pageSub").textContent = current.sub;
 
-		/* Sidebar — the nav list (plus an empty pinned bottom slot). No row is
-		   gated: see NAV_MIDDLE for why the zero-repo gate went away with the
-		   Repositories page it used to redirect to. */
+		/* Sidebar — the nav list (plus an empty pinned bottom slot). Nothing is
+		   gated by repo count: see NAV_MIDDLE for why the zero-repo gate went away
+		   with the Repositories page it used to redirect to. The one filter left is
+		   `navRowVisible` below, which hides the two OPTIONAL rows the user has not
+		   switched on in Settings → Advanced — a preference, not a gate, so their
+		   routes stay open either way. */
 		var navRow = (item, active) =>
 			'<button type="button" class="sb-item' +
 			(item.child ? " child" : "") +
@@ -631,6 +649,7 @@ window.JD = window.JD || {};
 			"</span></button>";
 		var nav = "";
 		NAV_MIDDLE.forEach((item) => {
+			if (!navRowVisible(item, model)) return;
 			if (item.kids) {
 				nav +=
 				'<div class="sb-group-label">' +


### PR DESCRIPTION
<!-- jollimemory-summary-start -->


## Quick recap

The dashboard now provides an Advanced section in Settings where users can independently toggle the Knowledge and Graph menu items in the sidebar. Both rows are hidden by default and appear only when explicitly enabled, with changes persisting immediately on Apply. The underlying pages for both sections remain fully accessible by direct URL, bookmarks, and cross-page navigation even when hidden from the sidebar menu. The implementation stores these preferences as machine-scoped settings alongside other dashboard configuration, and carefully handles backward compatibility so that older dashboard sessions don't accidentally re-enable hidden rows when users save unrelated settings.

---

## Topic (1)
<details>
<summary><strong>01 · Dashboard Advanced Settings for Knowledge and Graph menu visibility</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users needed the Knowledge and Graph menu items in the dashboard sidebar to be hidden by default, with toggle controls in Settings to show them when needed.

**💡 Decisions Behind the Code**

- **Configuration placement and model structure**: Stored menu flags in config.json alongside other machine-scoped settings and placed them at the top level of DashboardModel rather than inside SettingsPageModel. The sidebar renders on every view, not just settings, so these flags belong in every payload for a single source of truth.
- **Hidden defaults with backward compatibility**: Used `=== true` polarity so absent keys default to hidden, allowing existing installs to upgrade silently. Tri-state form fields (true/false/undefined) preserve stored values when older pages don't submit these fields, preventing stale tabs from resetting toggles on unrelated settings saves.
- **Visibility control independent from accessibility**: Only the sidebar row is gated by the toggle; routes to Knowledge, Graph, and their viewers remain accessible at 200. This treats the toggle as a sidebar layout preference rather than a permission gate, preserving workflows like bookmarks and direct navigation.

**✅ What Was Implemented**

- Added `dashboardKnowledgeMenuEnabled` and `dashboardGraphMenuEnabled` boolean fields to JolliMemoryConfig (cli/src/Types.ts), defaulting to hidden with `=== true` polarity so existing installs upgrade silently without requiring migration.
- Integrated DashboardMenus interface at the top level of DashboardModel (cli/src/dashboard/DashboardModel.ts) and updated server-side config reading in DashboardServer.ts to load and pass menu flags with every model payload, ensuring the sidebar has current values on every view.
- Built a new Advanced section in the Settings modal (cli/src/dashboard/assets/js/settings.js) with toggle switches for both rows, using tri-state form submission so pages predating the feature don't accidentally reset flags when saving unrelated settings.
- Implemented conditional sidebar rendering (cli/src/dashboard/assets/js/shell.js) to show or hide Knowledge and Graph rows based on the menus flags, while keeping underlying routes accessible so bookmarks and inter-page links continue working.

**📁 FILES**
- `cli/src/Types.ts`
- `cli/src/dashboard/DashboardModel.ts`
- `cli/src/dashboard/DashboardServer.ts`
- `cli/src/dashboard/SettingsMutations.ts`
- `cli/src/dashboard/assets/js/settings.js`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 18, 2026 at 5:02 PM · via Local agent - Claude Code*
<!-- jollimemory-summary-end -->