### PR TITLE
Add session stats sync channel with daily rollup cache and fixes

### DIFF
--- a/cli/src/Cli.test.ts
+++ b/cli/src/Cli.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { isBareMcpInvocation, isDetachedDaemonInvocation } from "./Cli.js";
 import { MCP_DAEMON_COMMAND, MCP_NO_DAEMON_ENV } from "./commands/McpCommand.js";
 import { GLOBAL_DAEMON_ENSURE_COMMAND } from "./daemon/EnsureGlobalDaemon.js";
-import { GLOBAL_DAEMON_COMMAND } from "./daemon/GlobalDaemon.js";
+import { GLOBAL_DAEMON_COMMAND } from "./daemon/GlobalDaemonProtocol.js";
 
 describe("isBareMcpInvocation", () => {
 	it("routes the bare `jolli mcp` a host spawns per session", () => {

--- a/cli/src/Cli.ts
+++ b/cli/src/Cli.ts
@@ -29,10 +29,16 @@ const MCP_DAEMON_COMMAND = "mcp-serve";
 
 /**
  * The hidden machine-global daemon subcommand, restated for the same reason:
- * `GlobalDaemon.ts` owns the canonical constant, but it also pulls in the
- * daemon's full dependency graph (storage, the scheduler, the backup task),
- * which is exactly what this file's static import list must stay leaf-only to
- * avoid — see `isBareMcpInvocation`. A test pins both spellings.
+ * `GlobalDaemonProtocol.ts` owns the canonical constant, and a static import of
+ * ANY module is what this file's fast path must not grow — see
+ * `isBareMcpInvocation`. A test pins both spellings.
+ *
+ * The constant used to live in `GlobalDaemon.ts`, whose graph is the daemon's
+ * whole world (storage, the scheduler, the backup task, the session sync's push
+ * client); it moved to the protocol module so the five spawn triggers stop
+ * paying for that. This copy stays regardless: the trigger is not the only reader
+ * of the name, the routing check below runs before Commander exists, and one
+ * pinned literal is cheaper here than a module load.
  */
 const GLOBAL_DAEMON_COMMAND = "global-daemon";
 const GLOBAL_DAEMON_ENSURE_COMMAND = "global-daemon-ensure";

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -139,6 +139,45 @@ export interface ConversationTokenBreakdown {
  */
 export interface ParsedTurnUsage extends ConversationTokenBreakdown {
 	readonly dedupKey?: string;
+	/**
+	 * Transcript model id for THIS response, when the line carries it.
+	 *
+	 * Present so the reader can emit one {@link SessionUsageEvent} per response
+	 * without a second pass: a per-model split derived from whole-slice
+	 * aggregation cannot say WHEN each model was used, and "when" is the whole
+	 * point of the per-call record.
+	 */
+	readonly model?: string;
+}
+
+/**
+ * One counted model response: what it cost and **when it happened**.
+ *
+ * The unit every usage and billing system records, and the reason this shape
+ * exists: a session is a grouping, not a quantity. Storing one cumulative total
+ * per session with a single timestamp cannot answer "how many tokens did I use
+ * on the 1st" for any conversation that spans days — the whole session lands on
+ * whichever day it was last touched. Recording the call keeps the question
+ * answerable by a plain `GROUP BY`.
+ *
+ * `respondedAtMs` is the response's own instant, taken from the transcript line that
+ * carried it. Absent when the source's parser cannot date a line; such an event
+ * is dropped rather than dated by guesswork, because a wrong day is worse than a
+ * missing one here.
+ */
+export interface SessionUsageEvent extends ConversationTokenBreakdown {
+	readonly respondedAtMs: number;
+	/** Empty string when the transcript recorded usage without naming a model. */
+	readonly model: string;
+	/** The response's identity, when the source can name it. See {@link ParsedTurnUsage}. */
+	readonly dedupKey?: string;
+	/**
+	 * USD at the price table in force when this was recorded. Absent for an
+	 * unpriced model — absent rather than 0, because 0 reads as "free" in every
+	 * sum while the truth is "unknown". Filled by the collector, not the reader:
+	 * pricing is not the transcript's business.
+	 */
+	readonly estCostUsd?: number;
 }
 
 /** Billing provider for a conversation model — selects the pricing formula. */
@@ -241,6 +280,15 @@ export interface TranscriptReadResult {
 	 *  Powers the USD cost estimate. Absent for sources whose parser exposes no
 	 *  usage; the summed segments equal {@link usageBreakdown}. */
 	readonly usageByModel?: ReadonlyArray<ModelTokenUsage>;
+	/** One entry per counted response, each carrying its own instant — the record
+	 *  a per-day figure can actually be built from (see {@link SessionUsageEvent}).
+	 *  {@link usageByModel} is the same numbers with the time thrown away, kept
+	 *  because the summary stores the aggregate. Present-but-empty (never
+	 *  omitted) for a source whose parser can report usage at all, so a re-read
+	 *  that sees nothing datable can clear rows a better read left behind;
+	 *  absent only for sources whose parser exposes no usage. Entries the parser
+	 *  cannot date are omitted. */
+	readonly usageEvents?: ReadonlyArray<SessionUsageEvent>;
 	/** Tool calls over the slice, one bucket per distinct tool. ABSENT means the
 	 *  source's transcripts carry no tool records this runtime can read — see
 	 *  `TOOL_RECORDING_SOURCES` for which sources those are and why the list is
@@ -1860,6 +1908,23 @@ export interface JolliMemoryConfig {
 	 * path, no duplicates.
 	 */
 	readonly syncOnPush?: boolean;
+	/**
+	 * Whether SESSION STATISTICS are synced to the server. `undefined` = on.
+	 *
+	 * ⚠ Its own switch on purpose, and the reason is the largest privacy change
+	 * this product has made. Until this channel, data left a machine only for a
+	 * repo the user had explicitly bound to a Space. Session statistics go up for
+	 * EVERY repo on the machine — private projects, client work, repos the user
+	 * never intended to connect to anything — because the API key alone says where
+	 * they belong. Sessions carry a `title`, which several agents populate with the
+	 * user's own first message, and tool names include MCP server names.
+	 *
+	 * Do NOT fold this into {@link syncOnPush} or a per-repo push toggle. Those
+	 * mean "push this repo's memories", and the decision here is precisely that
+	 * statistics do not follow that rule — sharing the switch would make the
+	 * setting lie about what it controls.
+	 */
+	readonly syncSessions?: boolean;
 	/**
 	 * Whether to **auto-sync** Memory Bank to the user's private Personal
 	 * Space vault on a recurring schedule. Plan §0.7 made manual sync the

--- a/cli/src/commands/ConfigureCommand.ts
+++ b/cli/src/commands/ConfigureCommand.ts
@@ -106,6 +106,7 @@ const VALID_CONFIG_KEYS = [
 	"localFolder",
 	"aiProvider",
 	"syncTranscripts",
+	"syncSessions",
 	"syncPollIntervalSec",
 	"syncOnPush",
 	"localAgentTool",
@@ -190,6 +191,7 @@ function coerceConfigValue(key: ConfigKey, raw: string): string | number | boole
 		key === "kimiEnabled" ||
 		key === "mcpPlatformToolsEnabled" ||
 		key === "syncTranscripts" ||
+		key === "syncSessions" ||
 		key === "syncOnPush"
 	) {
 		const lower = raw.toLowerCase();
@@ -359,6 +361,19 @@ const CONFIG_KEY_INFO: ReadonlyArray<{ key: ConfigKey; type: string; description
 		key: "syncTranscripts",
 		type: "boolean",
 		description: "Include raw AI conversation transcripts in cloud sync (default: false)",
+	},
+	{
+		key: "syncSessions",
+		type: "boolean",
+		// Spelled out because this switch does not follow the rule the two around it
+		// follow. `syncTranscripts` and `syncOnPush` are about a repo whose memories
+		// the user chose to push; this one covers EVERY repo Jolli is enabled in,
+		// bound to a Space or not. Until it existed, the dashboard's Sync tab was the
+		// only place it could be turned off — not this command, not the editors — which
+		// is a thin opt-out for the one channel that uploads from repositories the
+		// user never connected to anything.
+		description:
+			"Sync session statistics (tokens, cost, tool names, session titles) to your Jolli organization, for every repo on this machine (default: true)",
 	},
 	{
 		key: "syncOnPush",

--- a/cli/src/commands/DoctorCommand.test.ts
+++ b/cli/src/commands/DoctorCommand.test.ts
@@ -31,7 +31,10 @@ const h = vi.hoisted(() => ({
 	install: vi.fn(),
 	inspectPlugins: vi.fn(),
 	resolveProjectDir: vi.fn(),
+	runSessionSync: vi.fn(),
 }));
+
+vi.mock("../dashboard/SessionSyncRunner.js", () => ({ runSessionSync: h.runSessionSync }));
 
 vi.mock("../core/GitOps.js", () => ({
 	orphanBranchExists: h.orphanBranchExists,
@@ -1075,6 +1078,79 @@ describe("doctor — parked events", () => {
 		} finally {
 			restoreHome();
 			rmSync(home, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("doctor --sync-sessions", () => {
+	// `process.exitCode` is process-global, and the reset hooks above belong to the
+	// FIRST describe in this file — so they do not run here. Two cases below assert
+	// on it, and `runDoctor` sets it to 1 on any warning, so without this they read
+	// whichever value an earlier block left behind rather than what this command
+	// did: the skip case failed while the code under test was correct.
+	beforeEach(() => {
+		process.exitCode = undefined;
+	});
+
+	afterEach(() => {
+		process.exitCode = undefined;
+	});
+
+	/** Captures stdout for one call and hands back what was printed. */
+	async function run(outcome: unknown): Promise<string> {
+		const { runSessionSyncNow } = await import("./DoctorCommand.js");
+		h.runSessionSync.mockResolvedValue(outcome);
+		const logs: string[] = [];
+		const spy = vi.spyOn(console, "log").mockImplementation((m) => void logs.push(String(m)));
+		try {
+			await runSessionSyncNow();
+			return logs.join("\n");
+		} finally {
+			spy.mockRestore();
+		}
+	}
+
+	it("routes the flag to the upload instead of running the whole diagnostic", async () => {
+		// The flag is a different command wearing `doctor`'s clothes: the ordinary
+		// run probes hooks, the registry and the queue, and none of that is what a
+		// user typing `--sync-sessions` is waiting for. It also returns straight
+		// after, so no diagnostic output follows the upload's one line.
+		h.runSessionSync.mockResolvedValue({ status: "done", batches: 0, rows: 0 });
+		const lines = await runDoctor(["--sync-sessions", "--cwd", "/repo"]);
+		// No cwd on the call: the channel is cross-repo, so this covers the whole
+		// machine and withholds the disabled repos row by row rather than skipping
+		// the run because the user happened to type it inside one.
+		expect(h.runSessionSync).toHaveBeenCalledWith({ force: true });
+		expect(lines.join("\n")).toContain("up to date");
+	});
+
+	it("forces the run, so a fixed backend does not have to wait out its silence", async () => {
+		await run({ status: "done", batches: 2, rows: 40 });
+		expect(h.runSessionSync).toHaveBeenCalledWith({ force: true });
+	});
+
+	it("reports what was uploaded", async () => {
+		expect(await run({ status: "done", batches: 2, rows: 40 })).toContain("Uploaded 40 row(s) in 2 batch(es)");
+	});
+
+	it("says so when there was nothing to send, rather than printing a bare success", async () => {
+		expect(await run({ status: "done", batches: 0, rows: 0 })).toContain("up to date");
+	});
+
+	it("names a skip reason instead of exiting quietly", async () => {
+		// Every reason is either the user's own setting or the server's answer, so
+		// this is the one output that makes the command worth typing.
+		const out = await run({ status: "skipped", reason: "syncSessions is off" });
+		expect(out).toContain("syncSessions is off");
+		expect(process.exitCode).not.toBe(1);
+	});
+
+	it("exits non-zero on a failure, so a script can tell", async () => {
+		try {
+			expect(await run({ status: "failed", reason: "network down" })).toContain("network down");
+			expect(process.exitCode).toBe(1);
+		} finally {
+			process.exitCode = 0;
 		}
 	});
 });

--- a/cli/src/commands/DoctorCommand.ts
+++ b/cli/src/commands/DoctorCommand.ts
@@ -1009,6 +1009,41 @@ export async function runSchemaLog(action: { mark?: string }): Promise<void> {
 	}
 }
 
+/**
+ * Uploads pending session statistics now, bypassing both the throttle and a
+ * backend silence.
+ *
+ * ⚠ This is the documented way out of a silence, and it has to exist for the
+ * silence to be defensible. A 403/404/412 stops one backend scope for 24h, which
+ * is right while the server is still refusing and wrong the moment the operator
+ * fixes it — and the only alternative was hand-editing
+ * `session-push-channel.json`. `force` is what turns "wait until tomorrow" into
+ * "say so and try again", and the run reports which it did.
+ *
+ * Lives on `doctor` rather than as a command of its own for the same reason
+ * `--mark-migration` does: it is a repair for a state the automatic path cannot
+ * argue itself out of, not part of anyone's normal day.
+ */
+export async function runSessionSyncNow(): Promise<void> {
+	const { runSessionSync } = await import("../dashboard/SessionSyncRunner.js");
+	// No cwd: the channel is cross-repo, so this run covers the whole machine and
+	// withholds the repos `jolli disable` is set on row by row — including the one
+	// the user typed this in, if it is one of them.
+	const outcome = await runSessionSync({ force: true });
+	if (outcome.status === "done") {
+		console.log(
+			outcome.rows === 0
+				? "✓ Session statistics are up to date — nothing new to upload."
+				: `✓ Uploaded ${outcome.rows} row(s) in ${outcome.batches} batch(es).`,
+		);
+		return;
+	}
+	// Not an exception and not silent: every reason here is either the user's own
+	// setting or an answer from the server, and both are things they can act on.
+	console.log(`✗ Session statistics were not uploaded: ${outcome.reason}`);
+	if (outcome.status === "failed") process.exitCode = 1;
+}
+
 /** Registers the `doctor` sub-command on the given Commander program. */
 export function registerDoctorCommand(program: Command): void {
 	program
@@ -1027,6 +1062,10 @@ export function registerDoctorCommand(program: Command): void {
 		.option("--from <path>", "With --recover: restore the database from this snapshot file")
 		.option("--schema-log", "Print the database's migration log (who ran what, when, and how it went)")
 		.option("--mark-migration <name>", "Record one migration as applied by other means (see --schema-log)")
+		.option(
+			"--sync-sessions",
+			"Upload pending session statistics now, ignoring the throttle and any 24h backend silence",
+		)
 		.option("--cwd <dir>", "Project directory (default: git repo root)", resolveProjectDir())
 		.action(
 			async (options: {
@@ -1038,6 +1077,7 @@ export function registerDoctorCommand(program: Command): void {
 				from?: string;
 				schemaLog?: boolean;
 				markMigration?: string;
+				syncSessions?: boolean;
 			}) => {
 				setLogDir(options.cwd);
 				log.info("Running 'doctor' command");
@@ -1050,6 +1090,10 @@ export function registerDoctorCommand(program: Command): void {
 				// `--schema-log` would reasonably conclude it did nothing.
 				if (options.schemaLog === true || options.markMigration) {
 					await runSchemaLog({ mark: options.markMigration });
+					return;
+				}
+				if (options.syncSessions === true) {
+					await runSessionSyncNow();
 					return;
 				}
 				await runDoctor(

--- a/cli/src/commands/GlobalDaemonCommand.ts
+++ b/cli/src/commands/GlobalDaemonCommand.ts
@@ -12,7 +12,8 @@
 
 import type { Command } from "commander";
 import { ensureGlobalDaemon, GLOBAL_DAEMON_ENSURE_COMMAND } from "../daemon/EnsureGlobalDaemon.js";
-import { GLOBAL_DAEMON_COMMAND, runGlobalDaemon } from "../daemon/GlobalDaemon.js";
+import { runGlobalDaemon } from "../daemon/GlobalDaemon.js";
+import { GLOBAL_DAEMON_COMMAND } from "../daemon/GlobalDaemonProtocol.js";
 
 export function registerGlobalDaemonCommand(program: Command): void {
 	program

--- a/cli/src/core/JolliMemoryPushClient.test.ts
+++ b/cli/src/core/JolliMemoryPushClient.test.ts
@@ -14,6 +14,8 @@ import {
 	NotAuthenticatedError,
 	PermissionDeniedError,
 	type PlatformToolManifestEntry,
+	SessionEndpointMissingError,
+	SessionPreconditionFailedError,
 } from "./JolliMemoryPushClient.js";
 
 const KEY = "sk-jol-test"; // parseJolliApiKey may return null for a plain key → baseUrlOverride supplies the URL
@@ -1166,5 +1168,122 @@ describe("invokePlatformTool", () => {
 		expect(capturedMethod).toBe("POST");
 		expect(capturedUrl).toBe("https://jolli.ai/api/mcp/tools/list_tickets");
 		expect(capturedBody).toBe(JSON.stringify({ status: "open" }));
+	});
+});
+
+describe("pushSessions", () => {
+	const payload = { version: 1, clientId: "c1", cursor: {}, tables: {} } as const;
+
+	it("rejects a 2xx whose body is not JSON, instead of reading it as an empty success", async () => {
+		// The failure this was found by, in production. A single-page app answers an
+		// unknown route with 200 and its index.html, so a backend that never
+		// deployed this endpoint looks exactly like one that did: `call`'s defensive
+		// parse turns the HTML into `{}`, `accepted` and `cursor` both read empty,
+		// the runner falls back to its own high-water mark, and the cursor advances
+		// over rows nobody received. Measured against the live backend — every
+		// request 200 + `<!doctype html>`, the channel reporting success, nothing
+		// ever ingested.
+		const c = client(async () => textResponse(200, "<!doctype html><html><title>Jolli</title></html>"));
+		await expect(c.pushSessions(payload)).rejects.toThrow(/Malformed \(non-JSON\) response/);
+	});
+
+	it("raises a non-JSON 2xx as SessionEndpointMissingError, the class that silences the channel", async () => {
+		// The runner silences a scope for 24h on this CLASS. It used to match the
+		// phrase "may not implement this endpoint" instead, which made the wording
+		// load-bearing; the class is what carries the meaning now.
+		const c = client(async () => textResponse(200, "<!doctype html>"));
+		await expect(c.pushSessions(payload)).rejects.toBeInstanceOf(SessionEndpointMissingError);
+	});
+
+	it("classifies a 404 by STATUS, even when the body carries a message of its own", async () => {
+		// The bug this pins. A non-2xx is raised as `errorMessage(json)` whenever the
+		// body has one, so a gateway answering `{"error":"Not Found"}` produced the
+		// message `Not Found` — which the runner's `/HTTP 404/` regex did not match.
+		// No silence, and the channel retried a missing endpoint every 30 minutes for
+		// ever, one `info` line at a time.
+		await expect(
+			client(async () => jsonResponse(404, { error: "Not Found" })).pushSessions(payload),
+		).rejects.toBeInstanceOf(SessionEndpointMissingError);
+		// And with no body at all, where the old regex did work.
+		await expect(client(async () => jsonResponse(404, {})).pushSessions(payload)).rejects.toBeInstanceOf(
+			SessionEndpointMissingError,
+		);
+	});
+
+	it("classifies a 412 by STATUS, for the same reason", async () => {
+		// A 412 is the response most likely of all to carry the server's own prose,
+		// so a `/HTTP 412/` match was the least likely to fire — on the one branch
+		// whose whole purpose is to be FINDABLE rather than retried into the ground.
+		await expect(
+			client(async () => jsonResponse(412, { message: "this deployment requires a binding" })).pushSessions(
+				payload,
+			),
+		).rejects.toBeInstanceOf(SessionPreconditionFailedError);
+	});
+
+	it("accepts a valid but empty JSON body", async () => {
+		// `{}` is a real answer from a backend that ingested nothing and holds no
+		// cursor — not a parse failure, and must not be treated as one.
+		const c = client(async () => jsonResponse(200, {}));
+		await expect(c.pushSessions(payload)).resolves.toEqual({ accepted: {}, cursor: {} });
+	});
+
+	it("returns the server's counts and cursor when it answers properly", async () => {
+		const c = client(async () =>
+			jsonResponse(200, { accepted: { sessions: 3 }, cursor: { sessions: { stamp: 9, key: ["e1"] } } }),
+		);
+		await expect(c.pushSessions(payload)).resolves.toEqual({
+			accepted: { sessions: 3 },
+			cursor: { sessions: { stamp: 9, key: ["e1"] } },
+		});
+	});
+
+	it("carries the server's cursor on a 409 so the client can walk back down", async () => {
+		const c = client(async () => jsonResponse(409, { error: "cursor_ahead", cursor: { sessions: null } }));
+		await expect(c.pushSessions(payload)).rejects.toMatchObject({
+			name: "SessionCursorAheadError",
+			serverCursor: { sessions: null },
+		});
+	});
+
+	it("carries an empty cursor when the 409 names none, rather than an absent one", async () => {
+		// The caller adopts `serverCursor` unconditionally, so the shape has to be
+		// uniform: `{}` means "the server mentioned no table", which each table
+		// then answers from what the client already had. An `undefined` here would
+		// reach `adoptCursor` as a missing argument instead.
+		const c = client(async () => jsonResponse(409, { error: "cursor_ahead" }));
+		await expect(c.pushSessions(payload)).rejects.toMatchObject({
+			name: "SessionCursorAheadError",
+			serverCursor: {},
+		});
+	});
+
+	it("names the status when a 412 carries no prose of its own", async () => {
+		// The reason is reported to the user and recorded beside the 24h silence, so
+		// a bodyless refusal must still say what happened rather than silence a
+		// backend with an empty explanation.
+		const c = client(async () => jsonResponse(412, {}));
+		await expect(c.pushSessions(payload)).rejects.toThrow("HTTP 412");
+	});
+
+	it("raises any other non-2xx as a plain Error, which the runner retries", async () => {
+		// Deliberately NOT one of the classified errors: a 500 is a backend having a
+		// bad day, and silencing the scope for 24h over one would be the opposite of
+		// what a transient failure calls for.
+		const c = client(async () => jsonResponse(500, { error: "boom" }));
+		await expect(c.pushSessions(payload)).rejects.toThrow("boom");
+		await expect(c.pushSessions(payload)).rejects.not.toBeInstanceOf(SessionEndpointMissingError);
+	});
+
+	it("maps 401 / 403 / 426 to their own errors", async () => {
+		await expect(client(async () => jsonResponse(401, {})).pushSessions(payload)).rejects.toBeInstanceOf(
+			NotAuthenticatedError,
+		);
+		await expect(client(async () => jsonResponse(403, {})).pushSessions(payload)).rejects.toBeInstanceOf(
+			PermissionDeniedError,
+		);
+		await expect(client(async () => jsonResponse(426, {})).pushSessions(payload)).rejects.toBeInstanceOf(
+			ClientOutdatedError,
+		);
 	});
 });

--- a/cli/src/core/JolliMemoryPushClient.ts
+++ b/cli/src/core/JolliMemoryPushClient.ts
@@ -381,6 +381,108 @@ export interface BatchPushAttachment {
 	readonly docId?: number;
 }
 
+/**
+ * The server's cursor is BEHIND the one the client sent, so this backend is
+ * missing a range the client believes it already delivered. Raised for `409` +
+ * `error: "cursor_ahead"`, carrying the server's own cursor to fall back to.
+ *
+ * The case it exists for is mundane and otherwise silent: a user pushes to a dev
+ * backend, then points the same install at prod. The local cursor still says
+ * "delivered up to T" while prod has nothing, so without this the range before T
+ * would never be sent anywhere again. A wiped, rolled-back or restored-from-
+ * backup server is the same shape.
+ *
+ * ⚠ A server with NO record must answer this too, not 200 — see
+ * `SessionSyncRunner` for why "no opinion" is the one reading that loses data.
+ */
+export class SessionCursorAheadError extends Error {
+	constructor(readonly serverCursor: Readonly<Record<string, SessionPushCursor | number | null>>) {
+		super("the server is missing a range this client considers delivered");
+		this.name = "SessionCursorAheadError";
+	}
+}
+
+/**
+ * How far one table has been delivered — the wire form of `TableCursor`.
+ *
+ * `key` is the PRIMARY KEY of the last row accepted, in the order the client's
+ * `KEYSET_COLUMNS` declares, and it exists because a millisecond is not a unique
+ * position: rows written together share a stamp, and when more of them share one
+ * than a batch holds, a stamp-only cursor cannot get past that millisecond at
+ * all. The server stores and returns the pair verbatim; it never has to
+ * interpret `key`, only keep it beside its stamp.
+ *
+ * An EMPTY key means the start of that millisecond, so a position carrying only
+ * a stamp is a valid position on the same scale — see `SessionPushResult.cursor`
+ * for why the wire still has to read one.
+ */
+export interface SessionPushCursor {
+	readonly stamp: number;
+	readonly key: ReadonlyArray<string>;
+}
+
+/**
+ * This backend does not have the session endpoint — a `404`, or a 2xx whose body
+ * is not JSON (a single-page app answering an unknown route with its
+ * `index.html`, which is what production actually did).
+ *
+ * ⚠ A CLASS, deliberately, and never a regex over the message. It replaces a
+ * `/HTTP 404/` test in `SessionSyncRunner`, which was fragile by construction:
+ * a non-2xx here is raised as `errorMessage(json) ?? \`HTTP ${status}\``, so any
+ * backend or gateway that answers 404 with a JSON error body (`{"error":"Not
+ * Found"}` is the normal shape) produced the message `Not Found` — with no
+ * status in it, no match, and therefore NO 24h silence: the channel then retried
+ * a missing endpoint every 30 minutes for ever, logging one `info` line each
+ * time. 403 and 426 already had status-keyed classes; these two are the ones that
+ * were left to string matching.
+ */
+export class SessionEndpointMissingError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "SessionEndpointMissingError";
+	}
+}
+
+/**
+ * The server made a binding a precondition for the session channel (`412`).
+ *
+ * Should be unreachable — session statistics need no Space, since the API key
+ * already carries the organisation. Its own class for the same reason as
+ * {@link SessionEndpointMissingError}: it is the branch that has to be FINDABLE
+ * rather than retried into the ground, and a 412 is the response most likely of
+ * all to carry the server's own explanatory prose in `message` — which is
+ * exactly what made a `/HTTP 412/` regex miss it.
+ */
+export class SessionPreconditionFailedError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "SessionPreconditionFailedError";
+	}
+}
+
+/** The session channel's request envelope. `tables` carries local column names verbatim. */
+export interface SessionPushPayload {
+	/** 1 — this channel's only protocol. `cursor` is `{stamp, key}` throughout. */
+	readonly version: 1;
+	readonly clientId: string;
+	/** Client progress, per table — reconciled by the server on every request. */
+	readonly cursor: Readonly<Record<string, SessionPushCursor>>;
+	readonly tables: Readonly<Record<string, ReadonlyArray<Record<string, unknown>>>>;
+}
+
+export interface SessionPushResult {
+	readonly accepted: Readonly<Record<string, number>>;
+	/**
+	 * The server's cursor AFTER this batch. The client adopts it as-is.
+	 *
+	 * A bare `number` is accepted and read as `{stamp, key: []}`. The CLI and the
+	 * backend deploy independently, so this is wire tolerance rather than a
+	 * migration: a backend that echoes only a stamp keeps working, at the cost of
+	 * re-delivering one millisecond per pass into an upsert.
+	 */
+	readonly cursor: Readonly<Record<string, SessionPushCursor | number | null>>;
+}
+
 export class JolliMemoryPushClient {
 	private readonly fetchImpl: typeof fetch;
 	private readonly baseUrlOverride?: string;
@@ -581,6 +683,77 @@ export class JolliMemoryPushClient {
 			summaryJsonDocId: json.summaryJsonDocId,
 			...(jmSpace !== undefined ? { jmSpace } : {}),
 		};
+	}
+
+	/**
+	 * Sends one session-sync batch.
+	 *
+	 * ⚠ This channel's failures do NOT mean what the memory push's do, and reusing
+	 * that mapping would produce a user-visible regression in an unrelated place.
+	 * `push()` treats 401/403/412 as "the binding was refused" and clears the
+	 * cached repo→Space binding; this channel never consults a binding at all (the
+	 * API key already carries the org, so nothing has to be bound for session
+	 * statistics to have a home). Clearing that cache here would make `jolli
+	 * status` and the editors' Space panel re-probe, and briefly show a degraded
+	 * Space — over a failure that has nothing to do with Spaces.
+	 *
+	 * So: 403 and 404 are "not enabled here", to be silenced machine-wide by the
+	 * caller; 412 should be impossible and is treated the same way but logged as a
+	 * warning, because seeing one means the server has made a binding a
+	 * precondition after all.
+	 */
+	async pushSessions(payload: SessionPushPayload): Promise<SessionPushResult> {
+		const { status, json, parseFailed } = await this.call<{
+			error?: string;
+			message?: string;
+			accepted?: Record<string, number>;
+			cursor?: Record<string, SessionPushCursor | number | null>;
+		}>("POST", "/api/push/jollimemory/sessions", payload);
+		if (status === 409 && json.error === "cursor_ahead") {
+			throw new SessionCursorAheadError(json.cursor ?? {});
+		}
+		if (status === 401) throw new NotAuthenticatedError();
+		if (status === 403) throw new PermissionDeniedError(errorMessage(json));
+		if (status === 426)
+			throw new ClientOutdatedError(json.message ?? "Client outdated — update the CLI/extension.");
+		// 404 and 412 are classified HERE, by status, and the two lines are the whole
+		// point: the caller silences a scope for 24h on either, and it used to decide
+		// that by matching `/HTTP 404/` and `/HTTP 412/` against the message raised on
+		// the generic line below. That message is `errorMessage(json)` whenever the
+		// body carries one, so a backend answering 404 with `{"error":"Not Found"}` —
+		// the ordinary gateway shape — produced `Not Found`, matched neither regex, and
+		// got retried every 30 minutes for ever. A status is not a substring of prose;
+		// keep these keyed on the number.
+		if (status === 404)
+			throw new SessionEndpointMissingError(
+				errorMessage(json) ?? "HTTP 404 — the backend does not implement /api/push/jollimemory/sessions",
+			);
+		if (status === 412) throw new SessionPreconditionFailedError(errorMessage(json) ?? `HTTP ${status}`);
+		if (status < 200 || status >= 300) throw new Error(errorMessage(json) ?? `HTTP ${status}`);
+		if (parseFailed) {
+			// ⚠ THE most important check on this path, and it was the one missing.
+			// A single-page app answers an unknown route with 200 and its index.html,
+			// so a backend that has not deployed this endpoint is indistinguishable
+			// from one that has — the defensive parse in `call` turns that HTML into
+			// `{}`, `accepted` and `cursor` both read as empty, the caller falls back
+			// to its own high-water mark, and the cursor advances over rows that
+			// reached nobody. Measured against production: every request answered
+			// `200` with `<!doctype html>`, the channel reported success for months,
+			// and nothing had ever been ingested.
+			//
+			// Every other method here already checks this. Failing loudly costs a
+			// retry; not checking costs the data silently, which is the one outcome
+			// a sync must never have.
+			// Same CLASS as a 404, because it means the same thing: this deployment
+			// does not have the endpoint. Raising it as a bare `Error` left the caller
+			// recognising it by the phrase "may not implement this endpoint", which is
+			// the same fragility as the status regexes above one step removed.
+			throw new SessionEndpointMissingError(
+				`Malformed (non-JSON) response from /api/push/jollimemory/sessions (HTTP ${status}) — ` +
+					"the backend may not implement this endpoint",
+			);
+		}
+		return { accepted: json.accepted ?? {}, cursor: json.cursor ?? {} };
 	}
 
 	/**

--- a/cli/src/core/SessionPushCursor.test.ts
+++ b/cli/src/core/SessionPushCursor.test.ts
@@ -1,0 +1,258 @@
+/**
+ * The channel state file's parse rules.
+ *
+ * The cases that matter are the ones where a wrong reading loses data quietly:
+ * an unreadable cursor that resolves to "deliver everything" or to "already
+ * delivered", and the number-to-keyset upgrade, which has to mean exactly what
+ * the number meant or a machine either re-pushes its history or skips a range.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	cursorsFor,
+	getSessionPushChannelPath,
+	isChannelSilenced,
+	loadChannelForRun,
+	readSessionPushChannel,
+	toCursors,
+	toTableCursor,
+	withCursors,
+	withSilence,
+	writeSessionPushChannel,
+} from "./SessionPushCursor.js";
+
+let dir: string;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "jolli-pushcursor-"));
+});
+
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("toTableCursor", () => {
+	it("reads a bare number as the START of that millisecond", () => {
+		// An empty key sorts at or before every text key, so `(stamp, "")` selects
+		// the whole millisecond — exactly what a bare `stamp >= N` selects. Anything
+		// else would either skip rows already in that millisecond or re-push from
+		// further back.
+		expect(toTableCursor(4_242)).toEqual({ stamp: 4_242, key: [] });
+	});
+
+	it("reads this build's shape verbatim", () => {
+		expect(toTableCursor({ stamp: 7, key: ["a", "b"] })).toEqual({ stamp: 7, key: ["a", "b"] });
+	});
+
+	it("answers undefined for junk rather than a zero cursor", () => {
+		// `undefined` means "first run", which applies the 90-day window.
+		// `{stamp: 0}` means "deliver everything ever recorded". Guessing the second
+		// from a corrupt file would push a machine's entire history.
+		for (const junk of [undefined, null, "1000", {}, { stamp: "1000" }, { key: ["a"] }, [], Number.NaN, Infinity]) {
+			expect(toTableCursor(junk)).toBeUndefined();
+		}
+	});
+
+	it("drops non-string key entries instead of carrying them into a query", () => {
+		expect(toTableCursor({ stamp: 1, key: ["a", 5, null, "b"] })).toEqual({ stamp: 1, key: ["a", "b"] });
+		expect(toTableCursor({ stamp: 1, key: "not-an-array" })).toEqual({ stamp: 1, key: [] });
+	});
+});
+
+describe("toCursors", () => {
+	it("keeps readable tables and drops unreadable ones", () => {
+		// Per table, not all-or-nothing: one corrupt entry must not reset the
+		// progress of every other table on that backend.
+		expect(toCursors({ sessions: 10, recall_receipts: { stamp: 2, key: ["r"] }, bogus: "x" })).toEqual({
+			sessions: { stamp: 10, key: [] },
+			recall_receipts: { stamp: 2, key: ["r"] },
+		});
+	});
+
+	it("answers an empty map for a non-object", () => {
+		expect(toCursors(null)).toEqual({});
+		expect(toCursors("nope")).toEqual({});
+	});
+});
+
+describe("readSessionPushChannel", () => {
+	it("migrates a file written with bare-number cursors", () => {
+		// What every machine that ran an earlier build has on disk.
+		writeFileSync(
+			getSessionPushChannelPath(dir),
+			JSON.stringify({ version: 1, clientId: "c1", byOrigin: { "https://jolli.ai": { sessions: 999 } } }),
+		);
+		expect(readSessionPushChannel(dir).byOrigin["https://jolli.ai"]).toEqual({ sessions: { stamp: 999, key: [] } });
+	});
+
+	it("treats an unreadable file as absent rather than throwing", () => {
+		// It is read from a git hook; a bookkeeping file must never take one down.
+		// Losing the cursor costs a re-send the server upserts away.
+		writeFileSync(getSessionPushChannelPath(dir), "{ truncated");
+		const state = readSessionPushChannel(dir);
+		expect(state.byOrigin).toEqual({});
+		expect(state.clientId).not.toBe("");
+	});
+
+	it("reads a file written by a build with another version as absent", () => {
+		// The version is what says "this file means what this build thinks it
+		// means". Reading a foreign one field-by-field would hand the runner a
+		// cursor whose stamp is on a scale nothing here defines — and the two ways
+		// that lands are re-pushing a machine's whole history or skipping a range.
+		// Starting over costs one re-send the server upserts away.
+		writeFileSync(
+			getSessionPushChannelPath(dir),
+			JSON.stringify({ version: 2, clientId: "c1", byOrigin: { "https://jolli.ai": { sessions: 999 } } }),
+		);
+		const state = readSessionPushChannel(dir);
+		expect(state.byOrigin).toEqual({});
+		expect(state.clientId).not.toBe("c1");
+	});
+
+	it("reads a state carrying no clientId as absent, rather than running without one", () => {
+		// The server keys ITS cursor on `clientId`, so an empty one is not a
+		// cosmetic gap: every run would look like a different machine.
+		writeFileSync(getSessionPushChannelPath(dir), JSON.stringify({ version: 1, clientId: "" }));
+		expect(readSessionPushChannel(dir).clientId).not.toBe("");
+	});
+
+	it("reads a state with no byOrigin at all as no progress, not as a missing field", () => {
+		// What a state written before the first successful run looks like. `{}` is
+		// "first run for every table", which applies the 90-day window — the reading
+		// that under-delivers rather than over-delivers.
+		writeFileSync(getSessionPushChannelPath(dir), JSON.stringify({ version: 1, clientId: "c1" }));
+		const state = readSessionPushChannel(dir);
+		expect(state.clientId).toBe("c1");
+		expect(state.byOrigin).toEqual({});
+	});
+
+	it("treats a path that is not a file at all as absent, and still does not throw", () => {
+		// ENOENT is the ordinary case and is silent; anything else (a directory in
+		// the way, a permission problem) is worth a line in the log — but it is
+		// still only bookkeeping, and it runs from a git hook.
+		mkdirSync(getSessionPushChannelPath(dir));
+		const state = readSessionPushChannel(dir);
+		expect(state.byOrigin).toEqual({});
+		expect(state.clientId).not.toBe("");
+	});
+
+	it("does not write on read", () => {
+		// Callers on the decide-whether-to-run path must be able to ask without
+		// touching the disk.
+		readSessionPushChannel(dir);
+		expect(() => readSessionPushChannel(dir)).not.toThrow();
+		expect(readSessionPushChannel(dir).clientId).not.toBe(readSessionPushChannel(dir).clientId);
+	});
+});
+
+describe("loadChannelForRun", () => {
+	it("persists a generated clientId before the run, not after it succeeds", () => {
+		// The server keys its own cursor on `clientId`. A client that minted a new
+		// one on every failed attempt would look like a new machine each time and be
+		// handed an empty cursor for ever.
+		const first = loadChannelForRun(dir);
+		expect(loadChannelForRun(dir).clientId).toBe(first.clientId);
+	});
+});
+
+describe("cursor bookkeeping", () => {
+	it("replaces one origin and leaves the others alone", () => {
+		const state = withCursors(
+			withCursors(loadChannelForRun(dir), "https://a", { sessions: { stamp: 1, key: [] } }),
+			"https://b",
+			{ sessions: { stamp: 2, key: [] } },
+		);
+		expect(cursorsFor(state, "https://a")).toEqual({ sessions: { stamp: 1, key: [] } });
+		expect(cursorsFor(state, "https://b")).toEqual({ sessions: { stamp: 2, key: [] } });
+		expect(cursorsFor(state, "https://never-seen")).toEqual({});
+	});
+
+	it("round-trips through the file", () => {
+		const state = withCursors(loadChannelForRun(dir), "https://a", { sessions: { stamp: 5, key: ["e1"] } });
+		writeSessionPushChannel(state, dir);
+		expect(cursorsFor(readSessionPushChannel(dir), "https://a")).toEqual({ sessions: { stamp: 5, key: ["e1"] } });
+	});
+
+	it("falls back to a legacy bare-origin key, so an upgrade keeps its place", () => {
+		// Progress written before the key carried a tenant. Losing it would re-send
+		// from the 90-day window on the first run of every upgraded machine.
+		const state = withCursors(loadChannelForRun(dir), "https://a", { sessions: { stamp: 9, key: [] } });
+		expect(cursorsFor(state, "https://a/tenant", "https://a")).toEqual({ sessions: { stamp: 9, key: [] } });
+	});
+
+	it("prefers the scoped key over the legacy one once it exists", () => {
+		const state = withCursors(
+			withCursors(loadChannelForRun(dir), "https://a", { sessions: { stamp: 9, key: [] } }),
+			"https://a/tenant",
+			{ sessions: { stamp: 20, key: [] } },
+		);
+		expect(cursorsFor(state, "https://a/tenant", "https://a")).toEqual({ sessions: { stamp: 20, key: [] } });
+	});
+
+	it("keeps two tenants on one origin apart", () => {
+		// The reason the scope is not just the origin: a cursor means nothing across
+		// tenants, and a refusal from one says nothing about the other.
+		const state = withCursors(
+			withCursors(loadChannelForRun(dir), "https://a/one", { sessions: { stamp: 1, key: [] } }),
+			"https://a/two",
+			{ sessions: { stamp: 2, key: [] } },
+		);
+		expect(cursorsFor(state, "https://a/one")).toEqual({ sessions: { stamp: 1, key: [] } });
+		expect(cursorsFor(state, "https://a/two")).toEqual({ sessions: { stamp: 2, key: [] } });
+	});
+});
+
+describe("silence bookkeeping", () => {
+	const base = { version: 1, clientId: "c", byOrigin: {} } as const;
+
+	it("reports a silence only while it is still in effect", () => {
+		const state = { ...base, silencedByScope: { "https://a": 100 } };
+		expect(isChannelSilenced(state, 99, "https://a")).toBe(true);
+		expect(isChannelSilenced(state, 100, "https://a")).toBe(false);
+		expect(isChannelSilenced({ ...base, silencedByScope: {} }, 100, "https://a")).toBe(false);
+	});
+
+	it("silences one scope without touching another", () => {
+		// The whole point of the field: one backend's 403 must not stop the others.
+		const state = withSilence({ ...base, silencedByScope: {} }, "https://a", 500, 0);
+		expect(isChannelSilenced(state, 100, "https://a")).toBe(true);
+		expect(isChannelSilenced(state, 100, "https://b")).toBe(false);
+	});
+
+	it("prunes expired scopes as it writes, so the map cannot grow forever", () => {
+		const state = withSilence({ ...base, silencedByScope: { "https://old": 50 } }, "https://a", 500, 100);
+		expect(state.silencedByScope).toEqual({ "https://a": 500 });
+	});
+
+	it("keeps another scope's live silence when writing one", () => {
+		const state = withSilence({ ...base, silencedByScope: { "https://b": 900 } }, "https://a", 500, 100);
+		expect(state.silencedByScope).toEqual({ "https://b": 900, "https://a": 500 });
+	});
+
+	it("round-trips through the file", () => {
+		writeSessionPushChannel(withSilence({ ...base, silencedByScope: {} }, "https://a", 500, 0), dir);
+		expect(readSessionPushChannel(dir).silencedByScope).toEqual({ "https://a": 500 });
+	});
+
+	it("DROPS a legacy machine-wide mark instead of folding it onto every scope", () => {
+		// Folding it in would carry the very outage this change fixes across the
+		// upgrade that fixes it: the whole machine stayed silent for 24h even after
+		// the key was re-pointed at a working backend.
+		writeFileSync(
+			getSessionPushChannelPath(dir),
+			JSON.stringify({ version: 1, clientId: "c", silencedUntilMs: 9_999_999, byOrigin: {} }),
+		);
+		const state = readSessionPushChannel(dir);
+		expect(state.silencedByScope).toEqual({});
+		expect(isChannelSilenced(state, 0, "https://a")).toBe(false);
+	});
+
+	it("ignores a non-numeric stored entry rather than refusing to run", () => {
+		writeFileSync(
+			getSessionPushChannelPath(dir),
+			JSON.stringify({ version: 1, clientId: "c", silencedByScope: { "https://a": "soon" }, byOrigin: {} }),
+		);
+		expect(readSessionPushChannel(dir).silencedByScope).toEqual({});
+	});
+});

--- a/cli/src/core/SessionPushCursor.ts
+++ b/cli/src/core/SessionPushCursor.ts
@@ -1,0 +1,347 @@
+/**
+ * The session sync channel's own state file: cursors, client identity, the
+ * throttle mark, and the per-scope silences.
+ *
+ * `~/.jolli/jollimemory/session-push-channel.json` — MACHINE-level, and that is
+ * a correctness requirement rather than tidiness. The sync itself is cross-repo:
+ * one run carries every repo's rows out of the one machine-level database (there
+ * is only one). A per-project file would mean three open projects keep three
+ * separate records of the same machine-wide progress, and each of their daemons
+ * would push the whole machine again.
+ *
+ * It is deliberately NOT `config.json`: that file is the user's own settings, and
+ * mixing runtime state into it makes the two overwrite each other.
+ *
+ * ⚠ No SQLite here, and no imports that reach it. Hooks call into this
+ * synchronously to decide whether there is anything to do at all, and the whole
+ * point of that check is that it costs one file read — opening the database to
+ * find out there is nothing to send would defeat it.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { createLogger, errMsg, isEnoent } from "../Logger.js";
+import { getGlobalConfigDir } from "./SessionTracker.js";
+
+const log = createLogger("SessionPushCursor");
+
+/**
+ * How far one table has been delivered: a sync stamp, plus the primary key of
+ * the last row sent to break ties inside it.
+ *
+ * The key is what makes the cursor able to move. A stamp alone deadlocks the
+ * moment more rows share a millisecond than fit in one batch — see
+ * `KEYSET_COLUMNS` for the measurement. The tuple `(stamp, ...key)` is unique,
+ * so it strictly increases with every row sent.
+ *
+ * An EMPTY key means "the start of that millisecond": every text key sorts at or
+ * after `""`, so `(stamp, "") <=` any row in that millisecond. That is what lets
+ * a bare stamp — all a backend echoing no tie-breaker gives us — be read as
+ * `{stamp, key: []}` without skipping a row; it re-delivers that millisecond
+ * once, which is harmless since the server upserts.
+ */
+export interface TableCursor {
+	readonly stamp: number;
+	/** PK values of the last row sent, in `KEYSET_COLUMNS` order. */
+	readonly key: ReadonlyArray<string>;
+}
+
+/**
+ * One cursor per table — see `SYNC_STAMP_COLUMNS` for why each has its own, and
+ * why they must advance independently (a run where one table succeeds and
+ * another fails would otherwise skip the failed one's rows forever).
+ *
+ * Keyed by table NAME rather than by the `SyncedTable` union on purpose: this
+ * module is imported by hooks that must not reach SQLite, and the union lives
+ * beside the reader that does. A stored file can also carry a table name a later
+ * build renamed, which a closed union would refuse to represent.
+ */
+export type SessionPushCursors = Readonly<Record<string, TableCursor>>;
+
+/**
+ * Reads one table's cursor out of anything that might be stored or received:
+ * this build's shape, a bare stamp with no tie-breaker, or junk.
+ *
+ * ⚠ Answers `undefined` rather than a zero cursor for junk, and the difference
+ * matters: absent means "first run", which applies the 90-day window, while
+ * `{stamp: 0}` means "deliver everything ever recorded". Guessing the second
+ * from a corrupt file would push a machine's whole history.
+ *
+ * The key is NOT validated against a column count here — this module knows
+ * nothing about table shapes by design. The reader pads or truncates it, which
+ * degrades to re-delivering one millisecond rather than to a wrong page.
+ */
+export function toTableCursor(value: unknown): TableCursor | undefined {
+	if (typeof value === "number") return Number.isFinite(value) ? { stamp: value, key: [] } : undefined;
+	if (!isRecord(value) || typeof value.stamp !== "number" || !Number.isFinite(value.stamp)) return undefined;
+	const key = Array.isArray(value.key) ? value.key.filter((k): k is string => typeof k === "string") : [];
+	return { stamp: value.stamp, key };
+}
+
+/** Every readable cursor in a stored or received map, junk entries dropped. */
+export function toCursors(value: unknown): SessionPushCursors {
+	if (!isRecord(value)) return {};
+	const out: Record<string, TableCursor> = {};
+	for (const [table, raw] of Object.entries(value)) {
+		const cursor = toTableCursor(raw);
+		if (cursor !== undefined) out[table] = cursor;
+	}
+	return out;
+}
+
+export interface SessionPushChannelState {
+	readonly version: 1;
+	/**
+	 * This INSTALLATION's stable id, generated once. Not the database's instance
+	 * id, which is the identity of the file and changes the moment it is rebuilt
+	 * — precisely when resuming matters most. Two accepted edges: copying a home
+	 * directory to a second machine shares one id (harmless — sessions are unique
+	 * by `session_id`), and losing this file means becoming a new client, which
+	 * falls back to the first-run window.
+	 */
+	readonly clientId: string;
+	/**
+	 * The database's own instance id as of the last successful run. A rebuilt
+	 * database can hold rows whose stamps are LOWER than the cursor, which no
+	 * cursor would ever select again, so a mismatch resets progress.
+	 */
+	readonly dbInstanceId?: string;
+	/**
+	 * Last attempt, success or failure. ⚠ Written on FAILURE too — unlike the
+	 * cursors, which only move on success. It is a throttle, not progress: if it
+	 * only moved on success, every tick would retry a request that is going to
+	 * fail again.
+	 */
+	readonly lastAttemptAtMs?: number;
+	/**
+	 * Silence after a 403/404/412, PER SCOPE — see `SILENCE_MS` and
+	 * {@link isChannelSilenced}.
+	 *
+	 * ⚠ It was one machine-wide `silencedUntilMs`, and that is the bug this field
+	 * replaces: the refusal is an answer from ONE backend about ONE tenant, while
+	 * the mark it wrote stopped every other backend too. Measured — a repo whose
+	 * key briefly pointed at a deployment with the session scope off got the whole
+	 * machine silenced for 24h, and re-pointing the key at a working backend
+	 * minutes later changed nothing: the upload stayed off until the next day,
+	 * having sent nothing and logged nothing.
+	 *
+	 * A legacy machine-wide mark is deliberately DROPPED on read rather than
+	 * folded onto every scope. Keeping it would carry exactly the outage above
+	 * across the upgrade that fixes it, and the cost of dropping it is one retry
+	 * against a backend that will refuse again and re-silence its own scope.
+	 */
+	readonly silencedByScope: Readonly<Record<string, number>>;
+	/**
+	 * Progress per backend SCOPE — origin plus tenant slug, as
+	 * `https://host[/tenant]`.
+	 *
+	 * Correctness does not depend on this split — the server reconciles every
+	 * mismatch with a 409 — but without it, switching between a dev and a prod
+	 * backend re-pushes a large range every time: rejected by dev, the cursor
+	 * drops to dev's low-water mark, and the next prod run starts from there and
+	 * re-sends everything prod already had.
+	 *
+	 * ⚠ The tenant slug is part of the key because one origin serves many
+	 * tenants, and a cursor is meaningless across them. The field NAME stays
+	 * `byOrigin` so an existing file keeps its progress: a bare-origin key written
+	 * by an earlier build is still read, via the `legacyKey` argument of
+	 * {@link cursorsFor}. New progress is written under the scoped key.
+	 */
+	readonly byOrigin: Readonly<Record<string, SessionPushCursors>>;
+}
+
+/**
+ * How long a permission/endpoint refusal silences ONE scope.
+ *
+ * 403 and 404 both mean "this will not work until something changes on the
+ * server" — a scope that is off, or a deployment that does not have the endpoint
+ * yet. Retrying either on every trigger is pure noise.
+ *
+ * ⚠ Scoped, never machine-wide: see `SessionPushChannelState.silencedByScope`.
+ * A user who wants the wait cut short does not have to edit this file — an
+ * explicit `jolli` run passes `force`, which bypasses the silence and says so.
+ */
+export const SILENCE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Minimum gap between attempts, machine-wide — the upload's real period.
+ *
+ * Beside `SILENCE_MS` because the two are the same kind of thing: both throttle
+ * this file's own marks (`lastAttemptAtMs` and `silencedUntilMs`), and both are
+ * read to answer "is there anything to do" WITHOUT opening the database, which
+ * is the whole point of `isDueForSessionSync` living one file read away from a
+ * git hook.
+ *
+ * ⚠ It is enforced HERE, by the run itself, and never by how often a caller
+ * asks. A scheduler that set its interval to this value would be a second owner
+ * of the period, and a losing one: the comparison is `>=`, so any negative
+ * jitter turns a tick that should have run into "throttled" and doubles the real
+ * period. Callers tick faster and get told no — see `SESSION_SYNC_TICK_MS`.
+ */
+export const MIN_ATTEMPT_INTERVAL_MS = 30 * 60 * 1000;
+
+/** Absolute path of the channel state file. */
+export function getSessionPushChannelPath(configDir: string = getGlobalConfigDir()): string {
+	return join(configDir, "session-push-channel.json");
+}
+
+function emptyState(): SessionPushChannelState {
+	return { version: 1, clientId: randomUUID(), silencedByScope: {}, byOrigin: {} };
+}
+
+/**
+ * Reads the state, answering a fresh one for anything unreadable.
+ *
+ * A corrupt or truncated file is treated as absent rather than surfaced: the
+ * cost of losing the cursor is re-sending rows the server upserts anyway, while
+ * throwing here would take down a git hook over a bookkeeping file.
+ *
+ * ⚠ Reading NEVER writes — no lazy `clientId` persistence here. Callers on the
+ * decide-whether-to-run path must be able to ask without touching the disk.
+ */
+export function readSessionPushChannel(configDir?: string): SessionPushChannelState {
+	return parseChannel(configDir).state;
+}
+
+/** The parse, plus whether the file already carried a usable state. */
+function parseChannel(configDir?: string): { state: SessionPushChannelState; stored: boolean } {
+	let raw: string;
+	try {
+		raw = readFileSync(getSessionPushChannelPath(configDir), "utf-8");
+	} catch (err) {
+		if (!isEnoent(err)) log.debug("session push channel state unreadable: %s", errMsg(err));
+		return { state: emptyState(), stored: false };
+	}
+	try {
+		const parsed = JSON.parse(raw) as Partial<SessionPushChannelState>;
+		if (parsed.version !== 1 || typeof parsed.clientId !== "string" || parsed.clientId === "") {
+			return { state: emptyState(), stored: false };
+		}
+		return {
+			state: {
+				version: 1,
+				clientId: parsed.clientId,
+				...(typeof parsed.dbInstanceId === "string" ? { dbInstanceId: parsed.dbInstanceId } : {}),
+				...(typeof parsed.lastAttemptAtMs === "number" ? { lastAttemptAtMs: parsed.lastAttemptAtMs } : {}),
+				// A legacy machine-wide `silencedUntilMs` is read past and dropped —
+				// see `silencedByScope` for why it must not be folded onto the scopes.
+				silencedByScope: toSilences(parsed.silencedByScope),
+				// Normalised on the way in, so nothing downstream has to handle a
+				// stored position that carries only a stamp.
+				byOrigin: isRecord(parsed.byOrigin)
+					? Object.fromEntries(Object.entries(parsed.byOrigin).map(([o, c]) => [o, toCursors(c)]))
+					: {},
+			},
+			stored: true,
+		};
+	} catch {
+		return { state: emptyState(), stored: false };
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Normalises the stored silence map, dropping anything that is not a number.
+ *
+ * A garbled entry reads as "not silenced" rather than as an error: the worst
+ * outcome is one request against a backend that refuses it and writes the mark
+ * again, while refusing to run over a malformed bookkeeping value would stop the
+ * upload with nothing able to repair it.
+ */
+function toSilences(value: unknown): Record<string, number> {
+	if (!isRecord(value)) return {};
+	const out: Record<string, number> = {};
+	for (const [scope, until] of Object.entries(value)) {
+		if (typeof until === "number" && Number.isFinite(until)) out[scope] = until;
+	}
+	return out;
+}
+
+/** Writes the state. Best effort: a failure here must not fail a caller. */
+export function writeSessionPushChannel(state: SessionPushChannelState, configDir?: string): void {
+	const path = getSessionPushChannelPath(configDir);
+	try {
+		mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+		writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+	} catch (err) {
+		log.debug("could not write session push channel state: %s", errMsg(err));
+	}
+}
+
+/**
+ * Reads the state, persisting a freshly generated `clientId` if there was none.
+ *
+ * Separate from {@link readSessionPushChannel} on purpose: this one writes, so
+ * only a caller that has already decided to run may use it.
+ */
+export function loadChannelForRun(configDir?: string): SessionPushChannelState {
+	const { state, stored } = parseChannel(configDir);
+	// The generated id must be persisted BEFORE the run, not after it succeeds:
+	// the server keys its own cursor on `clientId`, so a client that made a new
+	// one on every failed attempt would look like a new machine each time and be
+	// handed an empty cursor forever.
+	if (!stored) writeSessionPushChannel(state, configDir);
+	return state;
+}
+
+/**
+ * When `scope`'s 403/404/412 silence expires, or `undefined` if it is not
+ * silenced. Returned rather than a bare boolean so a caller can say how long is
+ * left instead of only that it waited.
+ */
+export function silencedUntilFor(state: SessionPushChannelState, scope: string, nowMs: number): number | undefined {
+	const until = state.silencedByScope[scope];
+	return until !== undefined && until > nowMs ? until : undefined;
+}
+
+/** True while `scope`'s 403/404/412 silence is still in effect. */
+export function isChannelSilenced(state: SessionPushChannelState, nowMs: number, scope: string): boolean {
+	return silencedUntilFor(state, scope, nowMs) !== undefined;
+}
+
+/**
+ * Silences one scope until `untilMs`, leaving every other scope untouched.
+ *
+ * Expired entries are pruned on the way through, so a machine that has talked to
+ * several backends over its life does not accumulate them forever.
+ */
+export function withSilence(
+	state: SessionPushChannelState,
+	scope: string,
+	untilMs: number,
+	nowMs: number,
+): SessionPushChannelState {
+	const kept: Record<string, number> = {};
+	for (const [key, until] of Object.entries(state.silencedByScope)) {
+		if (key !== scope && until > nowMs) kept[key] = until;
+	}
+	kept[scope] = untilMs;
+	return { ...state, silencedByScope: kept };
+}
+
+/**
+ * The cursors recorded for one backend scope. Empty for an unseen one.
+ *
+ * `legacyKey` is the bare origin an earlier build stored progress under; it is
+ * consulted only when the scoped key has nothing, so an upgrade keeps its place
+ * in the stream instead of re-sending from the first-run window.
+ */
+export function cursorsFor(state: SessionPushChannelState, scope: string, legacyKey?: string): SessionPushCursors {
+	const scoped = state.byOrigin[scope];
+	if (scoped !== undefined) return scoped;
+	if (legacyKey !== undefined && legacyKey !== scope) return state.byOrigin[legacyKey] ?? {};
+	return {};
+}
+
+/** Replaces one scope's cursors, leaving every other scope untouched. */
+export function withCursors(
+	state: SessionPushChannelState,
+	scope: string,
+	cursors: SessionPushCursors,
+): SessionPushChannelState {
+	return { ...state, byOrigin: { ...state.byOrigin, [scope]: cursors } };
+}

--- a/cli/src/core/TranscriptParser.ts
+++ b/cli/src/core/TranscriptParser.ts
@@ -122,6 +122,13 @@ export class ClaudeTranscriptParser implements TranscriptParser {
 			// the reader counts only the first. Omitted when the id is absent so the
 			// line still counts rather than being silently dropped.
 			...(usage.id && { dedupKey: usage.id }),
+			// Carried per line so the reader can date each response's model without
+			// a second whole-slice pass. `parseUsageByModel` still exists for the
+			// aggregate; both read `extractClaudeUsage`, so they cannot disagree.
+			// Omitted rather than emitted empty when the line names no model — the
+			// aggregate buckets those under an empty id, and inventing that value
+			// here would put it in front of every caller instead of one.
+			...(usage.model && { model: usage.model }),
 		};
 	}
 

--- a/cli/src/core/TranscriptReader.test.ts
+++ b/cli/src/core/TranscriptReader.test.ts
@@ -1014,6 +1014,144 @@ describe("TranscriptReader", () => {
 		});
 	});
 
+	describe("usageEvents — one record per response, with its own instant", () => {
+		// The whole point of the per-call record: a conversation that spans days
+		// must contribute to each of those days, not to whichever one it was last
+		// touched on. Everything downstream is a GROUP BY over these.
+		it("dates each response by its own line, not by the session", async () => {
+			const filePath = join(tempDir, "claude-spanning.jsonl");
+			const lines = [
+				JSON.stringify({
+					message: { role: "assistant", id: "msg_a", model: "claude-opus-5", content: [] },
+					usage: { input_tokens: 100, output_tokens: 10 },
+					timestamp: "2026-03-01T10:00:00Z",
+				}),
+				JSON.stringify({
+					message: { role: "assistant", id: "msg_b", model: "claude-opus-5", content: [] },
+					usage: { input_tokens: 200, output_tokens: 20 },
+					timestamp: "2026-03-03T09:00:00Z",
+				}),
+			];
+			await writeFile(filePath, lines.join("\n"), "utf-8");
+
+			const result = await readTranscript(filePath);
+			expect(result.usageEvents).toHaveLength(2);
+			expect(result.usageEvents?.[0]).toEqual({
+				respondedAtMs: Date.parse("2026-03-01T10:00:00Z"),
+				model: "claude-opus-5",
+				input: 100,
+				output: 10,
+				cached: 0,
+				dedupKey: "msg_a",
+			});
+			expect(result.usageEvents?.[1]?.respondedAtMs).toBe(Date.parse("2026-03-03T09:00:00Z"));
+			// The session-level totals still cover both, unchanged.
+			expect(result.usageTokens).toBe(330);
+		});
+
+		it("counts one response once even when it spans several block lines", async () => {
+			const filePath = join(tempDir, "claude-blocks.jsonl");
+			const block = (text: string) =>
+				JSON.stringify({
+					message: {
+						role: "assistant",
+						id: "msg_same",
+						model: "claude-opus-5",
+						content: [{ type: "text", text }],
+					},
+					usage: { input_tokens: 50, output_tokens: 5 },
+					timestamp: "2026-03-01T10:00:00Z",
+				});
+			await writeFile(filePath, [block("a"), block("b"), block("c")].join("\n"), "utf-8");
+
+			const result = await readTranscript(filePath);
+			// One response, not three — the same dedup identity the totals use.
+			expect(result.usageEvents).toHaveLength(1);
+			expect(result.usageTokens).toBe(55);
+		});
+
+		// A wrong day is worse than a missing one: these rows are what a per-day
+		// figure is built from. The totals still count it, so the two disagree by
+		// exactly what could not be dated.
+		it("drops an undatable response from the events while still counting its tokens", async () => {
+			const filePath = join(tempDir, "claude-undated.jsonl");
+			await writeFile(
+				filePath,
+				JSON.stringify({
+					message: { role: "assistant", id: "msg_x", model: "claude-opus-5", content: [] },
+					usage: { input_tokens: 9, output_tokens: 1 },
+				}),
+				"utf-8",
+			);
+
+			const result = await readTranscript(filePath);
+			// Present-but-empty: this source can report usage, so a downstream
+			// consumer may CLEAR rows an earlier read left behind — `undefined`
+			// is reserved for sources that cannot report usage at all.
+			expect(result.usageEvents).toEqual([]);
+			expect(result.usageTokens).toBe(10);
+		});
+
+		it("records nothing for a line that carries no usage at all", async () => {
+			// The defect this pins, measured on a real database: `parseUsageTokens`
+			// answers `{0,0,0}` rather than `undefined` for a line with no usage, so
+			// the `usage &&` guard was true for EVERY line and one row was stored per
+			// transcript line — 10,625 of 16,815 rows (63%), all `model: ''`.
+			//
+			// They summed to nothing and so moved no total, which is exactly why
+			// nothing caught them; what they did do is carry an empty `series_key`
+			// into `stats_daily`, which the Spend card renders as a NAMELESS legend
+			// swatch at $0.00 holding the first palette colour — and, with a fifth
+			// model present, pushes a real one into "Other".
+			const filePath = join(tempDir, "claude-no-usage-lines.jsonl");
+			const lines = [
+				JSON.stringify({
+					type: "user",
+					message: { role: "user", content: "hello" },
+					timestamp: "2026-03-01T09:00:00Z",
+				}),
+				JSON.stringify({ type: "summary", summary: "compacted", timestamp: "2026-03-01T09:30:00Z" }),
+				JSON.stringify({
+					message: { role: "assistant", id: "msg_real", model: "claude-opus-5", content: [] },
+					usage: { input_tokens: 7, output_tokens: 3 },
+					timestamp: "2026-03-01T10:00:00Z",
+				}),
+			];
+			await writeFile(filePath, lines.join("\n"), "utf-8");
+
+			const result = await readTranscript(filePath);
+			// One event for the one response, and no `model: ""` filler.
+			expect(result.usageEvents).toHaveLength(1);
+			expect(result.usageEvents?.[0]?.model).toBe("claude-opus-5");
+			expect(result.usageEvents?.every((e) => e.input + e.output + e.cached > 0)).toBe(true);
+			// The totals are untouched: a zero contributes nothing either way, which
+			// is what makes filtering these safe.
+			expect(result.usageTokens).toBe(10);
+		});
+
+		it("records nothing for a response whose usage is all zeroes", async () => {
+			// The narrower half of the same rule, and the one a source-level fix would
+			// have missed: `extractClaudeUsage` DID find a usage object here (it has an
+			// id), so `parseUsageTokens` cannot answer `undefined` — six such rows
+			// existed on the measured database, all `model: ''`. A response that spent
+			// nothing cannot move a bar, so its only possible effect is a legend entry.
+			const filePath = join(tempDir, "claude-zero-usage.jsonl");
+			await writeFile(
+				filePath,
+				JSON.stringify({
+					message: { role: "assistant", id: "msg_zero", content: [] },
+					usage: { input_tokens: 0, output_tokens: 0 },
+					timestamp: "2026-03-01T10:00:00Z",
+				}),
+				"utf-8",
+			);
+
+			const result = await readTranscript(filePath);
+			expect(result.usageEvents).toEqual([]);
+			expect(result.usageTokens).toBe(0);
+		});
+	});
+
 	describe("usageTokens accumulation", () => {
 		it("accumulates per-turn token usage from Claude transcript", async () => {
 			const filePath = join(tempDir, "claude-usage.jsonl");

--- a/cli/src/core/TranscriptReader.ts
+++ b/cli/src/core/TranscriptReader.ts
@@ -24,6 +24,7 @@ import { createLogger, isEnoent, type Logger } from "../Logger.js";
 import type {
 	ConversationTokenBreakdown,
 	ModelTokenUsage,
+	SessionUsageEvent,
 	ToolCallCount,
 	TranscriptCursor,
 	TranscriptEntry,
@@ -237,23 +238,40 @@ export function parseTranscriptContent(
 	// commit boundary — closing it fully means persisting the last counted id in
 	// the cursor, which is not worth the schema change at that magnitude.
 	const countedUsageKeys = new Set<string>();
+	// One entry per counted response, each with its own instant. Built in the same
+	// pass as the totals above rather than by a second scan: a separate pass would
+	// be a second place that decides what "a counted response" means, and it would
+	// have to re-resolve the same timestamps.
+	const usageEvents: SessionUsageEvent[] = [];
+
+	// The entry's own timestamp, else the parser's raw-line one.
+	//
+	// ⚠ Called only where the answer is actually used, never once per line up
+	// front. `ClaudeTranscriptParser.parseTimestamp` is a whole-line `JSON.parse`,
+	// this loop runs over every line of every transcript, and the collector re-reads
+	// each transcript WHOLE on every tick — so the fallback is charged only to the
+	// lines the cutoff or a usage event asks about, not to the entry-less lines
+	// (tool-only turns, meta records) that neither will look at. Hoisted rather
+	// than closed over `i` so resolving costs a call and not an allocation per line.
+	const timestampOf = (entry: TranscriptEntry | null, index: number): string | undefined =>
+		entry?.timestamp ?? activeParser.parseTimestamp?.(newLines[index], startLine + index);
 
 	for (let i = 0; i < newLines.length; i++) {
 		const lineNum = startLine + i;
 		const entry = parseFn(newLines[i], lineNum);
+		// Resolved here only when there IS a cutoff; reused below so a line that
+		// needs it for both purposes still pays once.
+		const cutoffTimestamp = cutoffTime ? timestampOf(entry, i) : undefined;
+
 		// Apply the time cutoff per LINE, not only per produced entry. A tool-only
 		// assistant turn yields no entry (extractContent keeps only text) yet carries
 		// a real timestamp and usage; gating only on entry-bearing lines let such a
 		// turn past the cutoff still have its tokens summed here and the cursor
 		// advanced over it, so the commit that owns it could never read those tokens.
-		// Falls back to the entry timestamp, then the parser's raw-line timestamp.
 		// Lines with no resolvable timestamp are conservatively included (they were
 		// written before the next timestamped line, so they belong to this window).
-		if (cutoffTime) {
-			const lineTimestamp = entry?.timestamp ?? activeParser.parseTimestamp?.(newLines[i], lineNum);
-			if (lineTimestamp && new Date(lineTimestamp).getTime() > cutoffTime) {
-				break; // Remaining lines (this one included) belong to a later commit
-			}
+		if (cutoffTime && cutoffTimestamp && new Date(cutoffTimestamp).getTime() > cutoffTime) {
+			break; // Remaining lines (this one included) belong to a later commit
 		}
 		if (entry) {
 			rawEntries.push(entry);
@@ -267,6 +285,46 @@ export function parseTranscriptContent(
 			usageInput += usage.input;
 			usageOutput += usage.output;
 			usageCached += usage.cached;
+			// Same response, now with its instant. A line the parser cannot date is
+			// DROPPED from the events rather than dated by guesswork: these rows are
+			// what a per-day figure is built from, and a wrong day is worse than a
+			// missing one. It still counts toward the totals above, so the session's
+			// own numbers stay whole — the two disagree only by what could not be
+			// dated, which is what `token_coverage` is for.
+			const lineTimestamp = cutoffTime ? cutoffTimestamp : timestampOf(entry, i);
+			const respondedAtMs = lineTimestamp ? new Date(lineTimestamp).getTime() : Number.NaN;
+			// A zero-token line is NOT a response worth recording, and the filter is
+			// the same one `parseUsageByModel` already applies to its buckets, for the
+			// same reason spelled out there.
+			//
+			// ⚠ Without it this pushes a row for EVERY line, not just for a response:
+			// `parseUsageTokens` answers `{input:0,output:0,cached:0}` rather than
+			// `undefined` when a line records no usage, so the `usage &&` guard above
+			// is true for user turns, tool results and meta records alike. Measured on
+			// a real database: 10,625 of 16,815 stored rows were zero-token, 63% of
+			// the table, all of them `model: ''` — and they were not inert. They
+			// carried an empty `series_key` into `stats_daily`, which the Spend card's
+			// legend renders as a NAMELESS swatch at $0.00 taking the first palette
+			// colour and shifting every real model's colour by one; with a fifth model
+			// present it would push a real one into "Other", which is exactly what
+			// `parseUsageByModel`'s filter exists to prevent. They also inflate a
+			// synced table and worsen the same-millisecond keyset pressure
+			// `SyncColumns.KEYSET_COLUMNS` measures.
+			//
+			// Filtered HERE rather than by changing `parseUsageTokens` to answer
+			// `undefined`: the totals above deliberately add a zero and do not care,
+			// the six real responses that reported zero usage still dedupe by id, and
+			// the interface keeps one return shape.
+			if (Number.isFinite(respondedAtMs) && usage.input + usage.output + usage.cached > 0) {
+				usageEvents.push({
+					respondedAtMs,
+					model: usage.model ?? "",
+					input: usage.input,
+					output: usage.output,
+					cached: usage.cached,
+					...(usage.dedupKey && { dedupKey: usage.dedupKey }),
+				});
+			}
 		}
 		// Only advance cursor for lines we actually processed (not past the break point)
 		lastConsumedLineIndex = startLine + i + 1;
@@ -300,6 +358,13 @@ export function parseTranscriptContent(
 		usageTokens: usageInput + usageOutput + usageCached,
 		usageBreakdown: { input: usageInput, output: usageOutput, cached: usageCached },
 		...(usageByModel && usageByModel.length > 0 && { usageByModel }),
+		// Present-but-empty when this source's parser can report usage at all: a
+		// re-read that sees no datable responses must be able to CLEAR rows a
+		// better read left behind (agents compact and rewrite their transcripts),
+		// and `undefined` — the one thing a consumer can distinguish from an
+		// empty set — is what "this source records none" means. Only the Claude
+		// parser defines `parseUsageTokens` today.
+		...(activeParser.parseUsageTokens ? { usageEvents } : {}),
 		// Kept even when empty: an empty array is the positive fact "this slice
 		// called no tools", which absence cannot express.
 		...(toolUse && { toolUse }),

--- a/cli/src/daemon/EnsureGlobalDaemon.ts
+++ b/cli/src/daemon/EnsureGlobalDaemon.ts
@@ -42,8 +42,8 @@ import { canUseDashboardDb } from "../dashboard/DashboardDb.js";
 import { createLogger, errMsg } from "../Logger.js";
 import { resolveCliInvocation } from "../util/CliEntry.js";
 import { spawnHidden } from "../util/Subprocess.js";
-import { GLOBAL_DAEMON_COMMAND } from "./GlobalDaemon.js";
 import {
+	GLOBAL_DAEMON_COMMAND,
 	GLOBAL_HELLO_TIMEOUT_MS,
 	type GlobalDaemonHello,
 	globalSocketPath,

--- a/cli/src/daemon/GlobalDaemon.ts
+++ b/cli/src/daemon/GlobalDaemon.ts
@@ -2,12 +2,13 @@
  * GlobalDaemon — the one resident process per machine per user.
  *
  * It exists to run work that must happen when NOBODY is asking for it: the daily
- * `jollimemory.db` snapshot, and the periodic re-scan that notices an agent
- * conversation has grown since the dashboard last imported it. Every other trigger
- * for either is opportunistic (the dashboard launcher, the post-commit worker,
- * `doctor`), which covers the user who commits regularly and abandons the user who
- * does not — exactly the user whose snapshot is oldest and whose afternoon of agent
- * work is least likely to have been recorded.
+ * `jollimemory.db` snapshot, the periodic re-scan that notices an agent conversation
+ * has grown since the dashboard last imported it, and the periodic session-activity
+ * upload. Every other trigger for any of them is opportunistic (the dashboard
+ * launcher, the post-commit worker, `doctor`), which covers the user who commits
+ * regularly and abandons the user who does not — exactly the user whose snapshot is
+ * oldest, whose afternoon of agent work is least likely to have been recorded, and
+ * whose week of sessions is least likely to have been synced.
  *
  * Owned by NO session, spawned detached. Unlike `McpDaemon` it has **no idle
  * timeout**, and that inversion is the whole point: the MCP daemon reaps itself
@@ -43,14 +44,31 @@ import { type DaemonTask, startScheduler } from "./TaskScheduler.js";
 
 const log = createLogger("GlobalDaemon");
 
-/** The hidden subcommand name, shared with the trigger that spawns it. */
-export const GLOBAL_DAEMON_COMMAND = "global-daemon";
-
 /** How long to wait for a client's greeting before dropping the connection. */
 const GREETING_TIMEOUT_MS = 5_000;
 
 /** How often to ASK the backup task whether it is due. See `TaskScheduler`. */
 const BACKUP_TICK_MS = 60 * 60 * 1000;
+
+/**
+ * How often to ASK the session sync whether it is due.
+ *
+ * The upload's real period is `MIN_ATTEMPT_INTERVAL_MS` (30 min) and it is
+ * enforced by `runSessionSync` itself, from `lastAttemptAtMs` in its own channel
+ * file — this is a tick rate, not a schedule, per the `TaskScheduler` rule that
+ * a task owns its own due-ness.
+ *
+ * ⚠ Deliberately SHORTER than that period, and equal is the bug it looks like a
+ * tidy choice. `isDueForSessionSync` is `now - lastAttempt >= interval`, so with
+ * a tick of exactly 30 min every tick lands on the boundary and any negative
+ * jitter — `setInterval` drift, a busy loop, a tick the previous run overlapped
+ * — answers "throttled" and pushes the real upload out to SIXTY minutes. It
+ * would present as the feature working, at half the rate it claims. Asking
+ * often and being told no is the shape the backup task already has (hourly, "no"
+ * 23 times out of 24); the cost here is one file read per tick, which is exactly
+ * what `isDueForSessionSync` is built to be.
+ */
+const SESSION_SYNC_TICK_MS = 5 * 60 * 1000;
 
 /** Why the daemon stopped — surfaced for logs and asserted by tests. */
 export type GlobalDaemonExitReason = "unsafe-socket-dir" | "address-in-use" | "listen-failed" | "retired";
@@ -67,13 +85,15 @@ export interface RunGlobalDaemonOptions {
 /**
  * The tasks a production daemon runs.
  *
- * Both are asked on a clock and decide for themselves whether to act, which is the
+ * Each is asked on a clock and decides for itself whether to act, which is the
  * whole of the scheduling model: `opportunisticSnapshot` reads `last-snapshot-at`
- * from the database and skips unless a day has passed, and the session re-scan
- * compares each conversation's instant against the one already stored. The daemon
- * adds no scheduling knowledge of its own — see `TaskScheduler`.
+ * from the database and skips unless a day has passed, the session re-scan compares
+ * each conversation's instant against the one already stored, and `runSessionSync`
+ * reads `lastAttemptAtMs` from its own channel file. The daemon adds no scheduling
+ * knowledge of its own — see `TaskScheduler` for why a second owner of "when did this
+ * last run" is the one thing that shape must not grow.
  *
- * The two intervals differ by two orders of magnitude and that is not an
+ * The intervals differ by two orders of magnitude and that is not an
  * inconsistency: an hourly question is right for work whose answer changes once a
  * day, and a 30-second one is right for work whose answer changes while the user is
  * typing. What makes the fast one affordable is that its converged tick does no I/O
@@ -85,6 +105,15 @@ export interface RunGlobalDaemonOptions {
  * database and writes a separate file, the re-scan's own write is a short transaction
  * at the very end, and WAL lets those coexist. Adding a cross-task mutex would mean
  * giving the scheduler shared state, which is the one thing it must not have.
+ *
+ * ⚠ The session sync belongs HERE, not only on the commit path, and the reason
+ * is the same one that put the backup here: the post-commit trigger in
+ * `QueueWorker` covers the user who commits, and abandons the user who does not
+ * — while most sessions never produce a commit at all, so gating the upload on
+ * one means a machine syncs only the conversations that happened to end in one.
+ * `runSessionSync` is called with NO cwd deliberately: the channel is
+ * cross-repo, and a machine-level timer has no single repository to ask about
+ * (see `SessionSyncOptions.cwd`).
  */
 export function defaultTasks(): ReadonlyArray<DaemonTask> {
 	return [
@@ -97,6 +126,21 @@ export function defaultTasks(): ReadonlyArray<DaemonTask> {
 			},
 		},
 		sessionRescanTask(),
+		{
+			name: "session-sync",
+			tickIntervalMs: SESSION_SYNC_TICK_MS,
+			run: async (): Promise<string> => {
+				// Imported here, not at module scope: this module is loaded by
+				// `GlobalDaemonCommand` on the ordinary CLI path, and the runner pulls in
+				// the push client and the whole HTTP stack behind it. Only the process
+				// that actually ticks needs them.
+				const { runSessionSync } = await import("../dashboard/SessionSyncRunner.js");
+				const outcome = await runSessionSync();
+				return outcome.status === "done"
+					? `sent ${outcome.rows} row(s) in ${outcome.batches} batch(es)`
+					: `${outcome.status}: ${outcome.reason}`;
+			},
+		},
 	];
 }
 

--- a/cli/src/daemon/GlobalDaemonProtocol.ts
+++ b/cli/src/daemon/GlobalDaemonProtocol.ts
@@ -33,6 +33,21 @@ import { normalizePathForCompareOn } from "../core/PathUtils.js";
 export const GLOBAL_DAEMON_PROTOCOL = 1;
 
 /**
+ * The hidden subcommand name the daemon runs under.
+ *
+ * Here rather than in `GlobalDaemon.ts` for the reason it was already
+ * documented with: it is shared with the TRIGGER that spawns it, and a trigger
+ * needs the string, not the daemon. Importing it from the implementation module
+ * put `GlobalDaemon`'s whole dependency graph — `node:net`, the backup path's
+ * `node:sqlite`, and now the session sync's push client — behind every one of
+ * `EnsureGlobalDaemon`'s five call sites, four of which are on a critical path
+ * (`post-commit`, `SessionStart`, both plugin bootstraps). Nothing in that graph
+ * is reachable from a trigger, and a trigger that only wants to spawn a
+ * subprocess should not pay to load it.
+ */
+export const GLOBAL_DAEMON_COMMAND = "global-daemon";
+
+/**
  * How long a trigger waits for `hello` before giving up on the version check.
  *
  * Deliberately NOT `HANDSHAKE_TIMEOUT_MS` (10 s). This handshake runs on the

--- a/cli/src/dashboard/DashboardCollector.ts
+++ b/cli/src/dashboard/DashboardCollector.ts
@@ -477,6 +477,23 @@ export async function sessionEventFromInfo(
 	try {
 		const read = await sessionContent.read();
 		const models: StatsModelUsage[] = toStatsModelUsage(read.usageByModel ?? []);
+		// Priced here, beside the aggregate, from the SAME model→provider mapping the
+		// aggregate was priced with — the two read the same transcript lines, so a
+		// response and the model bucket it belongs to are two views of one fact and
+		// must not be able to carry different prices.
+		//
+		// `estimateModelCostUsd` happens to key on the model id alone today, which
+		// would make any provider here produce the same number. Writing one in
+		// anyway (this used to say `"anthropic"` unconditionally) turns that
+		// implementation detail into the thing the guarantee rests on: the day
+		// pricing splits by provider — a same-named model billed differently on
+		// Bedrock or Vertex — the aggregate would move and the per-response rows
+		// would silently stay behind.
+		const providerOf = new Map((read.usageByModel ?? []).map((m) => [m.model, m.provider]));
+		const usageEvents = (read.usageEvents ?? []).map((e) => {
+			const cost = estimateModelCostUsd({ ...e, provider: providerOf.get(e.model) ?? "unknown" });
+			return { ...e, ...(cost !== null ? { estCostUsd: cost } : {}) };
+		});
 		const first = read.entries[0]?.timestamp;
 		const last = read.entries[read.entries.length - 1]?.timestamp;
 		const startedAtMs = first ? Date.parse(first) : Number.NaN;
@@ -505,6 +522,11 @@ export async function sessionEventFromInfo(
 			...(models.length > 0
 				? { models, tokenCoverage: "full" as const, pricesAsOf: PRICES_AS_OF }
 				: { tokenCoverage: "sessions-only" as const }),
+			// Forwarded whenever the reader says this source is usage-capable,
+			// including an EMPTY set: a re-read that can see usage but nothing
+			// datable must clear the rows an earlier, better read left behind —
+			// `undefined` alone means "this source records none" and leaves them.
+			...(read.usageEvents !== undefined && { usageEvents }),
 			// Forwarded only when an extractor actually answered. An empty array means
 			// "called no tools" and is worth storing; absence means "this source cannot
 			// report them", and the two must not collapse.

--- a/cli/src/dashboard/DashboardDb.test.ts
+++ b/cli/src/dashboard/DashboardDb.test.ts
@@ -523,6 +523,94 @@ describe("schema creation", () => {
 	});
 });
 
+describe("sync-stamp backfill", () => {
+	// The stamps arrived as a migration over databases that already had rows, and
+	// the whole promise is that the FIRST sync selects what business time would
+	// have selected. A fresh database proves none of that — its tables are empty
+	// when the entry runs — so this stops at the version before the stamps, seeds
+	// the rows a real machine would have, and then migrates the rest of the way.
+	async function migrateFromBeforeStamps(seed: (db: DashboardDbHandle) => void): Promise<DashboardDbHandle> {
+		const { DatabaseSync } = await import("node:sqlite");
+		const raw = new DatabaseSync(dbPath) as unknown as DashboardDbHandle;
+		// Everything up to (not including) SESSION_STATS_SYNC_DDL — the entry that
+		// carries the sync stamps — located by NAME rather than a hard-coded count: a
+		// migration appended ahead of it would otherwise silently change which version
+		// this seeds, and the seeded rows are the whole point of the test.
+		const stampIndex = MIGRATIONS.findIndex((m) => m.name === "SESSION_STATS_SYNC_DDL");
+		for (let slot = 0; slot < stampIndex; slot++) raw.exec(MIGRATIONS[slot].ddl);
+		raw.prepare("INSERT INTO schema_meta (key, value) VALUES ('schema_version', ?)").run(String(stampIndex));
+		// The log is what `migrateDashboardDb` decides from once its own entry
+		// (`SCHEMA_MIGRATIONS_DDL`) has run — the version stamp only speaks for a
+		// database with no log table at all. Seeding the entries above as applied is
+		// therefore what makes this a database at that version rather than one whose
+		// every entry looks unrun.
+		for (let slot = 0; slot < stampIndex; slot++) recordMigrationAsApplied(raw, MIGRATIONS[slot].name);
+		seed(raw);
+		migrateDashboardDb(raw);
+		return raw;
+	}
+
+	it("dates pre-existing rows from their business clock, not from 'now'", async () => {
+		const raw = await migrateFromBeforeStamps((db) => {
+			db.exec(
+				"INSERT INTO repos (repo_identity, repo_name, worktree_root, enabled_at) VALUES ('r', 'jolli', '/w', 1)",
+			);
+			db.exec(
+				`INSERT INTO sessions (event_id, repo_id, source, session_id, updated_at_ms)
+				 VALUES ('s1', 1, 'claude', 'sess-1', 1000)`,
+			);
+			db.exec(
+				`INSERT INTO session_model_usage (session_event_id, model, input_tokens, output_tokens, cached_tokens)
+				 VALUES ('s1', 'claude-opus-4-8', 1, 2, 3)`,
+			);
+			db.exec(
+				`INSERT INTO session_tool_use (session_event_id, tool_name, kind, calls)
+				 VALUES ('s1', 'Read', 'builtin', 4)`,
+			);
+			db.exec(
+				`INSERT INTO recall_receipts (receipt_id, repo_id, at_ms, surface, hit, commit_count)
+				 VALUES ('rc1', 1, 2000, 'cli', 1, 0)`,
+			);
+		});
+		try {
+			const one = (sql: string) => (raw.prepare(sql).get() as { v: number }).v;
+			// The session's own clock, and the parent's for its two child tables —
+			// so a cursor placed by business time sees exactly these rows.
+			expect(one("SELECT written_at_ms AS v FROM sessions")).toBe(1000);
+			expect(one("SELECT updated_at_ms AS v FROM session_model_usage")).toBe(1000);
+			expect(one("SELECT updated_at_ms AS v FROM session_tool_use")).toBe(1000);
+			expect(one("SELECT updated_at_ms AS v FROM recall_receipts")).toBe(2000);
+			// Commits are stamped 0 on purpose: "written before we tracked this",
+			// which is exactly right for a row that has not changed since and never
+			// makes a settled rollup day look stale.
+			expect(readSchemaVersion(raw)).toBe(DASHBOARD_SCHEMA_VERSION);
+		} finally {
+			raw.close();
+		}
+	});
+
+	it("survives a child row whose parent session is gone", async () => {
+		// The column is NOT NULL, so the backfill's subquery returning NULL would
+		// abort the migration — and an aborted migration is a database nobody can
+		// open. COALESCE is what keeps an orphan cheap: it lands on 0.
+		const raw = await migrateFromBeforeStamps((db) => {
+			db.exec("PRAGMA foreign_keys = OFF");
+			db.exec(
+				`INSERT INTO session_model_usage (session_event_id, model, input_tokens, output_tokens, cached_tokens)
+				 VALUES ('missing', 'claude-opus-4-8', 1, 2, 3)`,
+			);
+		});
+		try {
+			expect((raw.prepare("SELECT updated_at_ms AS v FROM session_model_usage").get() as { v: number }).v).toBe(
+				0,
+			);
+			expect(readSchemaVersion(raw)).toBe(DASHBOARD_SCHEMA_VERSION);
+		} finally {
+			raw.close();
+		}
+	});
+});
+
 describe("transactional migration runner", () => {
 	it("rolls a failed entry back — the version does not move and a retry succeeds", async () => {
 		// A conflicting object makes the entry fail part-way through, after it has

--- a/cli/src/dashboard/DashboardDb.ts
+++ b/cli/src/dashboard/DashboardDb.ts
@@ -37,7 +37,14 @@ import {
 	RECALL_RECEIPTS_DDL,
 	REPOS_DELETE_ALLOWED_DDL,
 	SCHEMA_MIGRATIONS_DDL,
+	SESSION_USAGE_EVENTS_DDL,
 	SKILL_CONTEXT_KIND_DDL,
+	STATS_DAILY_DAY_INDEX_DDL,
+	STATS_DAILY_DDL,
+	SYNC_KEYSET_INDEX_DDL,
+	SYNC_STAMP_DDL,
+	SYNC_STAMP_INDEX_DDL,
+	SYNC_STAMP_NULL_BACKFILL_DDL,
 	TOOL_CALL_TIME_DDL,
 } from "./SotSchema.js";
 
@@ -56,7 +63,27 @@ const log = createLogger("DashboardDb");
  * the fourth `context` kind; entry 3 adds `events_raw.failed_kind` so an event
  * parked by an older build that did not know its type can be un-parked by one
  * that does; entry 4 adds `session_tool_use.last_call_at_ms`; entry 5 adds the
- * `schema_migrations` log.
+ * `schema_migrations` log; entry 6 drops the `repos_no_delete` trigger;
+ * entry 7 is the session-statistics sync, whose seven DDL constants are
+ * concatenated into ONE entry rather than appended one per step: the per-row
+ * sync stamps that let an outbound sync select what changed, the
+ * `session_usage_events` table (one row per model response, because a session's
+ * cumulative total under a single timestamp cannot be split across the days the
+ * conversation actually spanned), the `stats_daily` rollup cache plus the
+ * `commits.written_at_ms` that detects a stale day, the stamp and keyset indexes
+ * those two need, and the backfill that gives every stamp a number.
+ *
+ * ONE entry because the intermediate versions those steps produced (8 through 13)
+ * exist on no database anybody will ever ship or receive — they were this
+ * branch's own development history, and a version the release cannot reach is
+ * bookkeeping nobody can act on. That merge is only legal because the feature has
+ * not shipped; once it has, the append-only rule below takes over and the next
+ * feature's steps must each be their own entry. The cost of getting this wrong is
+ * concrete and was measured here: `buildRollupQuietly` stops maintaining the
+ * daily cache the moment the file's number exceeds the build's, so five of those
+ * seven steps — three index entries, an ALTER and a backfill, none of which can
+ * introduce a table an older build cannot see — would each have disabled that
+ * cache on every older build for nothing.
  *
  * Bumping it is NOT a cross-surface event any more, and that is the one thing
  * worth knowing about it: nothing refuses a database over this number (see the
@@ -82,7 +109,7 @@ const log = createLogger("DashboardDb");
  * user's database (other processes may hold the file open, and the memory half
  * is the only copy there is).
  */
-export const DASHBOARD_SCHEMA_VERSION = 7;
+export const DASHBOARD_SCHEMA_VERSION = 8;
 
 /**
  * NOTE ON COMPATIBILITY, because its absence here is a decision.
@@ -328,6 +355,37 @@ BEGIN SELECT RAISE(ABORT, 'repos are never deleted: set disabled_at instead'); E
 	{ name: "TOOL_CALL_TIME_DDL", ddl: TOOL_CALL_TIME_DDL },
 	{ name: "SCHEMA_MIGRATIONS_DDL", ddl: SCHEMA_MIGRATIONS_DDL },
 	{ name: "REPOS_DELETE_ALLOWED_DDL", ddl: REPOS_DELETE_ALLOWED_DDL },
+	{
+		// The seven steps the session-statistics sync was developed in, in the order
+		// they were written, concatenated verbatim. Concatenated rather than rewritten
+		// so this entry is provably the same statement sequence a machine that took
+		// the granular path already ran — see `DASHBOARD_SCHEMA_VERSION` for why they
+		// are one entry, and note the redundancy that proves the point: `STATS_DAILY_DDL`
+		// already creates the `(tz, day)` index inline, so the index constant after it
+		// is a second `CREATE INDEX IF NOT EXISTS` over the same object. It stays,
+		// because "identical to what already ran" is worth more here than tidiness.
+		//
+		// ⚠ Nothing here may be a DATA cleanup, and the reason is measured. A schema
+		// step is idempotent or guarded, so a database that already ran this entry is
+		// already in the target state; a DELETE has to EXECUTE to mean anything, and
+		// the log is keyed by NAME — so a database with an `applied` row for this name
+		// skips it in silence. Appending one was tried: on a real database it left
+		// 10,631 junk rows and 550 stale cache rows untouched and the page bit-for-bit
+		// unfixed, and there is no repair either, because forcing a re-run dies on
+		// `duplicate column name: written_at_ms` at the first ALTER while
+		// `--mark-migration` just re-establishes the skip. While this entry is
+		// unreleased the affected databases are developers' own, so such data is
+		// cleared by hand instead.
+		name: "SESSION_STATS_SYNC_DDL",
+		ddl:
+			SYNC_STAMP_DDL +
+			SESSION_USAGE_EVENTS_DDL +
+			STATS_DAILY_DDL +
+			STATS_DAILY_DAY_INDEX_DDL +
+			SYNC_STAMP_INDEX_DDL +
+			SYNC_KEYSET_INDEX_DDL +
+			SYNC_STAMP_NULL_BACKFILL_DDL,
+	},
 ];
 
 /** Reads the stored schema version, treating a fresh DB as 0. */

--- a/cli/src/dashboard/DashboardModel.ts
+++ b/cli/src/dashboard/DashboardModel.ts
@@ -15,7 +15,14 @@
  */
 
 import type { KnowledgeGraph } from "../graph/GraphSchema.js";
-import type { LocalAgentToolId, RecallOutcome, ToolCallCount, ToolCallKind, TranscriptSource } from "../Types.js";
+import type {
+	LocalAgentToolId,
+	RecallOutcome,
+	SessionUsageEvent,
+	ToolCallCount,
+	ToolCallKind,
+	TranscriptSource,
+} from "../Types.js";
 
 /**
  * Version stamped on every event written to `events_raw`. Bump when an event's
@@ -58,6 +65,21 @@ export interface SessionUpsertedEvent {
 	readonly tokenCoverage?: TokenCoverage;
 	readonly pricesAsOf?: string;
 	readonly models?: ReadonlyArray<StatsModelUsage>;
+	/**
+	 * One entry per counted model response, each carrying its own instant.
+	 *
+	 * REPLACES the stored set when present, on the same terms as {@link models}:
+	 * a re-read attributing usage to fewer responses must not leave the extras
+	 * behind. `undefined` means this producer could not see per-response usage
+	 * (only the Claude parser can today) and leaves existing rows alone; an
+	 * empty array means it saw usage but nothing datable, which REPLACES the
+	 * stored set with nothing so a transcript rewrite cannot leave stale rows.
+	 *
+	 * {@link models} is the same numbers with the time thrown away. Both are
+	 * carried because the summary stores the aggregate, but only this one can be
+	 * placed on a calendar — see `SESSION_USAGE_EVENTS_DDL`.
+	 */
+	readonly usageEvents?: ReadonlyArray<SessionUsageEvent>;
 	/**
 	 * Tool calls observed in the session's transcript. REPLACES the stored set
 	 * when present; `undefined` means "this producer could not see tools" and
@@ -569,6 +591,22 @@ export interface SettingsMemoryBank {
 	readonly repoLabel?: string;
 }
 
+/**
+ * The Sync to Jolli tab's own fields. Sign-in state is NOT here (it comes from
+ * `summary.signedIn`, which the AI Summary tab needs too) and neither is the
+ * per-repo push list, which loads from its own endpoint.
+ */
+export interface SettingsSync {
+	/**
+	 * Session statistics sync — see `JolliMemoryConfig.syncSessions`. Seeds the
+	 * switch's initial position only: the page writes this one through
+	 * `/api/settings/set-sync-sessions` on change and never submits it with the
+	 * batched save, so that every switch on the tab applies immediately (the
+	 * per-repo ones beside it always did).
+	 */
+	readonly syncSessions: boolean;
+}
+
 /** The Others tab. */
 export interface SettingsOthers {
 	readonly dcoSignoff: boolean;
@@ -583,6 +621,7 @@ export interface SettingsOthers {
 export interface SettingsPageModel {
 	readonly agents: SettingsAgents;
 	readonly summary: SettingsSummary;
+	readonly sync: SettingsSync;
 	readonly memoryBank: SettingsMemoryBank;
 	readonly others: SettingsOthers;
 }

--- a/cli/src/dashboard/DashboardQuery.test.ts
+++ b/cli/src/dashboard/DashboardQuery.test.ts
@@ -22,16 +22,11 @@ import type {
 	ToolUsageRow,
 } from "./DashboardModel.js";
 import { MEMORY_CARDS_LIMIT, TOOL_ROWS_LIMIT } from "./DashboardModel.js";
-import {
-	addLocalDays,
-	buildDashboardModel,
-	buildToolUsagePage,
-	localDayKey,
-	localHour,
-	machineTimeZone,
-	type QueryOptions,
-	startOfLocalDay,
-} from "./DashboardQuery.js";
+
+/** UTC+8, no DST — the zone the day-boundary cases below contrast with UTC. */
+const SH = "Asia/Shanghai";
+
+import { buildDashboardModel, buildToolUsagePage, type QueryOptions } from "./DashboardQuery.js";
 import { volumeReachable } from "./RepoForget.js";
 import { applyStatsEvents } from "./StatsWriter.js";
 
@@ -188,56 +183,6 @@ async function applySummaryEvents(
 	);
 }
 
-const SH = "Asia/Shanghai"; // UTC+8, no DST
-const LA = "America/Los_Angeles"; // DST
-
-describe("time-zone engine", () => {
-	it("assigns a 23:30 UTC session to the NEXT local day in Asia/Shanghai", () => {
-		const ms = Date.parse("2026-07-29T23:30:00Z"); // 07:30 on the 30th in Shanghai
-		expect(localDayKey(ms, SH)).toBe("2026-07-30");
-		expect(localDayKey(ms, "UTC")).toBe("2026-07-29");
-	});
-
-	it("computes local midnight boundaries, not UTC ones", () => {
-		const ms = Date.parse("2026-07-30T10:00:00Z");
-		// Shanghai midnight of Jul 30 = Jul 29 16:00 UTC.
-		expect(startOfLocalDay(ms, SH)).toBe(Date.parse("2026-07-29T16:00:00Z"));
-		expect(startOfLocalDay(ms, "UTC")).toBe(Date.parse("2026-07-30T00:00:00Z"));
-	});
-
-	it("handles the 23-hour spring-forward day in America/Los_Angeles", () => {
-		// 2026-03-08: DST starts, 02:00 → 03:00. The day is 23 hours long.
-		const midnight = startOfLocalDay(Date.parse("2026-03-08T20:00:00Z"), LA);
-		expect(localDayKey(midnight, LA)).toBe("2026-03-08");
-		const nextMidnight = addLocalDays(midnight, 1, LA);
-		expect(localDayKey(nextMidnight, LA)).toBe("2026-03-09");
-		expect(nextMidnight - midnight).toBe(23 * 3_600_000);
-	});
-
-	it("handles the 25-hour fall-back day", () => {
-		// 2026-11-01: DST ends. The day is 25 hours long.
-		const midnight = startOfLocalDay(Date.parse("2026-11-01T20:00:00Z"), LA);
-		const nextMidnight = addLocalDays(midnight, 1, LA);
-		expect(nextMidnight - midnight).toBe(25 * 3_600_000);
-	});
-
-	it("addLocalDays walks backwards too", () => {
-		const ms = Date.parse("2026-07-30T10:00:00Z");
-		expect(localDayKey(addLocalDays(ms, -1, SH), SH)).toBe("2026-07-29");
-		expect(localDayKey(addLocalDays(ms, 0, SH), SH)).toBe("2026-07-30");
-	});
-
-	it("localHour reports the wall-clock hour in the requested zone", () => {
-		const ms = Date.parse("2026-07-29T23:30:00Z");
-		expect(localHour(ms, SH)).toBe(7); // 07:30 next day
-		expect(localHour(ms, "UTC")).toBe(23);
-	});
-
-	it("machineTimeZone returns a resolvable IANA name", () => {
-		expect(() => new Intl.DateTimeFormat("en", { timeZone: machineTimeZone() })).not.toThrow();
-	});
-});
-
 describe("buildDashboardModel", () => {
 	let dir: string;
 	let dbPath: string;
@@ -334,6 +279,105 @@ describe("buildDashboardModel", () => {
 			{ producerKind: "cli", dbPath },
 		);
 	}
+
+	/**
+	 * A session whose per-response rows are INCOMPLETE must be counted by its
+	 * session-level total, not by the part it has.
+	 *
+	 * The rule this pins used to be an existence test (`NOT EXISTS (…events…)`)
+	 * where the question is completeness, and the difference was silent loss.
+	 * Measured on a real database: one session of 2,048,519 tokens had a single
+	 * event row worth 52,020, so 97.5% of it appeared nowhere — 2,775,239 tokens
+	 * and $23.39 missing from a 30-day window. A partial row set is reachable by
+	 * construction, not a parser defect: `projectSession` replaces the rows
+	 * wholesale (so a read cut short by a `beforeTimestamp` cutoff writes only its
+	 * slice), while `projectCommitSummary` restores `sessions` and
+	 * `session_model_usage` to the full figures and has no write for this table.
+	 *
+	 * Both arms are asserted together, because the two failures are opposite: a
+	 * predicate that is not the exact complement of the other either drops the
+	 * partial session's remainder or counts the complete one twice.
+	 */
+	it("counts a session with partial usage rows by its session total, and a complete one by its rows", async () => {
+		const partialDay = Date.parse("2026-07-28T10:00:00Z");
+		const completeDay = Date.parse("2026-07-20T10:00:00Z");
+		await applySummaryEvents(
+			[
+				{
+					producerKind: "cli",
+					event: {
+						type: "repo.enabled",
+						repoIdentity: "repo-1",
+						repoName: "jolli",
+						worktreeRoot: "/w",
+						enabledAt: "t",
+					},
+				},
+				// Its rows account for 100 of 1000 — the shape a truncated read leaves.
+				session({
+					sessionId: "partial",
+					updatedAtMs: partialDay,
+					models: undefined,
+					inputTokens: 1000,
+					outputTokens: 0,
+					cachedTokens: 0,
+					usageEvents: [
+						{
+							respondedAtMs: partialDay,
+							model: "claude-opus-5",
+							input: 100,
+							output: 0,
+							cached: 0,
+							dedupKey: "p1",
+						},
+					],
+				}),
+				// Its rows account for all 500.
+				session({
+					sessionId: "complete",
+					updatedAtMs: partialDay,
+					models: undefined,
+					inputTokens: 500,
+					outputTokens: 0,
+					cachedTokens: 0,
+					usageEvents: [
+						{
+							respondedAtMs: completeDay,
+							model: "claude-opus-5",
+							input: 500,
+							output: 0,
+							cached: 0,
+							dedupKey: "c1",
+						},
+					],
+				}),
+			],
+			{ dbPath, producerKind: "cli" },
+		);
+
+		const model = await withDashboardDb(
+			(db) =>
+				buildDashboardModel(db, {
+					view: "stats",
+					scope: { kind: "all" },
+					timeZone: "UTC",
+					nowMs,
+					dimension: "model",
+					range: "month",
+				}),
+			{ dbPath },
+		);
+		const perDay = new Map(model.stats?.tokenBreakdown.perDay.map((d) => [d.date, d.input]) ?? []);
+
+		// 1500, not 600 (the partial session's remainder dropped) and not 2000
+		// (both arms counting it).
+		expect(model.stats?.tokenBreakdown.input).toBe(1500);
+		// The complete one is placed on its RESPONSE's day, eight days before the
+		// session was last touched — the distribution this table exists for.
+		expect(perDay.get("2026-07-20")).toBe(500);
+		// The partial one falls back whole onto its session day.
+		expect(perDay.get("2026-07-28")).toBe(1000);
+	});
 
 	it("serves every group-by axis, and falls back to model for memory-only axes at tier 0", async () => {
 		await seed();

--- a/cli/src/dashboard/DashboardQuery.ts
+++ b/cli/src/dashboard/DashboardQuery.ts
@@ -69,8 +69,18 @@ import {
 	splitDecisionBullets,
 	stripPluginPrefixSql,
 } from "./DashboardScopeUtil.js";
+import {
+	addLocalDays,
+	dayKeyToMidnight,
+	localDayKey,
+	localHour,
+	machineTimeZone,
+	startOfLocalDay,
+} from "./LocalDays.js";
 import { buildMemories, isReachable, type ReachableCommits } from "./MemoriesQuery.js";
 import { volumeReachable } from "./RepoForget.js";
+import { type DayPlan, planDays, readRollupSeries, TOKENS_KIND } from "./StatsRollup.js";
+import { MEMORY_LANDING_CTE, readAxisRows, readDatedUsage } from "./StatsSeries.js";
 import { WORKTREE_STATUS_MAX_AGE_MS } from "./StatsWriter.js";
 
 const log = createLogger("DashboardQuery");
@@ -110,131 +120,10 @@ const DEFAULT_RANGE: PresetRange = "month";
  */
 const MAX_CUSTOM_DAYS = 366;
 
-/** Shape of a local calendar day key, `YYYY-MM-DD`. */
-const DAY_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
 /** A session updated within this window renders as "live". */
 const LIVE_WINDOW_MS = 10 * 60 * 1000;
 /** Local hour at or after which a session counts as night-owl work. */
 const NIGHT_OWL_HOUR = 21;
-
-// ── Time-zone engine ────────────────────────────────────────────────────────
-
-/** The machine's IANA zone — the default for every query. */
-export function machineTimeZone(): string {
-	return Intl.DateTimeFormat().resolvedOptions().timeZone;
-}
-
-interface ZonedParts {
-	readonly year: number;
-	readonly month: number;
-	readonly day: number;
-	readonly hour: number;
-	readonly minute: number;
-}
-
-const partsFormatterCache = new Map<string, Intl.DateTimeFormat>();
-
-function partsFormatter(timeZone: string): Intl.DateTimeFormat {
-	let formatter = partsFormatterCache.get(timeZone);
-	if (!formatter) {
-		formatter = new Intl.DateTimeFormat("en-CA", {
-			timeZone,
-			year: "numeric",
-			month: "2-digit",
-			day: "2-digit",
-			hour: "2-digit",
-			minute: "2-digit",
-			hourCycle: "h23",
-		});
-		partsFormatterCache.set(timeZone, formatter);
-	}
-	return formatter;
-}
-
-/** Wall-clock components of `ms` in `timeZone`. */
-function zonedParts(ms: number, timeZone: string): ZonedParts {
-	const parts = partsFormatter(timeZone).formatToParts(ms);
-	const get = (type: string) => Number.parseInt(parts.find((p) => p.type === type)?.value ?? "0", 10);
-	return { year: get("year"), month: get("month"), day: get("day"), hour: get("hour"), minute: get("minute") };
-}
-
-/** Local calendar day of `ms` as `YYYY-MM-DD`. */
-export function localDayKey(ms: number, timeZone: string): string {
-	const p = zonedParts(ms, timeZone);
-	return `${p.year}-${String(p.month).padStart(2, "0")}-${String(p.day).padStart(2, "0")}`;
-}
-
-/** Local hour (0–23) of `ms`. */
-export function localHour(ms: number, timeZone: string): number {
-	return zonedParts(ms, timeZone).hour;
-}
-
-/**
- * Epoch-ms of local midnight at the start of the day containing `ms`.
- *
- * `Intl` can only map epoch → wall clock; this inverts it by guessing the UTC
- * value of the wall-clock midnight and correcting by the observed error. Two
- * iterations settle every real zone including DST transitions: the first
- * correction lands within the zone's offset step, the second removes any
- * residue from a transition between guess and target. (On a "spring forward"
- * day where 00:00 does not exist, this lands on the earliest existing instant
- * of the day — exactly what a day boundary should be.)
- */
-function localMidnight(year: number, month: number, day: number, timeZone: string): number {
-	let guess = Date.UTC(year, month - 1, day);
-	for (let i = 0; i < 3; i++) {
-		const seen = zonedParts(guess, timeZone);
-		const error =
-			Date.UTC(seen.year, seen.month - 1, seen.day, seen.hour, seen.minute) - Date.UTC(year, month - 1, day);
-		if (error === 0) break;
-		guess -= error;
-	}
-	return guess;
-}
-
-export function startOfLocalDay(ms: number, timeZone: string): number {
-	const target = zonedParts(ms, timeZone);
-	return localMidnight(target.year, target.month, target.day, timeZone);
-}
-
-/**
- * Epoch-ms of local midnight starting the day `key` (`YYYY-MM-DD`) names, or
- * `undefined` when `key` is not a real local day.
- *
- * The round-trip check is the validation: `Date.UTC` happily normalises
- * 2026-02-31 into March 3rd, so a request for a day that does not exist would
- * otherwise silently return data for a different one. Comparing the resolved
- * instant's own day key against the input rejects exactly that case — and
- * costs nothing on the overwhelmingly common valid input.
- */
-function dayKeyToMidnight(key: string, timeZone: string): number | undefined {
-	if (!DAY_KEY_RE.test(key)) return undefined;
-	const ms = localMidnight(
-		Number.parseInt(key.slice(0, 4), 10),
-		Number.parseInt(key.slice(5, 7), 10),
-		Number.parseInt(key.slice(8, 10), 10),
-		timeZone,
-	);
-	return localDayKey(ms, timeZone) === key ? ms : undefined;
-}
-
-/**
- * Start of the local day `n` days after the day containing `ms`. Steps through
- * midday rather than adding exact 24 h multiples, so 23- and 25-hour DST days
- * cannot skip or repeat a day.
- */
-export function addLocalDays(ms: number, days: number, timeZone: string): number {
-	let cursor = startOfLocalDay(ms, timeZone);
-	const step = days >= 0 ? 1 : -1;
-	for (let i = 0; i !== days; i += step) {
-		// ±24 h from midnight, then +12 h INTO the target day: lands mid-day in
-		// the neighbouring day whether it is 23, 24 or 25 hours long, and
-		// startOfLocalDay snaps back to its midnight. (A ±36 h jump would
-		// overshoot a whole day when stepping backwards.)
-		cursor = startOfLocalDay(cursor + step * 86_400_000 + 43_200_000, timeZone);
-	}
-	return cursor;
-}
 
 // ── Range resolution ────────────────────────────────────────────────────────
 
@@ -573,115 +462,6 @@ const TOPIC_INSIGHTS_CTE = `WITH topic_insights AS (
 	   AND TRIM(COALESCE(json_extract(t.value, '$.todo'), '')) <> ''
 )`;
 
-/**
- * Where a memory LANDED: the commit its work sits on today, and that commit's
- * committer date.
- *
- * **One of TWO spellings of that rule.** This one is for callers that need the
- * landing as DATA — the `category` axis windows on `at_ms`, and
- * {@link buildMemoryCards} needs both `at_ms` and `live_hash`. Callers that only
- * need to know which memory belongs to a commit they already have use
- * {@link MEMORY_FOR_COMMIT} instead, and the choice between them is a measured
- * performance fact, not a style preference — see that constant's note.
- *
- * The three queries here join it on `commit_hash`, a REAL column, which is what
- * keeps it cheap (38 ms against the pre-alias query's 43 ms on a 165 MB
- * database). `live_hash` is a COALESCE and therefore unindexable: joining on
- * THAT is what cost 3,146 ms.
- *
- * A hash rewritten after it was summarized leaves the memory filed under the
- * PRE-rewrite hash while `commits` moves on to the new one, so `m.commit_hash`
- * alone answers neither question. `commit_aliases` maps the surviving hash back
- * (`old_hash` -> the memory's `target_hash`), which is the direction
- * {@link commitsInRange} and {@link buildDecisionsCard} enter from; this CTE
- * walks it BACKWARDS, from the memory to whichever live commit points at it.
- *
- * Two consequences that are the whole reason it exists:
- *
- * - **`live_hash` is what a reachability check has to be asked about.** The
- *   memory's own hash was rewritten away, so `isReachable` answers `false` for
- *   it forever — dropping a memory from the feed that `memoriesCreated`, which
- *   enters from the live commit, has just counted.
- * - **`at_ms` is the LANDED committer date.** The old fallback went straight to
- *   `m.commit_date_ms`, which is `CommitSummary.commitDate` — an AUTHOR date
- *   (`%aI`), while every window in this file is a committer-date window. For a
- *   rebase or a cherry-pick those are different days, and for a rewritten
- *   commit the fallback was not an edge case but the permanent state: no
- *   `commits` row will ever carry the memory's own hash again. `commit_date_ms`
- *   survives as the third choice, for a memory whose commit this database has
- *   not collected at all.
- *
- * **The alias sub-select is grouped, and the JOIN onto `commits` is what keeps
- * that honest.** A memory rewritten more than once collects an alias row per
- * rewrite, and `live_hash`/`at_ms` have to come from ONE of them — but only
- * aliases whose commit still EXISTS survive that join, and
- * `pruneUnreachableCommits` deletes every superseded link in the chain, so the
- * group is normally a single row. `MAX(c.committed_at_ms)` picks the newest for
- * the window before it converges, and `c.hash` rides along as a bare column,
- * which SQLite documents as coming from that same max row. Two live commits
- * aliasing one memory at the identical millisecond is the only case that would
- * make the pair ambiguous, and it resolves to a real commit either way.
- *
- * **`cm` wins over `al` when both resolve.** A tree-hash alias is not proof the
- * memory moved: cherry-picking a commit onto two branches gives it aliases while
- * its own commit is still very much alive, and that memory belongs to its own
- * commit. So the alias is consulted only when nothing carries the memory's own
- * hash — the same order as `getSummary`'s direct-then-alias lookup.
- *
- * `parent_hash IS NULL` for the same reason every caller states it: `memories`
- * holds one row per GENERATION.
- */
-const MEMORY_LANDING_CTE = `WITH memory_landing AS (
-	SELECT m.repo_id, m.commit_hash,
-	       COALESCE(cm.hash, al.live_hash, m.commit_hash) AS live_hash,
-	       COALESCE(cm.committed_at_ms, al.at_ms, m.commit_date_ms) AS at_ms
-	  FROM memories m
-	  LEFT JOIN commits cm ON cm.repo_id = m.repo_id AND cm.hash = m.commit_hash
-	  LEFT JOIN (
-	      SELECT a.repo_id, a.target_hash, c.hash AS live_hash, MAX(c.committed_at_ms) AS at_ms
-	        FROM commit_aliases a
-	        JOIN commits c ON c.repo_id = a.repo_id AND c.hash = a.old_hash
-	       GROUP BY a.repo_id, a.target_hash
-	  ) al ON al.repo_id = m.repo_id AND al.target_hash = m.commit_hash
-	 WHERE m.parent_hash IS NULL
-)`;
-
-/**
- * The same landing rule as {@link MEMORY_LANDING_CTE}, read from the COMMIT end:
- * "which memory belongs to this commit". Joins as
- * `JOIN memories m ON m.repo_id = c.repo_id AND (${MEMORY_FOR_COMMIT})`, with the
- * commit aliased `c`.
- *
- * **Two spellings of one rule is a deliberate, measured exception**, so the
- * numbers matter. The CTE exposes `live_hash` as a COALESCE — a computed column,
- * which SQLite cannot index — so an axis that enters from `commits` and joins
- * `ml.live_hash = c.hash` re-scans the whole materialised CTE per commit. On the
- * author's 165 MB database (1,123 memories / 2,434 commits / 87 aliases), the
- * branch axis measured:
- *
- * - joining the CTE on `live_hash`: **3,146 ms** (`MATERIALIZED` hint: 94 ms)
- * - this predicate: **1.1 ms**, against 0.9 ms for the pre-alias query it replaces
- *
- * `buildSeries` runs twice per render (the window and its predecessor), so the
- * CTE spelling was a ~6 s page. The axes that keep the CTE — `category` and
- * `buildMemoryCards` — join it on `commit_hash`, a REAL column, and measured
- * 38 ms against the old query's 43 ms.
- *
- * **`NOT EXISTS` is what makes this safe, and it is the `cm`-beats-`al`
- * precedence written from the other side.** Without it the alias branch fires
- * while the memory's own commit row is still present, so the pre-rewrite commit
- * matches the memory directly AND the live one matches it through the alias —
- * measured 2x on a synthetic prune-window fixture. With it, exactly one commit
- * claims each memory in every state: the memory's own row while it survives, the
- * aliasing commit once `pruneUnreachableCommits` has removed it. All four
- * variants were verified to return byte-identical rows on the real database.
- */
-const MEMORY_FOR_COMMIT = `m.commit_hash = c.hash
-	     OR (m.commit_hash = (SELECT a.target_hash FROM commit_aliases a
-	                           WHERE a.repo_id = c.repo_id AND a.old_hash = c.hash)
-	         AND NOT EXISTS (SELECT 1 FROM commits c2
-	                          WHERE c2.repo_id = c.repo_id AND c2.hash = m.commit_hash))`;
-
 const totalTokens = (row: SessionRow): number => row.input_tokens + row.output_tokens + row.cached_tokens;
 
 // ── Stats page ──────────────────────────────────────────────────────────────
@@ -710,187 +490,124 @@ interface SeriesResult {
 }
 
 /**
- * The 14-day series along one dimension. `model`/`agent` read session usage;
- * `branch`/`ticket` read the memory-enriched commit columns (and silently fall
- * back to `model` below the memory tier, so a stale URL cannot render an empty
- * chart pretending to be data).
+ * The token card's segments, placed on the day each response happened.
  *
- * **Every memory-driven axis filters `m.parent_hash IS NULL`.** `memories` holds
- * one row per GENERATION, not per memory: amending or squashing a commit leaves
- * its predecessor behind as a child row carrying the same cost, so an unfiltered
- * SUM bills one piece of work once per rewrite. `parent_hash IS NULL` is the
- * repo-wide spelling of "current generation" (`MemoriesQuery.ts`,
- * {@link TOPIC_INSIGHTS_CTE} above, `buildMemoryCards` below) — never "has no
- * children", which is a different set.
+ * Reads the same two sources the spend axes do, through the same plan: settled
+ * days come out of the rollup's `tokens` kind, the rest out of
+ * {@link readDatedUsage}. Keeping the two halves on one plan is what makes the
+ * card's total equal the sum of its own bars — the failure this replaces put a
+ * three-day conversation's whole token count on the day it ended.
+ */
+function readTokenTotals(
+	db: DashboardDbHandle,
+	scope: DashboardScope,
+	timeZone: string,
+	plan: DayPlan,
+): TokenBreakdown {
+	const perDay = new Map<string, { input: number; output: number; cached: number }>();
+	for (const day of plan.dayKeys) perDay.set(day, { input: 0, output: 0, cached: 0 });
+
+	for (const row of readRollupSeries(db, timeZone, TOKENS_KIND, plan.cached, scope)) {
+		const cell = perDay.get(row.day);
+		if (!cell) continue;
+		if (row.series_key === "input") cell.input += row.value;
+		else if (row.series_key === "output") cell.output += row.value;
+		else if (row.series_key === "cached") cell.cached += row.value;
+	}
+	if (plan.live.size > 0) {
+		for (const row of readDatedUsage(db, scope, plan.liveFromMs, plan.liveToMs)) {
+			const day = localDayKey(row.bucket_at_ms, timeZone);
+			if (!plan.live.has(day)) continue;
+			const cell = perDay.get(day);
+			if (!cell) continue;
+			cell.input += row.input;
+			cell.output += row.output;
+			cell.cached += row.cached;
+		}
+	}
+
+	let input = 0;
+	let output = 0;
+	let cached = 0;
+	for (const cell of perDay.values()) {
+		input += cell.input;
+		output += cell.output;
+		cached += cell.cached;
+	}
+	// Rounded at emission rather than per row, for the reason `buildSeries`
+	// records: a cached day sums pre-aggregated subtotals while a live day sums
+	// raw rows, and the apportioning axes make both fractional.
+	return {
+		input: Math.round(input),
+		output: Math.round(output),
+		cached: Math.round(cached),
+		perDay: [...perDay.entries()].map(([date, v]) => ({
+			date,
+			input: Math.round(v.input),
+			output: Math.round(v.output),
+			cached: Math.round(v.cached),
+		})),
+	};
+}
+
+/**
+ * One dimension's per-day series over the window `plan` was cut for.
  *
- * The INNER JOIN on `commits` is NOT a substitute, though it looks like one: it
- * drops only predecessors whose commit row is gone, and `commits` deliberately
- * retains unreachable rows (see the `isReachable` filter on `memoriesCreated`).
- * Measured on a real database before this filter existed: the ticket axis read
- * $150.97 against a true $92.93 (1.6x) and the LEFT-JOINed category axis read
- * $3,490.47 against $366.03 (9.5x).
+ * The window arrives as the PLAN and not as a `fromMs`/`toMs` pair: `plan.dayKeys`
+ * is already every local day in it, produced by the same walk this used to repeat
+ * — and repeating it meant two ways of deciding which days a chart has, one of
+ * which could disagree with the cache's own split.
  *
- * **And every memory-driven axis resolves a rewritten commit, by one of the two
- * spellings of the landing rule.** `category` windows on the landing DATE, so it
- * carries {@link MEMORY_LANDING_CTE}; `branch` and `ticket` only need the memory
- * that belongs to a commit they already have in hand, so they enter from
- * `commits` with {@link MEMORY_FOR_COMMIT}. That split is a measured performance
- * fact — the CTE spelling made the branch axis a 3,146 ms query — and NOT an
- * invitation to unify them the other way.
- *
- * What neither spelling may become is the naive repair. Joining plain
- * `m.commit_hash = c.hash` drops a rewritten commit's memory outright (its hash
- * moved, the memory's did not) — that is the bug this PR fixes, where `branch`
- * and `ticket` lost spend that Memory Activity and Decisions, both of which walk
- * the alias, went on counting. But adding a bare `OR c.hash = al.target_hash`
- * trades the hole for a double count: until `pruneUnreachableCommits` sweeps,
- * the pre-rewrite commit row is still there and matches the memory directly
- * while the live one matches it through the alias, so one piece of work bills
- * twice (measured 2x). `MEMORY_FOR_COMMIT`'s `NOT EXISTS` is precisely what
- * closes that, and it is why the predicate is longer than it looks like it
- * needs to be.
+ * See {@link ./StatsSeries.ts} for the axis SQL itself and the rules it encodes
+ * (`m.parent_hash IS NULL`, and the two spellings of the rewritten-commit landing
+ * rule); the numbers here are that reader's rows, bucketed.
  */
 function buildSeries(
 	db: DashboardDbHandle,
 	scope: DashboardScope,
 	dimension: SeriesDimension,
 	tier: AdoptionTier,
-	fromMs: number,
-	toMs: number,
 	timeZone: string,
+	plan: DayPlan,
 ): SeriesResult {
 	// Memory-only axes fall back to `model` below the memory tier, so a stale URL
 	// renders real data instead of an empty chart pretending to be one.
+	//
+	// The fallback is resolved HERE and never reaches the cache: it is a display
+	// decision, and a repo that crosses the tier later must not find its stored
+	// `branch` days holding model data.
 	const memoryOnly = dimension === "branch" || dimension === "ticket" || dimension === "category";
 	const effective: SeriesDimension = memoryOnly && tier === "installed" ? "model" : dimension;
 
-	interface UsageRow {
-		readonly at_ms: number;
-		readonly key: string;
-		readonly tokens: number;
-		readonly cost: number;
-	}
-	let rows: ReadonlyArray<UsageRow>;
-	if (effective === "model") {
-		const filter = scopeFilter(scopeToRepoIds(db, scope), "s.repo_id");
-		rows = db
-			.prepare(
-				`SELECT s.updated_at_ms AS at_ms, u.model AS key,
-				        u.input_tokens + u.output_tokens + u.cached_tokens AS tokens,
-				        COALESCE(u.est_cost_usd, 0) AS cost
-				   FROM session_model_usage u JOIN sessions s ON s.event_id = u.session_event_id
-				  WHERE s.updated_at_ms >= ? AND s.updated_at_ms < ?${filter.sql}`,
-			)
-			.all(fromMs, toMs, ...filter.params) as UsageRow[];
-	} else if (effective === "agent") {
-		const filter = scopeFilter(scopeToRepoIds(db, scope), "repo_id");
-		rows = db
-			.prepare(
-				`SELECT updated_at_ms AS at_ms, source AS key,
-				        input_tokens + output_tokens + cached_tokens AS tokens,
-				        COALESCE(est_cost_usd, 0) AS cost
-				   FROM sessions WHERE updated_at_ms >= ? AND updated_at_ms < ?${filter.sql}`,
-			)
-			.all(fromMs, toMs, ...filter.params) as UsageRow[];
-	} else if (effective === "project") {
-		const filter = scopeFilter(scopeToRepoIds(db, scope), "s.repo_id");
-		rows = db
-			.prepare(
-				`SELECT s.updated_at_ms AS at_ms, r.repo_name AS key,
-				        s.input_tokens + s.output_tokens + s.cached_tokens AS tokens,
-				        COALESCE(s.est_cost_usd, 0) AS cost
-				   FROM sessions s JOIN repos r ON r.id = s.repo_id
-				  WHERE s.updated_at_ms >= ? AND s.updated_at_ms < ?${filter.sql}`,
-			)
-			.all(fromMs, toMs, ...filter.params) as UsageRow[];
-	} else if (effective === "category") {
-		const filter = scopeFilter(scopeToRepoIds(db, scope), "m.repo_id");
-		// One row per TOPIC, with the commit's tokens shared across its topics —
-		// category belongs to a topic, and the old per-commit mode erased every
-		// category that never won a commit's vote (security and docs vanished
-		// entirely on this repo's data). Sharing keeps the axis summing to the
-		// real total, the property the mode existed to protect; the cost
-		// figures are apportioned by design, not exact per-topic spend.
-		// The LEFT JOIN keeps memories with no topics on the axis: their window
-		// COUNT(*) is 1 and their whole spend lands in '(uncategorised)'.
-		//
-		// `parent_hash IS NULL` — see the note above `buildSeries`. This axis is
-		// where the double-count was worst (measured 9.5x) precisely because the
-		// LEFT JOIN keeps predecessors whose commit row is gone.
-		rows = db
-			.prepare(
-				`${MEMORY_LANDING_CTE}
-				 SELECT ml.at_ms AS at_ms,
-				        COALESCE(t.category, '(uncategorised)') AS key,
-				        COALESCE(m.tokens, 0) * 1.0
-				          / COUNT(*) OVER (PARTITION BY m.repo_id, m.commit_hash) AS tokens,
-				        COALESCE(m.est_cost_usd, 0) * 1.0
-				          / COUNT(*) OVER (PARTITION BY m.repo_id, m.commit_hash) AS cost
-				   FROM memories m
-				   JOIN memory_landing ml ON ml.repo_id = m.repo_id AND ml.commit_hash = m.commit_hash
-				   LEFT JOIN memory_topics t ON t.repo_id = m.repo_id AND t.commit_hash = m.commit_hash
-				  WHERE m.tokens IS NOT NULL
-				    AND m.parent_hash IS NULL
-				    AND ml.at_ms >= ? AND ml.at_ms < ?${filter.sql}`,
-			)
-			.all(fromMs, toMs, ...filter.params) as UsageRow[];
-	} else if (effective === "branch") {
-		const filter = scopeFilter(scopeToRepoIds(db, scope), "c.repo_id");
-		// `commit_branches` now holds ONE row per commit — the branch it was
-		// committed on — so this axis answers "what did the work on this branch
-		// cost", which is the per-PR question, and a commit counts once.
-		//
-		// **The apportioning division is kept deliberately even though the divisor
-		// is 1 for anything this build wrote.** It is the transition safeguard: a
-		// database written by an older client still holds that client's per-branch
-		// `git rev-list` UNION (every commit on `main` also listed under every
-		// feature branch based off it) until the first sweep re-projects each commit.
-		// Unapportioned against those rows, one 10k-token commit on a repo with five
-		// such branches would add 60k tokens — and 6x the cost — to the day. Dividing
-		// keeps the reading sane until the rows converge, then costs nothing.
-		// Removing it would make THIS build the one that reads a mid-transition
-		// database wrong while an older client read it correctly.
-		rows = db
-			.prepare(
-				`SELECT c.committed_at_ms AS at_ms, br.name AS key,
-				        COALESCE(m.tokens, 0) * 1.0
-				          / COUNT(*) OVER (PARTITION BY c.repo_id, c.hash) AS tokens,
-				        COALESCE(m.est_cost_usd, 0) * 1.0
-				          / COUNT(*) OVER (PARTITION BY c.repo_id, c.hash) AS cost
-				   FROM commits c
-				   JOIN commit_branches b ON b.commit_id = c.id
-				   JOIN branches br ON br.id = b.branch_id
-				   JOIN memories m ON m.repo_id = c.repo_id AND (${MEMORY_FOR_COMMIT})
-				  WHERE m.tokens IS NOT NULL AND m.parent_hash IS NULL
-				    AND c.committed_at_ms >= ? AND c.committed_at_ms < ?${filter.sql}`,
-			)
-			.all(fromMs, toMs, ...filter.params) as UsageRow[];
-	} else {
-		const filter = scopeFilter(scopeToRepoIds(db, scope), "c.repo_id");
-		rows = db
-			.prepare(
-				`SELECT c.committed_at_ms AS at_ms, COALESCE(m.ticket_id, '(no ticket)') AS key,
-				        COALESCE(m.tokens, 0) AS tokens, COALESCE(m.est_cost_usd, 0) AS cost
-				   FROM commits c
-				   JOIN memories m ON m.repo_id = c.repo_id AND (${MEMORY_FOR_COMMIT})
-				  WHERE m.tokens IS NOT NULL AND m.parent_hash IS NULL
-				    AND c.committed_at_ms >= ? AND c.committed_at_ms < ?${filter.sql}`,
-			)
-			.all(fromMs, toMs, ...filter.params) as UsageRow[];
-	}
-
 	const seriesByDay = new Map<string, { tokens: number; cost: number; bySeries: Map<string, number> }>();
-	for (let dayStart = fromMs; dayStart < toMs; dayStart = addLocalDays(dayStart, 1, timeZone)) {
-		seriesByDay.set(localDayKey(dayStart, timeZone), { tokens: 0, cost: 0, bySeries: new Map() });
-	}
+	for (const day of plan.dayKeys) seriesByDay.set(day, { tokens: 0, cost: 0, bySeries: new Map() });
 	const seriesKeys = new Set<string>();
-	for (const row of rows) {
-		const bucket = seriesByDay.get(localDayKey(row.at_ms, timeZone));
-		if (!bucket) continue;
-		bucket.tokens += row.tokens;
-		bucket.cost += row.cost;
-		bucket.bySeries.set(row.key, (bucket.bySeries.get(row.key) ?? 0) + row.tokens);
-		seriesKeys.add(row.key);
+	const add = (day: string, key: string, tokens: number, cost: number) => {
+		const bucket = seriesByDay.get(day);
+		if (!bucket) return;
+		bucket.tokens += tokens;
+		bucket.cost += cost;
+		bucket.bySeries.set(key, (bucket.bySeries.get(key) ?? 0) + tokens);
+		seriesKeys.add(key);
+	};
+
+	// Settled days come out of the cache; the rest are computed. The two sets are
+	// disjoint by construction, and the live pass filters on day MEMBERSHIP rather
+	// than on the range — see DayPlan for why the range alone is not enough.
+	//
+	// Both halves ultimately read `readAxisRows`: the cache was built through it,
+	// and the live pass calls it directly. That is not a tidiness rule — the
+	// `category` and `branch` axes divide by a window `COUNT(*)`, so a second
+	// query with a differently-shaped join would make a cached day and a live day
+	// disagree by an apportioning fraction that nothing would ever flag.
+	for (const row of readRollupSeries(db, timeZone, effective, plan.cached, scope)) {
+		add(row.day, row.series_key, row.value, row.cost_usd);
+	}
+	if (plan.live.size > 0) {
+		for (const row of readAxisRows(db, scope, effective, plan.liveFromMs, plan.liveToMs)) {
+			const day = localDayKey(row.bucket_at_ms, timeZone);
+			if (plan.live.has(day)) add(day, row.key, row.tokens, row.cost);
+		}
 	}
 	return {
 		series: [...seriesByDay.entries()].map(([date, b]) => ({
@@ -901,7 +618,17 @@ function buildSeries(
 			// day's error under half a token.
 			tokens: Math.round(b.tokens),
 			estCostUsd: b.cost,
-			bySeries: Object.fromEntries([...b.bySeries.entries()].map(([k, v]) => [k, Math.round(v)])),
+			// Sorted, because insertion order is not the same on both halves of a
+			// plan: the cache returns a day's series ordered by `series_key`, while a
+			// live day arrives in whatever order the axis query emits. Object key
+			// order survives `JSON.stringify` all the way to the browser, so without
+			// this a day's legend would silently reorder itself the moment that day
+			// settled — same numbers, visibly different chart.
+			bySeries: Object.fromEntries(
+				[...b.bySeries.entries()]
+					.sort(([a], [c]) => (a < c ? -1 : a > c ? 1 : 0))
+					.map(([k, v]) => [k, Math.round(v)]),
+			),
 		})),
 		seriesKeys: [...seriesKeys].sort(),
 		seriesDimension: effective,
@@ -1105,32 +832,31 @@ function buildStats(
 		? windowSessions.filter((s) => inWindow(s.updated_at_ms))
 		: sessionsInRange(db, scope, window.startMs, window.endMs);
 
-	const rangeCached = rangeSessions.reduce((sum, s) => sum + s.cached_tokens, 0);
+	// The plan splits the window into days already settled in the rollup cache and
+	// days that still have to be computed. Resolved per window, because a plan is
+	// only valid for the range it was cut for — the prior window below cuts its
+	// own.
+	const plan = planDays(db, timeZone, window.startMs, window.endMs, nowMs);
 
 	// "Tokens" — input/output/cache over the range, day-bucketed for the card's
-	// chart. Reuses `rangeSessions`, already swept above, rather than a second
-	// query.
-	const perDayTokens = new Map<string, { input: number; output: number; cached: number }>();
-	for (let dayStart = window.startMs; dayStart < window.endMs; dayStart = addLocalDays(dayStart, 1, timeZone)) {
-		perDayTokens.set(localDayKey(dayStart, timeZone), { input: 0, output: 0, cached: 0 });
-	}
-	for (const s of rangeSessions) {
-		const cell = perDayTokens.get(localDayKey(s.updated_at_ms, timeZone));
-		if (cell) {
-			cell.input += s.input_tokens;
-			cell.output += s.output_tokens;
-			cell.cached += s.cached_tokens;
-		}
-	}
-	const tokenBreakdown: TokenBreakdown = {
-		input: rangeSessions.reduce((sum, s) => sum + s.input_tokens, 0),
-		output: rangeSessions.reduce((sum, s) => sum + s.output_tokens, 0),
-		cached: rangeCached,
-		perDay: [...perDayTokens.entries()].map(([date, v]) => ({ date, ...v })),
-	};
+	// chart, placed on the day each response actually happened.
+	//
+	// NOT from `rangeSessions`, and that is a different answer rather than a
+	// cheaper one: a session carries one cumulative total under a single
+	// timestamp, so a conversation spanning three days put all of its tokens on
+	// the last one. `rangeSessions` still answers everything that is genuinely
+	// about sessions — how many there were, when the machine was last active —
+	// and nothing about how much they spent.
+	//
+	// One consequence worth stating: a usage line the parser cannot date is
+	// counted in the session's own totals but dropped from the events (see
+	// `readTranscript`), so these figures can sit a hair BELOW the session-level
+	// ones. That is the right side to err on for a per-DAY card — an undatable
+	// token has no day to be shown on.
+	const tokenBreakdown = readTokenTotals(db, scope, timeZone, plan);
 
 	// Cost/token series along the requested dimension, over the range.
-	const seriesResult = buildSeries(db, scope, dimension, tier, window.startMs, window.endMs, timeZone);
+	const seriesResult = buildSeries(db, scope, dimension, tier, timeZone, plan);
 
 	// Cost vs the immediately preceding window of equal length — the Spend card's
 	// own self-trend, and BOTH ends are the same series the card draws.
@@ -1143,7 +869,8 @@ function buildStats(
 	// disagree — the series reads `session_model_usage`, not `sessions`. A
 	// self-trend is only worth printing if it trends the number it sits next to.
 	const priorRangeFrom = window.startMs - (window.endMs - window.startMs);
-	const priorSeries = buildSeries(db, scope, dimension, tier, priorRangeFrom, window.startMs, timeZone);
+	const priorPlan = planDays(db, timeZone, priorRangeFrom, window.startMs, nowMs);
+	const priorSeries = buildSeries(db, scope, dimension, tier, timeZone, priorPlan);
 	const priorDrawn = drawnCost(priorSeries);
 	const costTrendPct =
 		priorDrawn > 0 ? Math.round(((drawnCost(seriesResult) - priorDrawn) / priorDrawn) * 100) : undefined;

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -149,6 +149,7 @@ import {
 	countMissingForCwd,
 	parseSettingsApplyInput,
 	SettingsValidationError,
+	setSyncSessions,
 } from "./SettingsMutations.js";
 import { buildSettingsPageModel, clearLaunchRepoStateCache } from "./SettingsPageQuery.js";
 
@@ -1788,6 +1789,10 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 			await handleSetPush(res, b);
 			return;
 		}
+		if (url.pathname === "/api/settings/set-sync-sessions") {
+			await handleSetSyncSessions(res, b);
+			return;
+		}
 		if (url.pathname === "/api/settings/signin") {
 			await handleSignIn(res);
 			return;
@@ -1869,6 +1874,25 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 		} catch (err) {
 			log.warn("set-push failed: %s", errMsg(err));
 			sendJson(res, 500, { error: "could not change push setting" });
+		}
+	}
+
+	/**
+	 * Settings → Sync to Jolli: the machine-wide session-statistics switch. Applies
+	 * immediately, like `set-push` above and unlike the batched `apply` — the two
+	 * were the same tab's identical-looking switches with different rules.
+	 */
+	async function handleSetSyncSessions(res: ServerResponse, body: Record<string, unknown>): Promise<void> {
+		if (typeof body.enabled !== "boolean") {
+			sendJson(res, 400, { error: "enabled (boolean) is required" });
+			return;
+		}
+		try {
+			const result = await setSyncSessions(body.enabled, configDir ?? getGlobalConfigDir());
+			sendJson(res, 200, { ok: true, syncSessions: result.syncSessions });
+		} catch (err) {
+			log.warn("set-sync-sessions failed: %s", errMsg(err));
+			sendJson(res, 500, { error: "could not change the session-statistics setting" });
 		}
 	}
 

--- a/cli/src/dashboard/DbBackfill.ts
+++ b/cli/src/dashboard/DbBackfill.ts
@@ -82,6 +82,8 @@ import {
 	resolveProtectNewerThanMs,
 	type SotImportResult,
 } from "./SotImport.js";
+import { buildRollupQuietly, forgetRollupDays } from "./StatsRollup.js";
+import { MEMORY_LANDED_AT_SQL } from "./StatsSeries.js";
 import { applyToDb, countStuckEvents, pruneProjectedEvents } from "./StatsWriter.js"; // recordRepoGraph parked — see SotSchema
 
 const log = createLogger("DbBackfill");
@@ -692,11 +694,55 @@ export function pruneUnreachableCommits(
 		.filter((hash) => !reachable.has(hash))
 		.map((hash) => ({ hash }));
 	if (stale.length === 0) return 0;
+	// Read before deleting: the cached day a commit contributed to is derived
+	// from its own timestamp, and once the row is gone there is nothing left to
+	// ask. Staleness is otherwise detected from write stamps, which a deletion
+	// leaves none of — so this is the one direction the cache has to be told
+	// about rather than being able to work out.
+	const staleDays = db
+		.prepare(
+			`SELECT committed_at_ms FROM commits
+			  WHERE repo_id = (SELECT id FROM repos WHERE repo_identity = ?)
+			    AND hash IN (${stale.map(() => "?").join(", ")})`,
+		)
+		.all(repoIdentity, ...stale.map((row) => row.hash)) as ReadonlyArray<{ committed_at_ms: number }>;
+	// The commit rows are gone, but their memories survive (a rewritten commit's
+	// row is a DUPLICATE of the surviving one, kept by design), so each of those
+	// memories MOVES to another calendar day and the day it moves TO must be
+	// forgotten as well — otherwise it keeps serving a number that omits the
+	// memory, for ever, since an old day gets no further writes to rebuild it.
+	//
+	// ⚠ Asked through `MEMORY_LANDED_AT_SQL`, AFTER the delete, and never by
+	// restating the rule here. It was restated — as `commit_date_ms`, on the
+	// reasoning that the landing expression "falls back to `commit_date_ms`" once
+	// the commit row is gone — and that drops the middle term: the real rule is
+	// `COALESCE(cm.committed_at_ms, al.at_ms, m.commit_date_ms)`, and a PRUNE IS
+	// THE ALIAS CASE. A rebased commit's memory lands on the aliasing commit's
+	// `committed_at_ms`, while `commit_date_ms` is the AUTHOR date — up to 400 days
+	// away in this repo's own rebase fixture. So the wrong day was forgotten and
+	// the day that actually changed was not. Running the query after the delete is
+	// what makes it answer the post-delete landing without this code having to know
+	// which of the three terms wins.
+	const repoRow = db.prepare("SELECT id FROM repos WHERE repo_identity = ?").get(repoIdentity) as
+		| { id?: number }
+		| undefined;
+	const repoId = repoRow?.id;
 	const remove = db.prepare(
 		"DELETE FROM commits WHERE repo_id = (SELECT id FROM repos WHERE repo_identity = ?) AND hash = ?",
 	);
 	inTransaction(db, () => {
 		for (const row of stale) remove.run(repoIdentity, row.hash);
+		const landedDays: number[] = [];
+		if (repoId !== undefined) {
+			const landedAt = db.prepare(MEMORY_LANDED_AT_SQL);
+			for (const { hash } of stale) {
+				const landed = landedAt.get(repoId, hash) as { at_ms: number | null } | undefined;
+				if (landed?.at_ms != null) landedDays.push(landed.at_ms);
+			}
+		}
+		// Both directions in one call: the day each memory STOPPED being counted on
+		// is the pruned commit's own day, already in `staleDays`.
+		forgetRollupDays(db, [...staleDays.map((row) => row.committed_at_ms), ...landedDays]);
 	});
 	log.info("pruned %d unreachable commits for %s", stale.length, repoIdentity);
 	return stale.length;
@@ -1231,7 +1277,16 @@ function unchangedSessionEvent(event: SessionUpsertedEvent, stored: StoredSessio
 	);
 }
 
-/** Wraps events in envelopes and applies them in small batches. */
+/**
+ * Wraps events in envelopes and applies them in small batches.
+ *
+ * ⚠ Every batch opts out of the rollup settle (`skipRollup`). A backfill calls
+ * this a dozen times over hundreds of batches, and each batch's writes mark the
+ * days it just touched stale — so left on, the pass rebuilds the same newest
+ * days once per batch (measured at ~945 ms for a 14-day settle) and keeps only
+ * the last one. `dbBackfillRepo` settles once at the end instead; the other two
+ * callers here write only registry rows, which no spend axis reads.
+ */
 function applyBatches(
 	db: DashboardDbHandle,
 	events: ReadonlyArray<StatsEvent>,
@@ -1245,7 +1300,7 @@ function applyBatches(
 		const batch: StatsEventEnvelope[] = events
 			.slice(start, start + BATCH_SIZE)
 			.map((event) => ({ event, producerKind }));
-		const result = applyToDb(db, batch, { producerKind, now });
+		const result = applyToDb(db, batch, { producerKind, now, skipRollup: true });
 		applied += result.projected;
 		// Reported, not just discarded: an event that stayed pending did NOT
 		// reach the projection tables, so a caller whose cursor would skip the
@@ -1929,6 +1984,12 @@ export async function dbBackfillRepo(opts: DbBackfillOptions): Promise<DbBackfil
 			// hold, exactly as on the writer path.
 			const pruned = pruneProjectedEvents(db, now);
 			if (pruned > 0) log.debug("pruned %d projected event rows for %s", pruned, repo.repoName);
+
+			// The rollup settle every `applyToDb` normally does, hoisted out of the
+			// batch loop to here — once for the whole pass, against its final state.
+			// See `applyBatches` for why per batch is quadratic. Quiet and derived, so
+			// a failure here costs a slower page and never the backfill.
+			buildRollupQuietly(db, { now });
 
 			const mode = isBootstrap ? "bootstrapped" : "recovered";
 			log.info("%s %s: %d events applied", mode, repo.repoName, applied);

--- a/cli/src/dashboard/LocalDays.test.ts
+++ b/cli/src/dashboard/LocalDays.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The day-boundary rules the rollup cache and the dashboard read path share.
+ *
+ * Its own file because the module is: these functions used to live inside
+ * `DashboardQuery.ts` and were tested through it, which left the split module
+ * covered only by an import path its production callers no longer use.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+	addLocalDays,
+	dayKeyToMidnight,
+	localDayKey,
+	localHour,
+	machineTimeZone,
+	startOfLocalDay,
+} from "./LocalDays.js";
+
+const SH = "Asia/Shanghai"; // UTC+8, no DST
+const LA = "America/Los_Angeles"; // DST
+
+describe("local-day arithmetic", () => {
+	it("assigns a 23:30 UTC session to the NEXT local day in Asia/Shanghai", () => {
+		const ms = Date.parse("2026-07-29T23:30:00Z"); // 07:30 on the 30th in Shanghai
+		expect(localDayKey(ms, SH)).toBe("2026-07-30");
+		expect(localDayKey(ms, "UTC")).toBe("2026-07-29");
+	});
+
+	it("computes local midnight boundaries, not UTC ones", () => {
+		const ms = Date.parse("2026-07-30T10:00:00Z");
+		// Shanghai midnight of Jul 30 = Jul 29 16:00 UTC.
+		expect(startOfLocalDay(ms, SH)).toBe(Date.parse("2026-07-29T16:00:00Z"));
+		expect(startOfLocalDay(ms, "UTC")).toBe(Date.parse("2026-07-30T00:00:00Z"));
+	});
+
+	it("handles the 23-hour spring-forward day in America/Los_Angeles", () => {
+		// 2026-03-08: DST starts, 02:00 → 03:00. The day is 23 hours long.
+		const midnight = startOfLocalDay(Date.parse("2026-03-08T20:00:00Z"), LA);
+		expect(localDayKey(midnight, LA)).toBe("2026-03-08");
+		const nextMidnight = addLocalDays(midnight, 1, LA);
+		expect(localDayKey(nextMidnight, LA)).toBe("2026-03-09");
+		expect(nextMidnight - midnight).toBe(23 * 3_600_000);
+	});
+
+	it("handles the 25-hour fall-back day", () => {
+		// 2026-11-01: DST ends. The day is 25 hours long.
+		const midnight = startOfLocalDay(Date.parse("2026-11-01T20:00:00Z"), LA);
+		const nextMidnight = addLocalDays(midnight, 1, LA);
+		expect(nextMidnight - midnight).toBe(25 * 3_600_000);
+	});
+
+	it("addLocalDays walks backwards too", () => {
+		const ms = Date.parse("2026-07-30T10:00:00Z");
+		expect(localDayKey(addLocalDays(ms, -1, SH), SH)).toBe("2026-07-29");
+		expect(localDayKey(addLocalDays(ms, 0, SH), SH)).toBe("2026-07-30");
+	});
+
+	it("addLocalDays refuses a day count that is not an integer, rather than hanging on it", () => {
+		// The loop ends on `i !== days`, and NaN is not equal to anything — itself
+		// included — so this used to spin forever inside a synchronous call with
+		// nothing logged and no slow query to blame. A throw is the whole point:
+		// the caller computed the value, so a silent fallback to the default window
+		// would render a range nobody asked for.
+		const ms = Date.parse("2026-07-30T10:00:00Z");
+		expect(() => addLocalDays(ms, Number.NaN, SH)).toThrow(/finite integer/);
+		expect(() => addLocalDays(ms, Number.POSITIVE_INFINITY, SH)).toThrow(/finite integer/);
+		expect(() => addLocalDays(ms, 1.5, SH)).toThrow(/finite integer/);
+	});
+
+	it("localHour reports the wall-clock hour in the requested zone", () => {
+		const ms = Date.parse("2026-07-29T23:30:00Z");
+		expect(localHour(ms, SH)).toBe(7); // 07:30 next day
+		expect(localHour(ms, "UTC")).toBe(23);
+	});
+
+	it("machineTimeZone returns a resolvable IANA name", () => {
+		expect(() => new Intl.DateTimeFormat("en", { timeZone: machineTimeZone() })).not.toThrow();
+	});
+
+	it("round-trips a day key, and rejects one that names no real day", () => {
+		// `Date.UTC` normalises 2026-02-31 into March 3rd, so without the round-trip
+		// check a request for a day that does not exist answers with another day's
+		// data rather than refusing.
+		const midnight = dayKeyToMidnight("2026-07-30", SH);
+		expect(midnight).toBe(Date.parse("2026-07-29T16:00:00Z"));
+		expect(dayKeyToMidnight("2026-02-31", SH)).toBeUndefined();
+		expect(dayKeyToMidnight("2026-7-30", SH)).toBeUndefined();
+		expect(dayKeyToMidnight("not-a-day", SH)).toBeUndefined();
+	});
+
+	it("puts a spring-forward day's boundary on its earliest existing instant", () => {
+		// 2026-03-08 00:00 exists in Los Angeles, but the general case this guards is
+		// a zone whose midnight is skipped entirely; the boundary must still be the
+		// first instant OF that day rather than land in the previous one.
+		const midnight = dayKeyToMidnight("2026-03-08", LA);
+		expect(midnight).toBeDefined();
+		expect(localDayKey(midnight as number, LA)).toBe("2026-03-08");
+	});
+});

--- a/cli/src/dashboard/LocalDays.ts
+++ b/cli/src/dashboard/LocalDays.ts
@@ -1,0 +1,152 @@
+/**
+ * Local-calendar arithmetic, DST-safe.
+ *
+ * Its own module because the day-bucketing rules now have two callers that must
+ * not import each other: the read path in {@link ./DashboardQuery.ts} and the
+ * rollup builder in {@link ./StatsRollup.ts}, which runs on the WRITE side and
+ * is reached from `StatsWriter` — while `DashboardQuery` already imports
+ * `StatsWriter`. Leaving these here rather than in either of them is what keeps
+ * that from becoming a cycle.
+ *
+ * A cached day and a live day must agree on where a boundary falls to the
+ * millisecond, so both sides deriving their days from THIS code is not tidiness
+ * — a second implementation would disagree exactly on the DST days these
+ * functions exist to get right, and disagree silently.
+ */
+
+/** Shape of a local calendar day key, `YYYY-MM-DD`. */
+const DAY_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** The machine's IANA zone — the default for every query. */
+export function machineTimeZone(): string {
+	return Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+
+interface ZonedParts {
+	readonly year: number;
+	readonly month: number;
+	readonly day: number;
+	readonly hour: number;
+	readonly minute: number;
+}
+
+const partsFormatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function partsFormatter(timeZone: string): Intl.DateTimeFormat {
+	let formatter = partsFormatterCache.get(timeZone);
+	if (!formatter) {
+		formatter = new Intl.DateTimeFormat("en-CA", {
+			timeZone,
+			year: "numeric",
+			month: "2-digit",
+			day: "2-digit",
+			hour: "2-digit",
+			minute: "2-digit",
+			hourCycle: "h23",
+		});
+		partsFormatterCache.set(timeZone, formatter);
+	}
+	return formatter;
+}
+
+/** Wall-clock components of `ms` in `timeZone`. */
+function zonedParts(ms: number, timeZone: string): ZonedParts {
+	const parts = partsFormatter(timeZone).formatToParts(ms);
+	const get = (type: string) => Number.parseInt(parts.find((p) => p.type === type)?.value ?? "0", 10);
+	return { year: get("year"), month: get("month"), day: get("day"), hour: get("hour"), minute: get("minute") };
+}
+
+/** Local calendar day of `ms` as `YYYY-MM-DD`. */
+export function localDayKey(ms: number, timeZone: string): string {
+	const p = zonedParts(ms, timeZone);
+	return `${p.year}-${String(p.month).padStart(2, "0")}-${String(p.day).padStart(2, "0")}`;
+}
+
+/** Local hour (0–23) of `ms`. */
+export function localHour(ms: number, timeZone: string): number {
+	return zonedParts(ms, timeZone).hour;
+}
+
+/**
+ * Epoch-ms of local midnight at the start of the day containing `ms`.
+ *
+ * `Intl` can only map epoch → wall clock; this inverts it by guessing the UTC
+ * value of the wall-clock midnight and correcting by the observed error. Two
+ * iterations settle every real zone including DST transitions: the first
+ * correction lands within the zone's offset step, the second removes any
+ * residue from a transition between guess and target. (On a "spring forward"
+ * day where 00:00 does not exist, this lands on the earliest existing instant
+ * of the day — exactly what a day boundary should be.)
+ */
+function localMidnight(year: number, month: number, day: number, timeZone: string): number {
+	let guess = Date.UTC(year, month - 1, day);
+	for (let i = 0; i < 3; i++) {
+		const seen = zonedParts(guess, timeZone);
+		const error =
+			Date.UTC(seen.year, seen.month - 1, seen.day, seen.hour, seen.minute) - Date.UTC(year, month - 1, day);
+		if (error === 0) break;
+		guess -= error;
+	}
+	return guess;
+}
+
+export function startOfLocalDay(ms: number, timeZone: string): number {
+	const target = zonedParts(ms, timeZone);
+	return localMidnight(target.year, target.month, target.day, timeZone);
+}
+
+/**
+ * Epoch-ms of local midnight starting the day `key` (`YYYY-MM-DD`) names, or
+ * `undefined` when `key` is not a real local day.
+ *
+ * The round-trip check is the validation: `Date.UTC` happily normalises
+ * 2026-02-31 into March 3rd, so a request for a day that does not exist would
+ * otherwise silently return data for a different one. Comparing the resolved
+ * instant's own day key against the input rejects exactly that case — and
+ * costs nothing on the overwhelmingly common valid input.
+ */
+export function dayKeyToMidnight(key: string, timeZone: string): number | undefined {
+	if (!DAY_KEY_RE.test(key)) return undefined;
+	const ms = localMidnight(
+		Number.parseInt(key.slice(0, 4), 10),
+		Number.parseInt(key.slice(5, 7), 10),
+		Number.parseInt(key.slice(8, 10), 10),
+		timeZone,
+	);
+	return localDayKey(ms, timeZone) === key ? ms : undefined;
+}
+
+/**
+ * Start of the local day `n` days after the day containing `ms`. Steps through
+ * midday rather than adding exact 24 h multiples, so 23- and 25-hour DST days
+ * cannot skip or repeat a day.
+ *
+ * ⚠ Throws on a `days` that is not a finite integer, and the alternative is
+ * worse than it looks. The loop terminates on `i !== days`, and `NaN` is not
+ * equal to anything — including itself — so a `NaN` here does not produce a
+ * wrong answer, it HANGS: the caller's thread spins forever inside a
+ * synchronous function, holding whatever it holds, with nothing logged. That
+ * is exactly how it presented (a dashboard query that never returned and no
+ * slow statement to blame), reached by `-(RANGE_DAYS[preset] - 1)` for a preset
+ * the table has no entry for.
+ *
+ * Throwing rather than clamping to 0 is deliberate: a non-integer day count
+ * means the CALLER computed one, and a silent fallback would leave the page
+ * rendering the default window as if that had been asked for. `parseRange`
+ * already keeps unrecognised input out of the type, so nothing reachable trips
+ * this — it is here because the function is now shared, and the failure mode it
+ * removes is a hang rather than a wrong number.
+ */
+export function addLocalDays(ms: number, days: number, timeZone: string): number {
+	if (!Number.isInteger(days)) throw new Error(`addLocalDays: days must be a finite integer, got ${days}`);
+	let cursor = startOfLocalDay(ms, timeZone);
+	const step = days >= 0 ? 1 : -1;
+	for (let i = 0; i !== days; i += step) {
+		// ±24 h from midnight, then +12 h INTO the target day: lands mid-day in
+		// the neighbouring day whether it is 23, 24 or 25 hours long, and
+		// startOfLocalDay snaps back to its midnight. (A ±36 h jump would
+		// overshoot a whole day when stepping backwards.)
+		cursor = startOfLocalDay(cursor + step * 86_400_000 + 43_200_000, timeZone);
+	}
+	return cursor;
+}

--- a/cli/src/dashboard/MigrationFingerprints.test.ts
+++ b/cli/src/dashboard/MigrationFingerprints.test.ts
@@ -45,6 +45,15 @@ const EXPECTED: ReadonlyArray<readonly [name: string, fingerprint: string]> = [
 	["TOOL_CALL_TIME_DDL", "6393ea338cd8"],
 	["SCHEMA_MIGRATIONS_DDL", "151c9e7a7af7"],
 	["REPOS_DELETE_ALLOWED_DDL", "52561786c1b7"],
+	// The seven unreleased steps the session-statistics sync was developed in,
+	// merged into one entry before shipping — see `DASHBOARD_SCHEMA_VERSION`. That
+	// is legal exactly once, while nothing has the old bytes: a machine that ran an
+	// intermediate build of this branch has the seven old names in its log and no
+	// row for this one, so it re-runs the entry and dies on `duplicate column` at
+	// the first ALTER. `jolli doctor --mark-migration SESSION_STATS_SYNC_DDL` is
+	// the documented repair, and it is the reason no further merge may happen after
+	// the first release.
+	["SESSION_STATS_SYNC_DDL", "e0c166639049"],
 ];
 
 describe("migration fingerprints", () => {

--- a/cli/src/dashboard/RepoForget.test.ts
+++ b/cli/src/dashboard/RepoForget.test.ts
@@ -176,6 +176,39 @@ describe("forgetRepo", () => {
 		expect(await countIn("commits", keptId)).toBe(1);
 	});
 
+	/**
+	 * `stats_daily` has no foreign key to `repos`, so `repoChildTables` cannot see
+	 * it and nothing refuses the `DELETE FROM repos` — the rows just stay.
+	 *
+	 * Left behind they are wrong NUMBERS rather than a stale cache: a cached day
+	 * expires when a source row is WRITTEN, a delete writes nothing, and the
+	 * `built` sentinel is stored once per day rather than per repo, so the day
+	 * keeps reading as settled and keeps serving them. The all-repos scope emits no
+	 * repo filter at all, so a forgotten repo's spend would count there for ever.
+	 */
+	it("clears the forgotten repo's rollup cache, which no foreign key reaches", async () => {
+		const goneId = await seedRepoWithChildren("local:aaa");
+		const keptId = await seedRepoWithChildren("local:bbb");
+		writeRegistry([entry({ repoIdentity: "local:aaa" })]);
+		await withDb((db) => {
+			const insert = db.prepare(
+				`INSERT INTO stats_daily (repo_id, tz, day, kind, series_key, value, cost_usd, built_at_ms, updated_at_ms)
+				 VALUES (?, 'UTC', '2026-08-17', ?, ?, 10, 0.5, 1, 1)`,
+			);
+			insert.run(goneId, "model", "sonnet");
+			insert.run(keptId, "model", "sonnet");
+			// The per-DAY sentinel, which belongs to no repo and must survive: the
+			// day's remaining rows are still correct, so recomputing it buys nothing.
+			insert.run(0, "built", "");
+		});
+
+		await forgetRepo("local:aaa", { configDir, dbPath });
+
+		expect(await countIn("stats_daily", goneId)).toBe(0);
+		expect(await countIn("stats_daily", keptId)).toBe(1);
+		expect(await countIn("stats_daily", 0)).toBe(1);
+	});
+
 	it("reports zeros for an identity nothing on this machine knows", async () => {
 		await withDb(() => undefined);
 		const result = await forgetRepo("local:never-seen", { configDir, dbPath });

--- a/cli/src/dashboard/RepoForget.ts
+++ b/cli/src/dashboard/RepoForget.ts
@@ -110,6 +110,13 @@ interface RepoChildTable {
  * after the schema change that caused it. `SotSchema`'s own test pins the derived
  * set, so a new referencing table shows up as a visible test edit instead.
  *
+ * ⚠ The derivation's guarantee is exactly as wide as the foreign keys, so a
+ * repo-scoped table with NO foreign key is invisible to it — and fails SILENTLY
+ * rather than loudly, because nothing then refuses the `DELETE FROM repos`. There
+ * is one today, `stats_daily`, deleted by hand in {@link deleteRepoRows}; adding
+ * another means adding it there. See that call site for why the silence is worse
+ * than the loud failure this list was written to prevent.
+ *
  * Sorted for determinism — the deletion order is irrelevant (every one of them is
  * a child of `repos`, and their own children cascade), but a stable order keeps
  * the assertion and the log line stable.
@@ -148,6 +155,30 @@ function deleteRepoRows(
 		for (const { table, column } of children) {
 			childRowsDeleted += changed(db.prepare(`DELETE FROM "${table}" WHERE "${column}" = ?`).run(row.id));
 		}
+		// `stats_daily` by hand, because the derived list above CANNOT reach it: that
+		// list is every table with a foreign key to `repos(id)`, and this one
+		// deliberately has none (it is a rebuilt cache, and nothing here should
+		// cascade — see its DDL). So the "a table added later shows up as a test
+		// edit" guarantee does not cover it, and a table with no FK must be handled
+		// explicitly. Any future one too.
+		//
+		// Leaving it behind is not a stale-cache annoyance but WRONG NUMBERS, for
+		// two compounding reasons. A cached day is invalidated by source rows being
+		// WRITTEN, and a delete leaves no write stamp — while the `built` sentinel is
+		// stored once per DAY rather than per repo, so the day stays "settled" and
+		// keeps serving these rows. And `scopeFilter` emits no WHERE clause at all
+		// for the all-repos scope, so a forgotten repo's spend would keep counting
+		// there for ever (an old day gets no further writes to rebuild it).
+		// Worse still, `repos.id` is `INTEGER PRIMARY KEY` without AUTOINCREMENT, so
+		// SQLite hands the next repo `max(id) + 1` — forget the highest id and a
+		// brand-new repo INHERITS these rows, which puts the ghost inside a
+		// single-repo view too.
+		//
+		// Not counted in `childRowsDeleted`: that number is documented as rows from
+		// the tables referencing `repos.id`, and `DashboardServer` reads it as "was
+		// there anything to remove". A derived row must not be able to answer yes to
+		// that on its own.
+		db.prepare("DELETE FROM stats_daily WHERE repo_id = ?").run(row.id);
 	}
 	const repoRowDeleted = row !== undefined && changed(db.prepare("DELETE FROM repos WHERE id = ?").run(row.id)) > 0;
 	// Not gated on `row`: an identity whose only trace is an unprojected event has

--- a/cli/src/dashboard/SessionPushManifest.test.ts
+++ b/cli/src/dashboard/SessionPushManifest.test.ts
@@ -1,0 +1,115 @@
+/**
+ * The guard the whole table-shaped format depends on.
+ *
+ * Sending tables verbatim means the default for anything new is "it goes up".
+ * These tests are what turns that default back into a decision: add a table, or
+ * a column to a synced one, and they fail. A failure is a question — is this
+ * meant to leave the machine? — not a list to widen on sight.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type DashboardDbHandle, withDashboardDb } from "./DashboardDb.js";
+import {
+	EXCLUDED_COLUMNS,
+	NEVER_SYNCED_TABLES,
+	REWRITTEN_COLUMNS,
+	SYNCED_COLUMNS,
+	SYNCED_TABLES,
+} from "./SessionPushManifest.js";
+import { declaredLocalColumns } from "./SessionPushReader.js";
+import { SYNC_STAMP_TABLES, syncStampColumn } from "./SyncColumns.js";
+
+describe("session push manifest", () => {
+	let dir: string;
+	let dbPath: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "jolli-manifest-"));
+		dbPath = join(dir, "dashboard.db");
+	});
+
+	afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+	const withDb = <T>(fn: (db: DashboardDbHandle) => T) => withDashboardDb(fn, { dbPath });
+
+	const tableNames = () =>
+		withDb((db) =>
+			(
+				db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name").all() as Array<{
+					name: string;
+				}>
+			).map((r) => r.name),
+		);
+
+	const columnsOf = (table: string) =>
+		withDb((db) => (db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>).map((c) => c.name));
+
+	it("accounts for EVERY table: each one is either synced or explicitly not", async () => {
+		// The partition is the mechanism. A new table lands in neither list and
+		// fails here, which is the moment to decide — rather than the moment it
+		// silently starts uploading, or silently does not.
+		const actual = await tableNames();
+		const declared = new Set<string>([...SYNCED_TABLES, ...NEVER_SYNCED_TABLES]);
+		expect(actual.filter((t) => !declared.has(t))).toEqual([]);
+		// And in the other direction, so a dropped table does not leave a name here
+		// forever, pretending to protect something that no longer exists.
+		const live = new Set(actual);
+		expect([...declared].filter((t) => !live.has(t) && t !== "sqlite_sequence")).toEqual([]);
+	});
+
+	it("the two lists are disjoint", () => {
+		const synced = new Set<string>(SYNCED_TABLES);
+		expect(NEVER_SYNCED_TABLES.filter((t) => synced.has(t))).toEqual([]);
+	});
+
+	for (const table of SYNCED_TABLES) {
+		it(`accounts for every column of ${table}`, async () => {
+			const actual = await columnsOf(table);
+			// Nothing the schema has may be unaccounted for — that is the added-column
+			// alarm, and the reason this is a set comparison rather than a length check.
+			expect(actual.filter((c) => !declaredLocalColumns(table).includes(c))).toEqual([]);
+			// And every column the manifest SENDS must exist. (The excluded ones are
+			// exempt in this direction on purpose: `metadata_json` is gone from the
+			// definition but still present on older databases, so it is legitimately
+			// absent here while still worth holding back.)
+			const sent = declaredLocalColumns(table).filter((c) => !EXCLUDED_COLUMNS[table].includes(c));
+			expect(sent.filter((c) => !actual.includes(c))).toEqual([]);
+		});
+	}
+
+	it("sends the sync stamp of every table, so the server can derive its own cursor", () => {
+		for (const table of SYNCED_TABLES) {
+			expect(SYNCED_COLUMNS[table]).toContain(syncStampColumn(table));
+		}
+		// And every stamped table is in the channel: a table that carries a stamp
+		// but is not sent is either a missing decision or a stale stamp.
+		expect([...SYNC_STAMP_TABLES].sort()).toEqual([...SYNCED_TABLES].sort());
+	});
+
+	it("rewrites the machine-local surrogate key and nothing else", async () => {
+		// `repos.id` is an autoincrement: the same repo has a different integer on
+		// every machine, so sending it would attach rows to whatever repo happened
+		// to hold that id on the server.
+		for (const table of SYNCED_TABLES) {
+			const local = await columnsOf(table);
+			for (const [from, to] of Object.entries(REWRITTEN_COLUMNS)) {
+				if (!local.includes(from)) continue;
+				expect(SYNCED_COLUMNS[table]).toContain(to);
+				expect(SYNCED_COLUMNS[table]).not.toContain(from);
+			}
+		}
+	});
+
+	it("never sends a transcript column, under any name", async () => {
+		// A blunt second net under the per-table lists: the one thing the product
+		// promises never leaves this machine is the conversation text.
+		for (const table of SYNCED_TABLES) {
+			for (const column of SYNCED_COLUMNS[table]) {
+				expect(column).not.toMatch(/transcript|content|body|text/i);
+			}
+		}
+	});
+});

--- a/cli/src/dashboard/SessionPushManifest.ts
+++ b/cli/src/dashboard/SessionPushManifest.ts
@@ -1,0 +1,213 @@
+/**
+ * What leaves this machine on the session channel — the two lists, and nothing
+ * else.
+ *
+ * The channel sends TABLES: the payload is `{table: rows}` with the local column
+ * names verbatim (snake_case, no camelCase rewrite), so the local column, the
+ * JSON field and the server column all carry one name and a mismatch is a bug
+ * rather than a translation table to maintain.
+ *
+ * ⚠ That format removes the step that used to decide what is sent. Picking
+ * fields by hand is tedious, but it also quietly withheld everything nobody had
+ * thought about; sending tables as they are inverts the default to "everything
+ * new goes up". This repo has already paid for that inversion once —
+ * `summaryJson` is a whitelist by omission, and every field added to it started
+ * uploading itself. So the lists below are explicit, and
+ * `SessionPushManifest.test.ts` compares them against the real schema: adding a
+ * table or a column makes it FAIL, which is the whole mechanism. Do not fix such
+ * a failure by widening the list without deciding.
+ *
+ * # No timezone travels on this channel, and that is a decision
+ *
+ * Every time value below is an epoch-millisecond INSTANT (`*_at_ms`), the envelope
+ * carries none, and no header carries one. The single timezone-bearing table is
+ * excluded on purpose — see `stats_daily` in {@link NEVER_SYNCED_TABLES}.
+ *
+ * ⚠ Do NOT "fix" this by adding a `timeZone` field. It was considered and
+ * rejected: the field would record the zone of whichever MACHINE wrote the row,
+ * and a person who travels, or who works from two machines, would have one
+ * account's history split across zones with nothing able to reconcile it. An
+ * instant has no zone; only a QUESTION about days does.
+ *
+ * Which day a response belongs to is therefore the READER's to decide, and the
+ * web API is where that lands: it must take the viewer's IANA zone as a request
+ * parameter and bucket on it. `DashboardModel.timeZone` is the shape to mirror on
+ * the way back — the response states which zone it bucketed in, so a client can
+ * never mistake one zone's chart for another's.
+ *
+ * The size of getting this wrong is measurable rather than theoretical. Bucketing
+ * in UTC for a UTC+8 user moves everything worked between local 00:00 and 08:00
+ * onto the previous day: on the author's own database that is 271 of 6,868
+ * responses and 1,014,210 of 31,171,692 tokens (3.3%), so the web chart and the
+ * local one disagree slightly every single day — the shape a user reports as a
+ * bug. It also shifts the window itself: one `nowMs` resolved to
+ * `2026-07-20..2026-08-18` in UTC and `2026-07-21..2026-08-19` in Asia/Shanghai,
+ * a whole day in and a whole day out.
+ *
+ * Note the local page needs no such parameter and is not a precedent: its server
+ * and its browser are the same machine, so `buildDashboardModel` falls back to
+ * `machineTimeZone()` and `ModelRequest` deliberately omits the field.
+ */
+
+/** Tables the session channel sends. Adding one here is a privacy decision. */
+export const SYNCED_TABLES = ["sessions", "session_model_usage", "session_tool_use", "session_usage_events"] as const;
+
+export type SyncedTable = (typeof SYNCED_TABLES)[number];
+
+/**
+ * Tables that must NEVER be sent, each for its own reason. The test requires
+ * every table in the database to appear in exactly one of the two lists, so this
+ * is not documentation — it is the other half of the partition.
+ *
+ * The first three are the ones that would be actively harmful:
+ *   - `transcripts` / `memory_transcripts` — the conversation text itself.
+ *   - `worktree_status` — the content of uncommitted changes.
+ * The rest are local bookkeeping with no meaning on another machine (integer
+ * ids, cursors, queue state), the memory half of the store, which travels on its
+ * own channel with its own binding rules, or a table nothing on the other side
+ * reads — sending those costs bytes and buys nothing.
+ */
+export const NEVER_SYNCED_TABLES = [
+	// The conversation text itself, on both halves of the store.
+	"transcripts",
+	"transcript_sessions",
+	"memory_transcripts",
+	// The content of uncommitted changes.
+	"worktree_status",
+	// Local bookkeeping: integer ids, ingest cursors, queue and repo state.
+	"events_raw",
+	"ingest_cursors",
+	"repo_state",
+	"repos",
+	"schema_meta",
+	"schema_migrations",
+	"sqlite_sequence",
+	// Written on every recall, read by nothing on the other side. The standalone
+	// Recall card is gone from both pages, and the server's request schema never
+	// listed this table — it strips keys it does not know, so every receipt sent
+	// was discarded on arrival. Nothing about the DATA changed (the receipts are
+	// still written locally, and the tool-usage card still counts recall calls off
+	// `session_tool_use`), so putting the table back on the wire is this line plus
+	// its `SYNCED_COLUMNS`, `SYNC_STAMP_COLUMNS`, `KEYSET_COLUMNS` and
+	// `BUSINESS_TIME_COLUMNS` entries. Its stamp column and the two indexes behind
+	// the channel's paging stay in the schema: they have already been migrated, so
+	// they are frozen rather than worth an entry to remove.
+	"recall_receipts",
+	// Derived locally and re-derivable there: a cache cut in THIS machine's
+	// timezone. Sending it would bake that zone into the server's numbers and
+	// leave the server unable to re-aggregate along any other axis. The other half
+	// of the no-timezone rule in this module's header: instants go up, days are
+	// cut by whoever is asking.
+	"stats_daily",
+	// The memory half. It travels on the commit-push channel, which has its own
+	// binding rules, and `commit_aliases` answers a rebase-matching question that
+	// does not exist on a server where commits and memories arrive together.
+	"memories",
+	"memory_topics",
+	"commits",
+	"commit_files",
+	"commit_aliases",
+	"commit_branches",
+	"branches",
+	"context",
+	"context_kinds",
+	// Not needed by the first web pages.
+	"plan_progress",
+	"topic_pages",
+	"topic_source_refs",
+	"topic_processed_sources",
+] as const;
+
+/**
+ * The columns sent for each table, in wire order.
+ *
+ * Two kinds of local column are deliberately absent and are listed in
+ * {@link REWRITTEN_COLUMNS} / {@link EXCLUDED_COLUMNS} instead, so the test can
+ * account for every column the schema has.
+ */
+export const SYNCED_COLUMNS: Readonly<Record<SyncedTable, ReadonlyArray<string>>> = {
+	sessions: [
+		"event_id",
+		"repo_identity",
+		"source",
+		"session_id",
+		"title",
+		"started_at_ms",
+		"updated_at_ms",
+		"message_count",
+		"duration_ms",
+		"model",
+		"input_tokens",
+		"output_tokens",
+		"cached_tokens",
+		"est_cost_usd",
+		"token_coverage",
+		"prices_as_of",
+		"written_at_ms",
+	],
+	session_model_usage: [
+		"session_event_id",
+		"model",
+		"input_tokens",
+		"output_tokens",
+		"cached_tokens",
+		"est_cost_usd",
+		"updated_at_ms",
+	],
+	session_tool_use: ["session_event_id", "tool_name", "kind", "server", "calls", "last_call_at_ms", "updated_at_ms"],
+	// Added after the three tables above were listed, and it is the one that makes
+	// a per-DAY number correct: a session row carries its cumulative total under
+	// a single timestamp, so a conversation spanning three days puts all of its
+	// spend on the last one. Syncing sessions alone would reproduce on the web
+	// exactly the bug this table was created to fix locally.
+	session_usage_events: [
+		"session_event_id",
+		"dedup_key",
+		"responded_at_ms",
+		"model",
+		"input_tokens",
+		"output_tokens",
+		"cached_tokens",
+		"est_cost_usd",
+		"updated_at_ms",
+	],
+};
+
+/**
+ * Integer surrogate keys, replaced by the natural key they stand for. This is
+ * the ONLY rewrite the format allows.
+ *
+ * `repos.id` is an autoincrement local to one machine: the same repo is 3 here
+ * and 17 there, so sending the integer would attach rows to whichever repo
+ * happened to take that id on the server. `session_event_id` needs no rewrite —
+ * an `event_id` already embeds repo, source and session id.
+ */
+export const REWRITTEN_COLUMNS: Readonly<Record<string, string>> = {
+	repo_id: "repo_identity",
+};
+
+/** Local columns held back per table, with the reason each one is held back. */
+export const EXCLUDED_COLUMNS: Readonly<Record<SyncedTable, ReadonlyArray<string>>> = {
+	sessions: [],
+	session_model_usage: [],
+	session_usage_events: [],
+	// Dropped from the schema definition long ago (recall_receipts replaced it),
+	// but still present on databases created before that. No writer, no reader.
+	session_tool_use: ["metadata_json"],
+};
+
+/**
+ * Rows per request, per table.
+ *
+ * Usage events are one narrow row per model response, so they get a larger batch.
+ * ⚠ Keep the resulting body well under whatever the gateway in front of the server
+ * allows: a body-size refusal arrives as a 413 that is indistinguishable from a
+ * transient failure, which is how the previous batch endpoint burned its whole
+ * retry budget and then expired silently.
+ */
+export const BATCH_LIMITS: Readonly<Record<SyncedTable, number>> = {
+	sessions: 200,
+	session_model_usage: 200,
+	session_tool_use: 200,
+	session_usage_events: 500,
+};

--- a/cli/src/dashboard/SessionPushReader.test.ts
+++ b/cli/src/dashboard/SessionPushReader.test.ts
@@ -1,0 +1,353 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { TableCursor } from "../core/SessionPushCursor.js";
+import { type DashboardDbHandle, withDashboardDb } from "./DashboardDb.js";
+import {
+	batchTables,
+	FIRST_RUN_WINDOW_MS,
+	isBatchEmpty,
+	readDbInstanceId,
+	readSessionBatch,
+	readTableSlice,
+} from "./SessionPushReader.js";
+
+const NOW = Date.UTC(2026, 7, 12, 12, 0, 0);
+
+/**
+ * A cursor at the START of one millisecond — the empty key.
+ *
+ * The position a bare stamp denotes, so a case that only cares about the
+ * millisecond can say so without spelling a key.
+ */
+const at = (stamp: number): TableCursor => ({ stamp, key: [] });
+
+describe("session push reader", () => {
+	let dir: string;
+	let dbPath: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "jolli-sessionpush-"));
+		dbPath = join(dir, "dashboard.db");
+	});
+
+	afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+	const withDb = <T>(fn: (db: DashboardDbHandle) => T) => withDashboardDb(fn, { dbPath });
+
+	/** Seeds one repo plus one session, with control over both clocks. */
+	let seq = 0;
+	async function seed(opts: {
+		identity?: string;
+		eventId?: string;
+		updatedAtMs?: number;
+		writtenAtMs?: number;
+	}): Promise<void> {
+		const identity = opts.identity ?? "https://github.com/acme/widgets";
+		const sessionId = `s${++seq}`;
+		const eventId = opts.eventId ?? `session:${identity}:claude:${sessionId}`;
+		await withDb((db) => {
+			db.prepare(
+				`INSERT OR IGNORE INTO repos (repo_identity, repo_name, worktree_root, enabled_at)
+				 VALUES (?, 'widgets', '/w', 1)`,
+			).run(identity);
+			const repo = db.prepare("SELECT id FROM repos WHERE repo_identity = ?").get(identity) as { id: number };
+			db.prepare(
+				`INSERT INTO sessions (event_id, repo_id, source, session_id, title, updated_at_ms, written_at_ms,
+				                       input_tokens, output_tokens, cached_tokens, est_cost_usd)
+				 VALUES (?, ?, 'claude', ?, 'Refactor the push executor', ?, ?, 100, 10, 5, 0.5)`,
+			).run(eventId, repo.id, sessionId, opts.updatedAtMs ?? NOW, opts.writtenAtMs ?? NOW);
+		});
+	}
+
+	it("puts the repo's identity on the row, so one batch can carry many repos", async () => {
+		await seed({});
+		await seed({ identity: "https://github.com/acme/other", eventId: "session:other:claude:s2" });
+
+		const batch = await withDb((db) => readSessionBatch(db, { cursors: {}, nowMs: NOW }));
+		const identities = batch.sessions.rows.map((r) => r.repo_identity);
+
+		expect(new Set(identities)).toEqual(
+			new Set(["https://github.com/acme/widgets", "https://github.com/acme/other"]),
+		);
+		// The envelope has no repo field at all — this column is the only thing
+		// that says where a row belongs.
+		expect(batch.sessions.rows[0]).not.toHaveProperty("repo_id");
+	});
+
+	it("passes values through untouched", async () => {
+		await seed({});
+
+		const batch = await withDb((db) => readSessionBatch(db, { cursors: {}, nowMs: NOW }));
+		const row = batch.sessions.rows[0];
+
+		// Integers stay integers, a REAL stays a REAL, and text stays text. The point
+		// is that "did this sync correctly" stays a field-by-field comparison rather
+		// than a question about two representations.
+		expect(row.updated_at_ms).toBe(NOW);
+		expect(row.input_tokens).toBe(100);
+		expect(row.est_cost_usd).toBe(0.5);
+		expect(row.title).toBe("Refactor the push executor");
+	});
+
+	it("selects on the SYNC stamp, not the business clock", async () => {
+		// The failure this prevents: `projectCommitSummary` enriches a session's
+		// token split without touching `updated_at_ms` (which means "last active"),
+		// so a sync keyed on that column would never see the better data it just
+		// wrote.
+		await seed({ updatedAtMs: 1_000, writtenAtMs: NOW });
+
+		const stale = await withDb((db) =>
+			readTableSlice(db, "sessions", { cursors: { sessions: at(2_000) }, nowMs: NOW }),
+		);
+		expect(stale.rows).toHaveLength(1);
+		expect(stale.next?.stamp).toBe(NOW);
+	});
+
+	it("selects with >= so a shared millisecond is never skipped", async () => {
+		// `>` would step over every row after the first in a millisecond, and
+		// nothing ever revisits them. Re-sending costs nothing: the server upserts.
+		await seed({ eventId: "a", writtenAtMs: 5_000 });
+		await seed({ eventId: "b", writtenAtMs: 5_000 });
+
+		const slice = await withDb((db) =>
+			readTableSlice(db, "sessions", { cursors: { sessions: at(5_000) }, nowMs: NOW }),
+		);
+		expect(slice.rows).toHaveLength(2);
+	});
+
+	it("advances past a millisecond holding more rows than one batch", async () => {
+		// The deadlock this keyset cursor exists to remove, caught in production: a
+		// stamp is not a unique position, so `stamp >= cursor ORDER BY stamp LIMIT n`
+		// returns the SAME first n rows on every pass once more than n rows share a
+		// millisecond. The highest stamp seen then equals the cursor it started
+		// from, the cursor stands still, and that table stops syncing for ever —
+		// measured on a real machine as 9,657 rows stranded behind one millisecond
+		// holding 840 of them, unmoved for five days.
+		//
+		// `sessions` takes 200 per batch; 201 rows on one millisecond is the
+		// smallest case that overflows it.
+		const SHARED = 7_000;
+		for (let i = 0; i < 201; i++) await seed({ eventId: `e${String(i).padStart(3, "0")}`, writtenAtMs: SHARED });
+
+		let cursor: TableCursor = at(SHARED);
+		const seen = new Set<string>();
+		for (let pass = 1; pass <= 3; pass++) {
+			const slice = await withDb((db) =>
+				readTableSlice(db, "sessions", { cursors: { sessions: cursor }, nowMs: NOW }),
+			);
+			for (const row of slice.rows) seen.add(String(row.event_id));
+			expect(slice.next).toBeDefined();
+			cursor = slice.next as TableCursor;
+		}
+		// Every row is delivered, inside the same millisecond, in three passes of a
+		// 200-row batch. Against the stamp-only cursor this saw the first 200 rows
+		// three times and `seen.size` stayed at 200.
+		expect(seen.size).toBe(201);
+	});
+
+	it("applies the first-run window to the BUSINESS clock, never to the stamp", async () => {
+		// A backfill rewrites every old row's stamp to "just now". Windowing on the
+		// stamp would then admit sessions from years ago as though they were recent
+		// — the window would filter nothing at all.
+		await seed({ eventId: "old", updatedAtMs: NOW - FIRST_RUN_WINDOW_MS - 1, writtenAtMs: NOW });
+		await seed({ eventId: "recent", updatedAtMs: NOW - 1_000, writtenAtMs: NOW });
+
+		const first = await withDb((db) => readTableSlice(db, "sessions", { cursors: {}, nowMs: NOW }));
+		expect(first.rows.map((r) => r.event_id)).toEqual(["recent"]);
+		expect(first.skipped).toBe(1);
+
+		// And with a cursor, the window is gone: this is a first-run trade, not a
+		// standing filter.
+		const later = await withDb((db) =>
+			readTableSlice(db, "sessions", { cursors: { sessions: at(0) }, nowMs: NOW }),
+		);
+		expect(later.rows).toHaveLength(2);
+	});
+
+	it("windows a table with no clock of its own through its parent session", async () => {
+		// `session_model_usage` has no instant of its own, and it used to get no
+		// window at all — so a first run shipped the WHOLE table, including children
+		// of the very sessions the window had just withheld. The server then held
+		// usage it could only file under a session it was never sent.
+		await seed({ eventId: "old", updatedAtMs: NOW - FIRST_RUN_WINDOW_MS - 1, writtenAtMs: NOW });
+		await seed({ eventId: "recent", updatedAtMs: NOW - 1_000, writtenAtMs: NOW });
+		await withDb((db) => {
+			for (const eventId of ["old", "recent"]) {
+				db.prepare(
+					`INSERT INTO session_model_usage (session_event_id, model, input_tokens, output_tokens,
+					                                  cached_tokens, updated_at_ms)
+					 VALUES (?, 'sonnet', 1, 2, 3, ?)`,
+				).run(eventId, NOW);
+			}
+		});
+
+		const slice = await withDb((db) => readTableSlice(db, "session_model_usage", { cursors: {}, nowMs: NOW }));
+
+		expect(slice.rows.map((r) => r.session_event_id)).toEqual(["recent"]);
+		// Counted through the same predicate, so what the window admitted and what
+		// it reports as the cost of the trade cannot drift apart.
+		expect(slice.skipped).toBe(1);
+	});
+
+	it("does not advance the cursor past rows the window declined to send", async () => {
+		// The window is inside the SELECT, so a row it excludes never reaches the
+		// stamp scan — the cursor cannot step over a row that was never sent.
+		await seed({ eventId: "old", updatedAtMs: NOW - FIRST_RUN_WINDOW_MS - 1, writtenAtMs: 9_000 });
+		await seed({ eventId: "recent", updatedAtMs: NOW - 1_000, writtenAtMs: 4_000 });
+
+		const slice = await withDb((db) => readTableSlice(db, "sessions", { cursors: {}, nowMs: NOW }));
+		expect(slice.next?.stamp).toBe(4_000);
+	});
+
+	it("still advances when a whole batch would fall outside the first-run window", async () => {
+		// The regression this pins: filtering AFTER `LIMIT` left a table whose oldest
+		// `LIMIT` rows are all outside the window with nothing kept, so no stamp, so
+		// no cursor — and the next run read and dropped exactly the same rows, for
+		// ever. The migration backfills `written_at_ms` from `updated_at_ms`, so
+		// stamp order tracks business order and that is the ORDINARY starting state
+		// of any machine with a batch of history older than 90 days. A limit of 1
+		// stands in for the real 200.
+		// Both strictly BELOW the floor: the window is `>=`, so `NOW -
+		// FIRST_RUN_WINDOW_MS` itself is still inside it.
+		const old = NOW - FIRST_RUN_WINDOW_MS - 2;
+		await seed({ eventId: "old-1", updatedAtMs: old, writtenAtMs: old });
+		await seed({ eventId: "old-2", updatedAtMs: old + 1, writtenAtMs: old + 1 });
+		await seed({ eventId: "recent", updatedAtMs: NOW - 1_000, writtenAtMs: NOW - 1_000 });
+
+		const slice = await withDb((db) => readTableSlice(db, "sessions", { cursors: {}, nowMs: NOW }));
+		// The in-window row is reached rather than being crowded out by two older
+		// ones, and its stamp is what the cursor moves to.
+		expect(slice.rows.map((r) => r.event_id)).toEqual(["recent"]);
+		expect(slice.next?.stamp).toBe(NOW - 1_000);
+		// Counted across the whole table, not just this batch — it is the backlog
+		// the window declines, and it is reported once rather than understated.
+		expect(slice.skipped).toBe(2);
+	});
+
+	it("omits empty tables from the wire payload", async () => {
+		await seed({});
+		const batch = await withDb((db) => readSessionBatch(db, { cursors: {}, nowMs: NOW }));
+		expect(Object.keys(batchTables(batch))).toEqual(["sessions"]);
+		expect(isBatchEmpty(batch)).toBe(false);
+	});
+
+	it("reports an empty batch when nothing is new", async () => {
+		await seed({ writtenAtMs: 1_000 });
+		const batch = await withDb((db) => readSessionBatch(db, { cursors: { sessions: at(2_000) }, nowMs: NOW }));
+		expect(isBatchEmpty(batch)).toBe(true);
+	});
+
+	it("counts the whole backlog the first-run window declines, across the batch", async () => {
+		// The window is a trade, not an optimisation, so what it cost has to be
+		// visible somewhere rather than inferred from a batch that looks empty for
+		// no stated reason. It is the table's whole backlog, counted once on the run
+		// that declines it — a per-batch figure could only ever see as far as one
+		// `LIMIT` reached.
+		await seed({ eventId: "old-1", updatedAtMs: NOW - FIRST_RUN_WINDOW_MS - 1, writtenAtMs: NOW });
+		await seed({ eventId: "old-2", updatedAtMs: NOW - FIRST_RUN_WINDOW_MS - 2, writtenAtMs: NOW });
+
+		const batch = await withDb((db) => readSessionBatch(db, { cursors: {}, nowMs: NOW }));
+		expect(isBatchEmpty(batch)).toBe(true);
+		expect(batch.sessions.skipped).toBe(2);
+	});
+
+	it("withholds every table's rows for a disabled repo, and keeps the other repo's", async () => {
+		// The promise the Settings page makes. `sessions` carries the repo itself;
+		// the three child tables can only reach it through their parent session, so
+		// each shape has to be exercised — a filter that covered `sessions` alone
+		// would still ship the usage rows the charts are built from.
+		await seed({ identity: "https://github.com/acme/off", eventId: "off" });
+		await seed({ identity: "https://github.com/acme/on", eventId: "on" });
+		await withDb((db) => {
+			for (const eventId of ["off", "on"]) {
+				db.prepare(
+					`INSERT INTO session_model_usage (session_event_id, model, input_tokens, output_tokens,
+					                                  cached_tokens, updated_at_ms)
+					 VALUES (?, 'sonnet', 1, 2, 3, ?)`,
+				).run(eventId, NOW);
+				db.prepare(
+					`INSERT INTO session_tool_use (session_event_id, tool_name, kind, calls, last_call_at_ms,
+					                               updated_at_ms)
+					 VALUES (?, 'Edit', 'builtin', 1, ?, ?)`,
+				).run(eventId, NOW, NOW);
+				db.prepare(
+					`INSERT INTO session_usage_events (session_event_id, dedup_key, responded_at_ms, model,
+					                                   input_tokens, output_tokens, cached_tokens, updated_at_ms)
+					 VALUES (?, ?, ?, 'sonnet', 1, 2, 3, ?)`,
+				).run(eventId, `${eventId}:1`, NOW, NOW);
+			}
+		});
+
+		const batch = await withDb((db) =>
+			readSessionBatch(db, {
+				cursors: {},
+				nowMs: NOW,
+				excludedIdentities: new Set(["https://github.com/acme/off"]),
+			}),
+		);
+
+		expect(batch.sessions.rows.map((r) => r.repo_identity)).toEqual(["https://github.com/acme/on"]);
+		for (const table of ["session_model_usage", "session_tool_use", "session_usage_events"] as const) {
+			expect(batch[table].rows.map((r) => r.session_event_id)).toEqual(["on"]);
+		}
+	});
+
+	it("pages OVER a withheld row rather than stopping on it", async () => {
+		// The deliberate cost of filtering inside the SELECT: the cursor advances
+		// past a withheld row, so re-enabling the repo does not send its backlog —
+		// which is what the Settings copy says. Holding the cursor back instead
+		// would let one disabled repo's single row block every other repo's
+		// statistics for ever.
+		await seed({ identity: "https://github.com/acme/off", eventId: "off", writtenAtMs: 1_000 });
+		await seed({ identity: "https://github.com/acme/on", eventId: "on", writtenAtMs: 2_000 });
+
+		const slice = await withDb((db) =>
+			readTableSlice(db, "sessions", {
+				cursors: {},
+				nowMs: NOW,
+				excludedIdentities: new Set(["https://github.com/acme/off"]),
+			}),
+		);
+
+		expect(slice.rows.map((r) => r.event_id)).toEqual(["on"]);
+		expect(slice.next?.stamp).toBe(2_000);
+	});
+
+	it("is byte-identical to the unfiltered read when nothing is excluded", async () => {
+		// The normal case on every machine: no disabled repo, so no predicate and no
+		// parameters. An empty set must not become an `IN ()`.
+		await seed({});
+		const plain = await withDb((db) => readSessionBatch(db, { cursors: {}, nowMs: NOW }));
+		const empty = await withDb((db) =>
+			readSessionBatch(db, { cursors: {}, nowMs: NOW, excludedIdentities: new Set() }),
+		);
+		expect(empty).toEqual(plain);
+	});
+
+	it("never sends an absolute path for a repo with no remote", async () => {
+		// `local:<hash>` is what the schema stores on purpose — the alternative puts
+		// a home directory into every table. `getCanonicalRepoUrl`'s `file:///…`
+		// fallback still exists elsewhere and must not reach this wire.
+		await seed({ identity: "local:9f2a1c", eventId: "session:local:claude:s9" });
+
+		const batch = await withDb((db) => readSessionBatch(db, { cursors: {}, nowMs: NOW }));
+		const wire = JSON.stringify(batchTables(batch));
+
+		expect(wire).toContain("local:9f2a1c");
+		expect(wire).not.toContain("file://");
+		expect(wire).not.toContain(dir);
+	});
+
+	it("reads the database identity without minting one", async () => {
+		// This whole path is read-only. `ensureInstanceId` creates the id when it is
+		// missing, which is right for a writer and wrong here — the sync must never
+		// be the first thing that writes to the database.
+		expect(await withDb(readDbInstanceId)).toBeUndefined();
+
+		const { ensureInstanceId } = await import("./Backup.js");
+		const minted = await withDb(ensureInstanceId);
+		expect(await withDb(readDbInstanceId)).toBe(minted);
+	});
+});

--- a/cli/src/dashboard/SessionPushReader.ts
+++ b/cli/src/dashboard/SessionPushReader.ts
@@ -1,0 +1,353 @@
+/**
+ * Reads the machine database and assembles one session-sync batch.
+ *
+ * Lives under `dashboard/` because it is a reader of the dashboard database, and
+ * nothing under `core/` opens that file. It does the SQL and nothing else — no
+ * network, no cursor persistence, no gating — so the whole "which rows would go
+ * out" question can be tested against a real database without a server.
+ *
+ * Three rules from the format decide almost everything here:
+ *
+ *  1. **Values pass through untouched.** Millisecond integers stay integers,
+ *     `hit` stays 0/1, `commits_json` stays the JSON string it is. Whether the
+ *     sync is correct then becomes a field-by-field comparison rather than a
+ *     question about two representations.
+ *  2. **The only rewrite is a surrogate key** — `repo_id` becomes the repo's own
+ *     `repo_identity`. See `SessionPushManifest.REWRITTEN_COLUMNS`.
+ *  3. **Selection walks the sync stamp**, never a business column, and uses
+ *     `>=` rather than `>`.
+ */
+
+import type { TableCursor } from "../core/SessionPushCursor.js";
+import { createLogger } from "../Logger.js";
+import type { DashboardDbHandle } from "./DashboardDb.js";
+import {
+	BATCH_LIMITS,
+	EXCLUDED_COLUMNS,
+	SYNCED_COLUMNS,
+	SYNCED_TABLES,
+	type SyncedTable,
+} from "./SessionPushManifest.js";
+import { KEYSET_COLUMNS, syncStampColumn, WINDOW_SOURCES } from "./SyncColumns.js";
+
+const log = createLogger("SessionPushReader");
+
+/** How far back the FIRST run reaches when there is no cursor. */
+export const FIRST_RUN_WINDOW_MS = 90 * 24 * 60 * 60 * 1000;
+
+/** One table's slice of a batch. */
+export interface TableSlice {
+	readonly rows: ReadonlyArray<Record<string, unknown>>;
+	/**
+	 * Keyset of the LAST row in `rows` — where this table's cursor moves to.
+	 *
+	 * The last row rather than the largest stamp, and those are different answers:
+	 * `ORDER BY` is the keyset itself, so the last row is the maximum of the tuple
+	 * that actually pages the table. Taking the largest STAMP is what deadlocked —
+	 * within a millisecond that is the cursor the read started from.
+	 */
+	readonly next?: TableCursor;
+	/**
+	 * Rows this table will never send because they fall outside the first-run
+	 * window. The whole table's count, not this batch's: the window is part of
+	 * the SELECT, so the rows it excludes never come back to be counted — and a
+	 * per-batch figure understated the trade anyway, since it could only see as
+	 * far as one `LIMIT` reached. 0 once a cursor exists.
+	 */
+	readonly skipped: number;
+}
+
+export type SessionBatch = Readonly<Record<SyncedTable, TableSlice>>;
+
+export interface ReadBatchOptions {
+	/** Per-table cursor. An absent entry means "first run for this table". */
+	readonly cursors: Partial<Record<SyncedTable, TableCursor>>;
+	/** Now, for the first-run window. */
+	readonly nowMs: number;
+	/**
+	 * Repo identities whose rows must never leave this machine — the repos
+	 * `jolli disable` is set on. Absent or empty leaves every statement here
+	 * byte-identical to what it was before the exclusion existed, which is the
+	 * normal case.
+	 *
+	 * ⚠ The identities come from `profile.json` (`isRepoDisabled`), never from
+	 * `repos.disabled_at`: that column is a projection only `dbBackfillRepos`
+	 * writes, so it stays set for a while after a re-enable — and a row skipped
+	 * during that lag is skipped for ever, since the cursor pages over it.
+	 */
+	readonly excludedIdentities?: ReadonlySet<string>;
+}
+
+/**
+ * The database's own identity, WITHOUT minting one.
+ *
+ * `Backup.ensureInstanceId` creates the id when it is missing, which is right
+ * for a writer and wrong here: this whole path is read-only, and a sync must
+ * never be the thing that first writes to the database. An absent id simply
+ * means "cannot verify", and the caller treats that as "do not bind".
+ */
+export function readDbInstanceId(db: DashboardDbHandle): string | undefined {
+	const row = db.prepare("SELECT value FROM schema_meta WHERE key = 'instance-id'").get() as
+		| { value?: string }
+		| undefined;
+	return typeof row?.value === "string" ? row.value : undefined;
+}
+
+/**
+ * The SELECT for one table.
+ *
+ * `repo_id` is joined out to `repos.repo_identity` here rather than mapped in
+ * TypeScript so the identity travels on the row, which is what makes a batch
+ * able to carry several repos at once — the envelope has no repo field at all.
+ *
+ * ⚠ The identity is taken from `repos.repo_identity`, deliberately not from
+ * `getCanonicalRepoUrl`. A repo with no remote is `local:<hash of path>` in this
+ * column — a substitution the schema made on purpose, because the alternative
+ * puts an absolute path and a home directory into every table. That fallback
+ * still returns `file:///<path>` elsewhere, and it must never reach this wire.
+ */
+function selectFor(table: SyncedTable, windowSql: string | undefined, excludeSql: string | undefined): string {
+	const stamp = syncStampColumn(table);
+	const keys = KEYSET_COLUMNS[table];
+	const columns = SYNCED_COLUMNS[table]
+		.map((c) => (c === "repo_identity" ? "r.repo_identity AS repo_identity" : `t.${c}`))
+		.join(", ");
+	const join = SYNCED_COLUMNS[table].includes("repo_identity") ? " JOIN repos r ON r.id = t.repo_id" : "";
+	const window = windowSql === undefined ? "" : ` AND ${windowSql}`;
+	const exclude = excludeSql === undefined ? "" : ` AND ${excludeSql}`;
+	// A ROW VALUE comparison, which SQLite has supported since 3.15 — the tuple
+	// `(stamp, ...pk)` is unique, so paging on it always advances. Comparing the
+	// stamp alone cannot: more rows may share one millisecond than a batch holds,
+	// and then every pass returns the same rows and the cursor stands still (see
+	// `KEYSET_COLUMNS`).
+	//
+	// `>=`, not `>`, and the reason is unchanged from when the stamp stood alone:
+	// a cursor that steps OVER a row never revisits it, and re-sending costs
+	// nothing because the server upserts. With the key in the tuple that costs
+	// exactly one duplicated row per batch — the boundary row — instead of a
+	// whole millisecond.
+	//
+	// ORDER BY repeats the tuple exactly. A different order here does not fail,
+	// it silently pages over rows.
+	const tuple = `(t.${stamp}, ${keys.map((k) => `t.${k}`).join(", ")})`;
+	const params = `(?, ${keys.map(() => "?").join(", ")})`;
+	const order = [`t.${stamp} ASC`, ...keys.map((k) => `t.${k} ASC`)].join(", ");
+	return `SELECT ${columns} FROM ${table} t${join} WHERE ${tuple} >= ${params}${window}${exclude} ORDER BY ${order} LIMIT ?`;
+}
+
+/**
+ * The cursor's key sized to this build's `KEYSET_COLUMNS`.
+ *
+ * A stored cursor can disagree — a position adopted from a backend that echoed
+ * only a stamp has no key at all, and a schema change could alter the key's
+ * width. Padding with `""` puts
+ * the read at the START of that millisecond, so the degradation is re-delivering
+ * one millisecond into an upsert. Truncating is the same trade in the other
+ * direction. Neither can skip a row, which is the only outcome that would lose
+ * data.
+ */
+function keyValues(table: SyncedTable, cursor: TableCursor): ReadonlyArray<string> {
+	const width = KEYSET_COLUMNS[table].length;
+	return Array.from({ length: width }, (_, i) => cursor.key[i] ?? "");
+}
+
+/** Keyset of the last row of a page — the cursor the next page starts from. */
+function nextCursor(table: SyncedTable, rows: ReadonlyArray<Record<string, unknown>>): TableCursor | undefined {
+	const last = rows[rows.length - 1];
+	if (last === undefined) return undefined;
+	const stamp = last[syncStampColumn(table)];
+	if (typeof stamp !== "number") return undefined;
+	return { stamp, key: KEYSET_COLUMNS[table].map((c) => String(last[c] ?? "")) };
+}
+
+/**
+ * The first-run window as a SQL predicate on alias `t`, with ONE `?` for the
+ * floor.
+ *
+ * Two shapes — see `WINDOW_SOURCES`, whose union is what guarantees there is
+ * always exactly one:
+ *
+ *  - A table with its own business clock is filtered on that column. A row whose
+ *    clock is NULL has no date to be judged on, so it is KEPT — the same reading
+ *    as the `typeof at !== "number"` this replaced.
+ *  - A table with no clock is filtered through its parent SESSION, because that
+ *    is where its date lives. `session_model_usage` used to get no window at all,
+ *    so a first run shipped the whole table — including children of the very
+ *    sessions the window had just withheld. `EXISTS` also drops a row whose
+ *    parent session is missing outright, which is right for the same reason: it
+ *    cannot be filed anywhere on arrival.
+ *
+ * A single predicate serves both the SELECT and the count below, so "what the
+ * window admits" and "what the window cost" cannot drift apart.
+ */
+function windowPredicate(table: SyncedTable): string {
+	const source = WINDOW_SOURCES[table];
+	return "own" in source
+		? `(t.${source.own} IS NULL OR t.${source.own} >= ?)`
+		: `EXISTS (SELECT 1 FROM sessions ws WHERE ws.event_id = t.${source.parent} AND ws.updated_at_ms >= ?)`;
+}
+
+/**
+ * The `jolli disable` exclusion as a SQL predicate on alias `t`, with one `?`
+ * per excluded identity — or `undefined` when nothing is excluded.
+ *
+ * ⚠ It has to be part of the SELECT, for the same reason the window does (see
+ * {@link readTableSlice}): filtered after `LIMIT`, a table whose oldest page is
+ * all excluded comes back empty, no stamp is learned, and that table stops
+ * syncing permanently.
+ *
+ * The consequence of being inside the SELECT is the deliberate cost of this
+ * feature: selection pages OVER an excluded row, so statistics written before a
+ * repo was disabled are not uploaded and are NOT sent later if it is re-enabled.
+ * The Settings copy says exactly that. Sending them on re-enable would need a
+ * per-repo cursor; holding the cursor back instead would let one disabled repo's
+ * single row block every other repo on the machine.
+ *
+ * Two shapes, because only `sessions` carries the repo:
+ *
+ *  - `sessions` already joins `repos` as `r` to put `repo_identity` on the wire,
+ *    so it just tests that column.
+ *  - The three child tables reach it through their parent session. Spelled as
+ *    `NOT EXISTS (… IN (excluded))` rather than `EXISTS (… NOT IN (…))` on
+ *    purpose: a row is withheld only when it can be PROVEN to belong to a
+ *    disabled repo, so a child whose parent session is missing keeps the
+ *    behaviour it had before — this predicate is not the place to start dropping
+ *    rows for a second reason.
+ *
+ * A table with neither column is a privacy decision nobody has made, so it
+ * throws rather than silently sending everything: the caller turns that into a
+ * skipped run, which is the safe direction.
+ */
+function excludedRepoPredicate(table: SyncedTable, count: number): string | undefined {
+	if (count === 0) return undefined;
+	const list = Array.from({ length: count }, () => "?").join(", ");
+	if (SYNCED_COLUMNS[table].includes("repo_identity")) return `r.repo_identity NOT IN (${list})`;
+	if (SYNCED_COLUMNS[table].includes("session_event_id")) {
+		return `NOT EXISTS (SELECT 1 FROM sessions ds JOIN repos dr ON dr.id = ds.repo_id
+		      WHERE ds.event_id = t.session_event_id AND dr.repo_identity IN (${list}))`;
+	}
+	/* v8 ignore next 2 -- structural guard: every SYNCED_TABLE carries one of the two columns today, and `SessionPushManifest.test.ts` is what keeps it that way */
+	throw new Error(`SessionPushReader: ${table} has no way to identify its repo — cannot honour jolli disable`);
+}
+
+/**
+ * How many rows the first-run window will never send.
+ *
+ * A separate COUNT because the window is inside the SELECT: the rows it excludes
+ * never reach JS to be counted. Deliberately blind to the `jolli disable`
+ * exclusion: this number is the WINDOW's account of what it declined, and a repo
+ * the user switched off is a different question with its own log line. `NOT (<the same predicate>)` rather than a
+ * hand-written inverse — an inverse spelled twice is an inverse that can be
+ * spelled wrong, and this one is only ever read as a log line, so a wrong number
+ * here would never be contradicted by anything. Only run on a first run, which
+ * is once per table per backend.
+ */
+function countOutsideWindow(db: DashboardDbHandle, table: SyncedTable, windowSql: string, floorMs: number): number {
+	const row = db.prepare(`SELECT COUNT(*) AS n FROM ${table} t WHERE NOT (${windowSql})`).get(floorMs) as
+		| { n?: number }
+		| undefined;
+	return row?.n ?? 0;
+}
+
+/**
+ * Reads one table's next slice.
+ *
+ * On a first run (no cursor) the window is applied to the table's BUSINESS time,
+ * not to the stamp — the two are different columns and confusing them here is
+ * quietly wrong in a specific way: a backfill rewrites every old row's stamp to
+ * "just now", so a stamp-based window would admit sessions from years ago as
+ * though they were recent. A table with no business clock of its own
+ * (`session_model_usage`) is windowed through its parent session instead — see
+ * {@link windowPredicate}.
+ *
+ * ⚠ The window is part of the SELECT, and putting it back on the RESULT is the
+ * bug it was moved out of. Filtered afterwards it sits on the wrong side of
+ * `LIMIT`: a table whose oldest `LIMIT` rows are all outside the window comes
+ * back with nothing kept, so no stamp is learned, so the cursor never moves —
+ * and the next run reads and drops exactly the same rows. That table stops
+ * syncing PERMANENTLY, with only a "skipped N rows" line to show for it. It is
+ * not a corner case either: the migration backfills `sessions.written_at_ms`
+ * from `updated_at_ms`, so stamp order tracks business order, and any machine
+ * with more than one batch of sessions older than the window starts there.
+ * Inside the SELECT, `LIMIT` counts only rows that will actually be sent.
+ */
+export function readTableSlice(db: DashboardDbHandle, table: SyncedTable, opts: ReadBatchOptions): TableSlice {
+	const cursor = opts.cursors[table];
+	const limit = BATCH_LIMITS[table];
+	// Non-undefined only when the window applies: a first run, on a table the
+	// window can be expressed on.
+	const windowSql = cursor === undefined ? windowPredicate(table) : undefined;
+	const floorMs = opts.nowMs - FIRST_RUN_WINDOW_MS;
+	const from = keyValues(table, cursor ?? { stamp: 0, key: [] });
+	// One statement for both cases: the window arm's stamp was written as a
+	// literal 0 before, which is the same value — `windowSql` is non-undefined
+	// only when there is no cursor. Parameter order follows the SQL exactly:
+	// keyset, then the window floor, then the excluded identities, then LIMIT.
+	const excluded = [...(opts.excludedIdentities ?? [])];
+	const excludeSql = excludedRepoPredicate(table, excluded.length);
+	const rows = db
+		.prepare(selectFor(table, windowSql, excludeSql))
+		.all(cursor?.stamp ?? 0, ...from, ...(windowSql === undefined ? [] : [floorMs]), ...excluded, limit) as Array<
+		Record<string, unknown>
+	>;
+
+	const next = nextCursor(table, rows);
+	const skipped = windowSql === undefined ? 0 : countOutsideWindow(db, table, windowSql, floorMs);
+	return { rows, ...(next !== undefined ? { next } : {}), skipped };
+}
+
+/** Reads every table's next slice. */
+export function readSessionBatch(db: DashboardDbHandle, opts: ReadBatchOptions): SessionBatch {
+	const batch = {} as Record<SyncedTable, TableSlice>;
+	let skipped = 0;
+	for (const table of SYNCED_TABLES) {
+		batch[table] = readTableSlice(db, table, opts);
+		skipped += batch[table].skipped;
+	}
+	// The first-run window is a trade, not an optimisation, so what it cost has to
+	// be visible somewhere rather than inferred from a number that looks low. This
+	// is the whole backlog it declines, counted once on the run that declines it.
+	if (skipped > 0) log.info("session sync: skipping %d row(s) older than the 90-day first-run window", skipped);
+	return batch;
+}
+
+/**
+ * True when some table filled its batch limit, so there is certainly more.
+ *
+ * This — not the cursor — is what ends the loop. Selection is `>=`, so the row
+ * sitting exactly on the cursor is deliberately re-read on the next pass; a loop
+ * that stopped only when a batch came back empty would therefore re-send that
+ * boundary row until it hit the per-run ceiling. Asking "was anything
+ * truncated?" answers the real question directly.
+ *
+ * Safe to loop on only because the cursor is a keyset: it advances by at least
+ * one row per pass, so "truncated" cannot mean "the same rows again". Against a
+ * stamp-only cursor this same `true` drove a spin — see `KEYSET_COLUMNS`.
+ */
+export function isBatchTruncated(batch: SessionBatch): boolean {
+	return SYNCED_TABLES.some((table) => batch[table].rows.length >= BATCH_LIMITS[table]);
+}
+
+/** True when no table has anything to send. */
+export function isBatchEmpty(batch: SessionBatch): boolean {
+	return SYNCED_TABLES.every((table) => batch[table].rows.length === 0);
+}
+
+/** Total rows across every table — for logging and the batch-loop's progress check. */
+export function batchSize(batch: SessionBatch): number {
+	return SYNCED_TABLES.reduce((sum, table) => sum + batch[table].rows.length, 0);
+}
+
+/** The wire payload's `tables` object: only the tables that have rows. */
+export function batchTables(batch: SessionBatch): Record<string, ReadonlyArray<Record<string, unknown>>> {
+	const tables: Record<string, ReadonlyArray<Record<string, unknown>>> = {};
+	for (const table of SYNCED_TABLES) {
+		if (batch[table].rows.length > 0) tables[table] = batch[table].rows;
+	}
+	return tables;
+}
+
+/** Every local column of `table` this build knows about — the manifest's view. */
+export function declaredLocalColumns(table: SyncedTable): ReadonlyArray<string> {
+	return [...SYNCED_COLUMNS[table].map((c) => (c === "repo_identity" ? "repo_id" : c)), ...EXCLUDED_COLUMNS[table]];
+}

--- a/cli/src/dashboard/SessionSyncRunner.test.ts
+++ b/cli/src/dashboard/SessionSyncRunner.test.ts
@@ -1,0 +1,779 @@
+/**
+ * The runner's contract, exercised against a real database and a fake server.
+ *
+ * The cases that matter here are the ones where a wrong choice loses data
+ * silently: a cursor that never comes down when the backend changes, a throttle
+ * mark that only records successes, a gate that reads the wrong switch.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type JolliMemoryPushClient, SessionCursorAheadError } from "../core/JolliMemoryPushClient.js";
+import {
+	MIN_ATTEMPT_INTERVAL_MS,
+	readSessionPushChannel,
+	type TableCursor,
+	writeSessionPushChannel,
+} from "../core/SessionPushCursor.js";
+import { type DashboardDbHandle, withDashboardDb } from "./DashboardDb.js";
+
+const NOW = Date.UTC(2026, 7, 12, 12, 0, 0);
+
+/**
+ * A cursor at the START of one millisecond — the empty key.
+ *
+ * The position a bare stamp denotes, so a case that only cares about the
+ * millisecond can say so without spelling a key. The fake servers here
+ * deliberately ANSWER with bare numbers: the wire tolerates a backend that
+ * echoes no tie-breaker, and that path must keep working.
+ */
+const at = (stamp: number): TableCursor => ({ stamp, key: [] });
+
+const h = vi.hoisted(() => ({
+	loadConfig: vi.fn(),
+	readRepoRegistryStrict: vi.fn(),
+	isRepoDisabled: vi.fn(),
+	getDashboardDbPath: vi.fn(),
+	canUseDashboardDb: vi.fn(),
+	log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Only `createLogger` is replaced: `errMsg` is what turns a thrown value into the
+// reason string every branch below reports, so a wholesale mock would assert
+// against text the production code never produces.
+vi.mock("../Logger.js", async (orig) => ({
+	...(await orig<Record<string, unknown>>()),
+	createLogger: () => h.log,
+}));
+
+vi.mock("../core/SessionTracker.js", async (orig) => ({
+	...(await orig<Record<string, unknown>>()),
+	loadConfig: h.loadConfig,
+}));
+
+// The two halves of "which repos are switched off". Mocked rather than driven
+// through real `profile.json` files because the predicate itself is
+// `RepoRegistry`'s to test — here the question is only what the runner does with
+// its answer.
+vi.mock("./RepoRegistry.js", async (orig) => ({
+	...(await orig<Record<string, unknown>>()),
+	readRepoRegistryStrict: h.readRepoRegistryStrict,
+	isRepoDisabled: h.isRepoDisabled,
+}));
+
+vi.mock("./DashboardDb.js", async (orig) => ({
+	...(await orig<Record<string, unknown>>()),
+	getDashboardDbPath: h.getDashboardDbPath,
+	canUseDashboardDb: h.canUseDashboardDb,
+}));
+
+/** A client whose two used methods are stubs. */
+function fakeClient(over: Partial<JolliMemoryPushClient> = {}): JolliMemoryPushClient {
+	return {
+		resolveBaseUrl: async () => "https://acme.jolli.ai",
+		pushSessions: async () => ({ accepted: {}, cursor: {} }),
+		...over,
+	} as unknown as JolliMemoryPushClient;
+}
+
+describe("session sync runner", () => {
+	let dir: string;
+	let dbPath: string;
+	let configDir: string;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		// The runner states each stable skip reason once per PROCESS, and a vitest
+		// file is one process for every case in it — so without this, a reason
+		// reported by an earlier case would be missing from a later one's log.
+		const { resetSessionSyncReportMemo } = await import("./SessionSyncRunner.js");
+		resetSessionSyncReportMemo();
+		dir = mkdtempSync(join(tmpdir(), "jolli-syncrun-"));
+		dbPath = join(dir, "dashboard.db");
+		configDir = join(dir, "cfg");
+		h.loadConfig.mockResolvedValue({ jolliApiKey: "sk-jol-x" });
+		h.readRepoRegistryStrict.mockResolvedValue({ version: 1, repos: [] });
+		h.isRepoDisabled.mockReturnValue(false);
+		h.getDashboardDbPath.mockReturnValue(dbPath);
+		h.canUseDashboardDb.mockReturnValue(true);
+	});
+
+	afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+	const run = async (over: Record<string, unknown> = {}) => {
+		const { runSessionSync } = await import("./SessionSyncRunner.js");
+		return runSessionSync({ nowMs: NOW, configDir, force: true, client: fakeClient(), ...over });
+	};
+
+	async function seedSession(writtenAtMs = NOW): Promise<void> {
+		await withDashboardDb(
+			(db: DashboardDbHandle) => {
+				db.prepare(
+					`INSERT OR IGNORE INTO repos (repo_identity, repo_name, worktree_root, enabled_at)
+				 VALUES ('https://github.com/acme/widgets', 'widgets', '/w', 1)`,
+				).run();
+				db.prepare(
+					`INSERT INTO sessions (event_id, repo_id, source, session_id, updated_at_ms, written_at_ms)
+				 VALUES ('e1', 1, 'claude', 's1', ?, ?)`,
+				).run(NOW, writtenAtMs);
+			},
+			{ dbPath },
+		);
+	}
+
+	/** `count` sessions with strictly increasing sync stamps. */
+	async function seedMany(count: number): Promise<void> {
+		await withDashboardDb(
+			(db: DashboardDbHandle) => {
+				db.prepare(
+					`INSERT OR IGNORE INTO repos (repo_identity, repo_name, worktree_root, enabled_at)
+					 VALUES ('https://github.com/acme/widgets', 'widgets', '/w', 1)`,
+				).run();
+				for (let i = 0; i < count; i++) {
+					db.prepare(
+						`INSERT INTO sessions (event_id, repo_id, source, session_id, updated_at_ms, written_at_ms)
+						 VALUES (?, 1, 'claude', ?, ?, ?)`,
+					).run(`e${i}`, `s${i}`, NOW, 1_000 + i);
+				}
+			},
+			{ dbPath },
+		);
+	}
+
+	/** Puts `identities` in the registry, so `isRepoDisabled` gets asked about them. */
+	function registered(...identities: string[]): void {
+		h.readRepoRegistryStrict.mockResolvedValue({
+			version: 1,
+			repos: identities.map((repoIdentity, i) => ({
+				repoIdentity,
+				repoName: `r${i}`,
+				worktreeRoot: `/w${i}`,
+				enabledAt: "2026-08-12T00:00:00.000Z",
+			})),
+		});
+	}
+
+	/** A second repo with one session, so a filter can be seen to keep one and drop one. */
+	async function seedSecondRepo(): Promise<void> {
+		await withDashboardDb(
+			(db: DashboardDbHandle) => {
+				db.prepare(
+					`INSERT OR IGNORE INTO repos (repo_identity, repo_name, worktree_root, enabled_at)
+					 VALUES ('https://github.com/acme/gadgets', 'gadgets', '/g', 1)`,
+				).run();
+				db.prepare(
+					`INSERT INTO sessions (event_id, repo_id, source, session_id, updated_at_ms, written_at_ms)
+					 VALUES ('e2', 2, 'claude', 's2', ?, ?)`,
+				).run(NOW, NOW);
+			},
+			{ dbPath },
+		);
+	}
+
+	describe("gates", () => {
+		it("sends nothing when syncSessions is off", async () => {
+			h.loadConfig.mockResolvedValue({ jolliApiKey: "sk-jol-x", syncSessions: false });
+			await seedSession();
+			const push = vi.fn();
+			expect(await run({ client: fakeClient({ pushSessions: push } as never) })).toMatchObject({
+				status: "skipped",
+			});
+			expect(push).not.toHaveBeenCalled();
+		});
+
+		it("sends nothing when not signed in", async () => {
+			h.loadConfig.mockResolvedValue({});
+			expect(await run()).toMatchObject({ status: "skipped", reason: "not signed in" });
+		});
+
+		it("withholds a disabled repository's rows whatever triggered the run", async () => {
+			// `jolli disable` is a ROW FILTER here, not a gate: this run has no cwd at
+			// all (the daemon's shape), and the rows must still stay put. The gate this
+			// replaced could only answer for the repo that triggered the run, so a
+			// commit in any OTHER repo shipped this one's backlog.
+			await seedSession();
+			registered("https://github.com/acme/widgets");
+			h.isRepoDisabled.mockReturnValue(true);
+			const push = vi.fn();
+			await run({ client: fakeClient({ pushSessions: push } as never) });
+			expect(push).not.toHaveBeenCalled();
+		});
+
+		it("still sends every OTHER repo's rows", async () => {
+			// The failure the old gate had in the other direction: one switched-off
+			// repo stopped the whole machine's statistics.
+			await seedSession();
+			await seedSecondRepo();
+			registered("https://github.com/acme/widgets", "https://github.com/acme/gadgets");
+			h.isRepoDisabled.mockImplementation(
+				(repo: { repoIdentity: string }) => repo.repoIdentity === "https://github.com/acme/widgets",
+			);
+			// Typed parameter so the captured call keeps its shape — `vi.fn(async () =>
+			// …)` infers an empty tuple for `calls`.
+			const push = vi.fn(async (_payload: { tables: { sessions?: Array<{ repo_identity: string }> } }) => ({
+				accepted: {},
+				cursor: {},
+			}));
+			await run({ client: fakeClient({ pushSessions: push } as never) });
+			const sent = push.mock.calls[0]?.[0];
+			expect(sent?.tables.sessions?.map((r) => r.repo_identity)).toEqual(["https://github.com/acme/gadgets"]);
+		});
+
+		it("sends nothing when the registry cannot be read", async () => {
+			// Fail CLOSED, the one read in this module that does. Degrading to
+			// "nothing is disabled" would upload statistics from a repo whose owner
+			// switched the product off, and no later run can take that back.
+			await seedSession();
+			h.readRepoRegistryStrict.mockRejectedValue(new Error("EACCES"));
+			const push = vi.fn();
+			expect(await run({ client: fakeClient({ pushSessions: push } as never) })).toMatchObject({
+				status: "skipped",
+			});
+			expect(push).not.toHaveBeenCalled();
+		});
+
+		it("skips whole on a runtime that cannot open the database", async () => {
+			// A Node without flag-free `node:sqlite`, or a machine that never enabled
+			// the dashboard. The rows stay put and the next capable runtime sends
+			// them, so this is a skip rather than a failure — and it says so, because
+			// otherwise it is indistinguishable from a machine with nothing new.
+			h.canUseDashboardDb.mockReturnValue(false);
+			await seedSession();
+			const push = vi.fn();
+			expect(await run({ client: fakeClient({ pushSessions: push } as never) })).toMatchObject({
+				status: "skipped",
+				reason: "runtime cannot open the database",
+			});
+			expect(push).not.toHaveBeenCalled();
+		});
+
+		it("sends for a repo with push turned off, and for one with no binding", async () => {
+			// The decision this channel is built on: statistics do not follow the
+			// memory push's rules. `syncOnPush: false` is that rule, and it must not
+			// reach here — otherwise the switch in Settings would be lying.
+			h.loadConfig.mockResolvedValue({ jolliApiKey: "sk-jol-x", syncOnPush: false });
+			await seedSession();
+			const push = vi.fn(async () => ({ accepted: {}, cursor: {} }));
+			await run({ client: fakeClient({ pushSessions: push } as never) });
+			expect(push).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe("cursors", () => {
+		it("adopts the server's cursor after a successful batch", async () => {
+			await seedSession();
+			await run({
+				client: fakeClient({
+					pushSessions: async () => ({ accepted: {}, cursor: { sessions: 4_242 } }),
+				} as never),
+			});
+			const state = readSessionPushChannel(configDir);
+			// Stored as a keyset even though the server answered with a bare number:
+			// an empty key IS "the start of that millisecond", so nothing downstream
+			// has to know which shape the answer arrived in.
+			expect(state.byOrigin["https://acme.jolli.ai"]).toEqual({ sessions: at(4_242) });
+		});
+
+		it("walks the cursor DOWN on 409 and re-sends that range", async () => {
+			// The whole reason the mechanism exists: pushing to one backend, then
+			// pointing the install at a fresh one. The local cursor still claims the
+			// range was delivered, and only lowering it sends that range anywhere.
+			await seedSession(1_000);
+			writeSessionPushChannel(
+				{
+					version: 1,
+					clientId: "c1",
+					silencedByScope: {},
+					byOrigin: { "https://acme.jolli.ai": { sessions: at(999_999) } },
+				},
+				configDir,
+			);
+			const seen: Array<Record<string, TableCursor>> = [];
+			const push = vi.fn(async (payload: { cursor: Record<string, TableCursor> }) => {
+				seen.push(payload.cursor);
+				if (seen.length === 1) throw new SessionCursorAheadError({ sessions: 500 });
+				return { accepted: { sessions: 1 }, cursor: { sessions: 1_000 } };
+			});
+
+			const outcome = await run({ client: fakeClient({ pushSessions: push } as never) });
+
+			expect(outcome.status).toBe("done");
+			expect(seen[0]).toEqual({ sessions: at(999_999) });
+			// The server's number, adopted and re-sent in this protocol's shape.
+			expect(seen[1]).toEqual({ sessions: at(500) });
+			expect(readSessionPushChannel(configDir).byOrigin["https://acme.jolli.ai"]).toEqual({
+				sessions: at(1_000),
+			});
+		});
+
+		it("treats a null server cursor as lower than anything, not as no opinion", async () => {
+			// A brand-new or wiped backend has no record. Reading that as "no
+			// opinion" and continuing from our own high-water mark is exactly how the
+			// range before it never reaches that backend at all.
+			await seedSession(1_000);
+			writeSessionPushChannel(
+				{
+					version: 1,
+					clientId: "c1",
+					silencedByScope: {},
+					byOrigin: { "https://acme.jolli.ai": { sessions: at(999_999) } },
+				},
+				configDir,
+			);
+			let calls = 0;
+			const push = vi.fn(async () => {
+				calls++;
+				if (calls === 1) throw new SessionCursorAheadError({ sessions: null });
+				return { accepted: {}, cursor: { sessions: 1_000 } };
+			});
+
+			await run({ client: fakeClient({ pushSessions: push } as never) });
+
+			// The cursor was cleared, so the second attempt is a first run again.
+			expect(calls).toBe(2);
+		});
+
+		it("keeps each backend's progress separate", async () => {
+			await seedSession();
+			writeSessionPushChannel(
+				{
+					version: 1,
+					clientId: "c1",
+					silencedByScope: {},
+					byOrigin: { "https://dev.jolli.ai": { sessions: at(7) } },
+				},
+				configDir,
+			);
+			await run({
+				client: fakeClient({ pushSessions: async () => ({ accepted: {}, cursor: { sessions: 99 } }) } as never),
+			});
+			const state = readSessionPushChannel(configDir);
+			expect(state.byOrigin["https://dev.jolli.ai"]).toEqual({ sessions: at(7) });
+			expect(state.byOrigin["https://acme.jolli.ai"]).toEqual({ sessions: at(99) });
+		});
+
+		it("gives up after two consecutive rejections instead of spinning", async () => {
+			await seedSession(1_000);
+			const push = vi.fn(async () => {
+				throw new SessionCursorAheadError({ sessions: 1 });
+			});
+			const outcome = await run({ client: fakeClient({ pushSessions: push } as never) });
+			expect(outcome.status).toBe("failed");
+			expect(push.mock.calls.length).toBeLessThanOrEqual(3);
+		});
+
+		it("resets progress when the local database was rebuilt", async () => {
+			// A rebuilt database re-derives rows whose stamps can be BELOW the stored
+			// cursor — rows no cursor would ever select again, with nothing to report
+			// it.
+			const { ensureInstanceId } = await import("./Backup.js");
+			await withDashboardDb(ensureInstanceId, { dbPath });
+			await seedSession(1_000);
+			writeSessionPushChannel(
+				{
+					version: 1,
+					clientId: "c1",
+					silencedByScope: {},
+					dbInstanceId: "a-different-database",
+					byOrigin: { "https://acme.jolli.ai": { sessions: at(999_999) } },
+				},
+				configDir,
+			);
+			const push = vi.fn(async () => ({ accepted: {}, cursor: {} }));
+
+			await run({ client: fakeClient({ pushSessions: push } as never) });
+
+			expect(push).toHaveBeenCalledTimes(1);
+			expect((push.mock.calls[0] as unknown as [{ cursor: unknown }])[0].cursor).toEqual({});
+		});
+
+		it("makes no request at all on a first run with nothing to send", async () => {
+			// The empty-batch reconciliation buys one request per throttle window so
+			// a client whose cursor sits above every local row still hears from the
+			// server. It must NOT fire on a machine that has never synced: there is
+			// no cursor to reconcile, so the request could only be empty in both
+			// directions.
+			await withDashboardDb(() => undefined, { dbPath });
+			const push = vi.fn(async () => ({ accepted: {}, cursor: {} }));
+			const outcome = await run({ client: fakeClient({ pushSessions: push } as never) });
+			expect(push).not.toHaveBeenCalled();
+			expect(outcome).toEqual({ status: "done", batches: 0, rows: 0 });
+		});
+
+		it("binds to the database's identity on first sight, and keeps the cursor it already had", async () => {
+			// Recording the id is not the same event as noticing a rebuild: the first
+			// run has nothing to compare against, so it must adopt the id and leave
+			// the progress alone. Clearing here would re-send the whole first-run
+			// window to a backend that already has it, every time a machine upgraded
+			// into this build.
+			await seedSession(1_000);
+			await withDashboardDb(
+				(db: DashboardDbHandle) =>
+					db.prepare("INSERT OR REPLACE INTO schema_meta (key, value) VALUES ('instance-id', 'db-1')").run(),
+				{ dbPath },
+			);
+			writeSessionPushChannel(
+				{
+					version: 1,
+					clientId: "c1",
+					silencedByScope: {},
+					byOrigin: { "https://acme.jolli.ai": { sessions: at(999_999) } },
+				},
+				configDir,
+			);
+
+			await run();
+			const first = readSessionPushChannel(configDir);
+			expect(first.dbInstanceId).toBe("db-1");
+			expect(first.byOrigin["https://acme.jolli.ai"]).toEqual({ sessions: at(999_999) });
+
+			// And the same database on the next run is not a rebuild either.
+			await run();
+			const second = readSessionPushChannel(configDir);
+			expect(second.dbInstanceId).toBe("db-1");
+			expect(second.byOrigin["https://acme.jolli.ai"]).toEqual({ sessions: at(999_999) });
+		});
+	});
+
+	describe("what it reports", () => {
+		/** True when some call's format string carries `text`. */
+		const said = (calls: Array<unknown[]>, text: string): boolean => calls.some((c) => String(c[0]).includes(text));
+
+		it("says why it is not uploading for each gate, instead of returning silently", async () => {
+			// The failure this exists for: a switched-off toggle, an invalid key and a
+			// silenced backend were all indistinguishable from a healthy machine with
+			// nothing new to send — in the log, in the channel file, everywhere.
+			h.loadConfig.mockResolvedValue({ jolliApiKey: "sk-jol-x", syncSessions: false });
+			await run();
+			expect(said(h.log.info.mock.calls, "syncSessions is off")).toBe(true);
+		});
+
+		it("says so when there is no API key", async () => {
+			h.loadConfig.mockResolvedValue({});
+			await run();
+			expect(said(h.log.info.mock.calls, "no API key configured")).toBe(true);
+		});
+
+		it("says so when a repository is being withheld", async () => {
+			registered("https://github.com/acme/widgets");
+			h.isRepoDisabled.mockReturnValue(true);
+			await run();
+			// `said` matches the FORMAT string, so the count is asserted separately.
+			expect(said(h.log.info.mock.calls, "withholding %d disabled repository")).toBe(true);
+			expect(h.log.info.mock.calls.some((c) => String(c[0]).includes("withholding") && c[1] === 1)).toBe(true);
+		});
+
+		it("states a stable reason ONCE per process, not once per trigger", async () => {
+			// Every trigger on the machine asks again, and the answer holds for hours.
+			// One line is the signal; forty-eight is a reason to stop reading the file.
+			h.loadConfig.mockResolvedValue({ jolliApiKey: "sk-jol-x", syncSessions: false });
+			await run();
+			await run();
+			await run();
+			expect(h.log.info.mock.calls.filter((c) => String(c[0]).includes("syncSessions is off"))).toHaveLength(1);
+		});
+
+		it("states a reason again once the memo has overflowed, instead of growing forever", async () => {
+			// Every other memo key is a constant; the catch-all keys on the message,
+			// which is arbitrary text. In the global daemon that set lives as long as
+			// the machine is up, so it is capped — and overflowing degrades it to
+			// "state this reason again", never to a leak and never to a lost line.
+			const saidBoomZero = () => h.log.info.mock.calls.filter((c) => c[1] === "boom 0").length;
+			h.loadConfig.mockRejectedValue(new Error("boom 0"));
+			await run();
+			await run();
+			expect(saidBoomZero()).toBe(1);
+
+			// Enough distinct reasons to fill the cap, at which point the memo starts over.
+			for (let i = 1; i <= 64; i++) {
+				h.loadConfig.mockRejectedValue(new Error(`boom ${i}`));
+				await run();
+			}
+			h.loadConfig.mockRejectedValue(new Error("boom 0"));
+			await run();
+			expect(saidBoomZero()).toBe(2);
+		});
+
+		it("warns, with the scope, when a backend refuses the channel", async () => {
+			const { PermissionDeniedError } = await import("../core/JolliMemoryPushClient.js");
+			await seedSession();
+			await run({
+				client: fakeClient({
+					pushSessions: async () => {
+						throw new PermissionDeniedError("scope not enabled");
+					},
+				} as never),
+			});
+			expect(said(h.log.warn.mock.calls, "refused this channel")).toBe(true);
+			// `flat()` + `toContain` rather than `some((c) => c.includes(scope))`, and the
+			// reason is CodeQL rather than taste: that spelling reads to
+			// `js/incomplete-url-substring-sanitization` as a URL literal inside a
+			// containment check, even though the receiver is the ARGS ARRAY — where
+			// `includes` is exact equality, not a substring test. The scope travels as its
+			// own `%s` argument (see the `log.warn` call), so both forms assert the same
+			// exact match; this one just cannot be misread as a host check.
+			//
+			// ⚠ Do NOT "fix" it by parsing and comparing `new URL(entry).host`: that
+			// accepts `http://` and `https://acme.jolli.ai/tenant` too, and the scoped-URL
+			// case below exists precisely because those are DIFFERENT scopes.
+			expect(h.log.warn.mock.calls.flat()).toContain("https://acme.jolli.ai");
+		});
+
+		it("warns on a 401 rather than leaving an invalid key to retry forever in silence", async () => {
+			// Not silenced — a key is re-issued by the user — so this one repeats every
+			// half hour with nothing to show for it unless it says something.
+			const { NotAuthenticatedError } = await import("../core/JolliMemoryPushClient.js");
+			await seedSession();
+			await run({
+				client: fakeClient({
+					pushSessions: async () => {
+						throw new NotAuthenticatedError("bad key");
+					},
+				} as never),
+			});
+			expect(said(h.log.warn.mock.calls, "rejected our credentials")).toBe(true);
+		});
+
+		it("records the bypass when a forced run overrides a silence", async () => {
+			const { PermissionDeniedError } = await import("../core/JolliMemoryPushClient.js");
+			await seedSession();
+			await run({
+				client: fakeClient({
+					pushSessions: async () => {
+						throw new PermissionDeniedError("scope not enabled");
+					},
+				} as never),
+			});
+			h.log.info.mockClear();
+			await run({ client: fakeClient({ pushSessions: async () => ({ accepted: {}, cursor: {} }) } as never) });
+			expect(said(h.log.info.mock.calls, "retrying anyway (forced)")).toBe(true);
+		});
+	});
+
+	describe("throttle and failure marks", () => {
+		it("records the attempt even when the request fails", async () => {
+			// ⚠ The opposite of the cursors, which only move on success. This is a
+			// throttle: recording only successes makes every trigger retry a request
+			// that is going to fail the same way.
+			await seedSession();
+			const outcome = await run({
+				client: fakeClient({
+					pushSessions: async () => {
+						throw new Error("network down");
+					},
+				} as never),
+			});
+			expect(outcome.status).toBe("failed");
+			expect(readSessionPushChannel(configDir).lastAttemptAtMs).toBe(NOW);
+		});
+
+		it("silences the refusing SCOPE for a day after a 403, not the machine", async () => {
+			const { PermissionDeniedError } = await import("../core/JolliMemoryPushClient.js");
+			await seedSession();
+			await run({
+				client: fakeClient({
+					pushSessions: async () => {
+						throw new PermissionDeniedError("scope not enabled");
+					},
+				} as never),
+			});
+			const state = readSessionPushChannel(configDir);
+			expect(state.silencedByScope["https://acme.jolli.ai"]).toBeGreaterThan(NOW);
+
+			// And an ordinary (unforced) run does not even reach the client.
+			const push = vi.fn();
+			const { runSessionSync } = await import("./SessionSyncRunner.js");
+			const outcome = await runSessionSync({
+				nowMs: NOW + MIN_ATTEMPT_INTERVAL_MS,
+				configDir,
+				client: fakeClient({ pushSessions: push } as never),
+			});
+			expect(outcome).toEqual({ status: "skipped", reason: "silenced" });
+			expect(push).not.toHaveBeenCalled();
+		});
+
+		it("silences a 404 whose body carries the server's own message", async () => {
+			// The end of the bug the CLASSES were introduced for. The runner used to
+			// decide this by matching `/HTTP 404/` against the error message, while the
+			// client raises `errorMessage(json)` whenever the body has one — so a
+			// gateway answering `{"error":"Not Found"}` produced `Not Found`, matched
+			// nothing, and the channel retried a missing endpoint every 30 minutes
+			// indefinitely. Nothing about the message is asserted here on purpose: the
+			// point of the fix is that the message stopped being the contract.
+			const { SessionEndpointMissingError } = await import("../core/JolliMemoryPushClient.js");
+			await seedSession();
+			await run({
+				client: fakeClient({
+					pushSessions: async () => {
+						throw new SessionEndpointMissingError("Not Found");
+					},
+				} as never),
+			});
+			expect(readSessionPushChannel(configDir).silencedByScope["https://acme.jolli.ai"]).toBeGreaterThan(NOW);
+		});
+
+		it("silences a 412 whose body carries prose instead of a status", async () => {
+			// Same fix, on the branch whose whole purpose is to be findable: a 412 is
+			// the response most likely to carry the server's own explanation, so the
+			// old `/HTTP 412/` match was the least likely of the two to ever fire.
+			const { SessionPreconditionFailedError } = await import("../core/JolliMemoryPushClient.js");
+			await seedSession();
+			await run({
+				client: fakeClient({
+					pushSessions: async () => {
+						throw new SessionPreconditionFailedError("this deployment requires a binding");
+					},
+				} as never),
+			});
+			expect(readSessionPushChannel(configDir).silencedByScope["https://acme.jolli.ai"]).toBeGreaterThan(NOW);
+		});
+
+		it("leaves a DIFFERENT backend running while one is silenced", async () => {
+			// The bug this replaced: one machine-wide mark, so a 403 from a
+			// misconfigured deployment stopped a healthy one too — and re-pointing the
+			// key at the healthy one changed nothing for 24h.
+			const { PermissionDeniedError } = await import("../core/JolliMemoryPushClient.js");
+			await seedSession();
+			await run({
+				client: fakeClient({
+					resolveBaseUrl: async () => "https://refuses.jolli.ai",
+					pushSessions: async () => {
+						throw new PermissionDeniedError("scope not enabled");
+					},
+				} as never),
+			});
+
+			const push = vi.fn(async () => ({ accepted: {}, cursor: {} }));
+			const { runSessionSync } = await import("./SessionSyncRunner.js");
+			const outcome = await runSessionSync({
+				nowMs: NOW + MIN_ATTEMPT_INTERVAL_MS,
+				configDir,
+				client: fakeClient({ pushSessions: push } as never),
+			});
+
+			expect(outcome.status).toBe("done");
+			expect(push).toHaveBeenCalled();
+		});
+
+		it("lets an explicit forced run through a silence", async () => {
+			// A user who has just fixed the server must not be told to wait a day; the
+			// throttle-only bypass left editing the state file as the only way out.
+			const { PermissionDeniedError } = await import("../core/JolliMemoryPushClient.js");
+			await seedSession();
+			await run({
+				client: fakeClient({
+					pushSessions: async () => {
+						throw new PermissionDeniedError("scope not enabled");
+					},
+				} as never),
+			});
+
+			const push = vi.fn(async () => ({ accepted: {}, cursor: {} }));
+			const outcome = await run({ client: fakeClient({ pushSessions: push } as never) });
+
+			expect(outcome.status).toBe("done");
+			expect(push).toHaveBeenCalled();
+		});
+
+		it("keeps two tenants on one origin apart", async () => {
+			// `x-tenant-slug` comes off the same path segment this key does, so a
+			// cursor cannot be filed against a tenant the rows did not go to.
+			await seedSession();
+			await run({
+				client: fakeClient({
+					resolveBaseUrl: async () => "https://one.jolli.ai/alpha",
+					pushSessions: async () => ({ accepted: {}, cursor: { sessions: 11 } }),
+				} as never),
+			});
+			await run({
+				client: fakeClient({
+					resolveBaseUrl: async () => "https://one.jolli.ai/beta",
+					pushSessions: async () => ({ accepted: {}, cursor: { sessions: 22 } }),
+				} as never),
+			});
+
+			const state = readSessionPushChannel(configDir);
+			expect(state.byOrigin["https://one.jolli.ai/alpha"]).toEqual({ sessions: at(11) });
+			expect(state.byOrigin["https://one.jolli.ai/beta"]).toEqual({ sessions: at(22) });
+		});
+
+		it("resumes from a legacy bare-origin cursor on the first scoped run", async () => {
+			await seedSession(1_000);
+			writeSessionPushChannel(
+				{
+					version: 1,
+					clientId: "c1",
+					silencedByScope: {},
+					byOrigin: { "https://acme.jolli.ai": { sessions: at(777) } },
+				},
+				configDir,
+			);
+			const seen: Array<Record<string, TableCursor>> = [];
+			await run({
+				client: fakeClient({
+					resolveBaseUrl: async () => "https://acme.jolli.ai/tenant",
+					pushSessions: async (p: { cursor: Record<string, TableCursor> }) => {
+						seen.push(p.cursor);
+						return { accepted: {}, cursor: {} };
+					},
+				} as never),
+			});
+			// Read from the legacy key, written under the scoped one.
+			expect(seen[0]).toEqual({ sessions: at(777) });
+			expect(readSessionPushChannel(configDir).byOrigin["https://acme.jolli.ai/tenant"]).toBeDefined();
+		});
+
+		it("does not run again inside the throttle window", async () => {
+			await seedSession();
+			await run();
+			const push = vi.fn();
+			const { runSessionSync } = await import("./SessionSyncRunner.js");
+			const outcome = await runSessionSync({
+				nowMs: NOW + 1_000,
+				configDir,
+				client: fakeClient({ pushSessions: push } as never),
+			});
+			expect(outcome).toMatchObject({ status: "skipped", reason: "throttled" });
+			expect(push).not.toHaveBeenCalled();
+		});
+
+		it("keeps a stable clientId across runs", async () => {
+			await seedSession();
+			await run();
+			const first = readSessionPushChannel(configDir).clientId;
+			await run();
+			expect(readSessionPushChannel(configDir).clientId).toBe(first);
+			expect(first).not.toBe("");
+		});
+	});
+
+	it("batches through the backlog and stops when the remainder is short", async () => {
+		await seedMany(250);
+		const push = vi.fn(async () => ({ accepted: {}, cursor: {} }));
+
+		const outcome = await run({ client: fakeClient({ pushSessions: push } as never) });
+
+		// 200 + 50, then done: selection is `>=`, so a loop that waited for an empty
+		// batch would re-send the boundary row until the per-run ceiling.
+		expect(outcome).toMatchObject({ status: "done", batches: 2 });
+		const sent = push.mock.calls as unknown as Array<[{ tables: { sessions: unknown[] } }]>;
+		expect(sent[0][0].tables.sessions).toHaveLength(200);
+		expect(sent[1][0].tables.sessions).toHaveLength(51);
+	});
+
+	it("stops at the per-run ceiling instead of draining a whole backlog at once", async () => {
+		// A first run on a long-used machine can be thousands of rows, and a
+		// background run is not the place to make dozens of serial requests. Stopping
+		// early is not a failure — the cursor is what makes the rest someone else's
+		// turn.
+		const { MAX_BATCHES_PER_RUN } = await import("./SessionSyncRunner.js");
+		await seedMany(2_100);
+		const push = vi.fn(async () => ({ accepted: {}, cursor: {} }));
+
+		const outcome = await run({ client: fakeClient({ pushSessions: push } as never) });
+
+		expect(outcome).toMatchObject({ status: "done", batches: MAX_BATCHES_PER_RUN });
+	});
+});

--- a/cli/src/dashboard/SessionSyncRunner.ts
+++ b/cli/src/dashboard/SessionSyncRunner.ts
@@ -1,0 +1,566 @@
+/**
+ * One run of the session sync: gate, read, send, reconcile, persist.
+ *
+ * The channel is CROSS-REPO. There is one database per machine, so a run carries
+ * whatever is new across every repo on it, and the envelope has no repo field —
+ * `repo_identity` rides on the rows. Two consequences shape everything here:
+ *
+ *  - Any trigger, from any project, does the whole machine's work. Several open
+ *    projects therefore mean several triggers wanting the same job, which is what
+ *    the machine-level `lastAttemptAtMs` throttle is for. It is not a politeness
+ *    delay; it is what stops N daemons from each pushing the same rows.
+ *  - The gates are about the PRODUCT being on, not about any repo's binding.
+ *    Session statistics need no Space: the API key carries the organisation, so
+ *    there is nowhere else for them to go. See {@link runSessionSync} for the
+ *    two that are still enforced.
+ *  - `jolli disable` is therefore NOT a gate here but a ROW FILTER, and that is
+ *    the only shape that can keep the promise the Settings page makes. A gate can
+ *    only answer for the repo that triggered the run — every other repo's rows
+ *    are in the same batch — so it both let a disabled repo's backlog out through
+ *    any other trigger and, when it did fire, stopped the whole machine over one
+ *    switched-off repo. See {@link disabledIdentities}.
+ *
+ * Nothing here may throw at its caller. It runs beside a git hook and beside a
+ * memory push, and neither may fail because a statistics upload did.
+ */
+
+import { parseBaseUrl } from "../core/JolliApiUtils.js";
+import {
+	ClientOutdatedError,
+	JolliMemoryPushClient,
+	NotAuthenticatedError,
+	PermissionDeniedError,
+	SessionCursorAheadError,
+	SessionEndpointMissingError,
+	SessionPreconditionFailedError,
+} from "../core/JolliMemoryPushClient.js";
+import {
+	cursorsFor,
+	loadChannelForRun,
+	MIN_ATTEMPT_INTERVAL_MS,
+	readSessionPushChannel,
+	type SessionPushChannelState,
+	type SessionPushCursors,
+	SILENCE_MS,
+	silencedUntilFor,
+	type TableCursor,
+	toTableCursor,
+	withCursors,
+	withSilence,
+	writeSessionPushChannel,
+} from "../core/SessionPushCursor.js";
+import { loadConfig } from "../core/SessionTracker.js";
+import { createLogger, errMsg } from "../Logger.js";
+import { canUseDashboardDb, getDashboardDbPath, withReadonlyDashboardDb } from "./DashboardDb.js";
+import { isRepoDisabled, readRepoRegistryStrict } from "./RepoRegistry.js";
+import { SYNCED_TABLES } from "./SessionPushManifest.js";
+import {
+	batchSize,
+	batchTables,
+	isBatchEmpty,
+	isBatchTruncated,
+	readDbInstanceId,
+	readSessionBatch,
+	type SessionBatch,
+} from "./SessionPushReader.js";
+
+const log = createLogger("SessionSync");
+
+/**
+ * Batches per run. The first run on a well-used machine can be thousands of
+ * rows; without a ceiling that is dozens of serial requests inside one
+ * background run. Stopping early is not a failure — the cursor is exactly the
+ * mechanism that makes the rest someone else's turn.
+ */
+export const MAX_BATCHES_PER_RUN = 10;
+
+/**
+ * Consecutive 409s tolerated before the run gives up until next time.
+ *
+ * A 409 is normally self-correcting: adopt the server's cursor, send that range,
+ * done. A server that keeps answering 409 is one whose cursor is moving
+ * backwards under us, and retrying that forever is a spin, not a recovery.
+ */
+export const MAX_CURSOR_RETRIES = 2;
+
+export interface SessionSyncOptions {
+	/**
+	 * No `cwd`: this run has no repo of its own. The channel is cross-repo, so
+	 * every trigger does the whole machine's work, and which repos are switched
+	 * off is asked of each repo's own profile — see {@link disabledIdentities}.
+	 */
+	readonly nowMs?: number;
+	readonly client?: JolliMemoryPushClient;
+	readonly configDir?: string;
+	/**
+	 * Bypasses the throttle AND a backend silence. For an explicit, user-initiated
+	 * run — `jolli doctor --sync-sessions` is the one caller.
+	 *
+	 * ⚠ It has to cover the silence, not just the throttle. A silence is a 24h bet
+	 * that the server's answer will not change, and the moment an operator fixes
+	 * the server that bet is wrong; without a bypass the only way out was editing
+	 * `session-push-channel.json` by hand. The bypass is logged, so a forced run
+	 * that hits a still-refusing backend explains itself.
+	 */
+	readonly force?: boolean;
+}
+
+export type SessionSyncOutcome =
+	| { readonly status: "skipped"; readonly reason: string }
+	| { readonly status: "done"; readonly batches: number; readonly rows: number }
+	| { readonly status: "failed"; readonly reason: string };
+
+/**
+ * True when enough time has passed to attempt again. One file read.
+ *
+ * ⚠ Answers the THROTTLE only, never the silence: a silence belongs to one
+ * backend scope, and the scope is not known until the key has been resolved,
+ * which is `sync`'s job. Consulting it here would have to read the mark
+ * scope-blind — the machine-wide behaviour that `silencedByScope` exists to
+ * remove. A silenced scope is still bounded by this throttle, so the cost of the
+ * split is one config read per 30 minutes, not per tick.
+ */
+export function isDueForSessionSync(nowMs: number, configDir?: string, intervalMs = MIN_ATTEMPT_INTERVAL_MS): boolean {
+	// Deliberately a pure file read: a caller deciding whether there is anything
+	// to do must not have to open SQLite to find out there is not.
+	const state = readSessionPushChannel(configDir);
+	return state.lastAttemptAtMs === undefined || nowMs - state.lastAttemptAtMs >= intervalMs;
+}
+
+/**
+ * Reasons already reported by this process, so a stable state is stated once.
+ *
+ * The skip reasons below are conditions that hold for hours — a switch the user
+ * turned off, a backend that refuses this scope — and every trigger on the
+ * machine asks again. Logging each one every time buries the file; logging none
+ * of them is what made a 24h silence leave no trace anywhere, which is the whole
+ * reason this memo exists rather than a plain `log.debug`. A long-lived daemon
+ * therefore states each reason once, and a short-lived hook process states it
+ * once per commit.
+ */
+const reported = new Set<string>();
+
+/**
+ * Cap on {@link reported}, because one of its keys is not drawn from a fixed set.
+ *
+ * Every other key is a constant (`off`, `no-key`, …), but the catch-all in
+ * {@link runSessionSync} keys on `throw:${errMsg(err)}` — an arbitrary string. In
+ * a hook process that set dies in milliseconds; in the global daemon it lives for
+ * as long as the machine is up, so a message carrying anything variable (a path, a
+ * port, a timestamp) would grow it without bound. Clearing on overflow degrades
+ * the memo to "state this reason again", which is the failure this whole mechanism
+ * is a nicety for — never a correctness matter.
+ */
+const MAX_REPORTED_KEYS = 64;
+
+/** Test seam: forget what this process has already reported. */
+export function resetSessionSyncReportMemo(): void {
+	reported.clear();
+}
+
+/** Logs at `info` the first time this process sees `key`. */
+function reportOnce(key: string, message: string, ...args: unknown[]): void {
+	if (reported.has(key)) return;
+	if (reported.size >= MAX_REPORTED_KEYS) reported.clear();
+	reported.add(key);
+	log.info(message, ...args);
+}
+
+/** Whole hours left, rounded up — enough precision for "come back tomorrow". */
+function hoursLeft(untilMs: number, nowMs: number): number {
+	return Math.max(1, Math.ceil((untilMs - nowMs) / (60 * 60 * 1000)));
+}
+
+/**
+ * Runs one sync. Never throws.
+ *
+ * Two gates, and only two:
+ *
+ *  - No API key — no credential, nowhere to send.
+ *  - `syncSessions: false` — this channel's own switch. ⚠ Deliberately NOT
+ *    `syncOnPush`, and not the per-repo push toggle: the decision is that session
+ *    statistics go up for every repo, bound or not, which is exactly what those
+ *    two do not mean. Reusing one would make the code contradict itself.
+ *
+ * ⚠ Every one of them says so in the log, once per process. They used to return
+ * silently, and "nothing is being uploaded and nothing anywhere says why" is the
+ * failure this channel actually shipped — a switched-off toggle, an invalid key
+ * and a silenced scope were indistinguishable from a healthy machine with nothing
+ * new to send. The throttle is the one skip that stays quiet: it is the normal
+ * case, it resolves itself within the half hour, and it is the only one that
+ * cannot be a misconfiguration.
+ */
+export async function runSessionSync(opts: SessionSyncOptions = {}): Promise<SessionSyncOutcome> {
+	const nowMs = opts.nowMs ?? Date.now();
+	try {
+		const config = await loadConfig();
+		if (config.syncSessions === false) {
+			reportOnce("off", "session sync: not uploading — syncSessions is off in the config");
+			return { status: "skipped", reason: "syncSessions is off" };
+		}
+		if (!config.jolliApiKey) {
+			reportOnce("no-key", "session sync: not uploading — no API key configured");
+			return { status: "skipped", reason: "not signed in" };
+		}
+		// Node without flag-free `node:sqlite`, or a machine that never enabled the
+		// dashboard: skip whole, never an error. The rows stay put and the next
+		// capable runtime sends them.
+		if (!canUseDashboardDb()) {
+			reportOnce("no-sqlite", "session sync: not uploading — this runtime cannot open the dashboard database");
+			return { status: "skipped", reason: "runtime cannot open the database" };
+		}
+		if (!opts.force && !isDueForSessionSync(nowMs, opts.configDir)) {
+			return { status: "skipped", reason: "throttled" };
+		}
+		return await sync(loadChannelForRun(opts.configDir), nowMs, opts);
+	} catch (err) {
+		// Includes "the database file does not exist", which is a normal state on a
+		// machine that has never enabled a repo — hence `reportOnce` rather than a
+		// line per attempt, and `info` rather than the `debug` this used to be: at
+		// `debug` it was invisible under the default threshold, so a key with no
+		// resolvable URL (this catch's other realistic arrival) reported nothing at
+		// all while the upload stayed off indefinitely.
+		reportOnce(`throw:${errMsg(err)}`, "session sync: not uploading — %s", errMsg(err));
+		return { status: "skipped", reason: errMsg(err) };
+	}
+}
+
+async function sync(
+	initial: SessionPushChannelState,
+	nowMs: number,
+	opts: SessionSyncOptions,
+): Promise<SessionSyncOutcome> {
+	const client = opts.client ?? new JolliMemoryPushClient();
+	const baseUrl = await client.resolveBaseUrl();
+	const scope = scopeOf(baseUrl);
+	const legacyKey = originOf(baseUrl);
+	// ⚠ Written whatever happens, unlike the cursors, which move only on success.
+	// It is a throttle: recording only successes would make every trigger retry a
+	// request that is going to fail the same way. Written BEFORE the silence check
+	// for the same reason — a silenced scope that left this mark alone would be
+	// re-resolved on every tick instead of every throttle window.
+	let state: SessionPushChannelState = { ...initial, lastAttemptAtMs: nowMs };
+	writeSessionPushChannel(state, opts.configDir);
+
+	const silencedUntil = silencedUntilFor(state, scope, nowMs);
+	if (silencedUntil !== undefined) {
+		if (!opts.force) {
+			reportOnce(
+				`silenced:${scope}:${silencedUntil}`,
+				"session sync: not uploading to %s — silenced for another %dh after it refused this channel; run `jolli doctor --sync-sessions` to retry now",
+				scope,
+				hoursLeft(silencedUntil, nowMs),
+			);
+			return { status: "skipped", reason: "silenced" };
+		}
+		// Not `reportOnce`: an explicit run is a thing the user just did, and the
+		// answer to "why did my forced sync try a backend that was refusing?" has to
+		// be in the log for THAT run, not only for whichever earlier run first hit it.
+		log.info(
+			"session sync: %s is silenced for another %dh — retrying anyway (forced)",
+			scope,
+			hoursLeft(silencedUntil, nowMs),
+		);
+	}
+
+	// Which repos are switched off, asked once per run rather than per batch: every
+	// batch shares one answer, and the read is one `profile.json` per registered
+	// repo. A throw here reaches `runSessionSync`'s catch — see the function.
+	const excludedIdentities = await disabledIdentities(opts.configDir);
+	if (excludedIdentities.size > 0) {
+		reportOnce(
+			`excluded:${excludedIdentities.size}`,
+			"session sync: withholding %d disabled repository(ies) — their statistics are not uploaded, and re-enabling does not send the backlog",
+			excludedIdentities.size,
+		);
+	}
+
+	const dbPath = getDashboardDbPath();
+	const instanceId = await withReadonlyDashboardDb(readDbInstanceId, { dbPath });
+	state = reconcileInstance(state, instanceId, scope);
+
+	let batches = 0;
+	let rows = 0;
+	let cursorRetries = 0;
+	let reconciled = false;
+	while (batches < MAX_BATCHES_PER_RUN) {
+		const cursors = cursorsFor(state, scope, legacyKey);
+		const batch = await withReadonlyDashboardDb(
+			(db) => readSessionBatch(db, { cursors, nowMs, excludedIdentities }),
+			{ dbPath },
+		);
+		// An empty batch still gets ONE request per run, and only the first one.
+		// Reconciliation happens on requests, so a client whose cursor sits above
+		// every local row would otherwise never contact the server at all — and
+		// that is precisely the shape of "pointed at a fresh backend": nothing new
+		// to send, so nothing discovers that the new backend has none of it. One
+		// small request per throttle window closes it.
+		if (isBatchEmpty(batch)) {
+			if (reconciled || isEmptyCursor(cursors)) break;
+			reconciled = true;
+		}
+		try {
+			const result = await client.pushSessions({
+				version: 1,
+				clientId: state.clientId,
+				cursor: wireCursor(cursors),
+				tables: batchTables(batch),
+			});
+			rows += batchSize(batch);
+			batches++;
+			cursorRetries = 0;
+			// The server's answer wins where it has one — it is the authority on what
+			// it holds, and taking its word is what lets a restored-from-backup server
+			// pull the client back. Where it says nothing, the batch's own high-water
+			// mark is used, which is what guarantees the loop advances: a server that
+			// echoes no cursor would otherwise leave the same rows selected forever
+			// and burn the whole per-run ceiling re-sending them.
+			state = withCursors(
+				state,
+				scope,
+				adoptCursor(cursorsFor(state, scope, legacyKey), result.cursor, localMaxima(batch)),
+			);
+			writeSessionPushChannel(state, opts.configDir);
+			// Nothing was truncated, so this batch WAS the remainder. Selection is
+			// `>=`, so looping again would re-read the boundary row and keep doing so
+			// until the per-run ceiling — see `isBatchTruncated`.
+			if (!isBatchTruncated(batch)) break;
+		} catch (err) {
+			if (err instanceof SessionCursorAheadError) {
+				cursorRetries++;
+				if (cursorRetries > MAX_CURSOR_RETRIES) {
+					log.warn("session sync: the server kept rejecting our cursor — stopping until the next trigger");
+					return { status: "failed", reason: "cursor kept moving backwards" };
+				}
+				// ⚠ Down, never up: this is the whole point. The server is missing a
+				// range we thought we had delivered, and only lowering the cursor
+				// re-sends it. `null` means the server has no record at all, which is
+				// treated as "lower than anything" — the new-backend case.
+				state = withCursors(state, scope, adoptCursor(cursorsFor(state, scope, legacyKey), err.serverCursor));
+				writeSessionPushChannel(state, opts.configDir);
+				log.info("session sync: adopted the server's cursor and re-sending that range");
+				continue;
+			}
+			return { status: "failed", reason: classifyAndRecord(err, state, nowMs, scope, opts) };
+		}
+	}
+	if (batches > 0) log.info("session sync: sent %d row(s) in %d batch(es)", rows, batches);
+	return { status: "done", batches, rows };
+}
+
+/**
+ * Silences ONE SCOPE for the failures that cannot be retried into success, and
+ * names the rest.
+ *
+ * ⚠ Every branch logs, and that is the point of the function rather than a
+ * detail of it. The three silencing branches used to return their reason as a
+ * string and log nothing — and both callers drop the returned outcome
+ * (`QueueWorker` is `void runSessionSync().catch()`, the daemon hands it to a
+ * `log.debug`), so a scope going quiet for 24h left no line anywhere. The 401
+ * branch was the same, and worse: it silences nothing, so an invalid key retried
+ * every half hour forever with no trace at all.
+ *
+ * ⚠ None of these touches the repo→Space binding cache. The memory push clears
+ * it on 401/403/412 because there those really are answers about a binding; here
+ * they are answers about a scope, and clearing it would degrade an unrelated,
+ * user-visible Space display.
+ *
+ * ⚠ Every branch dispatches on a CLASS, never on the message. Two of them used to
+ * be regexes over `errMsg(err)` (`/HTTP 404/`, `/HTTP 412/`) and both were
+ * fragile by construction: the client raises a non-2xx as the server's own
+ * message when the body carries one, so a 404 answered `{"error":"Not Found"}` —
+ * the ordinary gateway shape — fell through to the last line and was retried
+ * every half hour for ever, which is precisely the outcome the silences exist to
+ * prevent. `SessionEndpointMissingError` / `SessionPreconditionFailedError` are
+ * keyed on the status where the status is known.
+ */
+function classifyAndRecord(
+	err: unknown,
+	state: SessionPushChannelState,
+	nowMs: number,
+	scope: string,
+	opts: SessionSyncOptions,
+): string {
+	if (err instanceof NotAuthenticatedError) {
+		// Not silenced, deliberately: a key is re-issued by the user, and the next
+		// attempt after they do must go through. `warn`, because unlike the silences
+		// below this one will not clear on its own.
+		log.warn("session sync: %s rejected our credentials (401) — not uploading until the API key is fixed", scope);
+		return "not authenticated";
+	}
+	if (
+		err instanceof PermissionDeniedError ||
+		err instanceof ClientOutdatedError ||
+		err instanceof SessionEndpointMissingError
+	) {
+		// `SessionEndpointMissingError` covers BOTH ways a deployment says "no such
+		// endpoint": an honest 404, and a single-page app answering an unknown route
+		// with 200 and its `index.html` (which is what production actually did — the
+		// channel reported success for months and nothing had ever been ingested).
+		// The client raises one class for the two because they call for the same
+		// answer here: silence the scope for a day rather than retry it 48 times.
+		writeSessionPushChannel(withSilence(state, scope, nowMs + SILENCE_MS, nowMs), opts.configDir);
+		log.warn("session sync: %s refused this channel (%s) — silencing it for 24h", scope, errMsg(err));
+		return `not available on this backend (${errMsg(err)}) — silenced for 24h`;
+	}
+	if (err instanceof SessionPreconditionFailedError) {
+		// 412 should be unreachable: this channel does not require a binding. If one
+		// arrives, the server has made a binding a precondition after all, and that
+		// disagreement must be findable rather than retried into the ground.
+		writeSessionPushChannel(withSilence(state, scope, nowMs + SILENCE_MS, nowMs), opts.configDir);
+		log.warn(
+			"session sync: %s answered 412 — it appears to require a binding, which this channel does not; silencing it for 24h",
+			scope,
+		);
+		return "server requires a binding (412) — silenced for 24h";
+	}
+	log.info("session sync failed against %s: %s", scope, errMsg(err));
+	return errMsg(err);
+}
+
+/**
+ * The identities of every registered repo that `jolli disable` is set on.
+ *
+ * ⚠ A STRICT registry read, so an unreadable registry FAILS THE RUN instead of
+ * degrading to "nothing is disabled". Every other read in this module fails open
+ * because the cost of being wrong is a slower page or a delayed upload; the cost
+ * here is shipping statistics from a repo whose owner switched the product off,
+ * and no later run can take that back. `runSessionSync`'s catch turns the throw
+ * into a skipped run with a line in the log.
+ *
+ * `isRepoDisabled` is the same predicate `DbBackfill` and `listActiveRepos` use,
+ * deliberately: "which repos do I import", "which repos does the database call
+ * paused" and "which repos do I withhold from the wire" must not be three
+ * predicates that can disagree. It asks EVERY live checkout, because a registry
+ * row is one repo IDENTITY while `profile.json` is per clone — one clone still
+ * enabled means the repo is.
+ */
+async function disabledIdentities(configDir?: string): Promise<ReadonlySet<string>> {
+	const registry = await readRepoRegistryStrict(configDir);
+	return new Set(registry.repos.filter((repo) => isRepoDisabled(repo)).map((repo) => repo.repoIdentity));
+}
+
+/**
+ * Drops THIS SCOPE's cursors when the database is not the one the progress
+ * belongs to.
+ *
+ * A rebuilt database re-derives its rows, and their stamps can land BELOW the
+ * stored cursor — rows no cursor would ever select again, with nothing to report
+ * it. An absent id means the database has never been asked for one (it is minted
+ * lazily by a writer), and this path is read-only, so it neither mints nor binds:
+ * it simply leaves the recorded id alone.
+ *
+ * ⚠ One scope, not all of them, and the recorded id moves on the first run that
+ * notices — so a scope this machine has not talked to since the rebuild keeps a
+ * cursor that may sit above every local row, and will never be reset from here.
+ * That is deliberate rather than an oversight: it self-heals through the server,
+ * which is the only party that knows what a given backend actually holds. The
+ * empty-batch reconciliation in {@link sync} guarantees one request per throttle
+ * window even with nothing to send, the server answers 409 `cursor_ahead` (or
+ * echoes its own lower cursor), and `adoptCursor` takes it. Resetting every
+ * scope here instead would re-send the whole 90-day window to every backend the
+ * machine has ever used, on the strength of a rebuild that says nothing about
+ * what any of them received.
+ */
+function reconcileInstance(
+	state: SessionPushChannelState,
+	instanceId: string | undefined,
+	scope: string,
+): SessionPushChannelState {
+	if (instanceId === undefined) return state;
+	if (state.dbInstanceId === instanceId) return state;
+	if (state.dbInstanceId !== undefined) {
+		log.info("session sync: the local database was rebuilt — restarting from the first-run window");
+		return { ...withCursors(state, scope, {}), dbInstanceId: instanceId };
+	}
+	return { ...state, dbInstanceId: instanceId };
+}
+
+/** Only the tables that have a cursor — an absent one means "first run". */
+function wireCursor(cursors: SessionPushCursors): Record<string, TableCursor> {
+	const wire: Record<string, TableCursor> = {};
+	for (const table of SYNCED_TABLES) {
+		const value = cursors[table];
+		if (value !== undefined) wire[table] = value;
+	}
+	return wire;
+}
+
+/**
+ * Applies the server's cursor.
+ *
+ * A cursor replaces. An explicit `null` CLEARS — "this backend has no record"
+ * has to read as lower than anything rather than as no opinion, or the client
+ * carries on from its own high-water mark and the range below it never reaches
+ * that backend. A table the server did not mention falls back to `fallback` (the
+ * batch's own last row on success, nothing on a rejection), then to what the
+ * client already had.
+ *
+ * ⚠ A server answering with a bare NUMBER is read as `{stamp, key: []}` — the
+ * start of that millisecond. A backend that has not learned the keyset yet
+ * therefore keeps working and simply re-delivers one millisecond per pass into
+ * an upsert; what it must not do is make the client drop back to stamp-only
+ * paging, which is the deadlock this replaced.
+ */
+function adoptCursor(
+	current: SessionPushCursors,
+	server: Readonly<Record<string, TableCursor | number | null>>,
+	fallback: Readonly<Record<string, TableCursor>> = {},
+): SessionPushCursors {
+	const next: Record<string, TableCursor> = {};
+	for (const table of SYNCED_TABLES) {
+		const answered = table in server ? server[table] : (fallback[table] ?? current[table] ?? null);
+		const cursor = answered === null ? undefined : toTableCursor(answered);
+		if (cursor !== undefined) next[table] = cursor;
+	}
+	return next;
+}
+
+/** Each table's last row in this batch — the local view of progress. */
+function localMaxima(batch: SessionBatch): Record<string, TableCursor> {
+	const maxima: Record<string, TableCursor> = {};
+	for (const table of SYNCED_TABLES) {
+		const value = batch[table].next;
+		if (value !== undefined) maxima[table] = value;
+	}
+	return maxima;
+}
+
+/** True when this origin has no recorded progress at all — a first run. */
+function isEmptyCursor(cursors: SessionPushCursors): boolean {
+	return SYNCED_TABLES.every((table) => cursors[table] === undefined);
+}
+
+/**
+ * The backend's origin — the key EARLIER BUILDS filed progress under, kept only
+ * so {@link cursorsFor} can fall back to it on the first scoped run.
+ */
+function originOf(baseUrl: string): string {
+	try {
+		return new URL(baseUrl).origin;
+	} catch {
+		return baseUrl;
+	}
+}
+
+/**
+ * The key local progress and silences are filed under: origin plus tenant slug.
+ *
+ * ⚠ The tenant is part of it because one origin serves many, and neither a
+ * cursor nor a refusal carries across them. Filing by origin alone made two
+ * tenants on one host share a cursor (survivable — the server answers 409 and the
+ * client re-sends) and, before `silencedByScope`, made one tenant's 403 stop the
+ * others (not survivable — nothing retries for 24h).
+ *
+ * `parseBaseUrl` reads the slug off the first path segment, which is exactly what
+ * the request itself sends as `x-tenant-slug`, so this key cannot disagree with
+ * the tenant the rows actually went to.
+ */
+function scopeOf(baseUrl: string): string {
+	try {
+		const { origin, tenantSlug } = parseBaseUrl(baseUrl);
+		return tenantSlug === undefined ? origin : `${origin}/${tenantSlug}`;
+	} catch {
+		return baseUrl;
+	}
+}

--- a/cli/src/dashboard/SettingsAsset.test.ts
+++ b/cli/src/dashboard/SettingsAsset.test.ts
@@ -97,6 +97,7 @@ const MODEL = {
 				],
 			},
 		},
+		sync: { syncSessions: true },
 		memoryBank: { localFolder: "/mem/bank", compileExcludeFolders: "archive", syncTranscripts: false },
 		others: { dcoSignoff: true, excludePatterns: "*.lock" },
 	},
@@ -126,7 +127,16 @@ describe("settings.js renderSettings", () => {
 		expect(app.innerHTML).toContain("Opus");
 
 		go("sync");
-		expect(app.innerHTML).toContain("Outbound push per repo");
+		// The signed-OUT prompt names both outbound streams (the signed-in verdict
+		// is asserted below) — saying only "memories" reads as a denial that
+		// anything else is sent.
+		expect(app.innerHTML).toContain("Sign in to push session statistics and memories");
+		// …and each block heading carries its own scope, which is the pair the two
+		// switches differ on.
+		expect(app.innerHTML).toContain("Session statistics — for the whole machine");
+		expect(app.innerHTML).toContain("Memories — per repository");
+		// The session-statistics switch lives on THIS tab, not on Others.
+		expect(app.innerHTML).toContain("Sync session statistics");
 
 		go("bank");
 		expect(app.innerHTML).toContain("Folder Path");
@@ -135,10 +145,19 @@ describe("settings.js renderSettings", () => {
 		go("others");
 		expect(app.innerHTML).toContain("Exclude Patterns");
 		expect(app.innerHTML).toContain("Sign commits with DCO");
+		expect(app.innerHTML).not.toContain("Sync session statistics");
 
 		go("advanced");
 		expect(app.innerHTML).toContain("Show Knowledge");
 		expect(app.innerHTML).toContain("Show Graph");
+	});
+
+	it("names both outbound streams in the signed-in verdict", () => {
+		const { renderSettings, app, rail } = loadJD();
+		const summary = { ...MODEL.settings.summary, signedIn: true };
+		renderSettings({ ...MODEL, settings: { ...MODEL.settings, summary } });
+		rail.get("sync")?.onclick?.();
+		expect(app.innerHTML).toContain("Signed in — ready to push session statistics and memories");
 	});
 
 	it("survives a settings payload missing optional sections, still rendering each section's own content", () => {
@@ -150,7 +169,7 @@ describe("settings.js renderSettings", () => {
 		const markers: Record<string, string> = {
 			agents: "Claude Code",
 			summary: "Provider",
-			sync: "Outbound push per repo",
+			sync: "Memories — per repository",
 			bank: "Folder Path",
 			others: "Exclude Patterns",
 			advanced: "Show Knowledge",
@@ -189,6 +208,8 @@ function loadFormJD(
 ): {
 	fields: Map<string, FieldStub>;
 	applyBtn: { onclick?: () => void };
+	/** The Sync tab's immediate session-statistics switch. */
+	syncBox: { checked: boolean; onchange?: () => void };
 	posts: { path: string; body: Record<string, unknown> }[];
 	/** How many times doApply asked the PAGE to repaint (the sidebar refresh). */
 	pageRefreshes: () => number;
@@ -202,6 +223,9 @@ function loadFormJD(
 	const refreshArgs: unknown[] = [];
 	const app = { innerHTML: "", insertAdjacentHTML: () => undefined };
 	const applyBtn: { onclick?: () => void } = {};
+	// The Sync tab's immediate switch. It is reached by `querySelector`, not by the
+	// `[data-field]` sweep, precisely because it is NOT part of the form.
+	const syncBox: { checked: boolean; onchange?: () => void } = { checked: true };
 	const field = (name: string, type: string): FieldStub => ({
 		getAttribute: (n: string) => (n === "data-field" ? name : null),
 		type,
@@ -218,7 +242,7 @@ function loadFormJD(
 		getElementById: (id: string) =>
 			id === "settingsModalBody" ? app : id === "applyBtn" ? applyBtn : { innerHTML: "", textContent: "" },
 		querySelectorAll: (sel: string) => (sel.includes("[data-field]") ? [...fields.values()] : []),
-		querySelector: () => null,
+		querySelector: (sel: string) => (sel.includes("[data-sync-sessions]") ? syncBox : null),
 		addEventListener: () => undefined,
 		createElement: () => ({ innerHTML: "" }),
 		body: { innerHTML: "" },
@@ -253,12 +277,35 @@ function loadFormJD(
 	return {
 		fields,
 		applyBtn,
+		syncBox,
 		posts,
 		pageRefreshes: () => pageRefreshes,
 		refreshArgs: () => refreshArgs,
 		renderPage: (win.JD as { renderPage: unknown }).renderPage,
 	};
 }
+
+describe("settings.js session-statistics switch", () => {
+	// The unification this replaced: one switch on the Sync tab waited for "Apply
+	// Changes" while the identical-looking per-repo ones beside it did not. Both
+	// write on change now, so the switch must POST its own endpoint…
+	it("posts immediately on change instead of waiting for Apply", () => {
+		const { syncBox, posts } = loadFormJD();
+		syncBox.checked = false;
+		syncBox.onchange?.();
+		expect(posts).toEqual([{ path: "/api/settings/set-sync-sessions", body: { enabled: false } }]);
+	});
+
+	// …and must stay OUT of the batched save, or an Apply made afterwards would
+	// carry the pre-toggle value back to disk.
+	it("is absent from the Apply payload", () => {
+		const { applyBtn, posts } = loadFormJD();
+		applyBtn.onclick?.();
+		const apply = posts.find((p) => p.path === "/api/settings/apply");
+		expect(apply).toBeDefined();
+		expect(apply?.body).not.toHaveProperty("syncSessions");
+	});
+});
 
 describe("settings.js form wiring", () => {
 	it("captures edits and assembles the Apply payload from the controlled form", () => {

--- a/cli/src/dashboard/SettingsEndpoints.test.ts
+++ b/cli/src/dashboard/SettingsEndpoints.test.ts
@@ -198,6 +198,34 @@ describe("POST /api/settings/set-push validation", () => {
 	});
 });
 
+describe("POST /api/settings/set-sync-sessions", () => {
+	function readConfig(): Record<string, unknown> {
+		return JSON.parse(readFileSync(join(configDir, "config.json"), "utf-8"));
+	}
+
+	it("400s a non-boolean enabled", async () => {
+		const port = await startServer();
+		const res = await post(port, "/api/settings/set-sync-sessions", {});
+		expect(res.status).toBe(400);
+		expect((await jbody(res)).error).toMatch(/enabled/);
+	});
+
+	// Immediate, like set-push above: the config file carries the new value as
+	// soon as the request returns, with no Apply in between.
+	it("writes the switch on the spot, both ways, leaving the rest of the config alone", async () => {
+		const port = await startServer();
+		const off = await post(port, "/api/settings/set-sync-sessions", { enabled: false });
+		expect(off.status).toBe(200);
+		expect((await jbody(off)).syncSessions).toBe(false);
+		expect(readConfig().syncSessions).toBe(false);
+		expect(readConfig().localFolder).toBeTruthy();
+
+		const on = await post(port, "/api/settings/set-sync-sessions", { enabled: true });
+		expect(on.status).toBe(200);
+		expect(readConfig().syncSessions).toBe(true);
+	});
+});
+
 describe("POST /api/settings/probe-local-agent validation", () => {
 	it("400s a missing tool", async () => {
 		const port = await startServer();

--- a/cli/src/dashboard/SettingsMutations.test.ts
+++ b/cli/src/dashboard/SettingsMutations.test.ts
@@ -12,6 +12,7 @@ import {
 	parseSettingsApplyInput,
 	type SettingsApplyInput,
 	SettingsValidationError,
+	setSyncSessions,
 	syncAllReposHooks,
 } from "./SettingsMutations.js";
 import { maskApiKey } from "./SettingsPageQuery.js";
@@ -175,6 +176,20 @@ describe("parseSettingsApplyInput", () => {
 		).toBeUndefined();
 	});
 
+	// `syncSessions` is tri-state for the same reason, and absent from every
+	// submission the current page makes: it is an immediate switch now, so a
+	// batched save must not speak for it.
+	it("leaves an absent syncSessions undefined rather than reading it as off", () => {
+		expect(parseSettingsApplyInput(rawBody()).syncSessions).toBeUndefined();
+	});
+
+	// An older page still submits it, and that answer is honoured either way.
+	it("carries a submitted syncSessions through, false included", () => {
+		expect(parseSettingsApplyInput(rawBody({ syncSessions: true })).syncSessions).toBe(true);
+		expect(parseSettingsApplyInput(rawBody({ syncSessions: false })).syncSessions).toBe(false);
+		expect(parseSettingsApplyInput(rawBody({ syncSessions: "on" })).syncSessions).toBeUndefined();
+	});
+
 	it("rejects a submission with every agent disabled", () => {
 		const allOff = Object.fromEntries(
 			[
@@ -244,6 +259,21 @@ describe("applySettings", () => {
 		expect(config.dcoSignoff).toBe(true);
 		expect(config.dashboardKnowledgeMenuEnabled).toBe(true);
 		expect(config.dashboardGraphMenuEnabled).toBe(true);
+	});
+
+	// The failure this closes: the switch writes immediately, so a form saved
+	// afterwards must not carry a stale copy of it back to disk.
+	it("leaves a stored syncSessions untouched when the submission omits it", async () => {
+		const d = configDirWith({ syncSessions: false });
+		await applySettings(baseInput({ dcoSignoff: true }), d);
+		expect(readConfig(d).dcoSignoff).toBe(true);
+		expect(readConfig(d).syncSessions).toBe(false);
+	});
+
+	it("still honours a syncSessions an older page submits", async () => {
+		const d = configDirWith({ syncSessions: false });
+		await applySettings(baseInput({ syncSessions: true }), d);
+		expect(readConfig(d).syncSessions).toBe(true);
 	});
 
 	it("stores localAgentModel only when it differs from the default", async () => {
@@ -589,5 +619,23 @@ describe("checkLocalFolder", () => {
 		const filePath = join(dir, "a-file.txt");
 		writeFileSync(filePath, "x");
 		expect(await checkLocalFolder(filePath)).toBe("not-a-dir");
+	});
+});
+
+describe("setSyncSessions", () => {
+	// The immediate switch behind /api/settings/set-sync-sessions. A one-field
+	// merge, so it cannot clobber the rest of a config a batched save is editing.
+	it("writes the switch and leaves every other field alone", async () => {
+		const d = configDirWith({ syncSessions: true, dcoSignoff: true, model: "opus" });
+		expect(await setSyncSessions(false, d)).toEqual({ syncSessions: false });
+		let config = readConfig(d);
+		expect(config.syncSessions).toBe(false);
+		expect(config.dcoSignoff).toBe(true);
+		expect(config.model).toBe("opus");
+
+		expect(await setSyncSessions(true, d)).toEqual({ syncSessions: true });
+		config = readConfig(d);
+		expect(config.syncSessions).toBe(true);
+		expect(config.model).toBe("opus");
 	});
 });

--- a/cli/src/dashboard/SettingsMutations.ts
+++ b/cli/src/dashboard/SettingsMutations.ts
@@ -76,6 +76,17 @@ export interface SettingsApplyInput {
 	readonly localFolder: string;
 	readonly compileExcludeFolders: string;
 	readonly syncTranscripts: boolean;
+	/**
+	 * TRI-STATE, for the same reason as the two Advanced rows below: the Settings
+	 * page no longer submits this field at all. Session-statistics sync is an
+	 * IMMEDIATE switch now ({@link setSyncSessions} / `/api/settings/set-sync-sessions`),
+	 * so every other switch in the Sync to Jolli tab behaves like the per-repo
+	 * ones beside it. `undefined` therefore means "leave the stored value alone",
+	 * and a two-state read here would have this save silently undo a toggle the
+	 * user flipped moments earlier — including one flipped from an older page
+	 * still submitting it.
+	 */
+	readonly syncSessions?: boolean;
 	readonly dcoSignoff: boolean;
 	readonly excludePatterns: string;
 	/**
@@ -179,6 +190,7 @@ export function parseSettingsApplyInput(body: Record<string, unknown>): Settings
 	if (!AGENT_FIELDS.some((f) => agents[f])) {
 		throw new SettingsValidationError("At least one AI agent must be enabled");
 	}
+	const syncSessions = asOptionalBool(body.syncSessions);
 	const knowledgeMenu = asOptionalBool(body.dashboardKnowledgeMenuEnabled);
 	const graphMenu = asOptionalBool(body.dashboardGraphMenuEnabled);
 	const maxTokensRaw = body.maxTokens;
@@ -202,7 +214,8 @@ export function parseSettingsApplyInput(body: Record<string, unknown>): Settings
 		dcoSignoff: asBool(body.dcoSignoff),
 		excludePatterns: asString(body.excludePatterns),
 		// `asOptionalBool`, never `asBool` — see `SettingsApplyInput` for why these
-		// two must be able to say "the submission did not mention me".
+		// three must be able to say "the submission did not mention me".
+		...(syncSessions !== undefined ? { syncSessions } : {}),
 		...(knowledgeMenu !== undefined ? { dashboardKnowledgeMenuEnabled: knowledgeMenu } : {}),
 		...(graphMenu !== undefined ? { dashboardGraphMenuEnabled: graphMenu } : {}),
 	};
@@ -261,6 +274,25 @@ async function ensureLocalFolder(localFolder: string): Promise<void> {
 	const status = await checkLocalFolder(localFolder);
 	if (status === "ok" || status === "empty") return;
 	throw new SettingsValidationError(LOCAL_FOLDER_ERRORS[status](localFolder.trim()));
+}
+
+/**
+ * Settings → Sync to Jolli: flip the machine-wide session-statistics switch and
+ * persist it right away, the way the per-repo push toggles beside it already do.
+ *
+ * It is its own endpoint rather than a field of the batched save because the two
+ * kinds of control sat in one tab looking identical and behaving differently —
+ * one switch took effect on the next click, its neighbours only after "Apply
+ * Changes". The write is a one-field merge inside the config lock, so it cannot
+ * clobber a concurrent save of the rest of the form. Returns the value that was
+ * stored, which is what the page renders the checkbox from.
+ */
+export async function setSyncSessions(
+	enabled: boolean,
+	configDir: string = getGlobalConfigDir(),
+): Promise<{ readonly syncSessions: boolean }> {
+	await updateConfigTransactionalScoped(() => ({ update: { syncSessions: enabled }, result: undefined }), configDir);
+	return { syncSessions: enabled };
 }
 
 /**
@@ -331,6 +363,9 @@ export async function applySettings(
 			compileExcludeFolders: splitCsv(input.compileExcludeFolders),
 			syncTranscripts: input.syncTranscripts,
 			dcoSignoff: input.dcoSignoff,
+			// Conditional for the same reason as the two Advanced rows below: this
+			// field has its own immediate endpoint and is normally absent here.
+			...(input.syncSessions !== undefined ? { syncSessions: input.syncSessions } : {}),
 			// Conditional, unlike every other boolean above — an absent field must
 			// leave the stored row alone rather than switch it off. See
 			// `SettingsApplyInput` for the failure this closes.

--- a/cli/src/dashboard/SettingsPageQuery.test.ts
+++ b/cli/src/dashboard/SettingsPageQuery.test.ts
@@ -74,6 +74,8 @@ describe("buildSettingsPageModel", () => {
 			expect(marked[0]?.id).toBe(localAgentToolDefaultModel(tool as LocalAgentToolId));
 		}
 		expect(m.others.dcoSignoff).toBe(false);
+		// Absent key reads as ON — the config contract is `syncSessions !== false`.
+		expect(m.sync.syncSessions).toBe(true);
 		expect(m.memoryBank.compileExcludeFolders).toBe("");
 		expect(m.memoryBank.syncTranscripts).toBe(false);
 		expect(m.memoryBank.state).toBeUndefined();
@@ -141,6 +143,12 @@ describe("buildSettingsPageModel", () => {
 		expect(m.memoryBank.syncPollIntervalSec).toBe(5400);
 		expect(m.others.excludePatterns).toBe("*.lock, dist/**");
 		expect(m.others.dcoSignoff).toBe(true);
+	});
+
+	it("reports session-statistics sync as off only when it is explicitly disabled", async () => {
+		const configDir = writeConfig({ syncSessions: false });
+		const m = await buildSettingsPageModel(configDir, undefined);
+		expect(m.sync.syncSessions).toBe(false);
 	});
 
 	it("ignores a malformed jolliUrl for the site label", async () => {

--- a/cli/src/dashboard/SettingsPageQuery.ts
+++ b/cli/src/dashboard/SettingsPageQuery.ts
@@ -157,6 +157,12 @@ export async function buildSettingsPageModel(
 			localAgentModel: config.localAgentModel ?? "",
 			localAgentModels: localAgentModels(),
 		},
+		sync: {
+			// Default ON, so an absent key reads as enabled — matching the config
+			// contract (`syncSessions !== false`). Rendering an absent key as OFF
+			// would show every user a switch that disagrees with what is happening.
+			syncSessions: config.syncSessions !== false,
+		},
 		memoryBank: {
 			...(config.localFolder ? { localFolder: config.localFolder } : {}),
 			compileExcludeFolders: config.compileExcludeFolders ? config.compileExcludeFolders.join(", ") : "",

--- a/cli/src/dashboard/SotImport.ts
+++ b/cli/src/dashboard/SotImport.ts
@@ -48,6 +48,8 @@ import { importTakesPath } from "./ImportablePaths.js";
 import { cursorFingerprint, type ImportCursor, readImportStateRow, writeImportState } from "./ImportState.js";
 import { existingWorktrees, type RegisteredRepo } from "./RepoRegistry.js";
 import { REORDER_OFFSET } from "./SotSchema.js";
+import { forgetRollupDays } from "./StatsRollup.js";
+import { MEMORY_LANDED_AT_SQL } from "./StatsSeries.js";
 
 const log = createLogger("SotImport");
 
@@ -666,6 +668,89 @@ function pruneTable(
 	});
 	log.debug("pruned %d stale row(s) from %s", stale.length, table);
 	return stale.length;
+}
+
+/** What {@link upsertCommitAlias} did, and which cached days it invalidated. */
+export interface AliasUpsert {
+	/** False when the target has no memory row — the FK would refuse the insert. */
+	readonly stored: boolean;
+	/**
+	 * Landing days to hand to `forgetRollupDays`. Never empty when `stored` and
+	 * the alias actually moved something; may contain repeats, which that function
+	 * de-duplicates per zone.
+	 */
+	readonly days: ReadonlyArray<number>;
+}
+
+/**
+ * Records one tree-hash alias AND reports every cached day it moved.
+ *
+ * Shared by the two writers — `landAliases` in `SotWrite` and the import's alias
+ * pass below — because the days-to-forget rule is the interesting half and a
+ * second copy of it drifts silently: `commit_aliases` carries no write stamp the
+ * rollup's staleness test can see (`readSourcesWrittenSince` reads
+ * `memories.written_at_ms` and `commits.written_at_ms` only), so a day this
+ * function fails to name serves a wrong number until something unrelated is
+ * written on it. The import used to name none at all.
+ *
+ * ⚠ Asked BEFORE and AFTER the insert, of every memory whose landing this touches
+ * — rather than deriving the destination. `MEMORY_LANDED_AT_MS` is a COALESCE over
+ * three terms, so which one wins moves as aliases come and go, and the previous
+ * shape of this code only ever reasoned about the INCOMING target: a retarget
+ * (`old_hash` already pointing somewhere else) dropped the OUTGOING target back
+ * onto its own `commit_date_ms` and left that day cached without it. Asking the
+ * same query twice needs no reasoning about which term won.
+ *
+ * The `before` read of the target doubles as the FK precondition, exactly as it
+ * did before: a memory row that is not there answers `undefined`, not a null day.
+ */
+export function upsertCommitAlias(
+	db: DashboardDbHandle,
+	repoId: number,
+	oldHash: string,
+	targetHash: string,
+	nowMs: number,
+): AliasUpsert {
+	const landedAt = db.prepare(MEMORY_LANDED_AT_SQL);
+	const previous = (
+		db.prepare("SELECT target_hash FROM commit_aliases WHERE repo_id = ? AND old_hash = ?").get(repoId, oldHash) as
+			| { target_hash?: string }
+			| undefined
+	)?.target_hash;
+	// The outgoing target only when it is a DIFFERENT memory: re-landing the same
+	// pair is the common case (every index.json write replays the whole map) and
+	// changes nothing.
+	const affected = previous !== undefined && previous !== targetHash ? [targetHash, previous] : [targetHash];
+	const dayOf = (hash: string): number | undefined => {
+		const row = landedAt.get(repoId, hash) as { at_ms: number | null } | undefined;
+		return row?.at_ms ?? undefined;
+	};
+
+	const days: number[] = [];
+	let targetExists = false;
+	for (const hash of affected) {
+		const row = landedAt.get(repoId, hash) as { at_ms: number | null } | undefined;
+		if (hash === targetHash) targetExists = row !== undefined;
+		if (row?.at_ms != null) days.push(row.at_ms);
+	}
+	if (!targetExists) return { stored: false, days: [] };
+
+	db.prepare(
+		`INSERT INTO commit_aliases (repo_id, old_hash, target_hash, created_ms) VALUES (?, ?, ?, ?)
+		 ON CONFLICT(repo_id, old_hash) DO UPDATE SET target_hash = excluded.target_hash`,
+	).run(repoId, oldHash, targetHash, nowMs);
+
+	for (const hash of affected) {
+		const day = dayOf(hash);
+		if (day !== undefined) days.push(day);
+	}
+	if (previous !== undefined && previous !== targetHash) {
+		// Not an error — the schema allows it and a cross-source import can produce
+		// it — but `scanTreeHashAliases` skips a hash it has already aliased, so it
+		// should not arise from this machine's own scanning.
+		log.info("alias %s retargeted %s -> %s", oldHash, previous, targetHash);
+	}
+	return { stored: true, days };
 }
 
 /**
@@ -1491,24 +1576,26 @@ async function runRepoImport(db: DashboardDbHandle, opts: SotImportOptions): Pro
 	// null, not an empty set: a null index means "unreadable", and index.json is
 	// the only source of the alias map, so a corrupt read must not prune it away.
 	const liveAliases = index ? new Set(Object.keys(index.commitAliases ?? {})) : null;
+	// Through the same helper `landAliases` uses, so the "which cached days did
+	// this move" rule has one spelling. It also carries the FK precondition this
+	// pass used to ask for itself: asked of the DATABASE, not of a parsed-summary
+	// set, because after a resume the target's row may have been written by an
+	// earlier run whose in-memory state this process never saw — the row's
+	// existence is the only predicate the FK actually respects.
+	const aliasDays: number[] = [];
 	inChunkedTransactions(db, aliasEntries, ([oldHash, targetHash]) => {
-		// Asked of the DATABASE, not of a parsed-summary set: `commit_aliases` has
-		// a real FK onto `memories`, and after a resume the target's row may have
-		// been written by an earlier run whose in-memory state this process never
-		// saw. The row's existence is the only predicate the FK actually respects.
-		const target = db
-			.prepare("SELECT 1 AS ok FROM memories WHERE repo_id = ? AND commit_hash = ?")
-			.get(repoId, targetHash) as { ok?: number } | undefined;
-		if (!target) {
+		const outcome = upsertCommitAlias(db, repoId, oldHash, targetHash, nowMs);
+		if (!outcome.stored) {
 			skip("alias", `${oldHash} → ${targetHash} (target has no node)`);
 			return;
 		}
-		db.prepare(
-			`INSERT INTO commit_aliases (repo_id, old_hash, target_hash, created_ms) VALUES (?, ?, ?, ?)
-			 ON CONFLICT(repo_id, old_hash) DO UPDATE SET target_hash = excluded.target_hash`,
-		).run(repoId, oldHash, targetHash, nowMs);
+		aliasDays.push(...outcome.days);
 		aliases++;
 	});
+	// Outside the chunked transactions: this pass had no invalidation at all, so an
+	// import landing aliases into a database that already holds a rollup left those
+	// days serving numbers from before the rewrite.
+	forgetRollupDays(db, aliasDays);
 
 	// ── docs: plans first (plan_progress trigger depends on them) ──────────
 	let docs = 0;

--- a/cli/src/dashboard/SotSchema.ts
+++ b/cli/src/dashboard/SotSchema.ts
@@ -554,6 +554,135 @@ ALTER TABLE session_tool_use ADD COLUMN last_call_at_ms INTEGER;
  */
 
 /**
+ * A per-row "when did WE last write this" stamp on the four activity tables, so
+ * an outbound sync can select exactly the rows that changed since its cursor.
+ *
+ * It exists because **no business time column can answer that question**, and
+ * the counter-example is not hypothetical: `projectCommitSummary`'s `sessions`
+ * upsert updates the token columns, `token_coverage` and `prices_as_of` but
+ * deliberately NOT `updated_at_ms` — enriching a `sessions-only` row into a
+ * `full` one changes what the row says while leaving that column untouched. A
+ * cursor over `updated_at_ms` never sees the enrichment, so the better token
+ * split it just wrote would never leave this machine, and nothing would report
+ * it. That omission is CORRECT on its own terms (`updated_at_ms` means "when
+ * the session was last active", and the only clock that path has is the
+ * commit's, which would also move the session's whole spend into another day) —
+ * which is exactly why the two questions need two columns.
+ *
+ * So: business columns keep their meaning and are never bumped for bookkeeping;
+ * these columns are bumped unconditionally on every write and mean nothing else.
+ *
+ * ⚠ THE NAME IS NOT UNIFORM, and that is a trap worth stating rather than
+ * tidying: `sessions.updated_at_ms` is already taken by the business meaning, so
+ * that table's stamp is `written_at_ms` (matching `memories.written_at_ms`,
+ * which is the same concept) while the other three use `updated_at_ms`. A sync
+ * that assumes one name and writes `WHERE updated_at_ms >= ?` against all four
+ * compiles, runs, and silently reads the WRONG column on `sessions` — back to
+ * the bug above. Readers must go through the per-table map in `SyncColumns.ts`.
+ *
+ * Backfilled from each table's best available approximation (its own business
+ * time, or the parent session's for the two child tables). That is an
+ * approximation, not the real write instant, which is unknowable for rows
+ * already on disk — but it is the right one: it makes the first sync select the
+ * same rows it would have selected by business time.
+ *
+ * ⚠ `NOT NULL DEFAULT 0`, never a bare nullable column, and the reason is the
+ * same failure this whole mechanism exists to prevent. A cursor is spelled
+ * `WHERE <stamp> >= ?`, and SQL's answer for NULL there is NULL — not true — so
+ * a single NULL stamp makes its row invisible to EVERY sync, permanently and
+ * with nothing to notice it. Nullable is not the safe default here: it is the
+ * bug, one level down. 0 says "written before we tracked this", which no cursor
+ * past 0 needs to revisit and which the backfill above then improves wherever a
+ * business time exists. `commits.written_at_ms` is declared the same way for the
+ * same reason.
+ */
+/**
+ * One counted model response: what it cost and WHEN it happened.
+ *
+ * The record every usage and billing system keeps, and the reason it exists here
+ * is that `sessions` cannot answer the question it looks like it answers. That
+ * row holds a whole conversation's cumulative tokens under a single timestamp,
+ * so a conversation spanning three days contributes its ENTIRE spend to whichever
+ * day it was last active — the earlier days read as zero. No care in the query
+ * layer fixes that: the time was discarded before the write.
+ *
+ * With one row per response, "how much did I spend on the 1st" is a plain GROUP
+ * BY, and a session becomes what it always was — a grouping, not a quantity.
+ * `sessions` and `session_model_usage` keep their totals as DERIVED caches so the
+ * KPI stays a scalar scan; both are written from these rows in the same
+ * transaction, so they cannot disagree with the detail.
+ *
+ * Keyed on the response's own identity (`message.id` for Claude), falling back to
+ * `line:<n>` for a response the source cannot name.
+ *
+ * ⚠ That `<n>` is the response's POSITION among the counted responses of the read,
+ * not a transcript line number — the name is historical. Uniqueness within one
+ * read is all it has to provide, because `projectSession` replaces a session's
+ * rows wholesale (DELETE then INSERT) rather than upserting them, and the producer
+ * re-reads the whole transcript. Do not lean on it as a stable identity across
+ * reads: an earlier draft of this comment claimed append-only line numbers made it
+ * one, and if the wholesale replacement ever became an upsert that claim is what
+ * would make the change look safe.
+ *
+ * ⚠ NOT every source can fill this. `parseUsageTokens` is optional on
+ * `TranscriptParser` and only the Claude parser implements it today, so sessions
+ * from other sources have no rows here and keep being placed by their
+ * session-level timestamp. `token_coverage` is what tells the two apart; the
+ * dashboard must not present them as the same precision.
+ *
+ * ⚠ Instants, never local days. Bucketing is a READ-time decision because the
+ * timezone is a property of whoever is asking — storing a day would repeat the
+ * mistake this table exists to fix, one level up.
+ */
+export const SESSION_USAGE_EVENTS_DDL = `
+CREATE TABLE session_usage_events (
+  session_event_id TEXT NOT NULL REFERENCES sessions(event_id) ON DELETE CASCADE,
+  -- The response's identity, or 'line:<n>' when the source cannot name one.
+  dedup_key        TEXT NOT NULL,
+  -- THIS response's instant. The column the whole table exists for; named for
+  -- what it IS rather than what reads do with it, because those bucket it by a
+  -- timezone the table deliberately does not store.
+  responded_at_ms  INTEGER NOT NULL,
+  -- Empty string when the transcript recorded usage without naming a model,
+  -- matching how the whole-slice aggregate buckets those.
+  model            TEXT NOT NULL,
+  input_tokens     INTEGER NOT NULL DEFAULT 0,
+  output_tokens    INTEGER NOT NULL DEFAULT 0,
+  cached_tokens    INTEGER NOT NULL DEFAULT 0,
+  est_cost_usd     REAL,
+  -- Sync stamp, same rule as SYNC_STAMP_DDL's columns: bumped on every write,
+  -- never a business time. See that constant for why the two cannot be one.
+  updated_at_ms    INTEGER NOT NULL,
+  PRIMARY KEY (session_event_id, dedup_key)
+) STRICT, WITHOUT ROWID;
+-- Every read is "this window", and the window is on the RESPONSE's own time
+-- rather than its session's — which is the point of the table.
+CREATE INDEX ix_sue_at ON session_usage_events(responded_at_ms);
+CREATE INDEX ix_sue_sync ON session_usage_events(updated_at_ms);
+`;
+
+export const SYNC_STAMP_DDL = `
+ALTER TABLE sessions            ADD COLUMN written_at_ms INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE session_model_usage ADD COLUMN updated_at_ms INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE session_tool_use    ADD COLUMN updated_at_ms INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE recall_receipts     ADD COLUMN updated_at_ms INTEGER NOT NULL DEFAULT 0;
+
+UPDATE sessions        SET written_at_ms = updated_at_ms WHERE written_at_ms = 0;
+UPDATE recall_receipts SET updated_at_ms = at_ms         WHERE updated_at_ms = 0;
+-- COALESCE is load-bearing twice over: the column is NOT NULL, so a child row
+-- whose parent session is missing would abort the migration outright — and 0 is
+-- the right value for it anyway, matching a row that predates the column.
+UPDATE session_model_usage
+   SET updated_at_ms = COALESCE((SELECT s.updated_at_ms FROM sessions s
+                                  WHERE s.event_id = session_model_usage.session_event_id), 0)
+ WHERE updated_at_ms = 0;
+UPDATE session_tool_use
+   SET updated_at_ms = COALESCE((SELECT s.updated_at_ms FROM sessions s
+                                  WHERE s.event_id = session_tool_use.session_event_id), 0)
+ WHERE updated_at_ms = 0;
+`;
+
+/**
  * The migration log — "who ran what, when, and how did it go".
  *
  * A LOG, not a set of booleans, which is what fixes the table shape: the primary
@@ -1021,6 +1150,252 @@ CREATE TABLE topic_processed_sources (
  * literal here would be a fourth copy of the constant, and the check would
  * silently stop matching the reorder code that produces the residue.
  */
+/**
+ * Pre-computed per-day spend, plus the one write stamp that makes a stale day
+ * detectable.
+ *
+ * ⚠ DERIVED DATA. Every row here can be recomputed from the tables it
+ * summarises, and the read path falls back to computing a day live whenever a
+ * row is missing or out of date. `DELETE FROM stats_daily` is therefore always
+ * safe: the dashboard shows the same numbers, more slowly. Nothing may treat
+ * this table as a source of truth, and nothing may write a figure here that
+ * cannot be re-derived — the moment one exists, deleting the table loses data
+ * and the fallback silently starts lying.
+ *
+ * ⚠ `commits.written_at_ms` is NOT part of the cache; it is what the cache
+ * needs from the commit side. Staleness is decided by asking "did any source
+ * row change after this day was built", and three of the six axes read the
+ * commit graph. `memories.written_at_ms` already answers for the memory rows,
+ * and `memory_topics` is rewritten inside the same statement pair, so it is
+ * covered too — but two things it cannot see: a commit row arriving late (the
+ * `category` axis dates a memory by `commits.committed_at_ms` when it has one,
+ * so a late arrival can move a memory to a different day) and a change of
+ * branch membership. The second is why the stamp is here rather than on
+ * `commit_branches`: that set is only ever rewritten per-commit, in the same
+ * projection that upserts the commit row, so the commit's stamp already marks
+ * every membership change — and `commit_branches` is fifty times the larger
+ * table, deliberately shrunk once already (see its DDL).
+ *
+ * One thing NOTHING here can see, listed so the set above stays honest: a
+ * `repos.repo_name` rename. The `project` axis stores that name as its
+ * `series_key`, and `repos` carries no write stamp, so a settled day keeps
+ * labelling its rows with the old name until some unrelated write to that day
+ * rebuilds it. Deliberately left alone rather than given a fourth stamp — it is
+ * a label on the right number, it is self-correcting, and a repo's display name
+ * changes about as often as the repo is created.
+ *
+ * Backfilled to 0 rather than to `committed_at_ms`: 0 reads as "written before
+ * we tracked this", which is exactly right for a row that has not changed
+ * since, and never makes a settled day look stale. A business time here would
+ * be the same category error the sync stamps exist to avoid.
+ *
+ * ⚠ `stats_daily.updated_at_ms` is NOT a sync stamp, whatever its inline comment
+ * says. The DDL calls it one ("same rule as SYNC_STAMP_DDL's columns") and the
+ * shape and the rule really are the same, but this table is on
+ * `SessionPushManifest.NEVER_SYNCED_TABLES` — it is a cache cut in ONE machine's
+ * timezone — so it has no `SYNC_STAMP_COLUMNS` entry and no cursor ever reads
+ * this column. It is here for symmetry with every other projected table, and
+ * because "when was this row written" is the first thing wanted when the cache is
+ * being debugged. Do not read the inline wording as a licence to put the table on
+ * the wire on the strength of the column.
+ *
+ * (The clarification lives HERE rather than in the DDL text for the reason
+ * `SYNC_STAMP_NULL_BACKFILL_DDL` states about entry 7: these bytes have shipped,
+ * `MIGRATIONS` is keyed by name so editing them re-runs nothing, and a comment
+ * rewrap would cost every existing database a fingerprint-mismatch warning while
+ * fixing the text only for machines that have not seen it yet. A TypeScript
+ * docstring is not hashed.)
+ */
+/**
+ * The rollup's day-scoped DELETE paths (`buildDay`'s whole-day replacement and
+ * `forgetRollupDays`) filter on `tz` + `day`, neither of which is a PK prefix —
+ * the PK leads with `repo_id`, so both currently scan. Small today, but the
+ * table is never pruned, so the scan grows with history.
+ *
+ * Its own migration entry because a database that already applied
+ * {@link STATS_DAILY_DDL} predates it; a fresh one gets the index inline from
+ * that entry.
+ *
+ * Named rather than numbered on purpose. This used to read "entry (8) because
+ * rows already on disk at schema 8 predate it", and both numbers were wrong by
+ * then — entries had been inserted ahead of it, and the seven unreleased steps
+ * were later merged into `SESSION_STATS_SYNC_DDL`, which moved every number again.
+ * `MIGRATIONS` is keyed by NAME, so a name is the only identifier that cannot go
+ * stale; leave the numbering to `DashboardDb`'s own enumeration, which is derived
+ * from the array order.
+ */
+export const STATS_DAILY_DAY_INDEX_DDL = `
+CREATE INDEX IF NOT EXISTS ix_stats_daily_day ON stats_daily(tz, day);
+`;
+
+export const STATS_DAILY_DDL = `
+ALTER TABLE commits ADD COLUMN written_at_ms INTEGER NOT NULL DEFAULT 0;
+
+-- IF NOT EXISTS because an earlier, unreleased build of this branch already
+-- created this table on some machines (a developer's own among them) under a
+-- migration name this log has no row for. Without the guard, such a database
+-- re-runs the entry, dies on "table stats_daily already exists", and every open
+-- after that fails until 'doctor --mark-migration' is run by hand.
+--
+-- The ALTER above cannot be guarded the same way -- SQLite has no
+-- ADD COLUMN IF NOT EXISTS -- so a database that also already has that column
+-- still needs that repair, which is precisely the state 'doctor
+-- --mark-migration' documents itself as existing for. The two statements are
+-- deliberately NOT split into separate entries to make each independently
+-- markable: the split would leave a machine that has ALREADY applied this entry
+-- under this name re-running the ALTER from a new slot, turning a repair anyone
+-- can do into a failure everyone gets.
+CREATE TABLE IF NOT EXISTS stats_daily (
+  -- 0 on the 'built' sentinel, which speaks for the whole day rather than for
+  -- one repo; a real repos.id on every data row. No foreign key, for that
+  -- reason and because nothing here should cascade: this table is rebuilt, not
+  -- maintained, and its delete path is explicit.
+  repo_id       INTEGER NOT NULL,
+  -- IANA zone the day was cut in. In the key because a day boundary is a
+  -- property of the asker: a reader in another zone misses and builds its own
+  -- rows rather than reading someone else's days as if they were its own.
+  tz            TEXT NOT NULL,
+  day           TEXT NOT NULL,           -- local calendar day, YYYY-MM-DD
+  -- One of the spend axes, or 'tokens', or the 'built' sentinel.
+  --
+  -- The sentinel is what separates "this day was computed and had no activity"
+  -- from "this day was never computed". Without it every quiet day misses
+  -- forever and is recomputed on every request — the days most likely to be
+  -- quiet being exactly the ones a wide range is full of. It is stored ONCE per
+  -- day rather than once per repo so that a repo added later cannot leave old
+  -- days permanently unavailable: a repo that did not exist contributed
+  -- nothing, and when it does contribute, its own write stamp marks the day
+  -- stale and the day is rebuilt.
+  kind          TEXT NOT NULL,
+  -- The series within the kind: a model/branch/ticket name for an axis,
+  -- input|output|cached for 'tokens', '' for the sentinel.
+  series_key    TEXT NOT NULL,
+  -- REAL, not INTEGER: the category and branch axes apportion a commit's tokens
+  -- across its topics or branches, so a day's contribution is fractional. The
+  -- read path rounds at emission exactly as the live path does.
+  value         REAL NOT NULL,
+  cost_usd      REAL NOT NULL DEFAULT 0,
+  -- When this day was computed. Staleness is "a source row was written after
+  -- this", so it is compared against the sources' own write stamps and must
+  -- never hold a business time.
+  built_at_ms   INTEGER NOT NULL,
+  -- Sync stamp, same rule as SYNC_STAMP_DDL's columns.
+  updated_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (repo_id, tz, day, kind, series_key)
+) STRICT, WITHOUT ROWID;
+${STATS_DAILY_DAY_INDEX_DDL}
+`;
+
+/**
+ * An index on every sync stamp, for the two hot paths that were left scanning.
+ *
+ * `SYNC_STAMP_DDL` added the columns and `STATS_DAILY_DDL` added
+ * `commits.written_at_ms`, but neither added an index — so both readers of these
+ * columns walked whole tables, and both are on paths that run constantly:
+ *
+ *  - **The outbound sync** selects `WHERE <stamp> >= ? ORDER BY <stamp> ASC
+ *    LIMIT ?` per table. Without an index that is a scan plus a sort of every
+ *    row, to return at most 500 — every batch, every run.
+ *  - **The rollup's staleness test** (`readSourcesWrittenSince`) asks `WHERE
+ *    <stamp> > ?` of `sessions`, `commits` and `memories`. It runs inside the
+ *    writer's lock on EVERY `applyToDb` and twice per dashboard render, and the
+ *    predicate is unselective without an index however recent the cursor is.
+ *
+ * `session_usage_events` is absent because `SESSION_USAGE_EVENTS_DDL` already
+ * ships `ix_sue_sync`; adding it again would be a second index on one column.
+ *
+ * `IF NOT EXISTS` throughout so a re-run is free, and its own entry rather than
+ * an edit to the two entries above, which have already been applied.
+ */
+export const SYNC_STAMP_INDEX_DDL = `
+CREATE INDEX IF NOT EXISTS ix_sessions_written ON sessions(written_at_ms);
+CREATE INDEX IF NOT EXISTS ix_smu_sync ON session_model_usage(updated_at_ms);
+CREATE INDEX IF NOT EXISTS ix_stu_sync ON session_tool_use(updated_at_ms);
+CREATE INDEX IF NOT EXISTS ix_recall_receipts_sync ON recall_receipts(updated_at_ms);
+CREATE INDEX IF NOT EXISTS ix_commits_written ON commits(written_at_ms);
+CREATE INDEX IF NOT EXISTS ix_mem_written ON memories(written_at_ms);
+`;
+
+/**
+ * The keyset index behind the outbound sync's paging.
+ *
+ * Selection is now `(stamp, ...pk) >= (?, …) ORDER BY stamp, …pk LIMIT n` — see
+ * `SyncColumns.KEYSET_COLUMNS` for why a stamp alone deadlocks. A tuple compare
+ * only stays cheap when an index carries the tuple's leading columns in the
+ * tuple's order, so each index below is the stamp followed by that table's
+ * PRIMARY KEY. The stamp-only indexes from `SYNC_STAMP_INDEX_DDL` remain a
+ * PREFIX of these, so the rollup's staleness scans keep their plan either way.
+ *
+ * ⚠ Its own entry rather than an edit to `SYNC_STAMP_INDEX_DDL`, which databases
+ * have already applied — including the author's. Editing it would be caught by
+ * `MigrationFingerprints.test.ts`, and worse, its `CREATE INDEX IF NOT EXISTS`
+ * would then find the stamp-only index already there under the same name and
+ * silently skip the wider one.
+ *
+ * `session_usage_events` is deliberately ABSENT. It is `WITHOUT ROWID`, so
+ * SQLite appends the PRIMARY KEY to every secondary index automatically — its
+ * `ix_sue_sync(updated_at_ms)` already IS `(updated_at_ms, session_event_id,
+ * dedup_key)`. The other four are rowid tables, where the appended column is the
+ * rowid and the PK has to be spelled out.
+ */
+export const SYNC_KEYSET_INDEX_DDL = `
+CREATE INDEX IF NOT EXISTS ix_sessions_keyset ON sessions(written_at_ms, event_id);
+CREATE INDEX IF NOT EXISTS ix_smu_keyset ON session_model_usage(updated_at_ms, session_event_id, model);
+CREATE INDEX IF NOT EXISTS ix_stu_keyset ON session_tool_use(updated_at_ms, session_event_id, tool_name, kind);
+CREATE INDEX IF NOT EXISTS ix_recall_receipts_keyset ON recall_receipts(updated_at_ms, receipt_id);
+`;
+
+/**
+ * Gives every sync stamp a NUMBER, because on real databases some are NULL.
+ *
+ * ⚠ `SYNC_STAMP_DDL` declares these columns `NOT NULL DEFAULT 0` and backfills
+ * them, and on a database that actually RAN it both are true. On one that was
+ * handed those columns by a pre-log build, neither is: the log records that
+ * entry as `baseline` — "this file already looks migrated" — so the declaration
+ * never executed, the columns are nullable, and the backfill never ran. Measured
+ * on the author's own database: `sessions.written_at_ms` is `notnull=0`, with 30
+ * sessions, 201 tool-use rows and 56 model-usage rows holding NULL.
+ *
+ * A NULL there is not a small defect. Selection is `WHERE (<stamp>, …) >= (?, …)`
+ * and SQL answers NULL — not true — for every comparison against NULL, so such a
+ * row is invisible to EVERY cursor, for ever, with nothing anywhere reporting it.
+ * That is exactly the failure `SyncColumns.ts` warns about; it simply arrived
+ * through the migration log rather than through a hand-written column.
+ *
+ * The values mirror `SYNC_STAMP_DDL`'s own backfill, one clause wider: it looked
+ * only for `= 0`, which is precisely the case that cannot occur when the column
+ * was never given that default. 0 means "written before we tracked this", which
+ * no cursor past 0 revisits and which the first sync sends once.
+ *
+ * This cannot restore the NOT NULL constraint — SQLite has no ALTER COLUMN — and
+ * does not need to: every writer passes an explicit stamp, so nothing produces a
+ * new NULL. `SyncColumns.test.ts` asserts the invariant on a freshly migrated
+ * database.
+ *
+ * ⚠ `session_tool_use` prefers its OWN `last_call_at_ms` here, where
+ * `SYNC_STAMP_DDL` goes straight to the parent session — a deliberate divergence,
+ * not a copy that drifted. That column arrived in entry 4, so it is the better
+ * approximation of "when this row was written", and this entry is the one being
+ * added now. Entry 7 is not corrected to match: it has already been applied on
+ * real databases, so editing its SQL changes nothing there (a name-keyed
+ * migration never re-runs) while costing every one of them a fingerprint-mismatch
+ * warning — a rewrite that only fixes the text and only for machines that have
+ * not seen it yet.
+ */
+export const SYNC_STAMP_NULL_BACKFILL_DDL = `
+UPDATE sessions        SET written_at_ms = COALESCE(updated_at_ms, 0) WHERE written_at_ms IS NULL;
+UPDATE recall_receipts SET updated_at_ms = COALESCE(at_ms, 0)         WHERE updated_at_ms IS NULL;
+UPDATE session_model_usage
+   SET updated_at_ms = COALESCE((SELECT s.updated_at_ms FROM sessions s
+                                  WHERE s.event_id = session_model_usage.session_event_id), 0)
+ WHERE updated_at_ms IS NULL;
+UPDATE session_tool_use
+   SET updated_at_ms = COALESCE(last_call_at_ms,
+                                (SELECT s.updated_at_ms FROM sessions s
+                                  WHERE s.event_id = session_tool_use.session_event_id), 0)
+ WHERE updated_at_ms IS NULL;
+`;
+
 export const SOT_INSPECTION_QUERIES = {
 	/** Children whose root_hash/depth disagree with their parent's (also catches cycles). */
 	childTopology: `

--- a/cli/src/dashboard/SotWrite.test.ts
+++ b/cli/src/dashboard/SotWrite.test.ts
@@ -502,6 +502,129 @@ describe("no-op writes that still harvest", () => {
 		]);
 	});
 
+	it("forgets both cached days an alias moves a memory between", async () => {
+		// An alias is the one write that MOVES a memory between calendar days: the
+		// landing rule falls through to the aliasing commit's committer date once the
+		// memory's own commit row is gone. `commit_aliases` carries no write stamp, so
+		// the rollup's staleness scan cannot see it — both the day it leaves and the
+		// day it arrives on have to be forgotten here, or the memory is counted twice
+		// (once in each day's cached copy) until something unrelated rebuilds them.
+		const { localDayKey, machineTimeZone } = await import("./LocalDays.js");
+		const tz = machineTimeZone();
+		// The memory's own `commitDate`, i.e. where it lands with no commit row.
+		const leaves = Date.parse("2026-07-01T00:00:00.000Z");
+		// The surviving commit's COMMITTER date — deliberately a different day.
+		const arrives = Date.parse("2026-07-15T12:00:00.000Z");
+		await storage.writeFiles([file(`summaries/${H("a")}.json`, summary(H("a")))], "m");
+		await withDashboardDb(
+			(db) => {
+				const repoId = (db.prepare("SELECT id FROM repos WHERE repo_identity = ?").get(REPO) as { id: number })
+					.id;
+				db.prepare(
+					`INSERT INTO commits (event_id, repo_id, hash, branch, message, committed_at_ms, written_at_ms)
+					 VALUES (?, ?, ?, 'main', 'm', ?, ?)`,
+				).run(`commit:${H("9")}`, repoId, H("9"), arrives, arrives);
+				const settle = db.prepare(
+					`INSERT INTO stats_daily (repo_id, tz, day, kind, series_key, value, cost_usd, built_at_ms, updated_at_ms)
+					 VALUES (?, ?, ?, 'model', 'sonnet', 1, 0, 1, 1)`,
+				);
+				settle.run(repoId, tz, localDayKey(leaves, tz));
+				settle.run(repoId, tz, localDayKey(arrives, tz));
+			},
+			{ dbPath },
+		);
+
+		await storage.writeFiles(
+			[
+				file("index.json", {
+					version: 3,
+					entries: [{ commitHash: H("a"), parentCommitHash: null }],
+					commitAliases: { [H("9")]: H("a") },
+				}),
+			],
+			"m",
+		);
+
+		expect(await rows("SELECT day FROM stats_daily")).toEqual([]);
+	});
+
+	it("forgets the day a RETARGETED alias drops its previous target back onto", async () => {
+		// The gap the shared `upsertCommitAlias` closed. Retargeting `old_hash` moves
+		// the INCOMING target onto the aliasing commit's day — which this loop always
+		// handled — and simultaneously drops the OUTGOING one back to its own
+		// `commit_date_ms`. That second day used to be named nowhere: the previous
+		// target was never read, `commit_aliases` carries no stamp the rollup's
+		// staleness scan can see, and an old day gets no further writes — so its
+		// cached copy served a count missing that memory indefinitely.
+		const { localDayKey, machineTimeZone } = await import("./LocalDays.js");
+		const tz = machineTimeZone();
+		// Where a memory with no commit row of its own lands: its own `commitDate`.
+		// THREE distinct days, and that is what gives this case its teeth: the two
+		// memories must not share a fallback day, or the old code's "read the
+		// incoming target" would have named the outgoing one's day by coincidence.
+		const aFallback = Date.parse("2026-07-01T00:00:00.000Z");
+		const bFallback = Date.parse("2026-06-10T00:00:00.000Z");
+		// The aliasing commit's COMMITTER date — deliberately a third day.
+		const aliased = Date.parse("2026-07-15T12:00:00.000Z");
+		await storage.writeFiles(
+			[
+				file(`summaries/${H("a")}.json`, summary(H("a"))),
+				file(`summaries/${H("b")}.json`, summary(H("b"), { commitDate: "2026-06-10T00:00:00.000Z" })),
+			],
+			"m",
+		);
+		await withDashboardDb(
+			(db) => {
+				const repoId = (db.prepare("SELECT id FROM repos WHERE repo_identity = ?").get(REPO) as { id: number })
+					.id;
+				db.prepare(
+					`INSERT INTO commits (event_id, repo_id, hash, branch, message, committed_at_ms, written_at_ms)
+					 VALUES (?, ?, ?, 'main', 'm', ?, ?)`,
+				).run(`commit:${H("9")}`, repoId, H("9"), aliased, aliased);
+			},
+			{ dbPath },
+		);
+		const index = (target: string) =>
+			file("index.json", {
+				version: 3,
+				entries: [
+					{ commitHash: H("a"), parentCommitHash: null },
+					{ commitHash: H("b"), parentCommitHash: null },
+				],
+				commitAliases: { [H("9")]: target },
+			});
+
+		// First landing: `a` is the target, so it sits on the aliased day.
+		await storage.writeFiles([index(H("a"))], "m");
+		// Settle a cached day for each landing this retarget will touch, AFTER the
+		// first alias landed so it is not swept by that write's own invalidation.
+		await withDashboardDb(
+			(db) => {
+				const repoId = (db.prepare("SELECT id FROM repos WHERE repo_identity = ?").get(REPO) as { id: number })
+					.id;
+				const settle = db.prepare(
+					`INSERT INTO stats_daily (repo_id, tz, day, kind, series_key, value, cost_usd, built_at_ms, updated_at_ms)
+					 VALUES (?, ?, ?, 'model', 'sonnet', 1, 0, 1, 1)`,
+				);
+				settle.run(repoId, tz, localDayKey(aFallback, tz));
+				settle.run(repoId, tz, localDayKey(bFallback, tz));
+				settle.run(repoId, tz, localDayKey(aliased, tz));
+			},
+			{ dbPath },
+		);
+
+		// The retarget.
+		await storage.writeFiles([index(H("b"))], "m");
+
+		expect(await rows("SELECT old_hash, target_hash FROM commit_aliases")).toEqual([
+			{ old_hash: H("9"), target_hash: H("b") },
+		]);
+		// All three are gone: `b` left its own fallback day, both memories crossed the
+		// aliased day, and `a` came back to ITS fallback day — that last one is what
+		// used to survive, holding a count that no longer included `a`.
+		expect(await rows("SELECT day FROM stats_daily")).toEqual([]);
+	});
+
 	it("delete of index/catalog/v5-marker changes nothing", async () => {
 		await storage.writeFiles(
 			[

--- a/cli/src/dashboard/SotWrite.ts
+++ b/cli/src/dashboard/SotWrite.ts
@@ -53,8 +53,17 @@ import { resolveTranscriptIdsFiltered } from "../core/SummaryTree.js";
 import { createLogger } from "../Logger.js";
 import type { CommitSummary, FileWrite, StoredTranscript, SummaryIndex } from "../Types.js";
 import { type DashboardDbHandle, inTransaction } from "./DashboardDb.js";
-import { commitDateMs, markdownTitle, remountRepo, reportOffTypeNumerics, tryParse } from "./SotImport.js";
+import {
+	commitDateMs,
+	markdownTitle,
+	remountRepo,
+	reportOffTypeNumerics,
+	tryParse,
+	upsertCommitAlias,
+} from "./SotImport.js";
 import { REORDER_OFFSET } from "./SotSchema.js";
+import { forgetRollupDays } from "./StatsRollup.js";
+import { MEMORY_LANDED_AT_SQL } from "./StatsSeries.js";
 
 const log = createLogger("SotWrite");
 
@@ -252,11 +261,19 @@ function branchFromMemories(db: DashboardDbHandle, repoId: number, key: string):
 
 /** Lands node deletes, upserts, repositioning, re-grounding and remount. */
 function landSummaries(db: DashboardDbHandle, repoId: number, c: Classified, nowMs: number): void {
+	// Collected before the deletes, because a deleted row cannot tell anyone
+	// which cached day it used to contribute to, and a deletion leaves no write
+	// stamp for the rollup's staleness check to find. This is the one direction
+	// the cache must be told about; everything else it works out for itself.
+	const deletedDays: number[] = [];
 	for (const hash of c.summaryDeletes) {
+		const row = db.prepare(MEMORY_LANDED_AT_SQL).get(repoId, hash) as { at_ms: number | null } | undefined;
+		if (row?.at_ms != null) deletedDays.push(row.at_ms);
 		// The self-FK cascades: deleting a node takes its stored subtree with it,
 		// which is the plan's "pruning is a whole-tree decision".
 		db.prepare("DELETE FROM memories WHERE repo_id = ? AND commit_hash = ?").run(repoId, hash);
 	}
+	forgetRollupDays(db, deletedDays);
 	if (c.summaryTrees.length === 0) return;
 
 	// Phase 1 of the sibling reorder: every parent whose child SET this batch
@@ -393,7 +410,30 @@ function landSummaries(db: DashboardDbHandle, repoId: number, c: Classified, now
 		`UPDATE memories SET parent_hash = NULL, child_pos = NULL
 		  WHERE repo_id = ? AND parent_hash = ? AND child_pos >= ${REORDER_OFFSET}`,
 	);
-	for (const parent of rewritten) reground.run(repoId, parent);
+	// The days those rows land on, read BEFORE the update, and the second
+	// direction the rollup cache cannot work out for itself.
+	//
+	// `parent_hash IS NULL` is the "current generation" predicate every memory
+	// axis filters on, so re-grounding a parked child ADDS it to those axes — and
+	// changes the `COUNT(*)` divisor the category axis apportions by. Yet this
+	// statement touches no column carrying a write stamp, so the staleness check
+	// sees nothing. Nor can it be left to the batch's own writes: a regrounded row
+	// belongs to a DIFFERENT commit than the trees being landed, so its day is
+	// typically not among the days those writes invalidate.
+	const regroundedDays: number[] = [];
+	const regroundTargets = db.prepare(
+		`SELECT m.commit_hash FROM memories m
+		  WHERE m.repo_id = ? AND m.parent_hash = ? AND m.child_pos >= ${REORDER_OFFSET}`,
+	);
+	const landedAt = db.prepare(MEMORY_LANDED_AT_SQL);
+	for (const parent of rewritten) {
+		for (const { commit_hash } of regroundTargets.all(repoId, parent) as ReadonlyArray<{ commit_hash: string }>) {
+			const row = landedAt.get(repoId, commit_hash) as { at_ms: number | null } | undefined;
+			if (row?.at_ms != null) regroundedDays.push(row.at_ms);
+		}
+		reground.run(repoId, parent);
+	}
+	forgetRollupDays(db, regroundedDays);
 
 	remountRepo(db, repoId);
 }
@@ -405,22 +445,30 @@ function landSummaries(db: DashboardDbHandle, repoId: number, c: Classified, now
  * empty-tree early return.
  */
 function landAliases(db: DashboardDbHandle, repoId: number, c: Classified, nowMs: number): void {
+	// An alias MOVES a memory between calendar days: `MEMORY_LANDED_AT_MS` falls
+	// through to `al.at_ms` once the memory's own commit row is gone, so the row
+	// stops being counted on the day it used to sit on and starts being counted on
+	// the aliasing commit's. `commit_aliases` carries no write stamp, so those days
+	// have to be forgotten explicitly — the destination is usually covered by the
+	// aliasing commit's own projection, but relying on that makes correctness
+	// depend on an ORDERING between two independent write paths.
+	//
+	// Which days those are is `upsertCommitAlias`'s answer, shared with the
+	// import's alias pass: it asks the landing query before and after the write,
+	// for every memory the alias touches — including the one a RETARGET drops,
+	// which this loop used to leave stale.
+	const movedDays: number[] = [];
 	for (const [oldHash, target] of c.aliases) {
-		// The FK requires the target memory to exist; an alias pointing at a
-		// node this database has never seen is dropped with a log line — same
-		// tolerance the orphan gave it.
-		const exists = db
-			.prepare("SELECT 1 AS ok FROM memories WHERE repo_id = ? AND commit_hash = ?")
-			.get(repoId, target) as { ok?: number } | undefined;
-		if (!exists) {
+		const outcome = upsertCommitAlias(db, repoId, oldHash, target, nowMs);
+		// An alias pointing at a node this database has never seen is dropped with a
+		// log line — the same tolerance the orphan gave it.
+		if (!outcome.stored) {
 			log.info("dropping alias %s -> %s (no such memory row)", oldHash, target);
 			continue;
 		}
-		db.prepare(
-			`INSERT INTO commit_aliases (repo_id, old_hash, target_hash, created_ms) VALUES (?, ?, ?, ?)
-			 ON CONFLICT(repo_id, old_hash) DO UPDATE SET target_hash = excluded.target_hash`,
-		).run(repoId, oldHash, target, nowMs);
+		movedDays.push(...outcome.days);
 	}
+	forgetRollupDays(db, movedDays);
 }
 
 /** Lands transcript rows + their session projection. */

--- a/cli/src/dashboard/StatsRollup.test.ts
+++ b/cli/src/dashboard/StatsRollup.test.ts
@@ -1,0 +1,761 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DASHBOARD_SCHEMA_VERSION, withDashboardDb } from "./DashboardDb.js";
+import type { SeriesDimension, StatsEventEnvelope } from "./DashboardModel.js";
+import { buildDashboardModel } from "./DashboardQuery.js";
+import {
+	BUILT_KIND,
+	buildRollup,
+	buildRollupQuietly,
+	forgetRollupDays,
+	ROLLUP_AXES,
+	ROLLUP_KINDS,
+	readAvailableDays,
+	readRollupSeries,
+	TOKENS_KIND,
+} from "./StatsRollup.js";
+import { applyStatsEvents } from "./StatsWriter.js";
+
+const UTC = "UTC";
+/** 2026-07-30 12:00 UTC — "today" for every case here. */
+const NOW = Date.parse("2026-07-30T12:00:00Z");
+const day = (key: string, hour = 10) => Date.parse(`${key}T${String(hour).padStart(2, "0")}:00:00Z`);
+
+function session(
+	id: string,
+	atMs: number,
+	usage: ReadonlyArray<{ respondedAtMs: number; model: string; input: number; output: number }>,
+): StatsEventEnvelope {
+	return {
+		event: {
+			type: "session.upserted",
+			repoIdentity: "repo-1",
+			source: "claude",
+			sessionId: id,
+			updatedAtMs: atMs,
+			messageCount: 2,
+			usageEvents: usage.map((u) => ({ ...u, cached: 0, estCostUsd: 0.5, dedupKey: `${id}:${u.respondedAtMs}` })),
+		},
+		producerKind: "cli",
+	};
+}
+
+describe("stats rollup", () => {
+	let dir: string;
+	let dbPath: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "jolli-rollup-"));
+		dbPath = join(dir, "dashboard.db");
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	// Zone-scoped on purpose. `applyStatsEvents` settles days too (that is the
+	// production wiring), in the MACHINE's zone — so an unscoped read here would
+	// mix two calendars and the assertion would depend on where the test runs.
+	const rollupRows = async (tz: string = UTC) =>
+		withDashboardDb(
+			(db) =>
+				db
+					.prepare(
+						`SELECT repo_id, day, kind, series_key, value, cost_usd FROM stats_daily
+						  WHERE tz = ? ORDER BY day, kind, series_key`,
+					)
+					.all(tz) as ReadonlyArray<Record<string, unknown>>,
+			{ dbPath },
+		);
+
+	it("keeps the kind namespace free of collisions with the axis names", () => {
+		// `tokens` and `built` are invented here while the rest come from the
+		// dimension union; a new dimension taking one of those names would make a
+		// day's token split readable as an axis, with nothing to notice.
+		//
+		// This only means anything because `ROLLUP_AXES` is DERIVED from
+		// `SeriesDimension`. Against the hand-written list it replaced, it asserted
+		// that a list did not contain a name — which says nothing about the union,
+		// and stayed green for a dimension the list had simply never been told about.
+		const axes: ReadonlyArray<SeriesDimension> = ROLLUP_AXES;
+		expect(axes).not.toContain(TOKENS_KIND as SeriesDimension);
+		expect(axes).not.toContain(BUILT_KIND as SeriesDimension);
+		expect(new Set(ROLLUP_KINDS).size).toBe(ROLLUP_KINDS.length);
+	});
+
+	it("caches every dimension the page can draw, so none reads zero on a settled day", () => {
+		// The failure this guards is silent and one-directional: an axis absent from
+		// `ROLLUP_AXES` is never built, but `buildSeries` still treats every settled
+		// day as covered — the cache answers nothing for that kind and the live pass
+		// fills only `plan.live`, so the axis loses its whole cached history while
+		// still drawing a plausible chart. `SeriesDimension` is spelled out here on
+		// purpose: deriving both sides from one constant would assert nothing.
+		const everyDimension: ReadonlyArray<SeriesDimension> = [
+			"model",
+			"agent",
+			"project",
+			"branch",
+			"ticket",
+			"category",
+		];
+		expect([...ROLLUP_AXES].sort()).toEqual([...everyDimension].sort());
+	});
+
+	it("settles a past day and marks it available", async () => {
+		await applyStatsEvents(
+			[
+				session("s1", day("2026-07-28", 23), [
+					{ respondedAtMs: day("2026-07-28", 9), model: "claude-opus-5", input: 100, output: 10 },
+					{ respondedAtMs: day("2026-07-28", 21), model: "claude-opus-5", input: 200, output: 20 },
+				]),
+			],
+			{ producerKind: "cli", dbPath, now: () => NOW },
+		);
+		await withDashboardDb((db) => buildRollup(db, { now: () => NOW, timeZone: UTC }), { dbPath });
+
+		const tokens = (await rollupRows()).filter((r) => r.kind === TOKENS_KIND && r.day === "2026-07-28");
+		expect(tokens.map((r) => [r.series_key, r.value])).toEqual([
+			["cached", 0],
+			["input", 300],
+			["output", 30],
+		]);
+
+		const available = await withDashboardDb((db) => readAvailableDays(db, UTC, ["2026-07-28", "2026-07-29"], NOW), {
+			dbPath,
+		});
+		expect(available.has("2026-07-28")).toBe(true);
+		// A quiet day is still settled — the sentinel is what separates "computed,
+		// nothing happened" from "never computed".
+		expect(available.has("2026-07-29")).toBe(true);
+	});
+
+	it("a build older than the file does not settle any day", async () => {
+		// Nothing refuses an ahead-of-build database anymore, but the CACHE is a
+		// different question from the source tables: the expiry test reads every
+		// source table's write stamp, and a build that does not know a table added
+		// since cannot see it change — it would settle an already-incomplete day
+		// and keep serving it. Declining costs a recomputation per render.
+		await applyStatsEvents(
+			[
+				session("s1", day("2026-07-28", 23), [
+					{ respondedAtMs: day("2026-07-28", 9), model: "m", input: 1, output: 1 },
+				]),
+			],
+			{ producerKind: "cli", dbPath, now: () => NOW },
+		);
+		await withDashboardDb((db) => db.exec("DELETE FROM stats_daily"), { dbPath });
+		await withDashboardDb(
+			(db) => {
+				db.exec("UPDATE schema_meta SET value = '999' WHERE key = 'schema_version'");
+				buildRollupQuietly(db, { now: () => NOW, timeZone: UTC });
+			},
+			{ dbPath },
+		);
+		expect(await rollupRows()).toEqual([]);
+
+		// And the current build settles it on the next write, so the only cost was
+		// the delay.
+		await withDashboardDb(
+			(db) => {
+				db.exec(`UPDATE schema_meta SET value = '${DASHBOARD_SCHEMA_VERSION}' WHERE key = 'schema_version'`);
+				buildRollupQuietly(db, { now: () => NOW, timeZone: UTC });
+			},
+			{ dbPath },
+		);
+		expect((await rollupRows()).length).toBeGreaterThan(0);
+	});
+
+	it("never settles today, however many times it runs", async () => {
+		await applyStatsEvents(
+			[session("s1", NOW, [{ respondedAtMs: NOW, model: "claude-opus-5", input: 5, output: 5 }])],
+			{ producerKind: "cli", dbPath, now: () => NOW },
+		);
+		await withDashboardDb((db) => buildRollup(db, { now: () => NOW, timeZone: UTC }), { dbPath });
+
+		const days = new Set((await rollupRows()).map((r) => r.day));
+		expect(days.has("2026-07-30")).toBe(false);
+		const available = await withDashboardDb((db) => readAvailableDays(db, UTC, ["2026-07-30"], NOW), { dbPath });
+		expect(available.size).toBe(0);
+	});
+
+	it("expires a settled day when a source row lands on it afterwards", async () => {
+		await withDashboardDb((db) => buildRollup(db, { now: () => NOW, timeZone: UTC }), { dbPath });
+		const before = await withDashboardDb((db) => readAvailableDays(db, UTC, ["2026-07-28"], NOW), { dbPath });
+		expect(before.has("2026-07-28")).toBe(true);
+
+		// A session discovered later, carrying a response that belongs to the 28th.
+		//
+		// ⚠ `skipRollup`, because the subject here is the READ-side staleness check
+		// and the write path settles days of its own accord — in the MACHINE's
+		// zone, which on a UTC machine is the very calendar this case asserts in.
+		// There the write would re-settle the 28th (correctly, with the new row in
+		// it) before the read ever looked, stamping `built_at_ms` from the same
+		// `now` as the row it just wrote — so the day reads as fresh and this
+		// assertion inverts, on that machine only. Skipping the settle is safe by
+		// construction: the cache is derived, and a day nobody settles is computed
+		// live.
+		await applyStatsEvents(
+			[
+				session("late", day("2026-07-29", 8), [
+					{ respondedAtMs: day("2026-07-28", 9), model: "claude-opus-5", input: 70, output: 7 },
+				]),
+			],
+			{ producerKind: "cli", dbPath, now: () => NOW + 60_000, skipRollup: true },
+		);
+
+		const after = await withDashboardDb((db) => readAvailableDays(db, UTC, ["2026-07-28"], NOW), { dbPath });
+		expect(after.has("2026-07-28")).toBe(false);
+	});
+
+	/**
+	 * A REWRITTEN commit is where the staleness test and the axes used to date one
+	 * memory differently, and the difference is a permanently wrong number.
+	 *
+	 * The memory stays filed under its pre-rewrite hash, so it has no `commits` row
+	 * of its own and the axes reach the surviving commit through `commit_aliases` —
+	 * landing the spend on that commit's committer date. The staleness scan used to
+	 * spell its own `COALESCE(c.committed_at_ms, m.commit_date_ms)`, which for this
+	 * shape falls through to the AUTHOR date: it expired a day nothing was drawn on
+	 * and left the day that really changed serving its old numbers. Both now go
+	 * through `MEMORY_LANDED_AT_MS`.
+	 */
+	it("expires the day a rewritten commit's memory actually lands on", async () => {
+		const landed = "2026-07-28";
+		const authored = "2026-07-20";
+		await withDashboardDb(
+			(db) => {
+				db.prepare(
+					`INSERT INTO repos (repo_identity, repo_name, worktree_root, enabled_at)
+					 VALUES ('repo-1', 'r', '/r', '1970-01-01T00:00:00.000Z')`,
+				).run();
+				const repoId = (db.prepare("SELECT id FROM repos").get() as { id: number }).id;
+				db.prepare(
+					`INSERT INTO commits (event_id, repo_id, hash, branch, message, committed_at_ms, written_at_ms)
+					 VALUES ('c:new', ?, 'newhash', 'main', 'm', ?, ?)`,
+				).run(repoId, day(landed), day(landed));
+				// tokens / est_cost_usd are GENERATED from summary_json.
+				db.prepare(
+					`INSERT INTO memories (repo_id, commit_hash, parent_hash, child_pos, root_hash, depth,
+					                       summary_json, first_seen_ms, written_at_ms, commit_date_ms)
+					 VALUES (?, 'oldhash', NULL, NULL, 'oldhash', 0, ?, ?, ?, ?)`,
+				).run(
+					repoId,
+					JSON.stringify({ conversationTokens: 500, estimatedCostUsd: 0.5 }),
+					day(landed),
+					day(landed),
+					day(authored),
+				);
+				db.prepare(
+					`INSERT INTO commit_aliases (repo_id, old_hash, target_hash, created_ms)
+					 VALUES (?, 'newhash', 'oldhash', ?)`,
+				).run(repoId, day(landed));
+				buildRollup(db, { now: () => NOW, timeZone: UTC });
+			},
+			{ dbPath },
+		);
+		const before = await withDashboardDb((db) => readAvailableDays(db, UTC, [landed, authored], NOW), { dbPath });
+		expect([...before].sort()).toEqual([authored, landed]);
+
+		// A memory-only write: re-summarising touches no `commits` row, so the
+		// commit-side arm of the scan cannot cover for a wrong landing expression.
+		await withDashboardDb(
+			(db) => db.prepare("UPDATE memories SET written_at_ms = ? WHERE commit_hash = 'oldhash'").run(NOW + 60_000),
+			{ dbPath },
+		);
+
+		const after = await withDashboardDb((db) => readAvailableDays(db, UTC, [landed, authored], NOW), { dbPath });
+		expect(after.has(landed)).toBe(false);
+		// And the author date's day is NOT the one that expired — the old spelling
+		// had this exactly the wrong way round.
+		expect(after.has(authored)).toBe(true);
+	});
+
+	it("leaves settled days alone when the only new activity is dated today", async () => {
+		// The property the staleness scan's day bound rests on: today is never a
+		// candidate (it is still accumulating), so a row dated today cannot invalidate
+		// any settled day. That was already true — the bound is what stops such rows
+		// being READ, which on a machine older than the horizon was every row written
+		// in the last ~90 days, materialised and day-keyed one at a time on the
+		// writer's lock. See `readSourcesWrittenSince`.
+		await applyStatsEvents(
+			[
+				session("s1", day("2026-07-28", 12), [
+					{ respondedAtMs: day("2026-07-28", 9), model: "claude-opus-5", input: 100, output: 0 },
+				]),
+			],
+			{ producerKind: "cli", dbPath, now: () => NOW },
+		);
+		await withDashboardDb((db) => buildRollup(db, { now: () => NOW, timeZone: UTC }), { dbPath });
+		expect(
+			(await withDashboardDb((db) => readAvailableDays(db, UTC, ["2026-07-28"], NOW), { dbPath })).has(
+				"2026-07-28",
+			),
+		).toBe(true);
+
+		// A brand-new session on NOW's own day, written afterwards.
+		await applyStatsEvents(
+			[
+				session("s2", day("2026-07-30", 11), [
+					{ respondedAtMs: day("2026-07-30", 11), model: "claude-opus-5", input: 900, output: 0 },
+				]),
+			],
+			{ producerKind: "cli", dbPath, now: () => NOW + 60_000 },
+		);
+
+		const after = await withDashboardDb((db) => readAvailableDays(db, UTC, ["2026-07-28"], NOW), { dbPath });
+		expect(after.has("2026-07-28")).toBe(true);
+	});
+
+	/**
+	 * Pruning an unreachable commit MOVES its memory to another day, and the day it
+	 * moves TO has to be forgotten as well.
+	 *
+	 * `pruneUnreachableCommits` restated the landing rule by hand as
+	 * `m.commit_date_ms`, on the reasoning that the expression "falls back to" that
+	 * column once the commit row is gone. It skips the middle term — and a prune IS
+	 * the alias case, so the memory actually lands on the ALIASING commit's
+	 * committer date. The result: the author-date day was forgotten (it had not
+	 * changed) and the day that really changed kept serving a number missing this
+	 * memory, for ever, since an old day gets no further writes. It now asks
+	 * `MEMORY_LANDED_AT_SQL` after the delete.
+	 */
+	it("expires the day a pruned commit's memory moves TO, not its author date", async () => {
+		const authored = "2026-07-20"; // commit_date_ms — the wrong answer
+		const pruned = "2026-07-25"; // the unreachable commit's own day
+		const landed = "2026-07-28"; // the surviving aliasing commit's day
+		const { pruneUnreachableCommits } = await import("./DbBackfill.js");
+		await withDashboardDb(
+			(db) => {
+				db.prepare(
+					`INSERT INTO repos (repo_identity, repo_name, worktree_root, enabled_at)
+					 VALUES ('repo-1', 'r', '/r', '1970-01-01T00:00:00.000Z')`,
+				).run();
+				const repoId = (db.prepare("SELECT id FROM repos").get() as { id: number }).id;
+				const insertCommit = db.prepare(
+					`INSERT INTO commits (event_id, repo_id, hash, branch, message, committed_at_ms, written_at_ms)
+					 VALUES (?, ?, ?, 'main', 'm', ?, ?)`,
+				);
+				insertCommit.run("c:new", repoId, "newhash", day(landed), day(landed));
+				insertCommit.run("c:old", repoId, "oldhash", day(pruned), day(pruned));
+				db.prepare(
+					`INSERT INTO memories (repo_id, commit_hash, parent_hash, child_pos, root_hash, depth,
+					                       summary_json, first_seen_ms, written_at_ms, commit_date_ms)
+					 VALUES (?, 'oldhash', NULL, NULL, 'oldhash', 0, ?, ?, ?, ?)`,
+				).run(
+					repoId,
+					JSON.stringify({ conversationTokens: 500, estimatedCostUsd: 0.5 }),
+					day(pruned),
+					day(pruned),
+					day(authored),
+				);
+				db.prepare(
+					`INSERT INTO commit_aliases (repo_id, old_hash, target_hash, created_ms)
+					 VALUES (?, 'newhash', 'oldhash', ?)`,
+				).run(repoId, day(landed));
+				buildRollup(db, { now: () => NOW, timeZone: UTC });
+			},
+			{ dbPath },
+		);
+		const before = await withDashboardDb((db) => readAvailableDays(db, UTC, [authored, pruned, landed], NOW), {
+			dbPath,
+		});
+		expect([...before].sort()).toEqual([authored, pruned, landed]);
+
+		// `newhash` survives, `oldhash` does not — the shape a rebase leaves behind.
+		await withDashboardDb((db) => pruneUnreachableCommits(db, "repo-1", new Set(["newhash"])), { dbPath });
+
+		const after = await withDashboardDb((db) => readAvailableDays(db, UTC, [authored, pruned, landed], NOW), {
+			dbPath,
+		});
+		// The day it stopped being counted on, and the day it moved to.
+		expect(after.has(pruned)).toBe(false);
+		expect(after.has(landed)).toBe(false);
+		// The author date never had this memory on it and must be left alone — the
+		// hand-written spelling forgot exactly this one and nothing else.
+		expect(after.has(authored)).toBe(true);
+	});
+
+	it("rebuilds an expired day to the new numbers rather than adding to the old", async () => {
+		await applyStatsEvents(
+			[
+				session("s1", day("2026-07-28", 12), [
+					{ respondedAtMs: day("2026-07-28", 9), model: "claude-opus-5", input: 100, output: 0 },
+				]),
+			],
+			{ producerKind: "cli", dbPath, now: () => NOW },
+		);
+		await withDashboardDb((db) => buildRollup(db, { now: () => NOW, timeZone: UTC }), { dbPath });
+
+		// The same session re-read with one more response — the row is replaced,
+		// so a rebuild that added instead of replacing would report 300.
+		await applyStatsEvents(
+			[
+				session("s1", day("2026-07-28", 12), [
+					{ respondedAtMs: day("2026-07-28", 9), model: "claude-opus-5", input: 100, output: 0 },
+					{ respondedAtMs: day("2026-07-28", 15), model: "claude-opus-5", input: 100, output: 0 },
+				]),
+			],
+			{ producerKind: "cli", dbPath, now: () => NOW + 60_000 },
+		);
+		await withDashboardDb((db) => buildRollup(db, { now: () => NOW + 120_000, timeZone: UTC }), { dbPath });
+
+		const input = (await rollupRows()).find((r) => r.day === "2026-07-28" && r.series_key === "input");
+		expect(input?.value).toBe(200);
+	});
+
+	it("stops at the day budget and drains the rest on the next call", async () => {
+		const built = await withDashboardDb((db) => buildRollup(db, { now: () => NOW, timeZone: UTC, maxDays: 3 }), {
+			dbPath,
+		});
+		expect(built).toBe(3);
+		// Newest first: the days a reader is about to ask for settle before the
+		// ones nobody has open.
+		const days = [...new Set((await rollupRows()).map((r) => r.day))].sort();
+		expect(days).toEqual(["2026-07-27", "2026-07-28", "2026-07-29"]);
+
+		const more = await withDashboardDb((db) => buildRollup(db, { now: () => NOW, timeZone: UTC, maxDays: 2 }), {
+			dbPath,
+		});
+		expect(more).toBe(2);
+		expect([...new Set((await rollupRows()).map((r) => r.day))].sort()).toEqual([
+			"2026-07-25",
+			"2026-07-26",
+			"2026-07-27",
+			"2026-07-28",
+			"2026-07-29",
+		]);
+	});
+
+	it("answers nothing for an empty day list, without opening the cache", async () => {
+		// The read path asks this for whatever window the caller has; a window that
+		// covers no day at all must answer "none are cached" rather than fall
+		// through to a query with no bounds.
+		const available = await withDashboardDb((db) => readAvailableDays(db, UTC, [], NOW), { dbPath });
+		expect(available.size).toBe(0);
+	});
+
+	it("settles nothing when the budget is zero", async () => {
+		// The budget is what keeps this off the writer's lock for long. Zero has to
+		// mean zero: a build loop that treated it as "no limit" would hold the lock
+		// for the whole 90-day horizon on the one call that asked for the opposite.
+		const built = await withDashboardDb((db) => buildRollup(db, { now: () => NOW, timeZone: UTC, maxDays: 0 }), {
+			dbPath,
+		});
+		expect(built).toBe(0);
+		expect(await rollupRows()).toEqual([]);
+	});
+
+	it("settles nothing more once the horizon is caught up", async () => {
+		// Zero is the steady state, not an error: every call after the backlog
+		// drains re-reads the sentinels, finds every day settled and writes nothing.
+		const first = await withDashboardDb((db) => buildRollup(db, { now: () => NOW, timeZone: UTC, maxDays: 90 }), {
+			dbPath,
+		});
+		expect(first).toBe(90);
+		const again = await withDashboardDb((db) => buildRollup(db, { now: () => NOW, timeZone: UTC, maxDays: 90 }), {
+			dbPath,
+		});
+		expect(again).toBe(0);
+	});
+
+	it("takes its own clock when the caller supplies none", async () => {
+		// The production caller (`applyStatsEvents`) passes one; the daemon's does
+		// not. A missing clock must not settle "today" — the day the wall clock is
+		// in is still accumulating, whichever way the caller got it.
+		const built = await withDashboardDb((db) => buildRollup(db, { timeZone: UTC }), { dbPath });
+		expect(built).toBe(14);
+		const today = new Date().toISOString().slice(0, 10);
+		expect(new Set((await rollupRows()).map((r) => r.day)).has(today)).toBe(false);
+	});
+
+	it("still answers for a settled day whose key names no real calendar date", async () => {
+		// 2026-02-30 round-trips to March, so `dayKeyToMidnight` refuses it and the
+		// scan cannot derive its bounds from that key. Both fallbacks are therefore
+		// the WIDEST range rather than the narrowest: over-reading costs one scan,
+		// while an empty range would report every stale day as fresh — and a NaN one
+		// would hang `addLocalDays`.
+		await withDashboardDb(
+			(db) =>
+				db
+					.prepare(
+						`INSERT INTO stats_daily (repo_id, tz, day, kind, series_key, value, cost_usd,
+						                          built_at_ms, updated_at_ms)
+						 VALUES (0, ?, '2026-02-30', ?, '', 0, 0, ?, ?)`,
+					)
+					.run(UTC, BUILT_KIND, NOW, NOW),
+			{ dbPath },
+		);
+		const available = await withDashboardDb((db) => readAvailableDays(db, UTC, ["2026-02-30"], NOW), { dbPath });
+		expect(available.has("2026-02-30")).toBe(true);
+	});
+
+	it("caches each zone separately rather than handing one reader another's midnight", async () => {
+		// 23:00 UTC on the 28th is already the 29th in Shanghai.
+		await applyStatsEvents(
+			[
+				session("s1", day("2026-07-28", 23), [
+					{ respondedAtMs: day("2026-07-28", 23), model: "claude-opus-5", input: 90, output: 0 },
+				]),
+			],
+			{ producerKind: "cli", dbPath, now: () => NOW },
+		);
+		await withDashboardDb(
+			(db) => {
+				buildRollup(db, { now: () => NOW, timeZone: UTC, maxDays: 5 });
+				buildRollup(db, { now: () => NOW, timeZone: "Asia/Shanghai", maxDays: 5 });
+			},
+			{ dbPath },
+		);
+		const utc = (await rollupRows(UTC)).filter((r) => r.series_key === "input" && r.value === 90);
+		const sh = (await rollupRows("Asia/Shanghai")).filter((r) => r.series_key === "input" && r.value === 90);
+		expect(utc.map((r) => r.day)).toEqual(["2026-07-28"]);
+		expect(sh.map((r) => r.day)).toEqual(["2026-07-29"]);
+	});
+
+	it("forgets a day in every zone, since one instant is two calendar days", async () => {
+		await withDashboardDb(
+			(db) => {
+				buildRollup(db, { now: () => NOW, timeZone: UTC, maxDays: 3 });
+				buildRollup(db, { now: () => NOW, timeZone: "Asia/Shanghai", maxDays: 3 });
+			},
+			{ dbPath },
+		);
+		await withDashboardDb((db) => forgetRollupDays(db, [day("2026-07-28", 23)]), { dbPath });
+
+		const remaining = await withDashboardDb(
+			(db) =>
+				readAvailableDays(db, UTC, ["2026-07-28", "2026-07-29"], NOW).has("2026-07-28") ||
+				readAvailableDays(db, "Asia/Shanghai", ["2026-07-29"], NOW).has("2026-07-29"),
+			{ dbPath },
+		);
+		// The UTC 28th and the Shanghai 29th are the same instant's day; both go.
+		expect(remaining).toBe(false);
+	});
+
+	it("forgets a day whose only responses were dropped by a transcript rewrite", async () => {
+		await applyStatsEvents(
+			[
+				session("s1", day("2026-07-29", 12), [
+					{ respondedAtMs: day("2026-07-27", 9), model: "claude-opus-5", input: 100, output: 0 },
+					{ respondedAtMs: day("2026-07-29", 9), model: "claude-opus-5", input: 50, output: 0 },
+				]),
+			],
+			{ producerKind: "cli", dbPath, now: () => NOW },
+		);
+		await withDashboardDb((db) => buildRollup(db, { now: () => NOW, timeZone: UTC, maxDays: 10 }), { dbPath });
+		expect((await rollupRows()).find((r) => r.day === "2026-07-27" && r.series_key === "input")?.value).toBe(100);
+
+		// The agent compacts its transcript and the 27th's response stops existing.
+		// A removed row leaves no write stamp, so nothing expires that day on its
+		// own — only the 29th, which still has a response, would look stale.
+		await applyStatsEvents(
+			[
+				session("s1", day("2026-07-29", 12), [
+					{ respondedAtMs: day("2026-07-29", 9), model: "claude-opus-5", input: 50, output: 0 },
+				]),
+			],
+			{ producerKind: "cli", dbPath, now: () => NOW + 60_000 },
+		);
+		await withDashboardDb((db) => buildRollup(db, { now: () => NOW + 120_000, timeZone: UTC, maxDays: 10 }), {
+			dbPath,
+		});
+
+		const rows = await rollupRows();
+		expect(rows.find((r) => r.day === "2026-07-27" && r.series_key === "input")).toBeUndefined();
+		expect(rows.find((r) => r.day === "2026-07-29" && r.series_key === "input")?.value).toBe(50);
+	});
+
+	it("reads back per-repo rows summed across the scope", async () => {
+		await applyStatsEvents(
+			[
+				session("s1", day("2026-07-28", 12), [
+					{ respondedAtMs: day("2026-07-28", 9), model: "claude-opus-5", input: 100, output: 0 },
+				]),
+				{
+					event: {
+						type: "session.upserted",
+						repoIdentity: "repo-2",
+						source: "claude",
+						sessionId: "s2",
+						updatedAtMs: day("2026-07-28", 12),
+						messageCount: 1,
+						usageEvents: [
+							{
+								respondedAtMs: day("2026-07-28", 9),
+								model: "claude-opus-5",
+								input: 40,
+								output: 0,
+								cached: 0,
+								dedupKey: "s2:a",
+							},
+						],
+					},
+					producerKind: "cli",
+				},
+			],
+			{ producerKind: "cli", dbPath, now: () => NOW },
+		);
+		await withDashboardDb((db) => buildRollup(db, { now: () => NOW, timeZone: UTC }), { dbPath });
+
+		const [all, one] = await withDashboardDb(
+			(db) =>
+				[
+					readRollupSeries(db, UTC, TOKENS_KIND, ["2026-07-28"], { kind: "all" }),
+					readRollupSeries(db, UTC, TOKENS_KIND, ["2026-07-28"], {
+						kind: "repo",
+						repoIdentities: ["repo-1"],
+					}),
+				] as const,
+			{ dbPath },
+		);
+		expect(all.find((r) => r.series_key === "input")?.value).toBe(140);
+		expect(one.find((r) => r.series_key === "input")?.value).toBe(100);
+	});
+});
+
+/**
+ * The safety net for the whole cache: for every axis, the same data read
+ * through settled days and read live must produce byte-identical cards.
+ *
+ * This is the test that would catch a divergence between the two paths, and
+ * divergence here is not loud — a cached day is a plausible number, so a page
+ * built half from cache would look fine and simply be wrong. Anything added to
+ * `stats_daily` needs a case here, or the cache path is unguarded for it.
+ */
+describe("cached and live days agree", () => {
+	let dir: string;
+	let dbPath: string;
+	const nowMs = Date.parse("2026-07-30T12:00:00Z");
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "jolli-rollup-eq-"));
+		dbPath = join(dir, "dashboard.db");
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	/** Sessions, commits and memories with topics — enough to feed all six axes. */
+	async function seed(): Promise<void> {
+		await applyStatsEvents(
+			[
+				session("s1", day("2026-07-27", 12), [
+					{ respondedAtMs: day("2026-07-27", 9), model: "claude-opus-5", input: 100, output: 10 },
+					{ respondedAtMs: day("2026-07-28", 9), model: "claude-sonnet-5", input: 200, output: 20 },
+				]),
+				session("s2", day("2026-07-29", 12), [
+					{ respondedAtMs: day("2026-07-29", 9), model: "claude-opus-5", input: 300, output: 30 },
+				]),
+				// Today, so the live path always has at least one day of its own.
+				session("s3", nowMs, [{ respondedAtMs: nowMs, model: "claude-opus-5", input: 7, output: 7 }]),
+				{
+					event: {
+						type: "commit.created",
+						repoIdentity: "repo-1",
+						hash: "a".repeat(40),
+						branch: "main",
+						message: "JOLLI-1 first",
+						committedAtMs: day("2026-07-28", 11),
+						branches: ["main", "feature"],
+					},
+					producerKind: "cli",
+				},
+			],
+			{ producerKind: "cli", dbPath, now: () => nowMs },
+		);
+		// Memory rows with topics: the category, branch and ticket axes all read
+		// them, and only an orphan import writes them in production.
+		await withDashboardDb(
+			(db) => {
+				const { id } = db.prepare("SELECT id FROM repos WHERE repo_identity = 'repo-1'").get() as {
+					id: number;
+				};
+				const hash = "a".repeat(40);
+				// tokens / est_cost_usd / ticket_id are generated from this JSON, so
+				// they can only be seeded through it.
+				const summaryJson = JSON.stringify({
+					commitHash: hash,
+					conversationTokens: 900,
+					estimatedCostUsd: 1.25,
+					ticketId: "JOLLI-1",
+				});
+				db.prepare(
+					`INSERT INTO memories (repo_id, commit_hash, parent_hash, child_pos, root_hash, depth,
+					                       summary_json, first_seen_ms, written_at_ms, commit_date_ms)
+					 VALUES (?, ?, NULL, NULL, ?, 0, ?, 1, 1, ?)`,
+				).run(id, hash, hash, summaryJson, day("2026-07-28", 11));
+				["refactor", "docs"].forEach((category, pos) => {
+					db.prepare(
+						"INSERT INTO memory_topics (repo_id, commit_hash, pos, category, title) VALUES (?, ?, ?, ?, ?)",
+					).run(id, hash, pos, category, `topic ${pos}`);
+				});
+			},
+			{ dbPath },
+		);
+	}
+
+	const model = (dimension: SeriesDimension) =>
+		withDashboardDb(
+			(db) => buildDashboardModel(db, { view: "stats", scope: { kind: "all" }, timeZone: UTC, nowMs, dimension }),
+			{ dbPath },
+		);
+
+	for (const dimension of ROLLUP_AXES) {
+		it(`matches on the ${dimension} axis`, async () => {
+			await seed();
+			// Everything the writer settled along the way, so this really is the
+			// uncached path rather than "whatever happened to be cached".
+			await withDashboardDb((db) => db.prepare("DELETE FROM stats_daily").run(), { dbPath });
+			const live = await model(dimension);
+
+			await withDashboardDb((db) => buildRollup(db, { now: () => nowMs, timeZone: UTC, maxDays: 60 }), {
+				dbPath,
+			});
+			const cached = await model(dimension);
+
+			// Everything integral is compared SERIALISED rather than with `toEqual`,
+			// which ignores key order — and key order is one of the two ways these
+			// paths drifted on real data. Token counts are integers after rounding,
+			// so identity is the right bar for them and is reachable.
+			const withoutCost = (m: typeof live) =>
+				JSON.stringify((m.stats?.series ?? []).map(({ estCostUsd: _cost, ...rest }) => rest));
+			expect(withoutCost(cached)).toBe(withoutCost(live));
+			expect(cached.stats?.seriesKeys).toEqual(live.stats?.seriesKeys);
+			expect(JSON.stringify(cached.stats?.tokenBreakdown.perDay)).toBe(
+				JSON.stringify(live.stats?.tokenBreakdown.perDay),
+			);
+
+			// Cost is the one figure identity is the WRONG bar for: it is a float
+			// sum and the two paths sum in different groupings. They agree to
+			// ~1e-13 on real data, nine orders below the cent this is ever
+			// displayed to; demanding more would only invite a quantisation that
+			// makes the disagreement rarer and larger. See buildSeries.
+			const costs = (m: typeof live) => (m.stats?.series ?? []).map((p) => p.estCostUsd);
+			for (const [i, c] of costs(cached).entries()) expect(c).toBeCloseTo(costs(live)[i] ?? 0, 9);
+		});
+	}
+
+	it("does not double-count a settled day sitting between two live ones", async () => {
+		await seed();
+		await withDashboardDb(
+			(db) => {
+				buildRollup(db, { now: () => nowMs, timeZone: UTC, maxDays: 60 });
+				// Expire the 27th and the 29th, leaving the 28th settled INSIDE the
+				// range the live pass has to cover. Filtering by range alone would
+				// count the 28th twice — the one way this cache can overstate.
+				db.prepare("DELETE FROM stats_daily WHERE tz = ? AND day IN (?, ?)").run(
+					UTC,
+					"2026-07-27",
+					"2026-07-29",
+				);
+			},
+			{ dbPath },
+		);
+		const cached = await model("model");
+		const perDay = new Map((cached.stats?.tokenBreakdown.perDay ?? []).map((d) => [d.date, d.input]));
+		expect(perDay.get("2026-07-28")).toBe(200);
+	});
+});

--- a/cli/src/dashboard/StatsRollup.ts
+++ b/cli/src/dashboard/StatsRollup.ts
@@ -1,0 +1,566 @@
+/**
+ * The per-day cache in front of the spend axes and the token split.
+ *
+ * Two halves that must agree: {@link buildRollup} runs on the WRITE side and
+ * settles days into `stats_daily`; {@link readAvailableDays} and
+ * {@link readRollupSeries} run on the read side and use a settled day instead
+ * of recomputing it. Both derive their numbers from {@link ./StatsSeries.ts}
+ * and their day boundaries from {@link ./LocalDays.ts}, which is what makes a
+ * cached day and a live day the same number rather than two numbers that
+ * happen to match.
+ *
+ * ⚠ The cache is never authoritative. Every function here may answer "not
+ * available" and the caller must be able to compute the day itself; deleting
+ * every row changes only how long a page takes. That property is the whole
+ * safety argument, and it is easy to lose by storing something here that the
+ * sources can no longer produce.
+ *
+ * # How a day expires
+ *
+ * By asking the sources, not by being told. Each day carries the instant it was
+ * built, and every table an axis reads carries the instant its rows were last
+ * written; a day is stale when any source row belonging to it was written after
+ * that. Both halves of that sentence are filters in the SQL — written after the
+ * oldest build, AND dated inside the days being asked about — and the second one
+ * is what keeps the check cheap rather than growing with the machine's history
+ * (see {@link readSourcesWrittenSince}). The alternative — writers recording "this day changed" as they go —
+ * fails the way a ledger fails: one write path that forgets to record leaves a
+ * permanently wrong number that nothing detects. A new write path here is
+ * visible the moment it lands, because the rows it writes carry stamps.
+ *
+ * The one thing the sources cannot report is a DELETE — a removed row leaves no
+ * stamp behind. That gap is closed from the other side, by deleting the day's
+ * cached rows whenever source rows are deleted: a day with no rows is a day
+ * that was never computed, which already falls back to computing it. Over-
+ * rebuilding is the failure mode there, and it is self-correcting.
+ */
+
+import { createLogger, errMsg } from "../Logger.js";
+import type { DashboardDbHandle } from "./DashboardDb.js";
+import { DASHBOARD_SCHEMA_VERSION, inTransaction, readSchemaVersion } from "./DashboardDb.js";
+import type { DashboardScope, SeriesDimension } from "./DashboardModel.js";
+import { scopeFilter, scopeToRepoIds } from "./DashboardScopeUtil.js";
+import { addLocalDays, dayKeyToMidnight, localDayKey, machineTimeZone, startOfLocalDay } from "./LocalDays.js";
+import {
+	type AxisRow,
+	MEMORY_LANDED_AT_MS,
+	MEMORY_LANDING_JOINS,
+	readAxisRows,
+	readDatedUsage,
+} from "./StatsSeries.js";
+
+const log = createLogger("StatsRollup");
+
+/**
+ * The spend axes, every one of them cacheable.
+ *
+ * ⚠ DERIVED from a `Record` keyed on `SeriesDimension`, never written out as a
+ * list, so adding a dimension is a COMPILE error right here. That is not
+ * tidiness. An axis missing from this set is never built — but `buildSeries`
+ * still treats every settled day as covered, because the plan is computed once
+ * for the whole page and knows nothing about which axis is being drawn. The
+ * cache would answer nothing for that kind, the live pass would fill only
+ * `plan.live`, and the axis would read ZERO on every cached day: a plausible
+ * chart, quietly missing most of its history, with nothing to notice it. A hand-
+ * written list type-checks fine when the union grows, which is exactly the
+ * failure this shape removes.
+ */
+const ROLLUP_AXIS_SET: Readonly<Record<SeriesDimension, true>> = {
+	model: true,
+	agent: true,
+	project: true,
+	branch: true,
+	ticket: true,
+	category: true,
+};
+
+export const ROLLUP_AXES = Object.keys(ROLLUP_AXIS_SET) as ReadonlyArray<SeriesDimension>;
+
+/** `kind` of the row that records a day was computed. See the DDL. */
+export const BUILT_KIND = "built";
+
+/** `kind` of the "Where your tokens went" split. */
+export const TOKENS_KIND = "tokens";
+
+/** `series_key`s under {@link TOKENS_KIND}. */
+export const TOKEN_SERIES = ["input", "output", "cached"] as const;
+
+export type TokenSeries = (typeof TOKEN_SERIES)[number];
+
+/**
+ * Every `kind` this table stores.
+ *
+ * The axis names come from the dimension union and the other two are invented
+ * here, so they share one namespace and must not collide: a dimension called
+ * `tokens` would read a day's token split as if it were an axis, silently. The
+ * test that pins this is only meaningful because {@link ROLLUP_AXES} is now
+ * DERIVED from `SeriesDimension` — against a hand-written list it asserted that
+ * the list did not contain a name, which says nothing about the union.
+ */
+export const ROLLUP_KINDS: ReadonlyArray<string> = [...ROLLUP_AXES, TOKENS_KIND, BUILT_KIND];
+
+/**
+ * How far back a day is worth caching.
+ *
+ * Not a correctness bound — an older day simply computes live, exactly as every
+ * day does today. It bounds the work the staleness scan and the build loop can
+ * ever do, so that a machine with years of history does not pay for a range
+ * nobody opens. The stock ranges (7 / 14 / 30 days) sit well inside it.
+ */
+export const ROLLUP_HORIZON_DAYS = 90;
+
+/**
+ * Days one call may settle.
+ *
+ * ⚠ This runs inside the writer's lock, on a path an editor's periodic scan
+ * reaches, and that caller waits a few hundred milliseconds for the lock at
+ * most. Falling behind costs a slower page; holding the lock costs a dropped
+ * write. So the budget is deliberately small and the backlog drains across
+ * calls — there is always another call.
+ */
+export const ROLLUP_MAX_DAYS_PER_BUILD = 14;
+
+/** Sentinel `repo_id`: the day, rather than any one repo. Real ids start at 1. */
+const SENTINEL_REPO_ID = 0;
+
+interface StaleSourceRow {
+	readonly repo_id: number;
+	readonly at_ms: number;
+	readonly w: number;
+}
+
+/**
+ * Every source row that BOTH was written after `sinceMs` AND belongs to a day in
+ * `[fromMs, toMs)`, with the instant that decides which day that is.
+ *
+ * One query per side rather than one per axis: the four session-backed axes and
+ * the token split all read the same two tables, and the three memory-backed
+ * ones all read the same two.
+ *
+ * ⚠ BOTH bounds are load-bearing, and the day bound is the one that makes this
+ * affordable. `sinceMs` is the oldest `built_at_ms` among the days in play, and
+ * that value DECAYS: a settled day is never rebuilt, so it keeps the stamp it was
+ * settled with, and on a machine older than the horizon the oldest one is ~90 days
+ * back. Filtered on the write stamp alone this therefore returned every row
+ * written in the last ~90 days — for a heavy user 10^5 `session_usage_events` rows
+ * — materialised into JS and handed to `localDayKey` (an `Intl` format call) one by
+ * one, on the writer's lock once per `applyToDb` and twice per dashboard render.
+ * The module header's claim that a caught-up machine reads nothing was true only
+ * of a fresh cache.
+ *
+ * With the day bound it is true in general, because the two filters are nearly
+ * disjoint in the steady state: the bulk of recently-written rows are dated TODAY,
+ * and today is never a candidate (it is still accumulating). What survives both is
+ * exactly the interesting set — a row dated in the past but written recently: a
+ * re-read of an old session, a backfill, a rebase. On a quiet machine that is
+ * empty.
+ *
+ * The bound is on the same expression each row is BUCKETED by, never on the write
+ * stamp — the two are different questions, and filtering the day bound on the
+ * stamp would drop precisely the rows this exists to find.
+ */
+function readSourcesWrittenSince(
+	db: DashboardDbHandle,
+	sinceMs: number,
+	fromMs: number,
+	toMs: number,
+): ReadonlyArray<StaleSourceRow> {
+	const sessionSide = db
+		.prepare(
+			`SELECT s.repo_id, e.responded_at_ms AS at_ms, e.updated_at_ms AS w
+			   FROM session_usage_events e JOIN sessions s ON s.event_id = e.session_event_id
+			  WHERE e.updated_at_ms > ? AND e.responded_at_ms >= ? AND e.responded_at_ms < ?
+			 UNION ALL
+			SELECT s.repo_id, s.updated_at_ms AS at_ms, s.written_at_ms AS w
+			   FROM sessions s
+			  WHERE s.written_at_ms > ? AND s.updated_at_ms >= ? AND s.updated_at_ms < ?`,
+		)
+		.all(sinceMs, fromMs, toMs, sinceMs, fromMs, toMs) as StaleSourceRow[];
+	// The memory side dates a row through `MEMORY_LANDED_AT_MS` — the SAME
+	// expression the axes count it with, shared as a fragment rather than restated
+	// here, because a restatement is what this used to be and it was wrong for a
+	// rewritten commit (see that constant).
+	//
+	// It deliberately does NOT filter `parent_hash IS NULL`, which is why it
+	// composes the fragments instead of reusing `MEMORY_LANDING_CTE`: a write to
+	// ANY generation must be visible, since re-grounding one is precisely what
+	// moves a row into the set the axes count. Over-invalidating costs one
+	// recomputation; the other direction serves a wrong number for ever.
+	const memorySide = db
+		.prepare(
+			`SELECT m.repo_id, ${MEMORY_LANDED_AT_MS} AS at_ms, m.written_at_ms AS w
+			   FROM memories m
+			   ${MEMORY_LANDING_JOINS}
+			  WHERE m.written_at_ms > ?
+			    AND ${MEMORY_LANDED_AT_MS} >= ? AND ${MEMORY_LANDED_AT_MS} < ?
+			 UNION ALL
+			SELECT c.repo_id, c.committed_at_ms AS at_ms, c.written_at_ms AS w
+			   FROM commits c
+			  WHERE c.written_at_ms > ? AND c.committed_at_ms >= ? AND c.committed_at_ms < ?`,
+		)
+		.all(sinceMs, fromMs, toMs, sinceMs, fromMs, toMs) as StaleSourceRow[];
+	return [...sessionSide, ...memorySide];
+}
+
+/** `day -> built_at_ms` for every settled day in `[fromDay, toDay]`. */
+function readSentinels(db: DashboardDbHandle, timeZone: string, fromDay: string, toDay: string): Map<string, number> {
+	const rows = db
+		.prepare(
+			`SELECT day, built_at_ms FROM stats_daily
+			  WHERE tz = ? AND kind = ? AND repo_id = ? AND day >= ? AND day <= ?`,
+		)
+		.all(timeZone, BUILT_KIND, SENTINEL_REPO_ID, fromDay, toDay) as ReadonlyArray<{
+		day: string;
+		built_at_ms: number;
+	}>;
+	return new Map(rows.map((r) => [r.day, r.built_at_ms]));
+}
+
+/**
+ * Of `days`, the ones whose cached rows may be used as they stand.
+ *
+ * A day qualifies when it has been built and no source row belonging to it has
+ * been written since. `today` never qualifies, whatever the table holds: it is
+ * still accumulating, so a cached copy of it is stale by construction rather
+ * than by accident.
+ *
+ * Days outside the caller's window are ignored, so this is safe to call with a
+ * year of day keys — it just answers "none of them" for the ones past the
+ * horizon, and the caller computes those live.
+ */
+export function readAvailableDays(
+	db: DashboardDbHandle,
+	timeZone: string,
+	days: ReadonlyArray<string>,
+	nowMs: number,
+): ReadonlySet<string> {
+	if (days.length === 0) return new Set();
+	const today = localDayKey(nowMs, timeZone);
+	const candidates = days.filter((d) => d < today).sort();
+	const first = candidates[0];
+	const last = candidates[candidates.length - 1];
+	if (first === undefined || last === undefined) return new Set();
+
+	const sentinels = readSentinels(db, timeZone, first, last);
+	if (sentinels.size === 0) return new Set();
+
+	// Bounded by the OLDEST day in play: a row written before every candidate was
+	// built cannot have invalidated any of them, so it need not be read at all.
+	const oldestBuild = Math.min(...sentinels.values());
+	// And bounded again by the candidate days' own span, which is what keeps this
+	// scan from growing with the machine's history — see `readSourcesWrittenSince`.
+	// `dayKeyToMidnight` round-trips by construction here (every key came out of
+	// `localDayKey`), so the fallbacks are unreachable; they are the widest range
+	// rather than the narrowest so an impossible key degrades to the old
+	// over-reading behaviour instead of silently declaring stale days fresh.
+	const rangeFromMs = dayKeyToMidnight(first, timeZone) ?? 0;
+	const lastStartMs = dayKeyToMidnight(last, timeZone);
+	const rangeToMs = lastStartMs === undefined ? Number.MAX_SAFE_INTEGER : addLocalDays(lastStartMs, 1, timeZone);
+	// Intersected with what was ASKED for, not just with the range it spans. The
+	// sentinel read is bounded by `first`..`last` because that is one indexed scan
+	// instead of an `IN` of up to 90 keys — but the range is not the question. Every
+	// caller in production passes a CONTIGUOUS window, where the two coincide; a
+	// caller that passes two distant days got back every settled day between them,
+	// which reads as "these are cached" for days it never mentioned.
+	const requested = new Set(candidates);
+	const available = new Set([...sentinels.keys()].filter((d) => requested.has(d)));
+	for (const row of readSourcesWrittenSince(db, oldestBuild, rangeFromMs, rangeToMs)) {
+		const day = localDayKey(row.at_ms, timeZone);
+		const builtAt = sentinels.get(day);
+		// STRICTLY greater, and `>=` was considered and rejected. `built_at_ms` is
+		// captured BEFORE the day's rows are read, so any write this build could have
+		// missed carries a stamp at or after it — which leaves exactly one row that
+		// slips through: one stamped in the SAME millisecond as `nowMs` that also
+		// committed after the read began. That is a sub-millisecond cross-process
+		// race whose cost is one cached day serving a stale number until the next
+		// write touches it.
+		//
+		// `>=` closes it and opens something worse. A caller with a coarse or pinned
+		// clock (`applyToDb` takes `now` as an option, and both the backfill and the
+		// tests supply one) stamps the rows it writes and the day it then settles from
+		// the same value, so every settled day reads as stale IMMEDIATELY — the cache
+		// silently stops being used, which is the one failure mode with no signal at
+		// all. A 1 ms race that costs one stale day beats a comparison that can
+		// disable the whole mechanism.
+		if (builtAt !== undefined && row.w > builtAt) available.delete(day);
+	}
+	return available;
+}
+
+/**
+ * How one window splits between cached days and days that must be computed.
+ *
+ * ⚠ `live` is what the caller must FILTER on, not merely a hint about the span:
+ * `liveFromMs`..`liveToMs` is the enclosing range, so a cached day sitting
+ * between two live ones is inside it. A row from such a day would be added on
+ * top of the cached copy already counted — the one way this cache can produce a
+ * number larger than the truth rather than merely staler.
+ */
+export interface DayPlan {
+	/** Every local day the window covers, in order. */
+	readonly dayKeys: ReadonlyArray<string>;
+	readonly cached: ReadonlyArray<string>;
+	readonly live: ReadonlySet<string>;
+	/** Range enclosing every live day; both 0 when none are. */
+	readonly liveFromMs: number;
+	readonly liveToMs: number;
+}
+
+/**
+ * Splits `[fromMs, toMs)` into the days that can be read and the ones that must
+ * be recomputed.
+ *
+ * One scan of the cache per request, shared by every card, so the fallback
+ * decision cannot come out differently for two figures on the same page.
+ */
+export function planDays(
+	db: DashboardDbHandle,
+	timeZone: string,
+	fromMs: number,
+	toMs: number,
+	nowMs: number,
+): DayPlan {
+	const dayKeys: string[] = [];
+	const startByDay = new Map<string, number>();
+	for (let cursor = fromMs; cursor < toMs; cursor = addLocalDays(cursor, 1, timeZone)) {
+		const key = localDayKey(cursor, timeZone);
+		dayKeys.push(key);
+		startByDay.set(key, startOfLocalDay(cursor, timeZone));
+	}
+	const available = readAvailableDays(db, timeZone, dayKeys, nowMs);
+	const live = new Set(dayKeys.filter((d) => !available.has(d)));
+	let liveFromMs = 0;
+	let liveToMs = 0;
+	if (live.size > 0) {
+		const starts = [...live].map((d) => startByDay.get(d) ?? 0);
+		liveFromMs = Math.min(...starts);
+		liveToMs = addLocalDays(Math.max(...starts), 1, timeZone);
+	}
+	return { dayKeys, cached: dayKeys.filter((d) => available.has(d)), live, liveFromMs, liveToMs };
+}
+
+interface RollupRow {
+	readonly day: string;
+	readonly series_key: string;
+	readonly value: number;
+	readonly cost_usd: number;
+}
+
+/**
+ * Cached rows for one kind over `days`, summed across the repos in `scope`.
+ *
+ * Callers must pass only days {@link readAvailableDays} returned; nothing here
+ * re-checks that, because the check needs the whole window at once and doing it
+ * per read would make the fallback decision inconsistent within one page.
+ */
+export function readRollupSeries(
+	db: DashboardDbHandle,
+	timeZone: string,
+	kind: string,
+	days: ReadonlyArray<string>,
+	scope: DashboardScope,
+): ReadonlyArray<RollupRow> {
+	if (days.length === 0) return [];
+	const filter = scopeFilter(scopeToRepoIds(db, scope), "repo_id");
+	const placeholders = days.map(() => "?").join(", ");
+	return db
+		.prepare(
+			`SELECT day, series_key, SUM(value) AS value, SUM(cost_usd) AS cost_usd
+			   FROM stats_daily
+			  WHERE tz = ? AND kind = ? AND day IN (${placeholders})${filter.sql}
+			  GROUP BY day, series_key`,
+		)
+		.all(timeZone, kind, ...days, ...filter.params) as RollupRow[];
+}
+
+/** Accumulator key — a repo's contribution to one series on one day. */
+function cellKey(repoId: number, seriesKey: string): string {
+	return `${repoId}\u0000${seriesKey}`;
+}
+
+interface Cell {
+	repoId: number;
+	seriesKey: string;
+	value: number;
+	cost: number;
+}
+
+function accumulate(rows: ReadonlyArray<AxisRow>): Map<string, Cell> {
+	const cells = new Map<string, Cell>();
+	for (const row of rows) {
+		const key = cellKey(row.repo_id, row.key);
+		const cell = cells.get(key);
+		if (cell) {
+			cell.value += row.tokens;
+			cell.cost += row.cost;
+		} else {
+			cells.set(key, { repoId: row.repo_id, seriesKey: row.key, value: row.tokens, cost: row.cost });
+		}
+	}
+	return cells;
+}
+
+/**
+ * Recomputes one day from scratch and replaces its cached rows.
+ *
+ * Whole-day replacement, not an incremental adjustment. Two axes apportion a
+ * commit's spend across its topics or its branches, so an incremental update
+ * would have to compute a difference against a divisor that itself changed —
+ * and an arithmetic slip there accumulates forever with nothing to detect it. A
+ * rebuild is self-correcting: whatever was wrong yesterday is right today.
+ *
+ * The DELETE and the INSERTs share one transaction so a day is never half
+ * updated — one axis refreshed beside another still holding last week's values
+ * would be worse than an uncached day, because it looks computed.
+ */
+function buildDay(db: DashboardDbHandle, timeZone: string, day: string, nowMs: number): void {
+	const startMs = dayKeyToMidnight(day, timeZone);
+	if (startMs === undefined) return;
+	const endMs = addLocalDays(startMs, 1, timeZone);
+	const allRepos: DashboardScope = { kind: "all" };
+
+	const perKind = new Map<string, Map<string, Cell>>();
+	for (const axis of ROLLUP_AXES) {
+		perKind.set(axis, accumulate(readAxisRows(db, allRepos, axis, startMs, endMs)));
+	}
+	const tokenCells = new Map<string, Cell>();
+	for (const row of readDatedUsage(db, allRepos, startMs, endMs)) {
+		const segments: ReadonlyArray<readonly [TokenSeries, number]> = [
+			["input", row.input],
+			["output", row.output],
+			["cached", row.cached],
+		];
+		for (const [seriesKey, amount] of segments) {
+			const key = cellKey(row.repo_id, seriesKey);
+			const cell = tokenCells.get(key);
+			if (cell) cell.value += amount;
+			else tokenCells.set(key, { repoId: row.repo_id, seriesKey, value: amount, cost: 0 });
+		}
+	}
+	perKind.set(TOKENS_KIND, tokenCells);
+
+	inTransaction(db, () => {
+		db.prepare("DELETE FROM stats_daily WHERE tz = ? AND day = ?").run(timeZone, day);
+		const insert = db.prepare(
+			`INSERT INTO stats_daily (repo_id, tz, day, kind, series_key, value, cost_usd, built_at_ms, updated_at_ms)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		);
+		for (const [kind, cells] of perKind) {
+			for (const cell of cells.values()) {
+				insert.run(cell.repoId, timeZone, day, kind, cell.seriesKey, cell.value, cell.cost, nowMs, nowMs);
+			}
+		}
+		// Last, and inside the same transaction: its presence is what marks the
+		// day usable, so it must not exist without the rows it speaks for.
+		insert.run(SENTINEL_REPO_ID, timeZone, day, BUILT_KIND, "", 0, 0, nowMs, nowMs);
+	});
+}
+
+export interface BuildRollupOptions {
+	readonly now?: () => number;
+	readonly timeZone?: string;
+	readonly maxDays?: number;
+}
+
+/**
+ * Settles up to {@link ROLLUP_MAX_DAYS_PER_BUILD} days, newest first.
+ *
+ * Newest first because that is what a reader opens: the stock ranges all end
+ * today, so the most recent unsettled day is the one a page is about to ask
+ * for. A backlog therefore shortens from the end that matters, and an old gap
+ * that nobody looks at can wait indefinitely without costing anyone a slow
+ * page.
+ *
+ * Returns the number of days settled — for logging and tests; no caller should
+ * branch on it, since zero is the normal steady state.
+ */
+export function buildRollup(db: DashboardDbHandle, opts: BuildRollupOptions = {}): number {
+	const nowMs = (opts.now ?? Date.now)();
+	const timeZone = opts.timeZone ?? machineTimeZone();
+	const budget = opts.maxDays ?? ROLLUP_MAX_DAYS_PER_BUILD;
+	if (budget <= 0) return 0;
+
+	// Yesterday backwards: today is still accumulating and is never cached.
+	const days: string[] = [];
+	let cursor = addLocalDays(startOfLocalDay(nowMs, timeZone), -1, timeZone);
+	for (let i = 0; i < ROLLUP_HORIZON_DAYS; i++) {
+		days.push(localDayKey(cursor, timeZone));
+		cursor = addLocalDays(cursor, -1, timeZone);
+	}
+
+	const available = readAvailableDays(db, timeZone, days, nowMs);
+	const pending = days.filter((d) => !available.has(d)).slice(0, budget);
+	let built = 0;
+	for (const day of pending) {
+		buildDay(db, timeZone, day, nowMs);
+		built++;
+	}
+	if (built > 0) log.debug("settled %d day(s) of stats, %s..%s", built, pending[built - 1], pending[0]);
+	return built;
+}
+
+/**
+ * Forgets the cached days covering `atMs` instants, in every zone.
+ *
+ * The counterpart to staleness-by-write-stamp: a deleted row leaves nothing
+ * behind to notice, so whoever deletes says so here. Every zone, because a
+ * single instant falls on different calendar days in different ones and this
+ * process does not know which zones have cached rows — the table is small and
+ * a day dropped needlessly only costs one recomputation.
+ */
+export function forgetRollupDays(db: DashboardDbHandle, atMs: ReadonlyArray<number>): void {
+	if (atMs.length === 0) return;
+	const zones = db.prepare("SELECT DISTINCT tz FROM stats_daily").all() as ReadonlyArray<{ tz: string }>;
+	if (zones.length === 0) return;
+	// One statement per ZONE rather than per zone-day. This is reached once per
+	// session event whose usage rows are being replaced, so a batch runs it
+	// hundreds of times; there is normally exactly one zone, and the day set is
+	// small, so the `IN` collapses the whole call to a single DELETE.
+	for (const { tz } of zones) {
+		const days = [...new Set(atMs.map((ms) => localDayKey(ms, tz)))];
+		db.prepare(`DELETE FROM stats_daily WHERE tz = ? AND day IN (${days.map(() => "?").join(", ")})`).run(
+			tz,
+			...days,
+		);
+	}
+}
+
+/**
+ * Runs {@link buildRollup} as a side effect of a write, swallowing failures.
+ *
+ * The rollup is derived, so a build that throws must not fail the write that
+ * triggered it: the caller's events are already durable and the only cost of
+ * skipping is a slower page.
+ *
+ * ⚠ At `info`, NOT `debug`. The default file threshold is `info`, so a `debug`
+ * line here is written nowhere — which made this the exact failure the note
+ * below warns about, silent in the one place someone would look. `info` reaches
+ * `debug.log` while staying off the terminal in CLI mode (see `createLogger`),
+ * which is what a derived-data miss deserves: recorded, not shown.
+ *
+ * The failure worth catching this way is a STANDING one, and the likeliest is
+ * structural rather than transient: {@link ./DashboardDb.ts}'s `inTransaction`
+ * issues `BEGIN IMMEDIATE`, which SQLite refuses inside an open transaction, so
+ * a caller that ever wraps `applyToDb` in one turns every build here into a
+ * throw. Nothing would break — the page just recomputes every day forever, and
+ * without a line in the log there is nothing to connect that to a cause.
+ */
+export function buildRollupQuietly(db: DashboardDbHandle, opts: BuildRollupOptions = {}): void {
+	try {
+		// A build older than the file does not maintain this cache. Nothing here
+		// refuses such a build anymore (see `DASHBOARD_SCHEMA_VERSION`), and that is
+		// right for the source tables — but the cache is different: its expiry test
+		// reads the write stamps of every source table, and a build that does not
+		// know a table added since cannot see that table change. It would settle a
+		// day that is already incomplete and then keep answering with it. Declining
+		// to write costs a recomputation per render; writing costs a wrong number
+		// with no signal. The current build that next writes rebuilds the day.
+		if (readSchemaVersion(db) > DASHBOARD_SCHEMA_VERSION) {
+			log.info("stats rollup skipped: database schema is newer than this build");
+			return;
+		}
+		buildRollup(db, opts);
+	} catch (err) {
+		log.info("stats rollup skipped: %s", errMsg(err));
+	}
+}

--- a/cli/src/dashboard/StatsSeries.ts
+++ b/cli/src/dashboard/StatsSeries.ts
@@ -1,0 +1,391 @@
+/**
+ * The row readers behind the per-day spend series, in one place because two
+ * sides now run them: {@link ./DashboardQuery.ts} to answer a live request, and
+ * the rollup builder in {@link ./StatsRollup.ts} to pre-compute a settled day.
+ *
+ * A cached day and a live day have to come out equal to the last decimal, so
+ * they read through the SAME query rather than two that agree today. The
+ * apportioning in the `category` and `branch` axes is what makes that more than
+ * a tidiness rule: both divide by a window `COUNT(*)`, so a second query with a
+ * differently-shaped join produces plausible numbers that are quietly wrong.
+ *
+ * Rows carry `repo_id` because the rollup stores per repo — a single-repo view
+ * filters, an all-repos view sums, and neither needs a second cache. The live
+ * path ignores the column.
+ */
+
+import type { DashboardDbHandle } from "./DashboardDb.js";
+import type { DashboardScope, SeriesDimension } from "./DashboardModel.js";
+import { scopeFilter, scopeToRepoIds } from "./DashboardScopeUtil.js";
+
+/**
+ * Whether a session's per-response rows account for ALL of its tokens — the test
+ * that decides which of the two arms counts it, for a query whose `sessions` is
+ * aliased `s`.
+ *
+ * The spend axes read `session_usage_events` (one row per model response, each
+ * with its own instant) so that a conversation spanning days contributes to each
+ * of them. Only the Claude parser reports per-response usage, so every other
+ * source has nothing but a session-level total under a single timestamp and is
+ * still placed by it.
+ *
+ * ⚠ This used to be `NOT EXISTS (…)` — "does this session have any event rows" —
+ * and that is an EXISTENCE test standing in for a COMPLETENESS one. The
+ * difference is silent data loss, measured on a real database: one session of
+ * 2,048,519 tokens / $18.73 had exactly ONE event row worth 52,020 tokens, so it
+ * was excluded from the fallback arm while contributing 2.5% of itself to the
+ * events arm — 97.5% of its spend appeared nowhere on the page. Across a 30-day
+ * window that was 2,775,239 tokens and $23.39 missing from the Tokens card, the
+ * Spend headline and every bar.
+ *
+ * A partial row set is reachable by construction and is not a parser defect:
+ *   - `projectSession` REPLACES a session's rows wholesale, so a producer whose
+ *     read was cut short by a `beforeTimestamp` cutoff writes only its slice.
+ *   - `projectCommitSummary` then restores `sessions` and `session_model_usage`
+ *     to the full figures (they are equal, to the token, on the measured
+ *     database) but has no `session_usage_events` write at all — so the one
+ *     table the charts read is the only one nothing repairs.
+ * Both are writer-side facts a read must survive rather than trust.
+ *
+ * So the rule is: **a session is counted by its events only if its events are
+ * complete**, and by its session-level total otherwise. That is never worse than
+ * either alternative — the total is always right, and the finer per-day
+ * distribution is kept for every session whose rows do add up (55 of the 59
+ * measured).
+ *
+ * `>=`, not `=`: if the rows somehow exceed the stored total, they are the more
+ * detailed record and are trusted.
+ *
+ * ⚠ The `EXISTS` half is not redundant, and a test caught its absence. Written as
+ * the sum comparison alone, a session with NO rows and zero tokens compares
+ * `0 >= 0` — "covered" — and is counted by an events arm that has nothing to
+ * contribute, so it vanishes from the axis entirely. The fallback arm would have
+ * emitted a zero-token row, and that row is what registers the series KEY: a
+ * `cursor` session with no usage data is a real agent that ran, and dropping it
+ * silently removes it from the agent axis's legend. "The events are the whole
+ * story" presupposes that there ARE events; say so.
+ *
+ * ⚠ The two arms must use EXACTLY this predicate and its negation. They are
+ * complements, which is what makes the union neither double-count nor drop: a
+ * third spelling on either side re-opens one of the two failures.
+ */
+const EVENTS_COVER_SESSION = `EXISTS (SELECT 1 FROM session_usage_events e0
+	                                   WHERE e0.session_event_id = s.event_id)
+	                         AND (SELECT COALESCE(SUM(e2.input_tokens + e2.output_tokens + e2.cached_tokens), 0)
+	                                FROM session_usage_events e2
+	                               WHERE e2.session_event_id = s.event_id)
+	                             >= s.input_tokens + s.output_tokens + s.cached_tokens`;
+
+/** The events arm's guard: count these rows only when they are the whole story. */
+const HAS_DATED_USAGE = `(${EVENTS_COVER_SESSION})`;
+
+/** The fallback arm's guard — the exact negation, never a separate spelling. */
+const NO_DATED_USAGE = `NOT (${EVENTS_COVER_SESSION})`;
+
+/**
+ * The two joins the landing rule needs, for a query whose `memories` is aliased
+ * `m`: the memory's own commit as `cm`, and whichever live commit aliases it as
+ * `al`.
+ *
+ * Exported as a fragment because {@link MEMORY_LANDED_AT_MS} is only meaningful
+ * with them in scope, and a caller that spells the alias sub-select itself is
+ * one edit away from spelling it differently — see that constant for what that
+ * costs.
+ */
+export const MEMORY_LANDING_JOINS = `LEFT JOIN commits cm ON cm.repo_id = m.repo_id AND cm.hash = m.commit_hash
+	  LEFT JOIN (
+	      SELECT a.repo_id, a.target_hash, c.hash AS live_hash, MAX(c.committed_at_ms) AS at_ms
+	        FROM commit_aliases a
+	        JOIN commits c ON c.repo_id = a.repo_id AND c.hash = a.old_hash
+	       GROUP BY a.repo_id, a.target_hash
+	  ) al ON al.repo_id = m.repo_id AND al.target_hash = m.commit_hash`;
+
+/**
+ * WHICH DAY a memory's spend belongs to — the single expression every side of
+ * the cache must date a memory by, valid wherever {@link MEMORY_LANDING_JOINS}
+ * is in scope.
+ *
+ * ⚠ Its own constant because SEVERAL places ask this question and they are not
+ * allowed to answer it differently: the axes (which count the memory), the
+ * rollup's staleness test (which decides whose cached day just went stale), and
+ * every write path that has to forget a day outright — deletes, re-grounding and
+ * aliasing in `SotWrite`, plus the commit prune in `DbBackfill`. Counting them
+ * here was itself a hazard: the count went stale before the list did, and the
+ * prune was reached LAST, having restated the rule by hand in the meantime.
+ *
+ * The alias term is what makes them disagree if it is dropped — the rollup's
+ * memory side used to be
+ * `COALESCE(c.committed_at_ms, m.commit_date_ms)`, which for a REWRITTEN commit
+ * is a different day entirely: the memory's own commit row is gone, so that
+ * spelling fell through to `commit_date_ms` — an AUTHOR date, measured up to 400
+ * days from the committer date in this repo's own rebase fixture — while the axis
+ * counted the memory on the aliasing commit's committer date. The staleness test
+ * then marked a day nothing was drawn on and left the day that really changed
+ * serving its old numbers, permanently, since an old day gets no further writes.
+ */
+export const MEMORY_LANDED_AT_MS = `COALESCE(cm.committed_at_ms, al.at_ms, m.commit_date_ms)`;
+
+/**
+ * Where a memory's spend LANDS on the calendar, following a rewritten commit.
+ *
+ * Lives here rather than in the page because the rollup builds its cached days
+ * through {@link readAxisRows} too: a landing rule that differs between the two
+ * would settle a day under one attribution and serve it under another.
+ *
+ * `parent_hash IS NULL` inside the CTE is not a filter the callers could add
+ * afterwards — `memories` holds one row per GENERATION, so a re-summarised
+ * commit has several, and the window `COUNT(*)` that apportions the axis would
+ * count them all. It is also why the staleness test cannot reuse this CTE and
+ * composes the two fragments above instead: it must see a write to ANY
+ * generation, since re-grounding one is exactly what moves a row into this set.
+ */
+export const MEMORY_LANDING_CTE = `WITH memory_landing AS (
+	SELECT m.repo_id, m.commit_hash,
+	       COALESCE(cm.hash, al.live_hash, m.commit_hash) AS live_hash,
+	       ${MEMORY_LANDED_AT_MS} AS at_ms
+	  FROM memories m
+	  ${MEMORY_LANDING_JOINS}
+	 WHERE m.parent_hash IS NULL
+)`;
+
+/**
+ * The landing day of one memory row, as a standalone query returning `at_ms`.
+ *
+ * For the write paths: a row about to be deleted, re-grounded or re-aliased has
+ * to be asked which cached day it contributes to BEFORE the change, because a
+ * deletion leaves no write stamp and neither `parent_hash` nor `commit_aliases`
+ * carries one at all. Placeholders are `(repo_id, commit_hash)`.
+ *
+ * ⚠ It also answers AFTER a change, and `pruneUnreachableCommits` is the caller
+ * that needs it that way: deleting a commit row moves its memory to whichever
+ * term wins next (`al.at_ms`, then `commit_date_ms`), and asking afterwards is how
+ * that caller learns the destination day without knowing which term that is.
+ * Restating the rule instead — as a bare `commit_date_ms`, which reads like the
+ * obvious fallback — silently skips the alias term, i.e. exactly the rewritten
+ * commit a prune is about.
+ *
+ * No `parent_hash IS NULL` here, deliberately: the re-grounding caller asks about
+ * rows that are still parked as children, and `(repo_id, commit_hash)` is the
+ * PRIMARY KEY, so the answer is one row either way.
+ */
+export const MEMORY_LANDED_AT_SQL = `SELECT ${MEMORY_LANDED_AT_MS} AS at_ms
+	  FROM memories m
+	  ${MEMORY_LANDING_JOINS}
+	 WHERE m.repo_id = ? AND m.commit_hash = ?`;
+
+/**
+ * The same landing rule read from the COMMIT end: "which memory belongs to this
+ * commit". Joins as `JOIN memories m ON m.repo_id = c.repo_id AND (${MEMORY_FOR_COMMIT})`,
+ * with the commit aliased `c`.
+ *
+ * **Two spellings of one rule is a deliberate, measured exception.** The CTE
+ * exposes `live_hash` as a COALESCE — a computed column SQLite cannot index — so
+ * an axis entering from `commits` and joining `ml.live_hash = c.hash` re-scans
+ * the materialised CTE per commit: 3,146 ms for the branch axis on a 165 MB
+ * database, against 1.1 ms for this predicate. The axes that keep the CTE join
+ * it on `commit_hash`, a real column, and measure 38 ms.
+ *
+ * The naive repair is wrong in both directions and both were measured: a plain
+ * `m.commit_hash = c.hash` drops a rewritten commit's memory outright, while
+ * adding a bare `OR c.hash = al.target_hash` double-counts it until
+ * `pruneUnreachableCommits` sweeps. The `NOT EXISTS` is what closes that.
+ */
+const MEMORY_FOR_COMMIT = `m.commit_hash = c.hash
+	     OR (m.commit_hash = (SELECT a.target_hash FROM commit_aliases a
+	                           WHERE a.repo_id = c.repo_id AND a.old_hash = c.hash)
+	         AND NOT EXISTS (SELECT 1 FROM commits c2
+	                          WHERE c2.repo_id = c.repo_id AND c2.hash = m.commit_hash))`;
+
+/**
+ * Token segments placed on the day they were actually spent.
+ *
+ * The same UNION the spend axes use, kept in one place because the guard on the
+ * fallback side is the easy half to forget: without {@link NO_DATED_USAGE}
+ * every Claude session is counted twice, once as its responses and once as its
+ * total.
+ */
+export interface DatedUsageRow {
+	readonly repo_id: number;
+	readonly bucket_at_ms: number;
+	readonly input: number;
+	readonly output: number;
+	readonly cached: number;
+}
+
+export function readDatedUsage(
+	db: DashboardDbHandle,
+	scope: DashboardScope,
+	fromMs: number,
+	toMs: number,
+): ReadonlyArray<DatedUsageRow> {
+	const filter = scopeFilter(scopeToRepoIds(db, scope), "s.repo_id");
+	return db
+		.prepare(
+			`SELECT s.repo_id, e.responded_at_ms AS bucket_at_ms, e.input_tokens AS input,
+			        e.output_tokens AS output, e.cached_tokens AS cached
+			   FROM session_usage_events e JOIN sessions s ON s.event_id = e.session_event_id
+			  WHERE e.responded_at_ms >= ? AND e.responded_at_ms < ?${filter.sql} AND ${HAS_DATED_USAGE}
+			 UNION ALL
+			SELECT s.repo_id, s.updated_at_ms AS bucket_at_ms, s.input_tokens AS input,
+			        s.output_tokens AS output, s.cached_tokens AS cached
+			   FROM sessions s
+			  WHERE s.updated_at_ms >= ? AND s.updated_at_ms < ?${filter.sql} AND ${NO_DATED_USAGE}`,
+		)
+		.all(fromMs, toMs, ...filter.params, fromMs, toMs, ...filter.params) as DatedUsageRow[];
+}
+
+/** One contribution to a spend axis: a keyed amount at an instant. */
+export interface AxisRow {
+	readonly repo_id: number;
+	readonly bucket_at_ms: number;
+	readonly key: string;
+	readonly tokens: number;
+	readonly cost: number;
+}
+
+/**
+ * Every row feeding one spend axis over `[fromMs, toMs)`.
+ *
+ * `dimension` is the EFFECTIVE axis — the caller has already resolved the
+ * below-memory-tier fallback, which is a display decision and has no business
+ * reaching a cache: a repo that crosses the tier later must not find its stored
+ * `branch` days holding model data.
+ */
+export function readAxisRows(
+	db: DashboardDbHandle,
+	scope: DashboardScope,
+	dimension: SeriesDimension,
+	fromMs: number,
+	toMs: number,
+): ReadonlyArray<AxisRow> {
+	if (dimension === "model") {
+		const filter = scopeFilter(scopeToRepoIds(db, scope), "s.repo_id");
+		return db
+			.prepare(
+				`SELECT s.repo_id, e.responded_at_ms AS bucket_at_ms, e.model AS key,
+				        e.input_tokens + e.output_tokens + e.cached_tokens AS tokens,
+				        COALESCE(e.est_cost_usd, 0) AS cost
+				   FROM session_usage_events e JOIN sessions s ON s.event_id = e.session_event_id
+				  WHERE e.responded_at_ms >= ? AND e.responded_at_ms < ?${filter.sql} AND ${HAS_DATED_USAGE}
+				 UNION ALL
+				SELECT s.repo_id, s.updated_at_ms AS bucket_at_ms, u.model AS key,
+				        u.input_tokens + u.output_tokens + u.cached_tokens AS tokens,
+				        COALESCE(u.est_cost_usd, 0) AS cost
+				   FROM session_model_usage u JOIN sessions s ON s.event_id = u.session_event_id
+				  WHERE s.updated_at_ms >= ? AND s.updated_at_ms < ?${filter.sql} AND ${NO_DATED_USAGE}`,
+			)
+			.all(fromMs, toMs, ...filter.params, fromMs, toMs, ...filter.params) as AxisRow[];
+	}
+	if (dimension === "agent") {
+		const filter = scopeFilter(scopeToRepoIds(db, scope), "s.repo_id");
+		return db
+			.prepare(
+				`SELECT s.repo_id, e.responded_at_ms AS bucket_at_ms, s.source AS key,
+				        e.input_tokens + e.output_tokens + e.cached_tokens AS tokens,
+				        COALESCE(e.est_cost_usd, 0) AS cost
+				   FROM session_usage_events e JOIN sessions s ON s.event_id = e.session_event_id
+				  WHERE e.responded_at_ms >= ? AND e.responded_at_ms < ?${filter.sql} AND ${HAS_DATED_USAGE}
+				 UNION ALL
+				SELECT s.repo_id, s.updated_at_ms AS bucket_at_ms, s.source AS key,
+				        s.input_tokens + s.output_tokens + s.cached_tokens AS tokens,
+				        COALESCE(s.est_cost_usd, 0) AS cost
+				   FROM sessions s
+				  WHERE s.updated_at_ms >= ? AND s.updated_at_ms < ?${filter.sql} AND ${NO_DATED_USAGE}`,
+			)
+			.all(fromMs, toMs, ...filter.params, fromMs, toMs, ...filter.params) as AxisRow[];
+	}
+	if (dimension === "project") {
+		const filter = scopeFilter(scopeToRepoIds(db, scope), "s.repo_id");
+		return db
+			.prepare(
+				`SELECT s.repo_id, e.responded_at_ms AS bucket_at_ms, r.repo_name AS key,
+				        e.input_tokens + e.output_tokens + e.cached_tokens AS tokens,
+				        COALESCE(e.est_cost_usd, 0) AS cost
+				   FROM session_usage_events e
+				   JOIN sessions s ON s.event_id = e.session_event_id
+				   JOIN repos r ON r.id = s.repo_id
+				  WHERE e.responded_at_ms >= ? AND e.responded_at_ms < ?${filter.sql} AND ${HAS_DATED_USAGE}
+				 UNION ALL
+				SELECT s.repo_id, s.updated_at_ms AS bucket_at_ms, r.repo_name AS key,
+				        s.input_tokens + s.output_tokens + s.cached_tokens AS tokens,
+				        COALESCE(s.est_cost_usd, 0) AS cost
+				   FROM sessions s JOIN repos r ON r.id = s.repo_id
+				  WHERE s.updated_at_ms >= ? AND s.updated_at_ms < ?${filter.sql} AND ${NO_DATED_USAGE}`,
+			)
+			.all(fromMs, toMs, ...filter.params, fromMs, toMs, ...filter.params) as AxisRow[];
+	}
+	if (dimension === "category") {
+		const filter = scopeFilter(scopeToRepoIds(db, scope), "m.repo_id");
+		// One row per TOPIC, with the commit's tokens shared across its topics —
+		// category belongs to a topic, and the old per-commit mode erased every
+		// category that never won a commit's vote (security and docs vanished
+		// entirely on this repo's data). Sharing keeps the axis summing to the
+		// real total, the property the mode existed to protect; the cost
+		// figures are apportioned by design, not exact per-topic spend.
+		// The LEFT JOIN keeps memories with no topics on the axis: their window
+		// COUNT(*) is 1 and their whole spend lands in '(uncategorised)'.
+		//
+		// `parent_hash IS NULL` and the landing CTE both matter most HERE: this is
+		// where the double-count was worst (measured 9.5x) precisely because the
+		// LEFT JOIN keeps predecessors whose commit row is gone.
+		return db
+			.prepare(
+				`${MEMORY_LANDING_CTE}
+				 SELECT m.repo_id, ml.at_ms AS bucket_at_ms,
+				        COALESCE(t.category, '(uncategorised)') AS key,
+				        COALESCE(m.tokens, 0) * 1.0
+				          / COUNT(*) OVER (PARTITION BY m.repo_id, m.commit_hash) AS tokens,
+				        COALESCE(m.est_cost_usd, 0) * 1.0
+				          / COUNT(*) OVER (PARTITION BY m.repo_id, m.commit_hash) AS cost
+				   FROM memories m
+				   JOIN memory_landing ml ON ml.repo_id = m.repo_id AND ml.commit_hash = m.commit_hash
+				   LEFT JOIN memory_topics t ON t.repo_id = m.repo_id AND t.commit_hash = m.commit_hash
+				  WHERE m.tokens IS NOT NULL
+				    AND m.parent_hash IS NULL
+				    AND ml.at_ms >= ? AND ml.at_ms < ?${filter.sql}`,
+			)
+			.all(fromMs, toMs, ...filter.params) as AxisRow[];
+	}
+	if (dimension === "branch") {
+		const filter = scopeFilter(scopeToRepoIds(db, scope), "c.repo_id");
+		// `commit_branches` now holds ONE row per commit — the branch it was
+		// committed on — so this axis answers "what did the work on this branch
+		// cost", which is the per-PR question, and a commit counts once.
+		//
+		// **The apportioning division is kept deliberately even though the divisor
+		// is 1 for anything this build wrote.** It is the transition safeguard: a
+		// database written by an older client still holds that client's per-branch
+		// `git rev-list` UNION (every commit on `main` also listed under every
+		// feature branch based off it) until the first sweep re-projects each commit.
+		// Unapportioned against those rows, one 10k-token commit on a repo with five
+		// such branches would add 60k tokens — and 6x the cost — to the day. Dividing
+		// keeps the reading sane until the rows converge, then costs nothing.
+		return db
+			.prepare(
+				`SELECT c.repo_id, c.committed_at_ms AS bucket_at_ms, br.name AS key,
+				        COALESCE(m.tokens, 0) * 1.0
+				          / COUNT(*) OVER (PARTITION BY c.repo_id, c.hash) AS tokens,
+				        COALESCE(m.est_cost_usd, 0) * 1.0
+				          / COUNT(*) OVER (PARTITION BY c.repo_id, c.hash) AS cost
+				   FROM commits c
+				   JOIN commit_branches b ON b.commit_id = c.id
+				   JOIN branches br ON br.id = b.branch_id
+				   JOIN memories m ON m.repo_id = c.repo_id AND (${MEMORY_FOR_COMMIT})
+				  WHERE m.tokens IS NOT NULL AND m.parent_hash IS NULL
+				    AND c.committed_at_ms >= ? AND c.committed_at_ms < ?${filter.sql}`,
+			)
+			.all(fromMs, toMs, ...filter.params) as AxisRow[];
+	}
+	const filter = scopeFilter(scopeToRepoIds(db, scope), "c.repo_id");
+	return db
+		.prepare(
+			`SELECT c.repo_id, c.committed_at_ms AS bucket_at_ms,
+			        COALESCE(m.ticket_id, '(no ticket)') AS key,
+			        COALESCE(m.tokens, 0) AS tokens, COALESCE(m.est_cost_usd, 0) AS cost
+			   FROM commits c
+			   JOIN memories m ON m.repo_id = c.repo_id AND (${MEMORY_FOR_COMMIT})
+			  WHERE m.tokens IS NOT NULL AND m.parent_hash IS NULL
+			    AND c.committed_at_ms >= ? AND c.committed_at_ms < ?${filter.sql}`,
+		)
+		.all(fromMs, toMs, ...filter.params) as AxisRow[];
+}

--- a/cli/src/dashboard/StatsWriter.test.ts
+++ b/cli/src/dashboard/StatsWriter.test.ts
@@ -1619,3 +1619,264 @@ describe("projectSession — duplicate model entries", () => {
 		]);
 	});
 });
+
+describe("session_usage_events — spend lands on the day it happened", () => {
+	const at = (ms: number) => () => ms;
+	const DAY1 = Date.parse("2026-03-01T10:00:00Z");
+	const DAY3 = Date.parse("2026-03-03T09:00:00Z");
+
+	// THE assertion this whole table exists for. Before it, a conversation's
+	// entire spend was filed under `sessions.updated_at_ms` — one timestamp for
+	// the lot — so a session opened on the 1st and continued on the 3rd reported
+	// $0 on the 1st and everything on the 3rd.
+	it("splits one session across the days it actually spanned", async () => {
+		await applyStatsEvents(
+			[
+				envelope(
+					session({
+						updatedAtMs: DAY3,
+						usageEvents: [
+							{
+								respondedAtMs: DAY1,
+								model: "claude-opus-5",
+								input: 100,
+								output: 10,
+								cached: 0,
+								dedupKey: "a",
+							},
+							{
+								respondedAtMs: DAY3,
+								model: "claude-opus-5",
+								input: 200,
+								output: 20,
+								cached: 0,
+								dedupKey: "b",
+							},
+						],
+					}),
+				),
+			],
+			{ producerKind: "cli", dbPath, now: at(9_000) },
+		);
+
+		const rows = await query<{ responded_at_ms: number; input_tokens: number }>(
+			"SELECT * FROM session_usage_events ORDER BY responded_at_ms",
+		);
+		expect(rows.map((r) => [r.responded_at_ms, r.input_tokens])).toEqual([
+			[DAY1, 100],
+			[DAY3, 200],
+		]);
+		// The session row still says "last active on the 3rd" — that is what it
+		// means, and it is no longer what the daily numbers are built from.
+		const [s] = await query<{ updated_at_ms: number }>("SELECT * FROM sessions");
+		expect(s?.updated_at_ms).toBe(DAY3);
+	});
+
+	it("converges on re-read instead of doubling", async () => {
+		const events = [
+			{ respondedAtMs: DAY1, model: "claude-opus-5", input: 100, output: 10, cached: 0, dedupKey: "a" },
+		];
+		for (const now of [1_000, 2_000]) {
+			await applyStatsEvents([envelope(session({ usageEvents: events }))], {
+				producerKind: "cli",
+				dbPath,
+				now: at(now),
+			});
+		}
+		const rows = await query<{ updated_at_ms: number }>("SELECT * FROM session_usage_events");
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.updated_at_ms).toBe(2_000);
+	});
+
+	// `undefined` means "this source cannot report per-response usage" — every
+	// source but Claude today. It must not erase what a capable read collected.
+	it("leaves existing rows alone when the producer cannot see per-response usage", async () => {
+		const events = [
+			{ respondedAtMs: DAY1, model: "claude-opus-5", input: 100, output: 10, cached: 0, dedupKey: "a" },
+		];
+		await applyStatsEvents([envelope(session({ usageEvents: events }))], {
+			producerKind: "cli",
+			dbPath,
+			now: at(1_000),
+		});
+		await applyStatsEvents([envelope(session({ usageEvents: undefined, messageCount: 9 }))], {
+			producerKind: "cli",
+			dbPath,
+			now: at(2_000),
+		});
+
+		expect(await query("SELECT * FROM session_usage_events")).toHaveLength(1);
+	});
+
+	it("clears stored events when a re-read sees usage but nothing datable", async () => {
+		const events = [
+			{ respondedAtMs: DAY1, model: "claude-opus-5", input: 100, output: 10, cached: 0, dedupKey: "a" },
+		];
+		await applyStatsEvents([envelope(session({ usageEvents: events }))], {
+			producerKind: "cli",
+			dbPath,
+			now: at(1_000),
+		});
+		await applyStatsEvents([envelope(session({ usageEvents: [], messageCount: 9 }))], {
+			producerKind: "cli",
+			dbPath,
+			now: at(2_000),
+		});
+
+		expect(await query("SELECT * FROM session_usage_events")).toHaveLength(0);
+	});
+
+	it("falls back to the line position when the source cannot name the response", async () => {
+		await applyStatsEvents(
+			[
+				envelope(
+					session({
+						usageEvents: [
+							{ respondedAtMs: DAY1, model: "", input: 1, output: 1, cached: 0 },
+							{ respondedAtMs: DAY3, model: "", input: 2, output: 2, cached: 0 },
+						],
+					}),
+				),
+			],
+			{ producerKind: "cli", dbPath, now: at(1_000) },
+		);
+		const rows = await query<{ dedup_key: string }>("SELECT * FROM session_usage_events ORDER BY dedup_key");
+		expect(rows.map((r) => r.dedup_key)).toEqual(["line:0", "line:1"]);
+	});
+});
+
+describe("sync stamps", () => {
+	const at = (ms: number) => () => ms;
+
+	it("stamps the session and both child tables on the live path", async () => {
+		await applyStatsEvents([envelope(session({ tools: [{ name: "Edit", kind: "builtin", calls: 3 }] }))], {
+			producerKind: "cli",
+			dbPath,
+			now: at(9_000),
+		});
+
+		const [s] = await query<{ written_at_ms: number; updated_at_ms: number }>("SELECT * FROM sessions");
+		expect(s?.written_at_ms).toBe(9_000);
+		// The business clock still says what the event said, not when we wrote it.
+		expect(s?.updated_at_ms).toBe(1_700_000_000_000);
+
+		const [m] = await query<{ updated_at_ms: number }>("SELECT * FROM session_model_usage");
+		expect(m?.updated_at_ms).toBe(9_000);
+		const [t] = await query<{ updated_at_ms: number }>("SELECT * FROM session_tool_use");
+		expect(t?.updated_at_ms).toBe(9_000);
+	});
+
+	it("moves the stamp when a token-less re-read rewrites the row", async () => {
+		await applyStatsEvents([envelope(session())], { producerKind: "cli", dbPath, now: at(1_000) });
+		await applyStatsEvents([envelope(session({ messageCount: 9 }))], {
+			producerKind: "cli",
+			dbPath,
+			now: at(2_000),
+		});
+
+		const [s] = await query<{ written_at_ms: number }>("SELECT * FROM sessions");
+		expect(s?.written_at_ms).toBe(2_000);
+	});
+
+	// THE regression this column exists for. `projectCommitSummary` upgrades a
+	// `sessions-only` row to `full` without touching `updated_at_ms` — correctly,
+	// since the only clock it holds is the commit's. A sync keyed on that column
+	// would never learn the token split improved; the stamp is what makes it visible.
+	it("moves the stamp on a sessions-only -> full upgrade, leaving the business clock alone", async () => {
+		await applyStatsEvents([envelope(session({ models: undefined, tokenCoverage: "sessions-only" }))], {
+			producerKind: "cli",
+			dbPath,
+			now: at(1_000),
+		});
+		const [before] = await query<{ updated_at_ms: number; written_at_ms: number; token_coverage: string }>(
+			"SELECT * FROM sessions",
+		);
+		expect(before?.token_coverage).toBe("sessions-only");
+
+		await applyStatsEvents(
+			[
+				{
+					event: {
+						type: "commit.summary",
+						repoIdentity: "repo-1",
+						hash: "abc123",
+						committedAtMs: 1_700_000_500_000,
+						sessionLinks: [
+							{
+								source: "claude",
+								sessionId: "s1",
+								confidence: "exact",
+								models: [
+									{
+										model: "claude-opus-5",
+										provider: "anthropic",
+										inputTokens: 10,
+										outputTokens: 5,
+										cachedTokens: 0,
+										estCostUsd: 0.1,
+									},
+								],
+							},
+						],
+					},
+					producerKind: "cli",
+				} as unknown as StatsEventEnvelope,
+			],
+			{ producerKind: "cli", dbPath, now: at(5_000) },
+		);
+
+		const [after] = await query<{ updated_at_ms: number; written_at_ms: number; token_coverage: string }>(
+			"SELECT * FROM sessions",
+		);
+		expect(after?.token_coverage).toBe("full");
+		// Business clock untouched — the commit's time is not the session's.
+		expect(after?.updated_at_ms).toBe(before?.updated_at_ms);
+		// …but the row changed, so the stamp moved and a sync will pick it up.
+		expect(after?.written_at_ms).toBe(5_000);
+	});
+
+	it("moves the stamp on the tool-use conflict branch", async () => {
+		// Two buckets with the same (name, kind) inside one event take the
+		// ON CONFLICT path, which is a write like any other.
+		await applyStatsEvents(
+			[
+				envelope(
+					session({
+						tools: [
+							{ name: "Edit", kind: "builtin", calls: 1 },
+							{ name: "Edit", kind: "builtin", calls: 7 },
+						],
+					}),
+				),
+			],
+			{ producerKind: "cli", dbPath, now: at(4_000) },
+		);
+
+		const rows = await query<{ calls: number; updated_at_ms: number }>("SELECT * FROM session_tool_use");
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.calls).toBe(7);
+		expect(rows[0]?.updated_at_ms).toBe(4_000);
+	});
+
+	it("stamps recall receipts", async () => {
+		await applyStatsEvents(
+			[
+				{
+					event: {
+						type: "recall.observed",
+						repoIdentity: "repo-1",
+						atMs: 1_700_000_300_000,
+						surface: "mcp",
+						outcome: { hit: true, commitCount: 1, commits: [{ hash: "abc123", date: "2026-08-01" }] },
+					},
+					producerKind: "cli",
+				} as unknown as StatsEventEnvelope,
+			],
+			{ producerKind: "cli", dbPath, now: at(7_000) },
+		);
+
+		const [r] = await query<{ at_ms: number; updated_at_ms: number }>("SELECT * FROM recall_receipts");
+		expect(r?.at_ms).toBe(1_700_000_300_000);
+		expect(r?.updated_at_ms).toBe(7_000);
+	});
+});

--- a/cli/src/dashboard/StatsWriter.ts
+++ b/cli/src/dashboard/StatsWriter.ts
@@ -63,6 +63,7 @@ import {
 	statsEventId,
 	type WorktreeStatusEvent,
 } from "./DashboardModel.js";
+import { buildRollupQuietly, forgetRollupDays } from "./StatsRollup.js";
 
 const log = createLogger("StatsWriter");
 
@@ -81,6 +82,19 @@ export interface ApplyOptions {
 	readonly producerVersion?: string;
 	/** Injected clock for deterministic `received_at`. */
 	readonly now?: () => number;
+	/**
+	 * Skip the rollup settle at the end of the call. For a caller that makes MANY
+	 * `applyToDb` calls in a row and settles once itself.
+	 *
+	 * The default (settle every call) is right for the normal writer, which
+	 * handles one commit's events and then goes away. It is quadratic for a
+	 * backfill: each batch's writes mark the days it just touched stale, so the
+	 * next batch rebuilds the same days, and a pass of hundreds of batches pays
+	 * that repeatedly for a result only the last one keeps. Skipping is always
+	 * SAFE — the cache is derived, and a day nobody settles is simply computed
+	 * live — so the risk of this flag is a slower page, never a wrong number.
+	 */
+	readonly skipRollup?: boolean;
 }
 
 export interface ApplyResult {
@@ -141,6 +155,19 @@ export function applyToDb(
 		(id): id is string => typeof id === "string" && id.length > 0,
 	);
 	const drained = drainPending(db, { now, pendingScope });
+
+	// Tx3+ — settle whatever days the projections just invalidated. After the
+	// drain, not before: the rows this call wrote are exactly what makes a day
+	// stale, and building first would cache the state we are about to leave.
+	// Quietly, and on a budget: this is derived data on the writer's lock, and
+	// the callers holding it (an editor's periodic scan among them) wait
+	// milliseconds for it. Falling behind costs a slower page; holding the lock
+	// costs someone else's write.
+	//
+	// A caller running many batches back to back opts out and settles once at the
+	// end — see `skipRollup`.
+	if (opts.skipRollup !== true) buildRollupQuietly(db, { now });
+
 	return { accepted: envelopes.length, projected: drained.projected, pending: drained.pending };
 }
 
@@ -313,7 +340,7 @@ export function drainPending(
 					now(),
 					row.seq,
 				);
-				projectEvent(db, event);
+				projectEvent(db, event, now());
 				db.prepare("UPDATE events_raw SET projection_status = 'projected' WHERE seq = ?").run(row.seq);
 			});
 			projected++;
@@ -448,8 +475,16 @@ function isUnknownTypeError(err: unknown): boolean {
 	return err instanceof Error && err.message.startsWith(UNKNOWN_TYPE_MARKER);
 }
 
-/** Dispatches one event to its projection. Must run inside a transaction. */
-function projectEvent(db: DashboardDbHandle, event: StatsEvent): void {
+/**
+ * Dispatches one event to its projection. Must run inside a transaction.
+ *
+ * `nowMs` is the wall clock for the per-row sync stamps (see `SYNC_STAMP_DDL`).
+ * It is threaded rather than read inside each projection so tests can pin it,
+ * and so it is visibly NOT one of the event's own business timestamps — writing
+ * `event.updatedAtMs` into a stamp would quietly turn it into a second business
+ * clock and defeat the column's only purpose.
+ */
+function projectEvent(db: DashboardDbHandle, event: StatsEvent, nowMs: number): void {
 	switch (event.type) {
 		case "repo.enabled":
 			projectRepoEnabled(db, event);
@@ -458,19 +493,19 @@ function projectEvent(db: DashboardDbHandle, event: StatsEvent): void {
 			projectRepoDisabled(db, event);
 			return;
 		case "session.upserted":
-			projectSession(db, event);
+			projectSession(db, event, nowMs);
 			return;
 		case "commit.created":
-			projectCommit(db, event);
+			projectCommit(db, event, nowMs);
 			return;
 		case "commit.summary":
-			projectCommitSummary(db, event);
+			projectCommitSummary(db, event, nowMs);
 			return;
 		case "worktree.status":
 			projectWorktree(db, event);
 			return;
 		case "recall.observed":
-			projectRecallObserved(db, event);
+			projectRecallObserved(db, event, nowMs);
 			return;
 		default: {
 			// Two guarantees, both needed.
@@ -603,9 +638,13 @@ function resolveRepoId(db: DashboardDbHandle, repoIdentity: string): number | nu
  * at all. Written explicitly anyway — the arm that used to cover it silently summed.
  */
 const MODEL_USAGE_UPSERT = `INSERT INTO session_model_usage
-   (session_event_id, model, input_tokens, output_tokens, cached_tokens, est_cost_usd)
- VALUES (?, ?, ?, ?, ?, ?)
+   (session_event_id, model, input_tokens, output_tokens, cached_tokens, est_cost_usd,
+    updated_at_ms)
+ VALUES (?, ?, ?, ?, ?, ?, ?)
  ON CONFLICT(session_event_id, model) DO UPDATE SET
+   -- The stamp must be in THIS branch too: a conflict is still a write, and a sync
+   -- keyed on it would otherwise never see the summed segment.
+   updated_at_ms = excluded.updated_at_ms,
    input_tokens  = session_model_usage.input_tokens  + excluded.input_tokens,
    output_tokens = session_model_usage.output_tokens + excluded.output_tokens,
    cached_tokens = session_model_usage.cached_tokens + excluded.cached_tokens,
@@ -614,7 +653,7 @@ const MODEL_USAGE_UPSERT = `INSERT INTO session_model_usage
      ELSE session_model_usage.est_cost_usd + excluded.est_cost_usd
    END`;
 
-function projectSession(db: DashboardDbHandle, event: SessionUpsertedEvent): void {
+function projectSession(db: DashboardDbHandle, event: SessionUpsertedEvent, nowMs: number): void {
 	const eventId = statsEventId(event);
 
 	// Monotonic guard, and it runs before `ensureRepoRow` because it is the cheapest
@@ -828,9 +867,13 @@ function projectSession(db: DashboardDbHandle, event: SessionUpsertedEvent): voi
 		`INSERT INTO sessions
 		   (event_id, repo_id, source, session_id, title, started_at_ms,
 		    updated_at_ms, message_count, duration_ms, model,
-		    input_tokens, output_tokens, cached_tokens, est_cost_usd, token_coverage, prices_as_of)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		    input_tokens, output_tokens, cached_tokens, est_cost_usd, token_coverage, prices_as_of,
+		    written_at_ms)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(event_id) DO UPDATE SET
+		   -- Unconditional, and NOT a COALESCE: the stamp means "we wrote this row",
+		   -- so anything that preserves an older value defeats it.
+		   written_at_ms  = excluded.written_at_ms,
 		   title          = COALESCE(excluded.title, sessions.title),
 		   started_at_ms  = COALESCE(excluded.started_at_ms, sessions.started_at_ms),
 		   updated_at_ms  = excluded.updated_at_ms,
@@ -860,7 +903,65 @@ function projectSession(db: DashboardDbHandle, event: SessionUpsertedEvent): voi
 		cost,
 		event.tokenCoverage ?? existing?.token_coverage ?? "sessions-only",
 		event.pricesAsOf ?? null,
+		nowMs,
 	);
+
+	// Per-response rows, replaced wholesale on the same terms as the model split
+	// below. The producer re-reads the WHOLE transcript, so what arrives is the
+	// complete set — and a complete set can shrink: agents compact and rewrite
+	// their transcripts, so responses recorded earlier can stop existing. Upsert
+	// alone would keep those forever, with nothing to notice them.
+	//
+	// Only when the producer actually SAW per-response usage —
+	// `undefined` means "this source cannot report it" (today, everything but
+	// Claude) and must leave what a capable read collected alone.
+	//
+	// This is the only table that can place a conversation's spend on the days it
+	// actually spanned; `sessions` and `session_model_usage` are totals derived
+	// from the same numbers, kept because a KPI should not pay for a GROUP BY.
+	if (event.usageEvents !== undefined) {
+		// A response that stops existing takes its day's cached total with it, and
+		// leaves no write stamp for the rollup to notice — the replacement rows
+		// only expire the days that still have responses. Read the old days before
+		// emptying the set, and forget them; a day that kept its rows is rebuilt
+		// anyway, so over-forgetting here costs one recomputation and never a
+		// wrong number.
+		const previousDays = db
+			.prepare("SELECT DISTINCT responded_at_ms FROM session_usage_events WHERE session_event_id = ?")
+			.all(eventId) as ReadonlyArray<{ responded_at_ms: number }>;
+		forgetRollupDays(
+			db,
+			previousDays.map((row) => row.responded_at_ms),
+		);
+		db.prepare("DELETE FROM session_usage_events WHERE session_event_id = ?").run(eventId);
+		// Plain INSERT, no ON CONFLICT: the DELETE above just emptied this session's
+		// rows, and the producer cannot hand us the same key twice — the reader
+		// dedupes on the response id, and the fallback key below is an index. A
+		// conflict here would mean one of those two invariants broke, and throwing
+		// says so instead of quietly merging.
+		const insertUsage = db.prepare(
+			`INSERT INTO session_usage_events
+			   (session_event_id, dedup_key, responded_at_ms, model, input_tokens, output_tokens, cached_tokens,
+			    est_cost_usd, updated_at_ms)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		);
+		for (const [i, usage] of event.usageEvents.entries()) {
+			insertUsage.run(
+				eventId,
+				// A source that cannot name the response is keyed by its position
+				// among the counted responses — unique within the batch, which is all
+				// the key has to be once the set is replaced wholesale.
+				usage.dedupKey ?? `line:${i}`,
+				usage.respondedAtMs,
+				usage.model,
+				usage.input,
+				usage.output,
+				usage.cached,
+				usage.estCostUsd ?? null,
+				nowMs,
+			);
+		}
+	}
 
 	// Replace the model split wholesale — a partial update would leave a stale
 	// row behind whenever a re-read attributes tokens to fewer models than
@@ -879,7 +980,15 @@ function projectSession(db: DashboardDbHandle, event: SessionUpsertedEvent): voi
 		db.prepare("DELETE FROM session_model_usage WHERE session_event_id = ?").run(eventId);
 		const insertModel = db.prepare(MODEL_USAGE_UPSERT);
 		for (const m of models) {
-			insertModel.run(eventId, m.model, m.inputTokens, m.outputTokens, m.cachedTokens, m.estCostUsd ?? null);
+			insertModel.run(
+				eventId,
+				m.model,
+				m.inputTokens,
+				m.outputTokens,
+				m.cachedTokens,
+				m.estCostUsd ?? null,
+				nowMs,
+			);
 		}
 	}
 
@@ -889,9 +998,14 @@ function projectSession(db: DashboardDbHandle, event: SessionUpsertedEvent): voi
 	if (event.tools !== undefined) {
 		db.prepare("DELETE FROM session_tool_use WHERE session_event_id = ?").run(eventId);
 		const insertTool = db.prepare(
-			`INSERT INTO session_tool_use (session_event_id, tool_name, kind, server, calls, last_call_at_ms)
-			 VALUES (?, ?, ?, ?, ?, ?)
-			 ON CONFLICT(session_event_id, tool_name, kind) DO UPDATE SET calls = excluded.calls,
+			`INSERT INTO session_tool_use
+			   (session_event_id, tool_name, kind, server, calls, last_call_at_ms, updated_at_ms)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)
+			 ON CONFLICT(session_event_id, tool_name, kind) DO UPDATE SET
+			     calls = excluded.calls,
+			     -- The stamp must be in THIS branch too: a conflict is still a write,
+			     -- and a sync keyed on it would otherwise never see a recount.
+			     updated_at_ms = excluded.updated_at_ms,
 			     -- MAX, not the excluded value: a re-read of the same session by a parser
 			     -- that cannot stamp a time (or an older build) would otherwise erase an
 			     -- instant a better read already recorded, and NULL is the one value this
@@ -906,7 +1020,15 @@ function projectSession(db: DashboardDbHandle, event: SessionUpsertedEvent): voi
 			                                  COALESCE(session_tool_use.last_call_at_ms, 0)), 0)`,
 		);
 		for (const tool of event.tools) {
-			insertTool.run(eventId, tool.name, tool.kind, tool.server ?? null, tool.calls, tool.lastCallAtMs ?? null);
+			insertTool.run(
+				eventId,
+				tool.name,
+				tool.kind,
+				tool.server ?? null,
+				tool.calls,
+				tool.lastCallAtMs ?? null,
+				nowMs,
+			);
 		}
 	}
 }
@@ -919,14 +1041,16 @@ function projectSession(db: DashboardDbHandle, event: SessionUpsertedEvent): voi
  * every other projection here has, expressed as an UPSERT because there is no
  * natural business key for "a call" beyond when it happened.
  */
-function projectRecallObserved(db: DashboardDbHandle, event: RecallObservedEvent): void {
+function projectRecallObserved(db: DashboardDbHandle, event: RecallObservedEvent, nowMs: number): void {
 	const repoId = ensureRepoRow(db, event.repoIdentity);
 	const outcome = event.outcome;
 	db.prepare(
 		`INSERT INTO recall_receipts
-		   (receipt_id, repo_id, at_ms, surface, session_id, hit, commit_count, commits_json)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		   (receipt_id, repo_id, at_ms, surface, session_id, hit, commit_count, commits_json,
+		    updated_at_ms)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(receipt_id) DO UPDATE SET
+		   updated_at_ms = excluded.updated_at_ms,
 		   hit          = excluded.hit,
 		   commit_count = excluded.commit_count,
 		   commits_json = excluded.commits_json`,
@@ -939,6 +1063,7 @@ function projectRecallObserved(db: DashboardDbHandle, event: RecallObservedEvent
 		outcome.hit ? 1 : 0,
 		outcome.commitCount,
 		outcome.commits.length > 0 ? JSON.stringify(outcome.commits) : null,
+		nowMs,
 	);
 }
 
@@ -988,14 +1113,14 @@ function projectRecallObserved(db: DashboardDbHandle, event: RecallObservedEvent
 // 	return true;
 // }
 
-function projectCommit(db: DashboardDbHandle, event: CommitCreatedEvent): void {
+function projectCommit(db: DashboardDbHandle, event: CommitCreatedEvent, nowMs: number): void {
 	const repoId = ensureRepoRow(db, event.repoIdentity);
 	const eventId = statsEventId(event);
 	db.prepare(
 		`INSERT INTO commits
 		   (event_id, repo_id, hash, branch, message, author_name, author_email,
-		    committed_at_ms, files_changed, insertions, deletions)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		    committed_at_ms, files_changed, insertions, deletions, written_at_ms)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(event_id) DO UPDATE SET
 		   branch        = COALESCE(excluded.branch, commits.branch),
 		   message       = COALESCE(excluded.message, commits.message),
@@ -1004,7 +1129,11 @@ function projectCommit(db: DashboardDbHandle, event: CommitCreatedEvent): void {
 		   committed_at_ms = excluded.committed_at_ms,
 		   files_changed = COALESCE(excluded.files_changed, commits.files_changed),
 		   insertions    = COALESCE(excluded.insertions, commits.insertions),
-		   deletions     = COALESCE(excluded.deletions, commits.deletions)`,
+		   deletions     = COALESCE(excluded.deletions, commits.deletions),
+		   -- Unconditional, like every other sync/build stamp: this row just
+		   -- changed, and the rollup decides a cached day is stale by comparing
+		   -- against this. A COALESCE here would hide the change from it.
+		   written_at_ms = excluded.written_at_ms`,
 	).run(
 		eventId,
 		repoId,
@@ -1017,6 +1146,7 @@ function projectCommit(db: DashboardDbHandle, event: CommitCreatedEvent): void {
 		event.filesChanged ?? null,
 		event.insertions ?? null,
 		event.deletions ?? null,
+		nowMs,
 	);
 
 	// `branches` is authoritative when present — replacing the set is what drops an
@@ -1069,19 +1199,20 @@ function projectCommit(db: DashboardDbHandle, event: CommitCreatedEvent): void {
  * session older than the agents' retention exists nowhere but in the memory
  * pipeline's links, and the sessions table is activity data, not memory data.
  */
-function projectCommitSummary(db: DashboardDbHandle, event: CommitSummaryEvent): void {
+function projectCommitSummary(db: DashboardDbHandle, event: CommitSummaryEvent, nowMs: number): void {
 	const repoId = ensureRepoRow(db, event.repoIdentity);
 	// Same event_id namespace as commit.created — the enrichment lands on the
 	// SAME commits row, only the events_raw provenance ids differ.
 	const commitEventId = `commit:${event.repoIdentity}:${event.hash}`;
 	db.prepare(
 		`INSERT INTO commits
-		   (event_id, repo_id, hash, branch, message, committed_at_ms)
-		 VALUES (?, ?, ?, ?, ?, ?)
+		   (event_id, repo_id, hash, branch, message, committed_at_ms, written_at_ms)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(event_id) DO UPDATE SET
 		   branch        = COALESCE(excluded.branch, commits.branch),
-		   message       = COALESCE(excluded.message, commits.message)`,
-	).run(commitEventId, repoId, event.hash, event.branch ?? null, event.message ?? null, event.committedAtMs);
+		   message       = COALESCE(excluded.message, commits.message),
+		   written_at_ms = excluded.written_at_ms`,
+	).run(commitEventId, repoId, event.hash, event.branch ?? null, event.message ?? null, event.committedAtMs, nowMs);
 
 	// `commit_branches` too, and NOT just the `commits.branch` column above.
 	//
@@ -1139,24 +1270,35 @@ function projectCommitSummary(db: DashboardDbHandle, event: CommitSummaryEvent):
 		const seedSession = db.prepare(
 			`INSERT INTO sessions
 			   (event_id, repo_id, source, session_id, updated_at_ms, message_count,
-			    input_tokens, output_tokens, cached_tokens, est_cost_usd, token_coverage, prices_as_of)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			    input_tokens, output_tokens, cached_tokens, est_cost_usd, token_coverage, prices_as_of,
+			    written_at_ms)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			 ON CONFLICT(event_id) DO UPDATE SET
 			   input_tokens   = excluded.input_tokens,
 			   output_tokens  = excluded.output_tokens,
 			   cached_tokens  = excluded.cached_tokens,
 			   est_cost_usd   = excluded.est_cost_usd,
 			   token_coverage = excluded.token_coverage,
-			   prices_as_of   = excluded.prices_as_of
+			   prices_as_of   = excluded.prices_as_of,
+			   -- The whole reason this column exists. This UPDATE deliberately leaves
+			   -- updated_at_ms alone (the commit's clock is not the session's), so a
+			   -- sync keyed on that column would never learn the token split just
+			   -- improved here. The stamp is what makes the enrichment visible.
+			   written_at_ms  = excluded.written_at_ms
 			 WHERE sessions.token_coverage = 'sessions-only' AND excluded.token_coverage = 'full'`,
 		);
 		const deleteModels = db.prepare("DELETE FROM session_model_usage WHERE session_event_id = ?");
 		const insertModel = db.prepare(MODEL_USAGE_UPSERT);
 		const deleteTools = db.prepare("DELETE FROM session_tool_use WHERE session_event_id = ?");
 		const insertTool = db.prepare(
-			`INSERT INTO session_tool_use (session_event_id, tool_name, kind, server, calls, last_call_at_ms)
-			 VALUES (?, ?, ?, ?, ?, ?)
-			 ON CONFLICT(session_event_id, tool_name, kind) DO UPDATE SET calls = excluded.calls,
+			`INSERT INTO session_tool_use
+			   (session_event_id, tool_name, kind, server, calls, last_call_at_ms, updated_at_ms)
+			 VALUES (?, ?, ?, ?, ?, ?, ?)
+			 ON CONFLICT(session_event_id, tool_name, kind) DO UPDATE SET
+			     calls = excluded.calls,
+			     -- The stamp must be in THIS branch too: a conflict is still a write,
+			     -- and a sync keyed on it would otherwise never see a recount.
+			     updated_at_ms = excluded.updated_at_ms,
 			     -- NULLIF for the same reason as the live path above: both-NULL must stay
 			     -- NULL, or the row claims epoch 0 as a real last-call instant.
 			     last_call_at_ms = NULLIF(MAX(COALESCE(excluded.last_call_at_ms, 0),
@@ -1190,6 +1332,7 @@ function projectCommitSummary(db: DashboardDbHandle, event: CommitSummaryEvent):
 				cost,
 				models.length > 0 ? "full" : "sessions-only",
 				models.length > 0 ? PRICES_AS_OF : null,
+				nowMs,
 			) as { changes?: number | bigint };
 			if (Number(result?.changes ?? 0) > 0) {
 				deleteModels.run(linkEventId);
@@ -1201,6 +1344,7 @@ function projectCommitSummary(db: DashboardDbHandle, event: CommitSummaryEvent):
 						m.outputTokens,
 						m.cachedTokens,
 						m.estCostUsd ?? null,
+						nowMs,
 					);
 				}
 				// Tool calls ride the SAME gate as the model split, which is what keeps
@@ -1222,7 +1366,15 @@ function projectCommitSummary(db: DashboardDbHandle, event: CommitSummaryEvent):
 				if (link.tools !== undefined) {
 					deleteTools.run(linkEventId);
 					for (const t of link.tools) {
-						insertTool.run(linkEventId, t.name, t.kind, t.server ?? null, t.calls, t.lastCallAtMs ?? null);
+						insertTool.run(
+							linkEventId,
+							t.name,
+							t.kind,
+							t.server ?? null,
+							t.calls,
+							t.lastCallAtMs ?? null,
+							nowMs,
+						);
 					}
 				}
 			}

--- a/cli/src/dashboard/SyncColumns.test.ts
+++ b/cli/src/dashboard/SyncColumns.test.ts
@@ -1,0 +1,209 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { withDashboardDb } from "./DashboardDb.js";
+import { SYNCED_COLUMNS } from "./SessionPushManifest.js";
+import {
+	businessTimeColumn,
+	KEYSET_COLUMNS,
+	SYNC_STAMP_COLUMNS,
+	SYNC_STAMP_TABLES,
+	syncStampColumn,
+	WINDOW_SOURCES,
+} from "./SyncColumns.js";
+
+let dir: string;
+let dbPath: string;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "jolli-synccols-"));
+	dbPath = join(dir, "dashboard.db");
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+async function columnsOf(table: string): Promise<string[]> {
+	return withDashboardDb(
+		(db) => (db.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[]).map((r) => r.name),
+		{ dbPath },
+	);
+}
+
+async function isNotNull(table: string, column: string): Promise<boolean> {
+	return withDashboardDb(
+		(db) =>
+			(db.prepare(`PRAGMA table_info(${table})`).all() as { name: string; notnull: number }[]).some(
+				(r) => r.name === column && r.notnull === 1,
+			),
+		{ dbPath },
+	);
+}
+
+describe("sync stamp columns", () => {
+	// The map is the only thing standing between a caller and `WHERE
+	// updated_at_ms >= ?` against all four tables — which compiles, runs, and
+	// reads the wrong column on `sessions`. Pin every entry against the real
+	// schema so a rename cannot pass silently.
+	it("names a column that actually exists on each table", async () => {
+		for (const table of SYNC_STAMP_TABLES) {
+			expect(await columnsOf(table)).toContain(syncStampColumn(table));
+		}
+	});
+
+	it("keeps sessions on its own name, because updated_at_ms is taken there", async () => {
+		// Not cosmetic: `sessions.updated_at_ms` is the business clock, and the
+		// commit-summary path deliberately does not bump it. Collapsing the two
+		// names would put the sync back on the column that cannot see an
+		// enrichment.
+		expect(SYNC_STAMP_COLUMNS.sessions).toBe("written_at_ms");
+		expect(await columnsOf("sessions")).toContain("updated_at_ms");
+		expect(SYNC_STAMP_COLUMNS.sessions).not.toBe(businessTimeColumn("sessions"));
+	});
+
+	it("never points at a table's business time column", async () => {
+		for (const table of SYNC_STAMP_TABLES) {
+			const business = businessTimeColumn(table);
+			if (business) expect(syncStampColumn(table)).not.toBe(business);
+		}
+	});
+
+	it("names a business column that exists, where one is declared", async () => {
+		for (const table of SYNC_STAMP_TABLES) {
+			const business = businessTimeColumn(table);
+			if (business) expect(await columnsOf(table)).toContain(business);
+		}
+	});
+
+	// The first-run window has to reach EVERY synced table, and a table with no
+	// clock of its own reaches it through the parent session. `WindowSource` is a
+	// union so "neither" cannot be expressed at all — what is left to check is that
+	// whichever column the entry names is real.
+	it("names a real column on whichever side of the window it uses", async () => {
+		for (const table of SYNC_STAMP_TABLES) {
+			const source = WINDOW_SOURCES[table];
+			if ("own" in source) {
+				expect(await columnsOf(table)).toContain(source.own);
+			} else {
+				expect(await columnsOf(table)).toContain(source.parent);
+				// The window resolves through `sessions.event_id`, so the parent column
+				// has to be the one that points at it.
+				expect(await columnsOf("sessions")).toContain("event_id");
+			}
+		}
+	});
+
+	// A NULL stamp is invisible to a cursor forever, so the migration backfills
+	// every pre-existing row from its best available approximation. A fresh
+	// database has no rows to check, so this asserts the shape the backfill
+	// depends on: the two child tables can reach a parent timestamp.
+	it("leaves the child tables able to reach their parent's clock", async () => {
+		for (const table of ["session_model_usage", "session_tool_use"]) {
+			expect(await columnsOf(table)).toContain("session_event_id");
+		}
+		expect(await columnsOf("sessions")).toContain("event_id");
+	});
+
+	// The other half of "a NULL stamp is invisible forever", and the half a
+	// backfill cannot cover: `WHERE stamp >= ?` answers NULL — not false — for a
+	// NULL stamp, so such a row is unselectable by every cursor there will ever
+	// be. A nullable column would put that one orphaned child row (or one future
+	// INSERT that forgets the field) permanently outside the sync with nothing
+	// anywhere to report it, which is precisely the silent-wrong-set failure this
+	// module exists to prevent.
+	it("declares every stamp NOT NULL, so a cursor comparison is never NULL", async () => {
+		for (const table of SYNC_STAMP_TABLES) {
+			expect(await isNotNull(table, syncStampColumn(table))).toBe(true);
+		}
+		// The same rule on the two stamps that live outside the map.
+		expect(await isNotNull("commits", "written_at_ms")).toBe(true);
+		expect(await isNotNull("session_usage_events", "updated_at_ms")).toBe(true);
+	});
+});
+
+describe("keyset columns", () => {
+	/** The table's PRIMARY KEY, in key order, straight from SQLite. */
+	async function primaryKeyOf(table: string): Promise<string[]> {
+		return withDashboardDb(
+			(db) =>
+				(db.prepare(`PRAGMA table_info(${table})`).all() as { name: string; pk: number }[])
+					.filter((r) => r.pk > 0)
+					.sort((a, b) => a.pk - b.pk)
+					.map((r) => r.name),
+			{ dbPath },
+		);
+	}
+
+	it("is exactly each table's PRIMARY KEY, in key order", async () => {
+		// Uniqueness is the whole property: the cursor is `(stamp, ...these)` and
+		// paging only advances because that tuple cannot repeat. A subset of the PK
+		// is not unique — two rows would share a cursor position and the page would
+		// either stall or skip — and a superset is not what ORDER BY can index.
+		// Order matters as much as membership: the SELECT's ORDER BY repeats these
+		// columns, and a different order does not error, it silently pages over rows.
+		for (const table of SYNC_STAMP_TABLES) {
+			expect(KEYSET_COLUMNS[table]).toEqual(await primaryKeyOf(table));
+		}
+	});
+
+	it("is carried on the wire, so the next cursor can be read off the row just sent", async () => {
+		// The next cursor is taken from the LAST ROW of the page, which is the row
+		// as it goes out. A key column missing from `SYNCED_COLUMNS` would be absent
+		// there, `String(undefined ?? "")` would make it `""`, and the cursor would
+		// silently rewind to the start of that millisecond every pass — the same
+		// stall, arrived at from the other side.
+		for (const table of SYNC_STAMP_TABLES) {
+			for (const column of KEYSET_COLUMNS[table]) {
+				expect(SYNCED_COLUMNS[table]).toContain(column);
+			}
+		}
+	});
+
+	it("covers every synced table", () => {
+		expect(Object.keys(KEYSET_COLUMNS).sort()).toEqual([...SYNC_STAMP_TABLES].sort());
+	});
+});
+
+describe("sync stamps are never NULL", () => {
+	// The invariant every cursor rests on, asserted rather than assumed.
+	//
+	// `WHERE (<stamp>, …) >= (?, …)` answers NULL — not true — for a NULL stamp,
+	// so such a row is invisible to EVERY cursor for ever, and nothing reports it.
+	// `SYNC_STAMP_DDL` declares these columns NOT NULL, but a database handed them
+	// by a pre-log build records that entry as `baseline` and never applies the
+	// declaration: measured on a real machine as 30 sessions, 201 tool-use rows and
+	// 56 model-usage rows stuck permanently outside the channel.
+	it("has a number in every stamp column after migration", async () => {
+		await withDashboardDb(
+			(db) => {
+				db.prepare(
+					`INSERT INTO repos (repo_identity, repo_name, worktree_root, enabled_at)
+				 VALUES ('r', 'r', '/w', 1)`,
+				).run();
+				db.prepare(
+					`INSERT INTO sessions (event_id, repo_id, source, session_id, updated_at_ms)
+				 VALUES ('e1', 1, 'claude', 's1', 1000)`,
+				).run();
+				db.prepare(
+					`INSERT INTO session_model_usage (session_event_id, model) VALUES ('e1', 'claude-opus-5')`,
+				).run();
+				db.prepare(
+					`INSERT INTO session_tool_use (session_event_id, tool_name, kind) VALUES ('e1', 'Read', 'builtin')`,
+				).run();
+
+				// A row inserted WITHOUT naming the stamp must still have one — that is
+				// what `NOT NULL DEFAULT 0` buys, and what its absence took away.
+				for (const table of SYNC_STAMP_TABLES) {
+					const column = syncStampColumn(table);
+					const nulls = db.prepare(`SELECT COUNT(*) AS n FROM ${table} WHERE ${column} IS NULL`).get() as {
+						n: number;
+					};
+					expect({ table, nulls: nulls.n }).toEqual({ table, nulls: 0 });
+				}
+			},
+			{ dbPath },
+		);
+	});
+});

--- a/cli/src/dashboard/SyncColumns.ts
+++ b/cli/src/dashboard/SyncColumns.ts
@@ -1,0 +1,135 @@
+/**
+ * Which column on each activity table records "when did WE last write this row".
+ *
+ * An outbound sync selects changed rows with `WHERE <that column> >= cursor`,
+ * so getting the column wrong is not a compile error — it is a query that runs
+ * and quietly returns the wrong set. Hence a map rather than a convention.
+ *
+ * ⚠ The name is NOT uniform, and `sessions` is the exception that matters most.
+ * That table's `updated_at_ms` is already the business clock ("when was this
+ * session last active"), and `projectCommitSummary` deliberately does not bump
+ * it when it enriches a `sessions-only` row into a `full` one — so a sync keyed
+ * on it would never see the better token split it just wrote. `sessions` therefore
+ * stamps `written_at_ms` (the same concept `memories.written_at_ms` already
+ * carries) and the other three stamp `updated_at_ms`, which on them is free.
+ *
+ * Writing `WHERE updated_at_ms >= ?` against all four compiles, runs, and reads
+ * the WRONG column on `sessions`. Go through this map instead. `SyncColumns.test.ts`
+ * pins every entry against the real schema so a rename cannot pass silently.
+ *
+ * These columns are bookkeeping: bumped unconditionally on every write, to the
+ * current wall clock — never to a timestamp carried on the event, which would
+ * make them a second business clock and reintroduce the problem above.
+ *
+ * The map is exactly `SYNCED_TABLES`, and `SessionPushManifest.test.ts` asserts
+ * that: a stamped table that is not sent is either a missing decision or a stale
+ * stamp. `recall_receipts` is the stale case and has no entry here — it left the
+ * channel, while its stamp column and the two indexes behind the channel's paging
+ * stay in the schema because they have already been migrated.
+ *
+ * All four are `NOT NULL DEFAULT 0`, so `WHERE <stamp> >= ?` is always a real
+ * comparison. Do not relax that: NULL >= anything is NULL rather than false, so
+ * one nullable stamp is a row no cursor can ever select — the same silent-wrong-
+ * set failure this map exists to prevent, arrived at from the other side. 0
+ * means "written before we tracked this" and is what the backfill starts from.
+ */
+export const SYNC_STAMP_COLUMNS = {
+	sessions: "written_at_ms",
+	session_model_usage: "updated_at_ms",
+	session_tool_use: "updated_at_ms",
+	session_usage_events: "updated_at_ms",
+} as const;
+
+/** A table that carries a sync stamp. */
+export type SyncStampTable = keyof typeof SYNC_STAMP_COLUMNS;
+
+/** Every table carrying a sync stamp, in a stable order. */
+export const SYNC_STAMP_TABLES = Object.keys(SYNC_STAMP_COLUMNS) as ReadonlyArray<SyncStampTable>;
+
+/**
+ * The stamp column for `table`.
+ *
+ * Prefer this over spelling a column name at a call site: the point of the map
+ * is that no caller has to remember which table is the odd one out.
+ */
+export function syncStampColumn(table: SyncStampTable): string {
+	return SYNC_STAMP_COLUMNS[table];
+}
+
+/**
+ * The PRIMARY KEY columns that break a tie inside one sync stamp, in key order.
+ *
+ * A stamp alone cannot page a table, and the failure is a deadlock rather than a
+ * slowdown. Selection is `<stamp> >= cursor ORDER BY <stamp> LIMIT n`, so when
+ * MORE than `n` rows share one millisecond, every pass reads the same first `n`
+ * of them, the highest stamp it sees equals the cursor it started from, the
+ * cursor cannot advance, and the table stops syncing for good. Measured on a
+ * real machine: `session_usage_events` sat on a millisecond holding 840 rows
+ * against a limit of 500 and had not moved in five days, with 9,657 rows behind
+ * it and five more such milliseconds after that (the largest 2,307 rows).
+ *
+ * Rows written together share a stamp by construction — `projectSession` stamps
+ * every one of a session's usage events with the same `nowMs`, and a backfill
+ * projects many sessions inside one millisecond — so this is the normal case at
+ * scale, not a pathological one.
+ *
+ * So the cursor is `(stamp, ...these)` and paging is keyset: the tuple is unique,
+ * therefore strictly increasing, therefore always advances. `ORDER BY` must list
+ * exactly these columns in exactly this order — a mismatch does not error, it
+ * silently skips rows between pages.
+ *
+ * ⚠ Every column here must also appear in `SYNCED_COLUMNS` for its table: the
+ * next cursor is read back off the row that was just sent, so a key column the
+ * wire does not carry cannot be recovered. `SyncColumns.test.ts` pins both that
+ * and the match against the real PRIMARY KEY.
+ */
+export const KEYSET_COLUMNS: Readonly<Record<SyncStampTable, ReadonlyArray<string>>> = {
+	sessions: ["event_id"],
+	session_model_usage: ["session_event_id", "model"],
+	session_tool_use: ["session_event_id", "tool_name", "kind"],
+	session_usage_events: ["session_event_id", "dedup_key"],
+};
+
+/**
+ * How the first-run window reaches one table — the ONE thing that is per-table
+ * about it, as a two-case union rather than two half-filled maps.
+ *
+ * `own` is the table's own business time column. Kept beside the stamps because
+ * the first sync needs BOTH and they are easy to confuse: the cursor walks the
+ * stamp, while "only go back N days on the first run" filters on the business
+ * clock. Filtering that window on the stamp instead would be actively wrong —
+ * one backfill rewrites every old row's stamp to "just now", and the window then
+ * admits sessions from years ago.
+ *
+ * `parent` is the column pointing at the owning `sessions` row, for a table with
+ * no clock of its own. A table without a clock is NOT a table without a date:
+ * `session_model_usage` has no instant, but the session it hangs off does, and
+ * that session is what the window is really about. Without it the window applied
+ * to nothing there and the first run walked the WHOLE table — not merely "more
+ * data than asked for", since the extra rows are children of the very sessions
+ * the same window withheld, leaving the server usage it could only file under a
+ * session it was never sent.
+ *
+ * ⚠ A UNION, deliberately, and the shape is the invariant: every table has
+ * EXACTLY ONE answer. Two `Record<…, string | undefined>` maps could express
+ * "neither" — a table with no window at all, which is the bug above — and they
+ * did, so the reader carried a dead `undefined` branch no test could ever reach
+ * and no type could rule out. Here the compiler rules it out instead, and both
+ * arms of the one remaining branch are real cases.
+ */
+export type WindowSource = { readonly own: string } | { readonly parent: string };
+
+export const WINDOW_SOURCES: Readonly<Record<SyncStampTable, WindowSource>> = {
+	sessions: { own: "updated_at_ms" },
+	// Its own clock, and NOT routed through the parent even though it has one: a
+	// session touched today can hold a response from last month.
+	session_model_usage: { parent: "session_event_id" },
+	session_tool_use: { own: "last_call_at_ms" },
+	session_usage_events: { own: "responded_at_ms" },
+};
+
+/** The table's own business time column, or `undefined` when it has none. */
+export function businessTimeColumn(table: SyncStampTable): string | undefined {
+	const source = WINDOW_SOURCES[table];
+	return "own" in source ? source.own : undefined;
+}

--- a/cli/src/dashboard/assets/js/settings.js
+++ b/cli/src/dashboard/assets/js/settings.js
@@ -99,6 +99,11 @@ window.JD = window.JD || {};
 		pushRepos: null,
 		pushError: null,
 		pushStatus: null, // { repoIdentity, text, kind } — last per-repo toggle result
+		// The machine-wide session-statistics switch. NOT part of `form`: like the
+		// per-repo toggles beside it, it writes on change instead of on Apply, so
+		// it must not count towards the form's dirty state.
+		syncSessions: true,
+		syncStatus: null, // { text, kind } — last session-statistics toggle result
 		missing: undefined,
 		notice: null,
 		error: null,
@@ -120,6 +125,7 @@ window.JD = window.JD || {};
 		var a = s.agents || {};
 		var sum = s.summary || {};
 		var mb = s.memoryBank || {};
+		var syncCfg = s.sync || {};
 		var others = s.others || {};
 		var form = {
 			globalInstructions: a.globalInstructions || "default",
@@ -148,6 +154,8 @@ window.JD = window.JD || {};
 			form[pair[0]] = a[pair[0]] !== false;
 		});
 		state.originalGi = a.globalInstructions || "default";
+		// Immediate switch, so it is seeded beside the form rather than inside it.
+		state.syncSessions = syncCfg.syncSessions !== false;
 		return form;
 	}
 
@@ -524,10 +532,15 @@ window.JD = window.JD || {};
 	}
 
 	function syncSection(sum) {
+		// Both outbound streams are named in the sign-in verdict — the line that says
+		// what being signed in is FOR. It used to say "ready to push memories",
+		// which names one of the two and reads as a denial of the other. What each
+		// stream IS, and how far its switch reaches, is left to the two blocks
+		// below: restating it here only put the same sentence on screen twice.
 		var head = sum.signedIn
-			? '<div class="set-status ok"><span>✓</span> Signed in — ready to push memories</div>' +
+			? '<div class="set-status ok"><span>✓</span> Signed in — ready to push session statistics and memories</div>' +
 				'<div class="set-row set-row-inline"><button type="button" class="cta ghost sm" data-action="signout">Sign Out</button></div>'
-			: '<p class="section-hint">Sign in to push memories to Jolli cloud.</p>' +
+			: '<p class="section-hint">Sign in to push session statistics and memories to Jolli cloud. Nothing leaves this machine until you do.</p>' +
 				'<div class="set-row set-row-inline"><button type="button" class="cta sm" data-action="signin"' +
 				(state.busy === "signin" ? " disabled" : "") +
 				">" +
@@ -571,9 +584,35 @@ window.JD = window.JD || {};
 
 		return (
 			block("Account", head) +
+			// Machine-wide, so it sits ABOVE the per-repo list rather than under it:
+			// this switch is not one of the repos, and burying it below a list that
+			// grows with every tracked repo is what made it hard to find in Others.
 			block(
-				"Outbound push per repo",
-				'<p class="section-hint">Every repository on this machine that Jolli tracks. Turning one <strong>off</strong> keeps capturing its memory locally but blocks all outbound sync (auto and manual). New repos are allowed by default. <strong>Each toggle applies immediately</strong> — no “Apply Changes” needed. Re-enabling a repo syncs its retained backlog on that repo’s next activity (right away for the repo you’re currently in). (Local-only repos with no git remote are managed from within the repo instead.)</p>' +
+				"Session statistics — for the whole machine",
+				// Immediate, like the per-repo switches below: this tab used to hold
+				// one switch that waited for "Apply Changes" and a list of
+				// identical-looking ones that did not, which is a difference no row
+				// on screen can show. Both write on change now, and both report the
+				// result on a status line under the row they belong to.
+				'<label class="set-toggle-row"><span class="set-toggle-text"><span class="set-toggle-label">Sync session statistics</span><span class="set-hint">' +
+					"Sends usage — tokens, cost, and which AI tools ran — to your Jolli organization, so the web" +
+					" dashboard can chart it. <strong>Covers every repository Jolli is enabled in on this machine</strong>," +
+					" connected to a Space or not, whatever the per-repository switches below say — a repository you turned" +
+					" off with <code>jolli disable</code> is left out, and stays out: what it recorded before you turned it" +
+					" off is not uploaded later either. <strong>Conversation text is never sent</strong> — but" +
+					" session <em>titles</em> are, and many AI tools use your first message as the title; tool names include" +
+					" any MCP servers you use." +
+					'</span></span><input type="checkbox" class="set-switch" data-sync-sessions="1"' +
+					(state.syncSessions !== false ? " checked" : "") +
+					"/></label>" +
+					(state.syncStatus
+						? '<div class="set-push-status ' + state.syncStatus.kind + '">' + esc(state.syncStatus.text) + "</div>"
+						: ""),
+			) +
+			block(
+				"Memories — per repository",
+				'<p class="section-hint">Turning a repository <strong>off</strong> keeps capturing its memories locally and blocks only the outbound sync — automatic and manual alike. Turn it back on and the retained backlog goes up on that repo’s next activity, right away for the repo you’re in now.</p>' +
+					'<p class="section-hint">Every repository Jolli tracks on this machine is listed here, and a new one is allowed by default. A repo with no git remote is local-only and is managed from inside the repo instead.</p>' +
 					list,
 			)
 		);
@@ -809,6 +848,9 @@ window.JD = window.JD || {};
 			localFolder: f.localFolder,
 			compileExcludeFolders: f.compileExcludeFolders,
 			syncTranscripts: f.syncTranscripts === true,
+			// `syncSessions` is deliberately absent: it has its own immediate endpoint,
+			// and the server leaves an unmentioned value alone. Submitting the field
+			// here would let a batched Apply undo a toggle made after the page loaded.
 			dcoSignoff: f.dcoSignoff === true,
 			excludePatterns: f.excludePatterns,
 			dashboardKnowledgeMenuEnabled: f.dashboardKnowledgeMenuEnabled === true,
@@ -834,6 +876,7 @@ window.JD = window.JD || {};
 				// stale per-row toggle status.
 				state.pushError = null;
 				state.pushStatus = null;
+				state.syncStatus = null;
 				render(model);
 			};
 		});
@@ -872,6 +915,9 @@ window.JD = window.JD || {};
 		Array.prototype.forEach.call(document.querySelectorAll("#" + MOUNT + " [data-action]"), (btn) => {
 			btn.onclick = () => doAction(model, btn.getAttribute("data-action"));
 		});
+
+		var syncBox = document.querySelector("#" + MOUNT + " [data-sync-sessions]");
+		if (syncBox) syncBox.onchange = () => toggleSyncSessions(model, syncBox.checked === true);
 
 		Array.prototype.forEach.call(document.querySelectorAll("#" + MOUNT + " [data-push]"), (box) => {
 			box.onchange = () =>
@@ -1057,6 +1103,32 @@ window.JD = window.JD || {};
 		return isCurrent
 			? "Enabled — syncing retained memory now ✓"
 			: "Enabled ✓ — backlog will sync on this repo's next activity";
+	}
+
+	/**
+	 * The machine-wide session-statistics switch — immediate-apply, in the same
+	 * shape as `togglePush` below: post, report under the row, and on failure say
+	 * plainly that nothing changed and put the checkbox back where it was.
+	 */
+	function toggleSyncSessions(model, enabled) {
+		JD.post("/api/settings/set-sync-sessions", { enabled: enabled })
+			.then((data) => {
+				state.syncSessions = data.syncSessions !== false;
+				state.syncStatus = {
+					text: state.syncSessions
+						? "Enabled — session statistics upload from every repository on this machine ✓"
+						: "Disabled — nothing is uploaded, on any repository ✓",
+					kind: "ok",
+				};
+				render(model);
+			})
+			.catch(() => {
+				state.syncStatus = {
+					text: "Couldn't change session-statistics sync — see logs. No change was made.",
+					kind: "err",
+				};
+				render(model);
+			});
 	}
 
 	function togglePush(model, repoIdentity, disabled, isCurrent) {

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -157,6 +157,7 @@ import { wikiRebuildIsAuto } from "../core/WikiRebuildMode.js";
 import { maybeAutoCutover } from "../dashboard/AutoCutover.js";
 import { opportunisticSnapshot } from "../dashboard/Backup.js";
 import { recordCommitsFromWorker } from "../dashboard/ProducerHooks.js";
+import { runSessionSync } from "../dashboard/SessionSyncRunner.js";
 import { buildKnowledgeGraph } from "../graph/GraphBuilder.js";
 import { deriveSourceTag } from "../install/DistPathResolver.js";
 import { applyConfiguredLogLevel, createLogger, errMsg, getJolliMemoryDir, setLogDir } from "../Logger.js";
@@ -978,6 +979,24 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 		// underneath it.
 		if (summariesLandedThisRun) await warmBriefingCache(cwd);
 		if (summariesLandedThisRun) await maybeAutoCutover(cwd, { throttle: true });
+
+		// Session statistics sync — **outside** the "did any summary land" check
+		// above, and deliberately so: most sessions never produce a commit at all,
+		// and gating on new summaries would mean a machine only ever syncs the
+		// conversations that happened to end in one.
+		//
+		// ⚠ Fire-and-forget, never awaited. Everything above this line runs under a
+		// five-minute lock, and one network round trip inside that window delays
+		// every other worker on the machine. The run throttles itself, does its own
+		// gating, and swallows its own failures — see `runSessionSync`.
+		//
+		// This trigger covers the command-line user who commits but never opens an
+		// editor. The one that covers the rest is the global daemon's `session-sync`
+		// task (`GlobalDaemon.defaultTasks`) — which is what makes the reasoning
+		// above hold, since a commit-only trigger would reach exactly the sessions
+		// that ended in a commit whatever it is nested under. Both go through the
+		// same throttle, so having two costs nothing.
+		void runSessionSync().catch(() => undefined);
 	} finally {
 		// Backstops (idempotent): cover the early-return and mid-run-throw paths
 		// where the explicit releases above didn't run. worker.lock is released

--- a/vscode/src/views/SettingsCssBuilder.ts
+++ b/vscode/src/views/SettingsCssBuilder.ts
@@ -135,6 +135,11 @@ export function buildSettingsCss(): string {
     color: var(--vscode-descriptionForeground);
     margin-top: 2px;
   }
+  /* A hint long enough to split into two reads as one wall of text at the 2px
+     gap above — that gap sets a hint off from its label, not from another hint. */
+  .settings-label .hint + .hint {
+    margin-top: 7px;
+  }
 
   /* ── Inputs ── */
   input[type="text"],

--- a/vscode/src/views/SettingsHtmlBuilder.ts
+++ b/vscode/src/views/SettingsHtmlBuilder.ts
@@ -250,7 +250,8 @@ export function buildSettingsHtml(nonce: string): string {
       <div class="settings-row column">
         <label class="settings-label">
           Outbound push per repo
-          <span class="hint">Every repository on this machine that Jolli tracks. Turning one <strong>off</strong> keeps capturing its memory locally but blocks all outbound sync (auto and manual). New repos are allowed by default. <strong>Each toggle applies immediately</strong> — no “Apply Changes” needed. Re-enabling a repo syncs its retained backlog on that repo’s next activity (right away for the repo you’re currently in). (Local-only repos with no git remote are managed from within the repo instead.)</span>
+          <span class="hint">Turning a repository <strong>off</strong> keeps capturing its memories locally and blocks only the outbound sync — automatic and manual alike. Turn it back on and the retained backlog goes up on that repo’s next activity, right away for the repo you’re in now.</span>
+          <span class="hint">Every repository Jolli tracks on this machine is listed here, and a new one is allowed by default. <strong>These toggles apply immediately</strong> — no “Apply Changes” needed. A repo with no git remote is local-only and is managed from inside the repo instead.</span>
         </label>
         <div id="pushControlList" class="push-control-list">
           <div class="hint" id="pushControlEmpty">Loading…</div>


### PR DESCRIPTION
<!-- jollimemory-summary-start -->


## Quick recap

The dashboard now tracks per-session token counts, cost estimates, tool usage, and recall hits from every repository on a machine and pushes that data to the web dashboard. A new toggle in the Sync settings tab lets users stop their session statistics from leaving their machine entirely; the control sits just below the account status and above the per-repository list, where sync-related settings already live. Users who previously looked under the "Others" tab for this option will find it in a more intuitive location, and the setting is now also reachable from the terminal and editor plugins.

The daily spend view on the dashboard is now backed by a rollup cache, so the page loads quickly regardless of how much history has accumulated. Spending figures are now attributed to the correct calendar day even for conversations that spanned midnight, and deleted repositories no longer leave ghost spending figures in the all-repositories view. Several reliability fixes landed alongside these features: a sync that was silently stalling on machines with sessions older than 90 days now advances correctly, uploads that were retrying indefinitely against a missing server endpoint now silence themselves for a day, and a failure on one backend no longer blocks uploads to other backends on the same machine.

---

## E2E Test (4)
<details>
<summary><strong>1. Session statistics sync toggle in Settings</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the app open and signed in with an API key. Navigate to the Settings page.

**Steps:**
1. Open the Settings page and look for a "Sync" tab or section.
2. Inside the Sync tab, find the toggle labeled something like "Sync session statistics" or "syncSessions."
3. Note whether the toggle is on by default.
4. Turn the toggle off and click "Apply Changes."
5. Reopen Settings and check the Sync tab again.
6. Turn the toggle back on, click "Apply Changes," and confirm the setting is saved.

**Expected Results:**
- The session statistics toggle appears inside the Sync tab, not under "Others" or any other tab.
- The toggle is turned on by default.
- After turning it off and applying, reopening Settings shows it still off.
- After turning it back on and applying, reopening Settings shows it on again.
- A clear description near the toggle explains it covers every repository on the machine, not just ones connected to a Space.

</blockquote>
</details>
<details>
<summary><strong>2. Session sync via command line (configure and force-run)</strong></summary>
<br>
<blockquote>

**Preconditions:** Have the Jolli command-line tool installed and a terminal open.

**Steps:**
1. In the terminal, run the configure command to turn session sync off: type `jolli configure syncSessions false` and press Enter.
2. Confirm the command accepts the value without an error message.
3. Run `jolli configure syncSessions true` to turn it back on.
4. Run `jolli doctor --sync-sessions` to force an immediate upload of session statistics.
5. Read the output message carefully.

**Expected Results:**
- Both `jolli configure syncSessions false` and `jolli configure syncSessions true` complete without errors.
- `jolli doctor --sync-sessions` prints a clear result: either "up to date — nothing new to upload" if there is nothing pending, or a line showing how many rows were uploaded in how many batches.
- If the upload fails, the output names the reason (for example, a server error or the setting being off) and the command exits with a non-zero status code.
- No cryptic error messages or silent exits occur.

</blockquote>
</details>
<details>
<summary><strong>3. Ghost spend data removed after forgetting a repository</strong></summary>
<br>
<blockquote>

**Preconditions:** Have at least two repositories tracked in the dashboard, both with some spending history visible in the "all repositories" view.

**Steps:**
1. Open the dashboard and note the total spending figures shown across all repositories.
2. Run the command to stop tracking one of the repositories (the "disable" or "forget" command for that repo).
3. Return to the dashboard and open the "all repositories" spending view.
4. Check whether the removed repository's historical figures still appear.
5. Add a brand-new repository and check whether it shows any pre-existing spending data.

**Expected Results:**
- After removing the repository, its historical spending figures no longer appear anywhere in the dashboard.
- The kept repository's spending figures are unchanged.
- The newly added repository shows zero historical spending — it does not inherit any numbers from the removed one.

</blockquote>
</details>
<details>
<summary><strong>4. Per-day token and cost figures are accurate for multi-day conversations</strong></summary>
<br>
<blockquote>

**Preconditions:** Have at least one conversation (session) in the dashboard that was active across two or more calendar days — for example, started yesterday and continued today.

**Steps:**
1. Open the dashboard and navigate to the spending or token-usage chart.
2. Look at the per-day breakdown for the days the multi-day conversation was active.
3. Check that spending and token counts appear on each day the conversation was actually used, not only on the last day it was touched.

**Expected Results:**
- Each day the conversation was active shows a non-zero token count and cost estimate for that day.
- The final day does not show the entire conversation's total as if nothing happened on earlier days.
- Days when the conversation was not active show no contribution from it.

</blockquote>
</details>

---

## Topics (13)
<details>
<summary><strong>01 · Seven incremental database migrations consolidated into one before first release</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

During development of the session statistics sync feature, seven separate database migration steps accumulated as individual version entries. Each increment caused older installed builds of the app to unnecessarily disable a daily performance cache, even for low-risk steps like adding indexes or backfilling data.

**💡 Decisions Behind the Code**

- **Concatenate verbatim rather than rewrite**: Any machine that ran the granular development builds already executed those exact statements in that order. Rewriting the combined DDL would produce a different statement sequence and could cause failures on those machines. Identical bytes were treated as more valuable than tidy code, including the deliberate preservation of a redundant index creation.
- **One entry, not zero**: Collapsing to a single migration entry rather than eliminating the version bump entirely keeps the migration log honest — the schema genuinely changed and the log needs a record of it. The merge is only valid before first release; the append-only rule becomes a hard constraint the moment any user database receives version 8.
- **Fix at the migration layer, not the cache layer**: The daily rollup cache was being disabled by the version counter even for migration steps (indexes, column additions, backfills) that could never introduce tables an older build couldn't see. Rather than adding a second, slower-moving version number to govern cache behavior, the fix was to stop producing unnecessary version increments — keeping the version number meaningful and avoiding a second versioning axis to maintain.

**✅ What Was Implemented**

- In `DashboardDb.ts`, the seven individual migration entries (sync stamps, usage events table, daily stats cache, indexes, and backfill) were merged into a single entry named `SESSION_STATS_SYNC_DDL`, with all seven DDL constants concatenated verbatim in their original order. `DASHBOARD_SCHEMA_VERSION` was reduced from 14 back to 8.
- The DDL constants were not rewritten — a redundant index creation was deliberately preserved to guarantee the combined entry is byte-for-byte equivalent to what machines that ran the granular path already executed.
- The version block comment was rewritten to explain the consolidation rationale and document that this merge is a one-time action: intermediate versions 8–13 exist on no shipped database, and the append-only rule applies strictly after first release.
- In `DashboardDb.test.ts`, the test seeding a pre-stamp database was updated to locate the new combined entry by name. In `MigrationFingerprints.test.ts`, seven individual fingerprint entries were replaced with a single combined fingerprint (`e0c166639049`).

**📋 Future Enhancements**

- Any developer whose local database was stamped at version 14 during the branch's development history must manually reset the stored version number and mark the new combined migration entry as already applied. This repair path was documented but has no automated tooling.

**📁 FILES**
- `cli/src/dashboard/DashboardDb.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Session statistics sync channel pushes per-session usage data to web dashboard</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The web dashboard needed per-session token counts, cost estimates, tool usage, and recall hits from every repository on a machine, but no mechanism existed to push this data to the server.

**💡 Decisions Behind the Code**

- **Separate opt-out switch from the memory push toggle**: Session statistics travel for every repository on the machine regardless of Space bindings, which is the opposite of what the existing push toggle means. Reusing that switch would make the Settings UI misrepresent what it controls, and the privacy implications — titles, server names, cross-repo coverage — warranted an independently labeled control.
- **Per-backend cursor keying by origin and tenant slug**: Progress is stored per backend origin and tenant rather than globally. One origin serves many tenants, and a refusal or cursor from one tenant carries no information about another; using only the origin would have preserved cross-tenant interference for silences and left cursor sharing in place.
- **Keyset paging over expanding the batch to cover a full timestamp**: A simpler fix would have been to detect a full batch sharing one timestamp and expand it to include all rows at that timestamp. This was rejected because a single timestamp on the real database held over 2,000 rows, making the expanded batch large enough to risk rejection by the server's request-size limits — and that rejection path was already known to be mishandled. Keyset paging keeps batch sizes predictable and eliminates the problem structurally.
- **Fire-and-forget trigger from the worker, not awaited**: The worker runs under a five-minute lock shared across all open projects on the machine. Awaiting a network round trip inside that window would delay every other worker. The runner throttles itself, gates itself, and swallows its own failures, so the caller needs no error handling.
- **Daemon timer as primary trigger, commit hook as secondary**: The commit hook covers users who commit regularly but misses every session that ends without one. The daemon timer covers the rest. Both go through the same throttle, so having two triggers costs nothing and the throttle prevents duplicated work.

**✅ What Was Implemented**

- `SessionSyncRunner.ts` implements the full sync loop: gates on the API key and a per-channel opt-out setting, reads the machine-level database, sends batches to a new push endpoint via `JolliMemoryPushClient.pushSessions()`, and handles cursor-behind errors by adopting the server's lower cursor and re-sending the missing range. The runner is wired into `QueueWorker.ts` as a fire-and-forget call after each worker run, and also runs on a 30-minute background timer in the global daemon so sessions that never produce a commit are still uploaded.
- `SessionPushReader.ts` and `SessionPushManifest.ts` define what leaves the machine: four tables (`sessions`, `session_model_usage`, `session_tool_use`, `session_usage_events`) with explicit column allowlists. The reader selects rows using a sync-stamp column, applies a 90-day first-run window directly in the SQL `WHERE` clause, and rewrites the local integer repository surrogate to a portable identity string.
- `SessionPushCursor.ts` manages the machine-level state file storing the client identity, per-backend cursors keyed by origin and tenant slug, throttle timestamp, and per-scope silence windows — kept separate from the user config file and from SQLite so hooks can check whether a run is due with a single file read.
- Paging uses a composite keyset cursor (stamp plus primary key columns) rather than stamp alone, preventing a deadlock that had silently stranded thousands of rows on machines where many rows shared the same millisecond timestamp. A `TableCursor` type replaces the bare millisecond number, with backward-compatible handling for servers that still return bare numbers.

**📋 Future Enhancements**

- The server needs to be updated to store and return the full composite cursor rather than a bare number. Until it does, the client will re-deliver one millisecond worth of rows on every pass rather than advancing cleanly through it.
- The daemon timer trigger is the primary path; a user who neither commits nor opens an editor will not sync until the next timer fires. This gap was acknowledged as acceptable — the cursor preserves all data, it simply does not move.

**📁 FILES**
- `cli/src/dashboard/SessionSyncRunner.ts`
- `cli/src/dashboard/SessionPushReader.ts`
- `cli/src/dashboard/SessionPushManifest.ts`
- `cli/src/core/SessionPushCursor.ts`
- `cli/src/core/JolliMemoryPushClient.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Daily spend cache added to dashboard to avoid re-aggregating all history on every render</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The dashboard was re-aggregating all historical spend data on every page render, which became increasingly slow as history grew.

**💡 Decisions Behind the Code**

- **Cache invalidation by polling, not by notification**: The cache detects stale days by scanning source write stamps rather than having writers record which day changed. A notification approach fails silently when any write path forgets to record — leaving a permanently wrong number with nothing to detect it. The polling approach is self-correcting: a new write path is visible the moment its rows carry stamps, at the cost of one scan per request bounded by the oldest settled day.
- **Filter on business date, not write stamp, for the range bound**: The two questions are different — "was this row written recently?" and "does this row belong to a day we care about?" Filtering the range on the write stamp would drop exactly the rows this mechanism exists to find: a row dated in the past but written recently due to a backfill or rebase. The business date bound is what makes the steady-state scan empty on a quiet machine.
- **Explicit forget on delete**: Deleted rows leave no write stamp, so stamp-based expiry cannot detect them. Callers that delete source rows explicitly call the rollup forget function before deleting, capturing the affected timestamps while the rows still exist. Over-forgetting costs one recomputation and never produces a wrong number, making it the safe failure mode.
- **Shared SQL for cache build and live read**: The category and branch axes apportion a commit's spend using a window division. Two separate query implementations would produce plausible but quietly different numbers whenever their join shapes differed. Extracting both paths into one module and calling the same function from both sides makes disagreement structurally impossible rather than a property to test for.
- **Derived axis list over hand-written**: The failure mode of a hand-written axis list is one-directional and invisible — the cache builds successfully, the page renders, and the chart shows zeros that look like real data. A compile error at the point of definition is the only signal that arrives before the data is wrong.

**✅ What Was Implemented**

- `StatsRollup.ts` implements the full cache lifecycle: `buildRollup` settles past days into `stats_daily` newest-first on a per-call budget, `readAvailableDays` checks which settled days are still fresh by comparing source write stamps against the build timestamp, `planDays` splits a query window into cached and live halves, and `forgetRollupDays` explicitly invalidates days when source rows are deleted. `buildRollupQuietly` wraps the builder as a side effect of every write, swallowing failures so a cache miss never blocks a write.
- `StatsSeries.ts` extracts all six spend-axis SQL queries and the token-usage reader into a shared module. Both the live query path in `DashboardQuery.ts` and the rollup builder call the same functions, guaranteeing that a cached day and a live day are computed identically — critical for the apportioning axes that divide by a window count.
- `DashboardQuery.ts` and a new `readTokenTotals` function now accept a day plan and route each day to either the rollup cache or the live reader. The token breakdown card was also migrated off session-level totals onto per-response event rows, placing tokens on the day each response actually happened.
- The staleness check in `readSourcesWrittenSince` now filters on both the write-stamp and the row's own business date, so only rows dated within the candidate window are returned. On a quiet machine the scan returns nothing, restoring the intended behavior that had been silently degrading as history grew.
- The list of chart axes stored in the cache is derived from the TypeScript type that defines all valid chart dimensions, replacing a hand-written list. Adding a new dimension now produces a compile error at the cache definition rather than a silent data gap at runtime.

**📁 FILES**
- `cli/src/dashboard/StatsRollup.ts`
- `cli/src/dashboard/StatsSeries.ts`
- `cli/src/dashboard/DashboardQuery.ts`
- `cli/src/dashboard/StatsWriter.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Per-response usage events table places spending on the correct calendar day</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The existing session row stored a conversation's entire token spend under a single "last active" timestamp. A conversation spanning multiple days would report zero spending on all days except the last, making per-day cost figures wrong by construction.

**💡 Decisions Behind the Code**

- **Delete-then-insert rather than upsert for usage events**: Agents compact and rewrite their transcripts, so responses recorded in an earlier read can stop existing. An upsert-only approach would leave stale rows behind with nothing to notice them. The delete-then-insert pattern matches how the model split is already handled and makes a re-read converge rather than accumulate.
- **Drop undatable responses from events rather than guessing a timestamp**: These rows are what per-day figures are built from. A wrong day is worse than a missing one — the session totals still count the response, so the two disagree only by what could not be dated, which is surfaced via the existing token coverage field.
- **Present-but-empty array is distinct from absent**: An empty array means "this source can report usage but nothing was datable this read" and must clear any rows a better earlier read left behind. An absent field means "this source cannot report per-response usage at all" and must leave existing rows alone. Collapsing the two would make a transcript rewrite silently preserve stale rows.

**✅ What Was Implemented**

- A new `session_usage_events` table in `SotSchema.ts` is keyed on session event ID and dedup key, storing one row per counted model response with its own response timestamp. The schema stores instants rather than local days, treating bucketing as a read-time decision that depends on the viewer's timezone.
- `TranscriptReader.ts` and `TranscriptParser.ts` were extended to emit a usage events array alongside the existing aggregate: each entry carries the response's own timestamp, model name, token counts, and dedup key. Undatable responses are dropped from the array rather than guessed, while still counting toward session totals.
- `StatsWriter.ts` projects these events into the new table with a delete-then-insert pattern, and `DashboardCollector.ts` prices each event using the same model-to-provider mapping used for the aggregate so the two cannot carry different prices.

**📁 FILES**
- `cli/src/dashboard/SotSchema.ts`
- `cli/src/dashboard/StatsWriter.ts`
- `cli/src/core/TranscriptReader.ts`
- `cli/src/dashboard/DashboardCollector.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Sync stamp columns added to activity tables for reliable change detection</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

An outbound sync needed a way to select exactly the rows that changed since its last run, but no existing column could serve this purpose — the session table's "last active" timestamp is deliberately not updated when token data is enriched, so a sync keyed on it would miss those improvements entirely.

**💡 Decisions Behind the Code**

- **Separate stamp column rather than reusing any business column**: The session table's "last active" time is intentionally not bumped by the commit-attribution enrichment path — bumping it would misrepresent when the session was active. A sync keyed on that column would therefore never see the enrichment. A dedicated write-time stamp has no business meaning to preserve and can be bumped unconditionally on every write.
- **`NOT NULL DEFAULT 0` rather than nullable**: A null stamp produces null (not false) in a comparison, making that row permanently invisible to every cursor. One nullable column is enough to silently exclude a row forever with nothing to report it. Zero means "written before we tracked this" and is the correct sentinel for rows the backfill cannot improve.
- **Non-uniform column names documented explicitly via a map**: The sessions table's stamp is `written_at_ms` while the other three use `updated_at_ms` because the latter name was already taken by the business clock. Writing the wrong column name compiles and runs silently, returning the wrong set. The map in `SyncColumns.ts` and its tests exist specifically to make this trap findable rather than silent.
- **Union type over two optional maps for window sources**: Two maps with optional values can express a state — a table with no window source — that is a bug, not a valid configuration. A discriminated union makes that state unrepresentable at compile time, turning a runtime invariant into a type guarantee and removing a dead branch from the reader that could never be tested.

**✅ What Was Implemented**

- `SYNC_STAMP_DDL` in `SotSchema.ts` adds a `written_at_ms` column to `sessions` and `updated_at_ms` to `session_model_usage`, `session_tool_use`, and `recall_receipts`, all declared `NOT NULL DEFAULT 0`. A backfill populates pre-existing rows from their best available business-time approximation; child rows with no surviving parent land on 0 via `COALESCE`.
- `SyncColumns.ts` provides a per-table map from table name to stamp column name, plus a `WINDOW_SOURCES` map whose value type is a two-case union (`{own}` or `{parent}`) so "no window source" is unrepresentable at compile time. `StatsWriter.ts` was updated throughout to accept a `nowMs` parameter and write it into every stamp column on every insert and conflict branch.
- `DashboardDb.ts` registers the new migrations by name in the `MIGRATIONS` array.

**📁 FILES**
- `cli/src/dashboard/SotSchema.ts`
- `cli/src/dashboard/SyncColumns.ts`
- `cli/src/dashboard/StatsWriter.ts`
- `cli/src/dashboard/DashboardDb.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Session statistics sync toggle moved to Sync settings tab and exposed via command line</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Users who wanted to stop their session data from leaving their machine had to look under the "Others" settings tab, which groups local behaviors like commit sign-off and file exclusions — an unintuitive location that made the control easy to miss. The toggle was also inaccessible from the terminal or editor plugins.

**💡 Decisions Behind the Code**

- **Placement above the per-repo list in the Sync tab**: The toggle sits just below the account status and above the per-repository list. This positions it where users already look for sync-related controls, and its machine-wide scope is visually distinguished from the per-repository toggles below it.
- **Separate from the memory push toggle**: Session statistics travel for every repository on the machine regardless of Space bindings, which is the opposite of what the existing push toggle means. Reusing that switch would make the Settings UI misrepresent what it controls, and the privacy implications warranted an independently labeled control.

**✅ What Was Implemented**

- Introduced a new `SettingsSync` interface in `DashboardModel.ts` to hold the `syncSessions` field, removing it from `SettingsOthers`. The `SettingsPageModel` now carries a dedicated `sync` group alongside the existing groups.
- Updated `SettingsPageQuery.ts` to populate `sync.syncSessions` (preserving the `!== false` default-on contract) and removed it from the `others` block. Updated `settings.js` to render the toggle above the per-repo list inside the Sync tab, with a description clarifying it covers every repository Jolli is enabled in on the machine and that repositories turned off with the disable command are excluded. A sentence was added explicitly stating that the switch takes effect only when the user presses "Apply Changes," distinguishing it from the per-repository toggles that apply immediately.
- Added `syncSessions` to the list of accepted keys in `ConfigureCommand.ts`, with boolean coercion and a description that explains why this toggle has broader scope than the two adjacent sync settings.

**📁 FILES**
- `cli/src/dashboard/DashboardModel.ts`
- `cli/src/dashboard/SettingsPageQuery.ts`
- `cli/src/core/ConfigureCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Silent infinite retry fixed when session sync endpoint is missing or returns unexpected response</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The session statistics upload channel was retrying a missing or unavailable server endpoint every 30 minutes indefinitely, with no silence applied. The root cause was that error conditions were matched by searching for status codes inside error message text, which failed whenever the server returned a descriptive JSON error body or a webpage instead of the expected response.

**💡 Decisions Behind the Code**

- **Class-based errors over message matching**: Matching a status code pattern against an error message is fragile by construction — any server or gateway that returns a JSON error body produces a message like "Not Found" with no status code in it, causing the match to fail silently. Typed error classes keyed on the HTTP status at the point where the status is known make the classification immune to message content.
- **Same class for honest 404 and non-JSON 2xx**: Both conditions mean the same thing from the caller's perspective — this deployment does not have the endpoint — and call for the same response: silence the scope for a day. Giving them the same type means the runner's dispatch table stays flat and the two cases cannot accidentally diverge in future.
- **Fail loudly rather than silently succeed on non-JSON 2xx**: Every other method in the same client already checked the parse-failure flag; `pushSessions` was the sole exception. The cost of not checking was invisible data loss — rows were marked as delivered and the local cursor advanced, so they would never be retransmitted. A loud failure that triggers a retry or a silence period is strictly safer than a quiet false success that permanently discards data.
- **404 and 412 as separate classes**: A 404 means the endpoint does not exist on this backend and the channel should be silenced for a long period. A 412 means a configuration precondition is unmet and is a distinct operational state. Keeping them as separate types preserves the ability to handle them differently in the future without parsing message text.

**✅ What Was Implemented**

- Introduced two typed error classes, `SessionEndpointMissingError` and `SessionPreconditionFailedError`, in `JolliMemoryPushClient.ts`. The client raises these by HTTP status code (404 and 412 respectively) before falling through to generic message-based handling, and also raises `SessionEndpointMissingError` for non-JSON 2xx responses (a single-page app returning its index page on unknown routes).
- Updated `SessionSyncRunner.ts` to dispatch on these classes using `instanceof` checks, removing the two regex helper functions entirely. The 24-hour silence is now reliably applied on both 404 and the non-JSON 2xx case; the 412 branch is flagged and silenced rather than silently retried.

**📁 FILES**
- `cli/src/core/JolliMemoryPushClient.ts`
- `cli/src/dashboard/SessionSyncRunner.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Session sync silence scoped per backend instead of machine-wide</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A failed upload attempt to one backend was silencing session statistics uploads to all backends on the machine for 24 hours. Re-pointing an API key at a working backend had no effect until the silence expired, and nothing in the logs indicated why uploads had stopped.

**💡 Decisions Behind the Code**

- **Origin plus tenant slug as scope, not origin alone**: One origin serves many tenants, and a refusal or cursor from one tenant carries no information about another. Using only the origin would have preserved cross-tenant interference for silences and left cursor sharing in place. The tenant slug is read from the same path segment the request sends as a header, so the key cannot disagree with where the rows actually went.
- **Drop legacy machine-wide silence on read, never fold it into every scope**: Folding the old mark onto every scope would carry the exact outage the fix addresses across the upgrade that fixes it. A user who re-pointed their key at a working backend minutes after the silence was written would still wait until the next day. The cost of dropping it is one retry against a backend that will refuse again and re-silence its own scope, which is the correct outcome.
- **Silence check inside the sync call, not in the throttle check**: The throttle check is a pure file read with no scope context; consulting the silence there would require reading it scope-blind, recreating the machine-wide behavior under a different name. Keeping the two checks separate means a silenced scope still respects the 30-minute throttle, at the cost of one config read per window rather than per tick.

**✅ What Was Implemented**

- Replaced the single machine-wide silence marker in `SessionPushCursor.ts` with a map keyed by origin plus tenant slug. New helpers operate on one scope at a time; expired entries are pruned on each write so the map cannot grow unboundedly. Legacy machine-wide marks are dropped on read, so the upgrade itself clears any active silence automatically.
- Updated `SessionSyncRunner.ts` to introduce a scope key (origin plus tenant slug) alongside the existing origin-only key (kept only as a legacy fallback for cursor storage). The silence check, cursor reads/writes, and all classification branches now operate on the scoped key, so a refusal from one tenant on one host no longer affects any other tenant or host.
- `cursorsFor` gained a `legacyKey` parameter so machines upgrading from bare-origin cursor storage resume from their saved position rather than re-sending from the full 90-day window.

**📁 FILES**
- `cli/src/core/SessionPushCursor.ts`
- `cli/src/dashboard/SessionSyncRunner.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · Stats cache expiring the wrong day after a commit history rewrite</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When a commit was pruned from history during a rebase, the memory it held was reassigned to a surviving commit on a different day. The cache invalidation logic was expiring the original author date rather than the day the memory actually moved to, leaving the destination day serving stale numbers permanently.

**💡 Decisions Behind the Code**

The landing day calculation has three inputs (commit date, alias chain, fallback) and the pruning path was only using one of them. Calling the shared query after the delete means the pruning path can never drift out of sync with the rule used everywhere else, and the next time the rule changes there is only one place to update. Restating the rule by hand had already been wrong once, and a restatement is the failure mode that cannot be caught by tests that only exercise the common path.

**✅ What Was Implemented**

- Fixed `pruneUnreachableCommits` in `DbBackfill.ts` to query the canonical landing-day rule after deleting the unreachable commit, rather than re-deriving the day by hand using the commit's author date. The hand-written derivation skipped the aliasing step, which is precisely what a prune triggers.
- Added a regression test in `StatsRollup.test.ts` that sets up three distinct days — author date, pruned commit date, and surviving alias date — and verifies that only the pruned and landing days are expired while the author date is left untouched. The test was confirmed to fail against the old code before the fix was applied.

**📁 FILES**
- `cli/src/dashboard/DbBackfill.ts`
- `cli/src/dashboard/StatsRollup.test.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · Cache invalidation wired into commit prune and memory delete paths</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When commits or memories are deleted, the rollup cache has no way to detect the change through write stamps — deleted rows leave nothing behind. Days that lost their only contributing rows would serve stale cached totals indefinitely.

**💡 Decisions Behind the Code**

- **Read affected timestamps before deleting, not after**: Once a row is gone, there is no record of which cached day it contributed to. The cost is one extra read per deleted item on paths that already do significant work, and the alternative is a permanently stale cache entry with no mechanism for self-correction.
- **Query the database for the landing day after deletion rather than predicting the fallback**: The landing expression has three terms and the winning term changes when a commit row is removed. Predicting which term wins requires knowing whether an alias exists — the same join the query already performs. Asking the database after the fact is both simpler and guaranteed correct; restating the rule by hand had already been wrong once, and a restatement is the failure mode that cannot be caught by tests that only exercise the common path.

**✅ What Was Implemented**

- `DbBackfill.pruneUnreachableCommits` now reads the `committed_at_ms` of every commit about to be deleted, and also the `commit_date_ms` of any orphaned memories whose commit is being removed. Both sets of timestamps are passed to `forgetRollupDays` inside the same transaction as the deletes. The orphaned-memory day calculation was rewritten to query the shared `MEMORY_LANDED_AT_SQL` expression after the delete, rather than restating the landing rule inline.
- `SotWrite.landSummaries` reads the landing timestamp of each memory node before deleting it and calls `forgetRollupDays` with those timestamps after the deletes complete.
- `StatsSeries.ts` documentation for `MEMORY_LANDED_AT_SQL` was extended to enumerate all call sites and explain that the query is valid both before and after a change, with the prune being the canonical after-delete use case.

**📁 FILES**
- `cli/src/dashboard/DbBackfill.ts`
- `cli/src/dashboard/SotWrite.ts`
- `cli/src/dashboard/StatsSeries.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · NULL sync-stamp backfill fixes permanently invisible session rows</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

On databases set up before the sync-stamp migration was formally tracked, the migration was recorded as already complete without actually running, leaving timestamp columns nullable with no default value. Any row in that state was permanently invisible to the sync cursor and was never reported as missing.

**💡 Decisions Behind the Code**

- **Backfill rather than reject or skip**: Rows with NULL stamps are permanently invisible to every cursor with no error anywhere in the system. Backfilling with a real timestamp — even an approximate one derived from a related column — makes them selectable and sends them on the next sync run. Rejecting or deleting them would discard data the user already captured.
- **Wider condition than the original migration**: The original stamp migration only matched rows where the stamp equalled zero. On databases where that migration was recorded as applied without running, the columns are nullable and the default was never set, so the value is NULL rather than zero. Matching on NULL is the only condition that reaches the affected rows.
- **No NOT NULL constraint restoration**: SQLite does not support altering an existing column's constraints, so the fix cannot enforce the declaration retroactively. Every write path passes an explicit timestamp value, meaning no new NULLs can be produced going forward, and a new test guards this assumption on freshly migrated databases.

**✅ What Was Implemented**

- Added `SYNC_STAMP_NULL_BACKFILL_DDL` in `SotSchema.ts`: a multi-statement UPDATE that fills NULL sync-stamp values across all four affected tables (`sessions`, `recall_receipts`, `session_model_usage`, `session_tool_use`), using the best available fallback timestamp per table rather than a blanket zero.
- Bumped `DASHBOARD_SCHEMA_VERSION` and registered the new migration entry so the backfill runs automatically on next startup for any affected database.
- Added a test in `SyncColumns.test.ts` that inserts rows without explicitly naming the stamp column and then asserts zero NULLs remain across all sync-stamp tables after migration, pinning the invariant every cursor depends on.

**📁 FILES**
- `cli/src/dashboard/SotSchema.ts`
- `cli/src/dashboard/DashboardDb.ts`

</blockquote>
</details>
<details>
<summary><strong>12 · Session sync permanent stall fixed by moving age filter into database query</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

On any machine with a backlog of sessions older than 90 days, the session sync would read the same rows on every run, discard them all as too old, learn no cursor position, and repeat forever — silently syncing nothing while reporting only a skipped-rows count.

**💡 Decisions Behind the Code**

- **Window inside the query, not on the result**: Filtering after `LIMIT` is the root cause of the stall — the database returns the oldest rows first, the window discards them all, and no cursor stamp is learned. Moving the predicate into `WHERE` means `LIMIT` operates on qualifying rows only, and the cursor always advances when data exists inside the window.
- **Whole-table count for skipped rows**: A per-batch figure understated the backlog and required counting rows that were never fetched. A single `COUNT` against the full table gives the true backlog and is run exactly once, on the first pass that applies the window.

**✅ What Was Implemented**

- Rewrote `readTableSlice` in `SessionPushReader.ts` to embed the 90-day first-run window directly in the SQL `WHERE` clause rather than filtering returned rows in JavaScript. The `LIMIT` now counts only rows that will actually be sent, so a batch of entirely-too-old rows no longer blocks the cursor from advancing to newer data.
- Replaced the per-batch skipped-row count with a single `COUNT(*)` query against the whole table, reported once on the run that first applies the window. Added a regression test that reproduces the stall with a limit of 1 and verifies the cursor reaches the in-window row.

**📁 FILES**
- `cli/src/dashboard/SessionPushReader.ts`

</blockquote>
</details>
<details>
<summary><strong>13 · Ghost spend data persists after removing a repository from tracking</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

After a user ran the command to stop tracking a repository, that repository's historical spending figures kept appearing in the "all repositories" dashboard view indefinitely. A newly added repository could also silently inherit the deleted one's numbers.

**💡 Decisions Behind the Code**

- **Not counting deleted cache rows in the "rows removed" tally**: The existing count is documented as rows from tables that reference the repositories table, and the dashboard server reads it to decide whether anything was actually removed. Counting derived cache rows would let a cache-only deletion answer "yes, something was here" even when no real repository data existed — a misleading signal that could mask bugs.

**✅ What Was Implemented**

- `RepoForget.ts` now explicitly deletes rows from the daily rollup cache table inside the same database transaction that removes the repository. The existing auto-derived child-table list could not reach this table (it has no foreign key to the repositories table by design), so the deletion had to be added by hand. Extensive inline comments explain why silent omission here is worse than a loud schema error: the cache never re-evaluates old days with no new writes, and SQLite's ID reuse means a brand-new repository can inherit the ghost rows.
- `RepoForget.test.ts` adds a regression test covering three cases: the forgotten repo's cache rows are gone, the kept repo's rows survive, and the shared per-day sentinel row is preserved.

</blockquote>
</details>

---

*Generated by Jolli Memory · August 18, 2026 at 7:36 PM · via Anthropic*
<!-- jollimemory-summary-end -->