### PR TITLE
Attribute conversations to commits made across worktrees and checkouts

### DIFF
--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -62,7 +62,7 @@ export interface SessionInfo {
  * Each advances its own high-water mark, so adding one never strands data behind
  * a mark advanced by a dist that did not know it existed.
  */
-export type DiscoveryExtractor = "plans" | "references" | "skills";
+export type DiscoveryExtractor = "plans" | "references" | "skills" | "owners";
 
 export interface TranscriptCursor {
 	readonly transcriptPath: string;
@@ -829,6 +829,18 @@ export interface CommitSummary {
 	 * Release N keeps reading legacy data; Release N+M will make it required.
 	 */
 	readonly transcripts?: ReadonlyArray<string>;
+	/**
+	 * Set by `jolli doctor --repair-transcripts --fix` when this summary's empty
+	 * `transcripts` was refilled from local transcript history. Purely additive —
+	 * no schema bump, matching how `skills` / `excludedContext` shipped.
+	 *
+	 * Two jobs. It is the repair's idempotency key: a summary carrying it is never
+	 * a candidate again, so a repeated run cannot create a second artifact for the
+	 * same evidence window (spec §8.2). And it is what lets the memory-detail UI
+	 * say "repaired from local transcript history" rather than implying the
+	 * conversation was captured live.
+	 */
+	readonly transcriptsRepairedAt?: string;
 	/**
 	 * Marks a summary produced by the historical back-fill flow (`jolli backfill`
 	 * / enable-time catch-up) rather than the live post-commit pipeline. The

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -454,6 +454,20 @@ export interface CommitGitOperation {
 	 * id when absent.
 	 */
 	readonly traceId?: string;
+	/**
+	 * The agent session (`CLAUDE_CODE_SESSION_ID`) whose process executed this
+	 * git operation, captured at enqueue time from the hook's inherited env.
+	 *
+	 * This is authorship evidence the ledger cannot supply on its own: a session
+	 * running in worktree A that commits into worktree B leaves no cwd trace in
+	 * B, so B's drain would attribute the commit to nothing. The worker uses this
+	 * to add that session as a candidate and, when the forward ledger has not yet
+	 * recorded a B-ownership edge (the edit and the commit happened in one turn,
+	 * before the Stop hook ran), to synthesize the owner lower bound from the
+	 * session's own transcript. Absent for a plain-terminal / GUI commit and for
+	 * hosts that advertise no session id — see [AgentSessionEnv.ts](./core/AgentSessionEnv.js).
+	 */
+	readonly executingSessionId?: string;
 }
 
 /**

--- a/cli/src/commands/DoctorCommand.test.ts
+++ b/cli/src/commands/DoctorCommand.test.ts
@@ -8,9 +8,12 @@
  *     so a not-signed-in user gets actionable guidance
  */
 
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { JolliMemoryConfig } from "../Types.js";
+import type { CommitSummary, JolliMemoryConfig } from "../Types.js";
 
 // ─── Hoisted mocks ───────────────────────────────────────────────────────────
 
@@ -32,25 +35,48 @@ const h = vi.hoisted(() => ({
 	inspectPlugins: vi.fn(),
 	resolveProjectDir: vi.fn(),
 	runSessionSync: vi.fn(),
+	createStorage: vi.fn(),
+	// Sentinel commit hash the TranscriptRepair.js mock below throws for, so the
+	// `--repair-transcripts` per-candidate error-isolation test can make exactly
+	// one candidate fail without touching any other test's real repair behavior.
+	throwHash: "f".repeat(40),
 }));
 
 vi.mock("../dashboard/SessionSyncRunner.js", () => ({ runSessionSync: h.runSessionSync }));
 
-vi.mock("../core/GitOps.js", () => ({
+vi.mock("../core/GitOps.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../core/GitOps.js")>()),
 	orphanBranchExists: h.orphanBranchExists,
 	// Backup's default-folder guard probes whether $HOME is a git worktree (git
 	// clean -xdf there would delete every snapshot). The fake HOME is a tmpdir, so
 	// "false" is the honest answer and the snapshot proceeds.
 	execGit: vi.fn(async () => ({ exitCode: 0, stdout: "false", stderr: "" })),
+	// The `--repair-transcripts` tests below build fixtures with a real
+	// FolderStorage over a plain temp dir (not a git worktree) —
+	// resolveStateRoot/getTreeHash/getDiffStats are stubbed to their non-repo-cwd
+	// fallback values so repairSummaryTranscripts (via storeSummary's
+	// flattenSummaryTree) never shells `git` out against a directory that isn't
+	// one. Same rationale as TranscriptRepair.test.ts.
+	resolveStateRoot: vi.fn((cwd: string) => cwd),
+	getTreeHash: vi.fn().mockResolvedValue(null),
+	getDiffStats: vi.fn().mockResolvedValue({ filesChanged: 0, insertions: 0, deletions: 0 }),
 }));
 vi.mock("../core/LlmClient.js", () => ({ resolveLlmCredentialSource: h.resolveLlmCredentialSource }));
-vi.mock("../core/Locks.js", () => ({
+vi.mock("../core/Locks.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../core/Locks.js")>()),
 	isWorkerLockStale: h.isWorkerLockStale,
 	releaseWorkerLock: h.releaseWorkerLock,
 	// The repo-registry row's dry-run repair pass takes this lock. A plain
 	// pass-through rather than a spy: these tests are about doctor's output, and an
 	// unmocked export throws on the very first check that reaches it.
 	withRepoRegistryLock: async <T>(fn: () => Promise<T>) => fn(),
+	// storeSummary always wraps its write in withRequiredOrphanWriteLock, which
+	// calls these two directly regardless of active storage backend — stubbed
+	// to always-succeed/no-op so the `--repair-transcripts` fixtures (plain temp
+	// dirs, not git worktrees) don't shell out to `git rev-parse
+	// --git-common-dir` to resolve the shared lock directory.
+	acquireOrphanWriteLock: vi.fn().mockResolvedValue(true),
+	releaseOrphanWriteLock: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock("../core/localagent/BackendRegistry.js", () => ({ getBackend: h.getBackend }));
 vi.mock("../core/RepoProfile.js", () => ({
@@ -65,6 +91,34 @@ vi.mock("../core/SessionTracker.js", () => ({
 	loadConfig: h.loadConfig,
 }));
 vi.mock("../core/SotStorageResolver.js", () => ({ resolveSotBackend: h.resolveSotBackend }));
+// createStorage is the cutover router: on a real cutover repo it points the active
+// storage at SQLite. `runDoctor --repair-transcripts` must establish it itself, so
+// the tests below stand it in for the fixture FolderStorage. Every other export
+// (createFolderStorageAtRoot) stays real.
+vi.mock("../core/StorageFactory.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../core/StorageFactory.js")>()),
+	createStorage: h.createStorage,
+}));
+vi.mock("../core/TranscriptRepair.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../core/TranscriptRepair.js")>();
+	return {
+		...actual,
+		// Real behavior for every commit except the sentinel — `runRepairTranscripts`
+		// must isolate one candidate's failure from the rest of the loop, and the
+		// only way to prove that without mocking away the whole engine is to make
+		// exactly one real invocation throw.
+		repairSummaryTranscripts: vi.fn(
+			async (
+				commitHash: string,
+				cwd: string,
+				opts?: { readonly apply?: boolean; readonly globalDir?: string },
+			) => {
+				if (commitHash === h.throwHash) throw new Error("simulated lock contention");
+				return actual.repairSummaryTranscripts(commitHash, cwd, opts);
+			},
+		),
+	};
+});
 vi.mock("../install/DistPathResolver.js", () => ({ traverseDistPaths: h.traverseDistPaths }));
 vi.mock("../install/Installer.js", () => ({ getStatus: h.getStatus, install: h.install }));
 vi.mock("../PluginLoader.js", () => ({ inspectPlugins: h.inspectPlugins }));
@@ -81,8 +135,11 @@ vi.mock("./CliUtils.js", async (importOriginal) => {
 	return { ...actual, resolveProjectDir: h.resolveProjectDir };
 });
 
+import { recordClaudeOwners } from "../core/ClaudeOwnership.js";
+import { createFolderStorageAtRoot } from "../core/StorageFactory.js";
+import { getSummary, setActiveStorage, storeSummary } from "../core/SummaryStore.js";
 import { setIsolatedHome } from "../testUtils/isolatedHome.js";
-import { registerDoctorCommand } from "./DoctorCommand.js";
+import { registerDoctorCommand, runRepairTranscripts } from "./DoctorCommand.js";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -1152,5 +1209,204 @@ describe("doctor --sync-sessions", () => {
 		} finally {
 			process.exitCode = 0;
 		}
+	});
+});
+
+describe("doctor --repair-transcripts", () => {
+	// Storage seam (same as TranscriptRepair.test.ts): a real FolderStorage
+	// rooted at a temp "repo" dir, set as the process-global override so
+	// listSummaries/getSummary/storeSummary inside runRepairTranscripts read and
+	// write it without a real git worktree or the orphan branch. GitOps/Locks
+	// are stubbed at the top of this file for the same non-repo-cwd reason.
+	let globalDir: string;
+	let repo: string;
+	let transcript: string;
+
+	const HASH = "a".repeat(40);
+	const EDGE = { firstSeenAt: "2026-08-17T10:00:00.000Z", firstSeenLine: 0, lastSeenAt: "2026-08-17T10:00:00.000Z" };
+
+	function summary(over: Partial<CommitSummary> = {}): CommitSummary {
+		return {
+			version: 5,
+			commitHash: HASH,
+			commitMessage: "x",
+			commitAuthor: "a",
+			commitDate: "2026-08-17T11:00:00.000Z",
+			branch: "main",
+			generatedAt: "2026-08-17T11:00:05.000Z",
+			topics: [],
+			transcripts: [],
+			...over,
+		};
+	}
+
+	/** Same console.log-capture idiom as `runDoctor()` above, generalised to any callback. */
+	async function captureLog(fn: () => Promise<void>): Promise<string> {
+		const lines: string[] = [];
+		const spy = vi.spyOn(console, "log").mockImplementation((...a: unknown[]) => {
+			lines.push(a.map(String).join(" "));
+		});
+		try {
+			await fn();
+		} finally {
+			spy.mockRestore();
+		}
+		return lines.join("\n");
+	}
+
+	beforeEach(async () => {
+		globalDir = await mkdtemp(join(tmpdir(), "jolli-doctor-repair-g-"));
+		repo = await mkdtemp(join(tmpdir(), "jolli-doctor-repair-r-"));
+		transcript = join(globalDir, "s.jsonl");
+		// A real user turn (not just a bare `{cwd, timestamp}` line) — a line with
+		// no `message` object parses to zero entries, which would misreport every
+		// repair here as "no-entries-in-window".
+		await writeFile(
+			transcript,
+			`${JSON.stringify({
+				cwd: repo,
+				timestamp: "2026-08-17T10:00:00.000Z",
+				message: { role: "user", content: "hello" },
+			})}\n`,
+			"utf-8",
+		);
+		const st = await import("../core/SessionTracker.js");
+		vi.mocked(st.getGlobalConfigDir).mockReturnValue(globalDir);
+		setActiveStorage(createFolderStorageAtRoot(repo));
+		// What the cutover router hands the CLI entry: the same disk-backed fixture
+		// storage. Direct `runRepairTranscripts` unit calls ignore this (they use the
+		// pre-set active storage above); the `runDoctor` dispatch path consumes it.
+		h.createStorage.mockResolvedValue(createFolderStorageAtRoot(repo));
+	});
+
+	afterEach(() => {
+		setActiveStorage(undefined);
+	});
+
+	it("lists repair candidates without writing when --fix is absent", async () => {
+		await storeSummary(summary(), repo);
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[repo, EDGE]]) },
+			globalDir,
+		);
+
+		const out = await captureLog(() => runRepairTranscripts(repo, false));
+
+		expect(out).toContain("would repair");
+		expect((await getSummary(HASH, repo))?.transcripts ?? []).toHaveLength(0);
+	});
+
+	it("repairs and reports per-summary reasons with --fix", async () => {
+		await storeSummary(summary(), repo);
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[repo, EDGE]]) },
+			globalDir,
+		);
+
+		const out = await captureLog(() => runRepairTranscripts(repo, true));
+
+		expect(out).toContain("repaired");
+		expect((await getSummary(HASH, repo))?.transcripts).toHaveLength(1);
+	});
+
+	it("reports a clean result when no summary has an empty transcript list", async () => {
+		await storeSummary(summary({ transcripts: ["existing"] }), repo);
+
+		const out = await captureLog(() => runRepairTranscripts(repo, true));
+
+		expect(out).toContain("No summaries need transcript repair");
+	});
+
+	it("continues past a candidate whose repair throws, and the totals still add up", async () => {
+		// Two candidates: the default HASH one (which the mock lets through to
+		// the real engine and succeeds) and a second at the sentinel `throwHash`
+		// (which the TranscriptRepair.js mock above throws for, simulating real
+		// orphan-write-lock contention with a concurrently-running QueueWorker).
+		// Without per-candidate error isolation, the throw would abort the loop
+		// before the totals line ever printed and, depending on iteration order,
+		// might also swallow the first candidate's own line.
+		await storeSummary(summary(), repo);
+		await storeSummary(summary({ commitHash: h.throwHash }), repo);
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[repo, EDGE]]) },
+			globalDir,
+		);
+
+		const out = await captureLog(() => runRepairTranscripts(repo, true));
+
+		expect(out).toContain(`${h.throwHash.substring(0, 8)}  error — simulated lock contention`);
+		expect(out).toContain("repaired — 1 entries");
+		expect(out).toContain("Repaired 1 of 2 summaries.");
+		expect(out).toContain("1 errored — see above.");
+		// The surviving candidate's write still landed — one failure must not
+		// have rolled back or blocked an unrelated candidate's own repair.
+		expect((await getSummary(HASH, repo))?.transcripts).toHaveLength(1);
+	});
+
+	it("dispatches --repair-transcripts before the ordinary doctor report, honoring --fix", async () => {
+		await storeSummary(summary(), repo);
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[repo, EDGE]]) },
+			globalDir,
+		);
+		const st = await import("../core/SessionTracker.js");
+		vi.mocked(st.getGlobalConfigDir).mockReturnValue(globalDir);
+
+		const lines = await runDoctor(["--repair-transcripts", "--fix", "--cwd", repo]);
+		const out = lines.join("\n");
+
+		expect(out).toContain("repaired");
+		expect(out).not.toContain("Jolli Memory Doctor");
+		expect((await getSummary(HASH, repo))?.transcripts).toHaveLength(1);
+	});
+
+	it("establishes routed storage itself, so repair works when nothing pre-set the active storage", async () => {
+		// The real CLI entry never pre-sets active storage — the action handler must
+		// route its own via createStorage(cwd) (which the cutover router points at
+		// SQLite on a cutover repo). Without that, resolveStorage falls back to the
+		// system of record, which is FROZEN after cutover, and the repair reads
+		// nothing while claiming success. Plant the candidate through the fixture
+		// storage, then clear the global so the command is forced to re-establish it.
+		await storeSummary(summary(), repo);
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[repo, EDGE]]) },
+			globalDir,
+		);
+		setActiveStorage(undefined);
+		const st = await import("../core/SessionTracker.js");
+		vi.mocked(st.getGlobalConfigDir).mockReturnValue(globalDir);
+		// The system-of-record the command wrongly falls back to today is reachable
+		// but empty — post-cutover the orphan branch is frozen and holds nothing the
+		// routed SQLite storage has. So a fallback read finds zero candidates.
+		h.resolveSotBackend.mockResolvedValue({
+			ok: true,
+			state: "cutover",
+			storage: createFolderStorageAtRoot(await mkdtemp(join(tmpdir(), "jolli-doctor-repair-sot-"))),
+		});
+
+		const lines = await runDoctor(["--repair-transcripts", "--fix", "--cwd", repo]);
+
+		expect(lines.join("\n")).toContain("repaired");
+		expect((await getSummary(HASH, repo))?.transcripts).toHaveLength(1);
+	});
+
+	it("does not apply the repair through the CLI when --fix is omitted", async () => {
+		// Distinct from the unit-level "lists ... without writing" test above:
+		// that one calls runRepairTranscripts directly with apply=false, so it
+		// cannot catch a dispatch bug that hardcodes `apply: true` (or any other
+		// constant) instead of threading `options.fix === true` through.
+		await storeSummary(summary(), repo);
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[repo, EDGE]]) },
+			globalDir,
+		);
+		const st = await import("../core/SessionTracker.js");
+		vi.mocked(st.getGlobalConfigDir).mockReturnValue(globalDir);
+
+		const lines = await runDoctor(["--repair-transcripts", "--cwd", repo]);
+		const out = lines.join("\n");
+
+		expect(out).toContain("would repair");
+		expect((await getSummary(HASH, repo))?.transcripts ?? []).toHaveLength(0);
 	});
 });

--- a/cli/src/commands/DoctorCommand.ts
+++ b/cli/src/commands/DoctorCommand.ts
@@ -22,6 +22,10 @@ import { localAgentToolLabel, localAgentToolLoginHint } from "../core/localagent
 import { readManualDisableFlag } from "../core/RepoProfile.js";
 import { countActiveQueueEntries, getGlobalConfigDir, loadAllSessions, loadConfig } from "../core/SessionTracker.js";
 import { resolveSotBackend } from "../core/SotStorageResolver.js";
+import { createStorage } from "../core/StorageFactory.js";
+import { listSummaries, setActiveStorage } from "../core/SummaryStore.js";
+import { getTranscriptIds } from "../core/SummaryTree.js";
+import { repairSummaryTranscripts } from "../core/TranscriptRepair.js";
 import { probeGlobalDaemon } from "../daemon/EnsureGlobalDaemon.js";
 import type { GlobalDaemonHello } from "../daemon/GlobalDaemonProtocol.js";
 import { backupHealthCheck } from "../dashboard/Backup.js";
@@ -1044,6 +1048,71 @@ export async function runSessionSyncNow(): Promise<void> {
 	if (outcome.status === "failed") process.exitCode = 1;
 }
 
+/**
+ * `doctor --repair-transcripts` — offers, or performs, Task 7's bounded repair
+ * for every summary this repo stored with `transcripts: []`.
+ *
+ * List-then-act, mirroring `--recover`: the bare flag reports what it WOULD do
+ * and `--fix` performs it. Repair rewrites a stored memory from local
+ * transcript history that may be days old and is pruned on the agent's own
+ * schedule — never something a diagnostic command applies on its own. Running
+ * the bare flag first lets the user see every candidate's verdict (including
+ * the ones the engine will refuse — no owner proof, a vanished transcript, an
+ * unbounded window) before anything is written.
+ *
+ * The candidate filter mirrors `repairSummaryTranscripts`'s own "already
+ * present" check exactly, so this list and the engine's per-summary verdicts
+ * can never disagree about which summaries are in scope.
+ *
+ * Per-candidate errors are caught, not propagated: this runs over every
+ * candidate in the repo (plausibly hundreds), and `repairSummaryTranscripts`
+ * is not throw-free — under `apply: true` it writes through
+ * `withRequiredOrphanWriteLock`, which throws `OrphanWriteBusyError` on lock
+ * contention with a concurrently-running `QueueWorker`, and a corrupted
+ * on-disk summary or ownership ledger can throw earlier still. Letting one
+ * such failure abort the loop would deny every remaining candidate a verdict
+ * over an error this command is explicitly meant to run past. An error is
+ * reported inline and counted separately from both "repaired" and "skipped"
+ * — it is not an engine verdict (`RepairOutcome.reason` stays the engine's
+ * alone; this runner does not invent a seventh reason for it).
+ */
+export async function runRepairTranscripts(cwd: string, apply: boolean): Promise<void> {
+	const summaries = await listSummaries(Number.MAX_SAFE_INTEGER, cwd);
+	const candidates = summaries.filter(
+		(s) => s.transcriptsRepairedAt === undefined && getTranscriptIds(s).length === 0,
+	);
+	if (candidates.length === 0) {
+		console.log("No summaries need transcript repair.");
+		return;
+	}
+
+	let repaired = 0;
+	let errored = 0;
+	for (const candidate of candidates) {
+		const hash = candidate.commitHash.substring(0, 8);
+		let outcome: Awaited<ReturnType<typeof repairSummaryTranscripts>>;
+		try {
+			outcome = await repairSummaryTranscripts(candidate.commitHash, cwd, { apply });
+		} catch (err) {
+			errored++;
+			console.log(`  ${hash}  error — ${errMsg(err)}`);
+			continue;
+		}
+		if (outcome.repaired) {
+			repaired++;
+			console.log(`  ${hash}  ${apply ? "repaired" : "would repair"} — ${outcome.entries} entries`);
+		} else {
+			console.log(`  ${hash}  skipped — ${outcome.reason}`);
+		}
+	}
+	console.log(
+		(apply
+			? `Repaired ${repaired} of ${candidates.length} summaries.`
+			: `${repaired} of ${candidates.length} summaries can be repaired. Re-run with --fix to apply.`) +
+			(errored > 0 ? ` ${errored} errored — see above.` : ""),
+	);
+}
+
 /** Registers the `doctor` sub-command on the given Commander program. */
 export function registerDoctorCommand(program: Command): void {
 	program
@@ -1066,6 +1135,7 @@ export function registerDoctorCommand(program: Command): void {
 			"--sync-sessions",
 			"Upload pending session statistics now, ignoring the throttle and any 24h backend silence",
 		)
+		.option("--repair-transcripts", "Refill summaries written with no conversation from local transcript history")
 		.option("--cwd <dir>", "Project directory (default: git repo root)", resolveProjectDir())
 		.action(
 			async (options: {
@@ -1078,6 +1148,7 @@ export function registerDoctorCommand(program: Command): void {
 				schemaLog?: boolean;
 				markMigration?: string;
 				syncSessions?: boolean;
+				repairTranscripts?: boolean;
 			}) => {
 				setLogDir(options.cwd);
 				log.info("Running 'doctor' command");
@@ -1094,6 +1165,16 @@ export function registerDoctorCommand(program: Command): void {
 				}
 				if (options.syncSessions === true) {
 					await runSessionSyncNow();
+					return;
+				}
+				if (options.repairTranscripts === true) {
+					// Route the active storage the way every other summary command does
+					// (PrDescriptionCommand, CompileCommand): createStorage consults the
+					// cutover state and points at SQLite on a cutover repo. Without this
+					// the repair falls back to the frozen system-of-record and silently
+					// reads — or on --fix, tries to write — the wrong backend.
+					setActiveStorage(await createStorage(options.cwd, options.cwd));
+					await runRepairTranscripts(options.cwd, options.fix === true);
 					return;
 				}
 				await runDoctor(

--- a/cli/src/commands/IdeBridgeCommand.test.ts
+++ b/cli/src/commands/IdeBridgeCommand.test.ts
@@ -347,6 +347,14 @@ vi.mock("../core/references/ReferenceStore.js", () => ({
 	readReferenceMarkdownFromString: vi.fn().mockReturnValue({ description: "desc" }),
 }));
 
+// The predicate itself is covered by TranscriptRepair.test.ts; here the bridge
+// action is an adapter, so what matters is that it forwards to this and reports
+// what it answers. Stubbed also because the real one reads the machine-global
+// `claude-owners.json` and stats every transcript path it names.
+vi.mock("../core/TranscriptRepair.js", () => ({
+	transcriptRepairState: vi.fn().mockResolvedValue("unrepairable"),
+}));
+
 vi.mock("../core/SummaryStore.js", () => ({
 	// Pass-through: the must-land D6 lock wrapper's own behavior is covered in
 	// SummaryStore/Locks tests; here only "the write happens under it" matters.
@@ -1415,6 +1423,65 @@ describe("runIdeBridgeAction — discard-preview", () => {
 		await runIdeBridgeAction("discard-preview", "/repo", { relativePaths: ["a.txt"] });
 
 		expect(discardFiles).not.toHaveBeenCalled();
+	});
+});
+
+describe("runIdeBridgeAction — transcript-repair-state", () => {
+	beforeEach(async () => {
+		// `mockClear` only — the file-scope mock's resolved value is shared with
+		// every other describe here, so replacing the implementation would leak
+		// out of this block and break them.
+		const { getSummary } = await import("../core/SummaryStore.js");
+		vi.mocked(getSummary).mockClear();
+		const { transcriptRepairState } = await import("../core/TranscriptRepair.js");
+		vi.mocked(transcriptRepairState).mockReset();
+		vi.mocked(transcriptRepairState).mockResolvedValue("repairable");
+	});
+
+	it("answers the CLI predicate's state for a known commit", async () => {
+		// The action must FORWARD the predicate, not restate it: a Kotlin- or
+		// host-side restatement of "can this still be repaired?" is exactly the
+		// drift this bridge exists to prevent. Asserting the returned state comes
+		// from the predicate (and that the summary + cwd reach it) is what fails if
+		// someone hard-codes an answer here.
+		const { transcriptRepairState } = await import("../core/TranscriptRepair.js");
+
+		const result = await runIdeBridgeAction("transcript-repair-state", "/repo", { commitHash: "abc" });
+
+		expect(result).toEqual({ state: "repairable" });
+		expect(transcriptRepairState).toHaveBeenCalledWith({ commitHash: "abc" }, "/repo");
+	});
+
+	it("passes every state through unchanged", async () => {
+		const { transcriptRepairState } = await import("../core/TranscriptRepair.js");
+		for (const state of ["present", "repaired", "repairable", "unrepairable"] as const) {
+			vi.mocked(transcriptRepairState).mockResolvedValue(state);
+			expect(await runIdeBridgeAction("transcript-repair-state", "/repo", { commitHash: "abc" })).toEqual({
+				state,
+			});
+		}
+	});
+
+	it("answers unrepairable for an unknown commit rather than throwing", async () => {
+		// The mildest verdict is the right way to fail: a memory we cannot even
+		// find is no evidence that a repair is possible, and "repair may still be
+		// possible" is the one wrong direction to guess in.
+		const { getSummary } = await import("../core/SummaryStore.js");
+		vi.mocked(getSummary).mockResolvedValueOnce(null);
+		const { transcriptRepairState } = await import("../core/TranscriptRepair.js");
+
+		const result = await runIdeBridgeAction("transcript-repair-state", "/repo", { commitHash: "f".repeat(40) });
+
+		expect(result).toEqual({ state: "unrepairable" });
+		expect(transcriptRepairState).not.toHaveBeenCalled();
+	});
+
+	it("treats a missing commitHash as an unknown commit", async () => {
+		const { getSummary } = await import("../core/SummaryStore.js");
+		vi.mocked(getSummary).mockResolvedValueOnce(null);
+
+		expect(await runIdeBridgeAction("transcript-repair-state", "/repo", {})).toEqual({ state: "unrepairable" });
+		expect(getSummary).toHaveBeenCalledWith("", "/repo");
 	});
 });
 

--- a/cli/src/commands/IdeBridgeCommand.ts
+++ b/cli/src/commands/IdeBridgeCommand.ts
@@ -12,6 +12,7 @@ import { isAbsolute } from "node:path";
 import type { LiveSharePatch, LiveSharePayload } from "../core/JolliShareClient.js";
 import type { SkillTableRow } from "../core/SkillsAggregateMarkdown.js";
 import { runWithTrace } from "../core/TraceContext.js";
+import type { TranscriptRepairState } from "../core/TranscriptRepair.js";
 import { buildRefreshParams, computeWatchTargets } from "../daemon/DaemonServer.js";
 import { DaemonWatcher } from "../daemon/DaemonWatcher.js";
 import { recordMemoryEdit } from "../dashboard/ProducerHooks.js";
@@ -1892,6 +1893,25 @@ export async function runIdeBridgeAction(action: string, cwd: string, request: J
 			return {
 				entries: await loadTranscript({ source, transcriptPath: stringField(request, "transcriptPath") }),
 			};
+		}
+		case "transcript-repair-state": {
+			// Which of the three sentences spec §9 allows the memory-detail UI to
+			// print. VS Code answers this by calling `transcriptRepairState`
+			// in-process; the JVM host cannot import `cli/src`, so without this
+			// action the whole distinction would be silently VS Code-only — no
+			// compile error, no failing test, just an IntelliJ tab that shows the
+			// plainest sentence forever.
+			//
+			// A summary we cannot find answers `unrepairable`, the MILDEST verdict,
+			// rather than throwing. "Repair may still be possible" is the one wrong
+			// direction to guess in: it invites the user to run a repair that has
+			// nothing to work from, and a memory nobody can look up is no evidence
+			// that local transcripts survive.
+			const { getSummary } = await import("../core/SummaryStore.js");
+			const summary = await getSummary(optionalString(request, "commitHash") ?? "", cwd);
+			if (!summary) return { state: "unrepairable" satisfies TranscriptRepairState };
+			const { transcriptRepairState } = await import("../core/TranscriptRepair.js");
+			return { state: await transcriptRepairState(summary, cwd) };
 		}
 		case "compile": {
 			const config = request.config as JolliMemoryConfig | undefined;

--- a/cli/src/core/AgentSessionEnv.test.ts
+++ b/cli/src/core/AgentSessionEnv.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { currentAgentSessionId } from "./AgentSessionEnv.js";
+
+const KEY = "CLAUDE_CODE_SESSION_ID";
+const original = process.env[KEY];
+
+afterEach(() => {
+	if (original === undefined) delete process.env[KEY];
+	else process.env[KEY] = original;
+});
+
+describe("currentAgentSessionId", () => {
+	it("returns the Claude Code session id when the environment advertises one", () => {
+		process.env[KEY] = "4ad551f5-35b5-4331-b807-987843d81113";
+		expect(currentAgentSessionId()).toBe("4ad551f5-35b5-4331-b807-987843d81113");
+	});
+
+	it("trims surrounding whitespace", () => {
+		process.env[KEY] = "  sid-123  ";
+		expect(currentAgentSessionId()).toBe("sid-123");
+	});
+
+	it("is undefined when the variable is unset (plain terminal, or a host that advertises nothing)", () => {
+		delete process.env[KEY];
+		expect(currentAgentSessionId()).toBeUndefined();
+	});
+
+	it("is undefined for a blank value rather than returning an empty id", () => {
+		process.env[KEY] = "   ";
+		expect(currentAgentSessionId()).toBeUndefined();
+	});
+});

--- a/cli/src/core/AgentSessionEnv.ts
+++ b/cli/src/core/AgentSessionEnv.ts
@@ -1,0 +1,49 @@
+/**
+ * The agent session a process is running inside, when one advertised itself in
+ * the environment. Shared by every surface that needs to know "which session am
+ * I a child of" — the recall-receipt producer ([ProducerHooks.ts](../dashboard/ProducerHooks.ts))
+ * and the post-commit hook, which stamps it onto the queue entry so a commit
+ * made from one worktree can be attributed to the session that authored it even
+ * when that session ran in another checkout.
+ */
+
+/**
+ * Environment variables that carry the id of the agent session this process is
+ * running inside, most-specific first.
+ *
+ * **One entry, and that is a measured result rather than an unfinished list.**
+ * Claude Code exports `CLAUDE_CODE_SESSION_ID`, and it is the same uuid
+ * `sessions.session_id` carries, so a value read from it joins straight onto the
+ * session row (verified against a live session). The other hosts were checked
+ * the only way that settles it — reading `/proc/<pid>/environ` of a running one
+ * — and they publish nothing usable:
+ *
+ *   - **codex**: the whole environment carries no session/conversation/thread
+ *     variable; the only codex-specific entry is
+ *     `CODEX_INTERNAL_ORIGINATOR_OVERRIDE`, which names the front-end, not the
+ *     session. Its session id exists only inside its own rollout files.
+ *
+ * So a caller running under those hosts gets `undefined`, and that is the honest
+ * answer rather than a gap to paper over: the tempting fallback — pick the most
+ * recently touched session for this repo — is a GUESS that looks exactly like a
+ * fact once stored, and would attribute work to a session that never did it in
+ * the one direction nobody can audit. A null is visible as a null; an invented
+ * id is not.
+ *
+ * Adding a host means measuring it the same way and appending its real variable
+ * name here; nothing else changes.
+ */
+export const SESSION_ID_ENV_VARS: ReadonlyArray<string> = ["CLAUDE_CODE_SESSION_ID"];
+
+/**
+ * The agent session this process is running inside, or `undefined` for a plain
+ * terminal and for every host in the note above. A blank value is treated as
+ * absent rather than returned as an empty id.
+ */
+export function currentAgentSessionId(): string | undefined {
+	for (const name of SESSION_ID_ENV_VARS) {
+		const id = process.env[name]?.trim();
+		if (id) return id;
+	}
+	return undefined;
+}

--- a/cli/src/core/ClaudeOwnerScan.test.ts
+++ b/cli/src/core/ClaudeOwnerScan.test.ts
@@ -1,0 +1,197 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { resolveWorktreeRootOrNull } from "./GitOps.js";
+
+vi.mock("./GitOps.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("./GitOps.js")>()),
+	// `defaultResolveRoot` resolves through the null-returning variant so a
+	// non-git cwd never becomes an owner root. Identity here so the temp-dir
+	// fixtures below (not real git worktrees) resolve to themselves.
+	resolveWorktreeRootOrNull: vi.fn((cwd: string) => cwd),
+}));
+
+import { scanOwnerEdges, scanOwnersWithCursor } from "./ClaudeOwnerScan.js";
+import { loadClaudeOwners } from "./ClaudeOwnership.js";
+import { loadExtractorCursorLine, saveExtractorCursor } from "./SessionTracker.js";
+
+/** One transcript line carrying a cwd and a timestamp. */
+function line(cwd: string, ts: string): string {
+	return JSON.stringify({ cwd, timestamp: ts, message: { role: "user", content: "hi" } });
+}
+
+// Identity roots: each cwd's first path segment pair is its "worktree root".
+const roots = (cwd: string): string | null => (cwd.startsWith("/repo/") ? `/repo/${cwd.split("/")[2]}` : null);
+
+describe("scanOwnerEdges", () => {
+	it("records one edge per distinct worktree root", () => {
+		const lines = [
+			line("/repo/a", "2026-08-17T10:00:00.000Z"),
+			line("/repo/b/sub", "2026-08-17T10:01:00.000Z"),
+			line("/repo/a/deep", "2026-08-17T10:02:00.000Z"),
+		];
+		const { edges } = scanOwnerEdges(lines, 0, roots);
+		expect([...edges.keys()].sort()).toEqual(["/repo/a", "/repo/b"]);
+		expect(edges.get("/repo/a")?.firstSeenLine).toBe(0);
+		expect(edges.get("/repo/b")?.firstSeenLine).toBe(1);
+	});
+
+	it("keeps the FIRST line of a root and the LAST timestamp/cwd", () => {
+		const lines = [line("/repo/a", "2026-08-17T10:00:00.000Z"), line("/repo/a/sub", "2026-08-17T10:09:00.000Z")];
+		const edge = scanOwnerEdges(lines, 0, roots).edges.get("/repo/a");
+		expect(edge?.firstSeenLine).toBe(0);
+		expect(edge?.firstSeenAt).toBe("2026-08-17T10:00:00.000Z");
+		expect(edge?.firstSeenCwd).toBe("/repo/a");
+		expect(edge?.lastSeenAt).toBe("2026-08-17T10:09:00.000Z");
+		expect(edge?.lastSeenCwd).toBe("/repo/a/sub");
+	});
+
+	it("numbers lines against the WHOLE file, not the scanned window", () => {
+		const lines = [
+			line("/repo/a", "2026-08-17T10:00:00.000Z"),
+			line("/repo/a", "2026-08-17T10:01:00.000Z"),
+			line("/repo/b", "2026-08-17T10:02:00.000Z"),
+		];
+		const { edges, lastLine } = scanOwnerEdges(lines, 2, roots);
+		expect([...edges.keys()]).toEqual(["/repo/b"]);
+		expect(edges.get("/repo/b")?.firstSeenLine).toBe(2);
+		expect(lastLine).toBe(3);
+	});
+
+	it("returns the line count as lastLine so the caller can advance its mark", () => {
+		expect(scanOwnerEdges([line("/repo/a", "2026-08-17T10:00:00.000Z")], 0, roots).lastLine).toBe(1);
+	});
+
+	it("skips lines with no cwd, an empty cwd, or unparseable JSON", () => {
+		const lines = [
+			"not json",
+			"{ this looks like json but is not",
+			JSON.stringify({ timestamp: "2026-08-17T10:00:00.000Z" }),
+			JSON.stringify({ cwd: "", timestamp: "2026-08-17T10:00:00.000Z" }),
+			line("/repo/a", "2026-08-17T10:03:00.000Z"),
+		];
+		const { edges } = scanOwnerEdges(lines, 0, roots);
+		expect([...edges.keys()]).toEqual(["/repo/a"]);
+		expect(edges.get("/repo/a")?.firstSeenLine).toBe(4);
+	});
+
+	it("skips a cwd that resolves to no worktree root", () => {
+		const { edges } = scanOwnerEdges([line("/tmp/scratch", "2026-08-17T10:00:00.000Z")], 0, roots);
+		expect(edges.size).toBe(0);
+	});
+
+	it("falls back to a caller-supplied instant when a line carries no timestamp", () => {
+		const lines = [JSON.stringify({ cwd: "/repo/a" })];
+		const edge = scanOwnerEdges(lines, 0, roots, () => "2026-08-17T12:00:00.000Z").edges.get("/repo/a");
+		expect(edge?.firstSeenAt).toBe("2026-08-17T12:00:00.000Z");
+	});
+
+	it("falls back to the default clock when neither a timestamp nor a `now` override is given", () => {
+		const lines = [JSON.stringify({ cwd: "/repo/a" })];
+		const edge = scanOwnerEdges(lines, 0, roots).edges.get("/repo/a");
+		// Real wall-clock ISO string — assert shape, not an exact value.
+		expect(edge?.firstSeenAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+	});
+
+	it("reuses a cached root resolution for a repeated cwd", () => {
+		const resolveRootSpy = vi.fn(roots);
+		const lines = [line("/repo/a", "2026-08-17T10:00:00.000Z"), line("/repo/a", "2026-08-17T10:01:00.000Z")];
+		scanOwnerEdges(lines, 0, resolveRootSpy);
+		expect(resolveRootSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns no edges for an empty window", () => {
+		const { edges, lastLine } = scanOwnerEdges([], 0, roots);
+		expect(edges.size).toBe(0);
+		expect(lastLine).toBe(0);
+	});
+
+	// The brief's tests above all supply `roots` explicitly, so none of them ever
+	// exercise `defaultResolveRoot` — the parameter's own default value. These
+	// three cover it directly, including the catch path no other test reaches.
+	describe("default resolver (no resolveRoot argument supplied)", () => {
+		it("uses resolveWorktreeRootOrNull when the caller supplies no resolver", () => {
+			vi.mocked(resolveWorktreeRootOrNull).mockReturnValueOnce("/mocked/root");
+			const { edges } = scanOwnerEdges([line("/whatever", "2026-08-17T10:00:00.000Z")], 0);
+			expect([...edges.keys()]).toEqual(["/mocked/root"]);
+		});
+
+		it("treats a null resolved root (non-git cwd) as no owner", () => {
+			vi.mocked(resolveWorktreeRootOrNull).mockReturnValueOnce(null);
+			const { edges } = scanOwnerEdges([line("/whatever", "2026-08-17T10:00:00.000Z")], 0);
+			expect(edges.size).toBe(0);
+		});
+
+		it("swallows a throwing resolver and treats the line as ownerless", () => {
+			vi.mocked(resolveWorktreeRootOrNull).mockImplementationOnce(() => {
+				throw new Error("boom");
+			});
+			const { edges } = scanOwnerEdges([line("/whatever", "2026-08-17T10:00:00.000Z")], 0);
+			expect(edges.size).toBe(0);
+		});
+	});
+});
+
+describe("scanOwnersWithCursor", () => {
+	it("records edges and advances only the owners mark", async () => {
+		const global = await mkdtemp(join(tmpdir(), "jolli-owners-g-"));
+		const repo = await mkdtemp(join(tmpdir(), "jolli-owners-r-"));
+		const transcript = join(global, "s1.jsonl");
+		await writeFile(
+			transcript,
+			`${JSON.stringify({ cwd: repo, timestamp: "2026-08-17T10:00:00.000Z" })}\n`,
+			"utf-8",
+		);
+
+		await scanOwnersWithCursor(transcript, "s1", repo, global);
+
+		const ledger = await loadClaudeOwners(global);
+		expect(Object.keys(ledger.sessions)).toEqual(["claude:s1"]);
+		expect(await loadExtractorCursorLine(transcript, "owners", repo)).toBe(1);
+		expect(await loadExtractorCursorLine(transcript, "plans", repo)).toBe(0);
+	});
+
+	it("re-scans nothing once the mark has passed the file", async () => {
+		const global = await mkdtemp(join(tmpdir(), "jolli-owners-g2-"));
+		const repo = await mkdtemp(join(tmpdir(), "jolli-owners-r2-"));
+		const transcript = join(global, "s2.jsonl");
+		await writeFile(
+			transcript,
+			`${JSON.stringify({ cwd: repo, timestamp: "2026-08-17T10:00:00.000Z" })}\n`,
+			"utf-8",
+		);
+		await saveExtractorCursor(transcript, "owners", 1, repo);
+
+		await scanOwnersWithCursor(transcript, "s2", repo, global);
+
+		expect(await loadClaudeOwners(global)).toEqual({ version: 1, sessions: {} });
+	});
+
+	it("never throws when the transcript is missing", async () => {
+		const global = await mkdtemp(join(tmpdir(), "jolli-owners-g3-"));
+		const repo = await mkdtemp(join(tmpdir(), "jolli-owners-r3-"));
+		await expect(scanOwnersWithCursor(join(repo, "gone.jsonl"), "s3", repo, global)).resolves.toBeUndefined();
+	});
+
+	it("does NOT advance the owners mark when the ledger write was not durable", async () => {
+		// A best-effort (unlocked) write can be clobbered by a concurrent peer, so
+		// advancing past these lines would strand the dropped edge forever. The
+		// injected recorder reports `false` (undurable); the cursor must stay at 0
+		// so the next Stop hook re-scans and re-emits.
+		const global = await mkdtemp(join(tmpdir(), "jolli-owners-g4-"));
+		const repo = await mkdtemp(join(tmpdir(), "jolli-owners-r4-"));
+		const transcript = join(global, "s4.jsonl");
+		await writeFile(
+			transcript,
+			`${JSON.stringify({ cwd: repo, timestamp: "2026-08-17T10:00:00.000Z" })}\n`,
+			"utf-8",
+		);
+
+		const undurable = vi.fn(async () => false);
+		await scanOwnersWithCursor(transcript, "s4", repo, global, undurable);
+
+		expect(undurable).toHaveBeenCalledOnce();
+		expect(await loadExtractorCursorLine(transcript, "owners", repo)).toBe(0);
+	});
+});

--- a/cli/src/core/ClaudeOwnerScan.test.ts
+++ b/cli/src/core/ClaudeOwnerScan.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -12,13 +12,27 @@ vi.mock("./GitOps.js", async (importOriginal) => ({
 	resolveWorktreeRootOrNull: vi.fn((cwd: string) => cwd),
 }));
 
-import { scanOwnerEdges, scanOwnersWithCursor } from "./ClaudeOwnerScan.js";
-import { loadClaudeOwners } from "./ClaudeOwnership.js";
+import {
+	backfillExecutingSessionOwnership,
+	resolveClaudeTranscriptPath,
+	scanOwnerEdges,
+	scanOwnersWithCursor,
+} from "./ClaudeOwnerScan.js";
+import { claudeSessionsOwnedBy, loadClaudeOwners } from "./ClaudeOwnership.js";
 import { loadExtractorCursorLine, saveExtractorCursor } from "./SessionTracker.js";
 
 /** One transcript line carrying a cwd and a timestamp. */
 function line(cwd: string, ts: string): string {
 	return JSON.stringify({ cwd, timestamp: ts, message: { role: "user", content: "hi" } });
+}
+
+/** An assistant tool_use line: one `tool` call whose `input[key]` names a file. */
+function toolLine(cwd: string, ts: string, tool: string, key: string, path: string): string {
+	return JSON.stringify({
+		cwd,
+		timestamp: ts,
+		message: { role: "assistant", content: [{ type: "tool_use", name: tool, input: { [key]: path } }] },
+	});
 }
 
 // Identity roots: each cwd's first path segment pair is its "worktree root".
@@ -130,6 +144,159 @@ describe("scanOwnerEdges", () => {
 			const { edges } = scanOwnerEdges([line("/whatever", "2026-08-17T10:00:00.000Z")], 0);
 			expect(edges.size).toBe(0);
 		});
+	});
+});
+
+describe("scanOwnerEdges — edited-file ownership", () => {
+	it("records an edge for the worktree root of a file the session EDITED, on top of the cwd edge", () => {
+		const lines = [toolLine("/repo/a", "2026-08-17T10:00:00.000Z", "Edit", "file_path", "/repo/b/src/x.ts")];
+		const { edges } = scanOwnerEdges(lines, 0, roots);
+		expect([...edges.keys()].sort()).toEqual(["/repo/a", "/repo/b"]);
+		expect(edges.get("/repo/b")?.firstSeenLine).toBe(0);
+	});
+
+	it("recognizes Write, MultiEdit, and NotebookEdit as authoring a file", () => {
+		const cases: Array<[string, string, string]> = [
+			["Write", "file_path", "/repo/b/w.ts"],
+			["MultiEdit", "file_path", "/repo/b/m.ts"],
+			["NotebookEdit", "notebook_path", "/repo/b/n.ipynb"],
+		];
+		for (const [tool, key, path] of cases) {
+			const { edges } = scanOwnerEdges(
+				[toolLine("/repo/a", "2026-08-17T10:00:00.000Z", tool, key, path)],
+				0,
+				roots,
+			);
+			expect(edges.has("/repo/b")).toBe(true);
+		}
+	});
+
+	it("does NOT create an edge for a file that was only READ (read-only tools author nothing)", () => {
+		for (const tool of ["Read", "Grep", "Glob", "Bash"]) {
+			const { edges } = scanOwnerEdges(
+				[toolLine("/repo/a", "2026-08-17T10:00:00.000Z", tool, "file_path", "/repo/b/x.ts")],
+				0,
+				roots,
+			);
+			expect([...edges.keys()]).toEqual(["/repo/a"]);
+		}
+	});
+
+	it("resolves a relative edited path against the line cwd", () => {
+		// join("/repo/a/sub", "../../b/x.ts") === "/repo/b/x.ts" → dirname "/repo/b"
+		const lines = [toolLine("/repo/a/sub", "2026-08-17T10:00:00.000Z", "Edit", "file_path", "../../b/x.ts")];
+		const { edges } = scanOwnerEdges(lines, 0, roots);
+		expect(edges.has("/repo/b")).toBe(true);
+	});
+
+	it("merges an edited-file edge into the cwd edge when they share a root", () => {
+		const lines = [toolLine("/repo/a", "2026-08-17T10:00:00.000Z", "Edit", "file_path", "/repo/a/x.ts")];
+		const { edges } = scanOwnerEdges(lines, 0, roots);
+		expect([...edges.keys()]).toEqual(["/repo/a"]);
+		expect(edges.get("/repo/a")?.firstSeenLine).toBe(0);
+	});
+
+	it("stamps the EDITING line as firstSeenLine for the edited root", () => {
+		const lines = [
+			line("/repo/a", "2026-08-17T10:00:00.000Z"),
+			toolLine("/repo/a", "2026-08-17T10:01:00.000Z", "Edit", "file_path", "/repo/b/x.ts"),
+		];
+		const { edges } = scanOwnerEdges(lines, 0, roots);
+		expect(edges.get("/repo/a")?.firstSeenLine).toBe(0);
+		expect(edges.get("/repo/b")?.firstSeenLine).toBe(1);
+	});
+
+	it("ignores an edited path whose directory resolves to no worktree root", () => {
+		const lines = [toolLine("/repo/a", "2026-08-17T10:00:00.000Z", "Edit", "file_path", "/tmp/scratch/x.ts")];
+		const { edges } = scanOwnerEdges(lines, 0, roots);
+		expect([...edges.keys()]).toEqual(["/repo/a"]);
+	});
+
+	it("tolerates malformed content blocks and non-string paths without a spurious edge", () => {
+		// content is an array of junk: a null block, a text block, a tool_use with no
+		// name, an Edit with no input, and an Edit whose file_path is not a string.
+		const lines = [
+			JSON.stringify({
+				cwd: "/repo/a",
+				timestamp: "2026-08-17T10:00:00.000Z",
+				message: {
+					role: "assistant",
+					content: [
+						null,
+						{ type: "text", text: "thinking" },
+						{ type: "tool_use", input: { file_path: "/repo/b/x.ts" } },
+						{ type: "tool_use", name: "Edit" },
+						{ type: "tool_use", name: "Edit", input: { file_path: 42 } },
+					],
+				},
+			}),
+		];
+		const { edges } = scanOwnerEdges(lines, 0, roots);
+		expect([...edges.keys()]).toEqual(["/repo/a"]);
+	});
+});
+
+describe("resolveClaudeTranscriptPath", () => {
+	it("finds <projectsDir>/<any>/<sessionId>.jsonl", async () => {
+		const projects = await mkdtemp(join(tmpdir(), "jolli-proj-"));
+		const proj = join(projects, "-Users-me-repo");
+		await mkdir(proj);
+		const transcript = join(proj, "sid-1.jsonl");
+		await writeFile(transcript, "", "utf-8");
+		expect(await resolveClaudeTranscriptPath("sid-1", projects)).toBe(transcript);
+	});
+
+	it("returns null when no project directory holds the session", async () => {
+		const projects = await mkdtemp(join(tmpdir(), "jolli-proj2-"));
+		await mkdir(join(projects, "-Users-me-repo"));
+		expect(await resolveClaudeTranscriptPath("missing", projects)).toBeNull();
+	});
+
+	it("returns null when the projects directory does not exist", async () => {
+		expect(await resolveClaudeTranscriptPath("sid", join(tmpdir(), "jolli-no-such-dir-xyz"))).toBeNull();
+	});
+});
+
+describe("backfillExecutingSessionOwnership", () => {
+	const NOW = "2026-08-17T10:00:00.000Z";
+	/** An assistant Edit line: cwd=`cwd`, editing the absolute path `file`. */
+	const editLine = (cwd: string, file: string) =>
+		JSON.stringify({
+			cwd,
+			timestamp: NOW,
+			message: { role: "assistant", content: [{ type: "tool_use", name: "Edit", input: { file_path: file } }] },
+		});
+
+	it("records an owner edge for a worktree the executing session EDITED but never cd'd into", async () => {
+		const global = await mkdtemp(join(tmpdir(), "jolli-exec-g-"));
+		const worktreeB = await mkdtemp(join(tmpdir(), "jolli-exec-b-"));
+		const transcript = join(global, "exec.jsonl");
+		// Session sat in /elsewhere/A the whole time, but authored a file under B.
+		await writeFile(transcript, `${editLine("/elsewhere/A", join(worktreeB, "x.ts"))}\n`, "utf-8");
+
+		await backfillExecutingSessionOwnership("exec-1", worktreeB, global, async () => transcript);
+
+		const owned = await claudeSessionsOwnedBy(worktreeB, global);
+		expect(owned.map((o) => o.sessionId)).toEqual(["exec-1"]);
+	});
+
+	it("records NOTHING for B when the session neither entered nor authored under B", async () => {
+		const global = await mkdtemp(join(tmpdir(), "jolli-exec-g2-"));
+		const worktreeB = await mkdtemp(join(tmpdir(), "jolli-exec-b2-"));
+		const transcript = join(global, "exec2.jsonl");
+		// cwd and edit are both under /elsewhere/A — no evidence for B.
+		await writeFile(transcript, `${editLine("/elsewhere/A", "/elsewhere/A/x.ts")}\n`, "utf-8");
+
+		await backfillExecutingSessionOwnership("exec-2", worktreeB, global, async () => transcript);
+
+		expect(await claudeSessionsOwnedBy(worktreeB, global)).toEqual([]);
+	});
+
+	it("is a no-op when the executing session's transcript cannot be located", async () => {
+		const global = await mkdtemp(join(tmpdir(), "jolli-exec-g3-"));
+		const worktreeB = await mkdtemp(join(tmpdir(), "jolli-exec-b3-"));
+		await backfillExecutingSessionOwnership("gone", worktreeB, global, async () => null);
+		expect(await loadClaudeOwners(global)).toEqual({ version: 1, sessions: {} });
 	});
 });
 

--- a/cli/src/core/ClaudeOwnerScan.ts
+++ b/cli/src/core/ClaudeOwnerScan.ts
@@ -1,0 +1,133 @@
+/**
+ * Turns a window of Claude transcript lines into owner edges.
+ *
+ * `cwd` is read off the RAW line object, never off `parseTranscriptLine`: Claude
+ * stamps it on records that are not conversation turns at all (`attachment`,
+ * `queue-operation`), and gating on the turn parser throws away most of the
+ * directories a session ever visited. This mirrors `ClaudeSessionDiscoverer`'s
+ * `scanSlice`, which learned the same lesson against 64 real transcripts.
+ *
+ * The index a line reports is its index in the WHOLE file, because it becomes a
+ * cursor lower bound — the caller passes the file's full `splitTranscriptLines`
+ * output plus the line to start at, rather than a pre-sliced window, so the two
+ * notions of "line N" cannot drift apart.
+ */
+
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { createLogger } from "../Logger.js";
+import { type ClaudeOwnerEdge, recordClaudeOwners } from "./ClaudeOwnership.js";
+import { resolveWorktreeRootOrNull } from "./GitOps.js";
+import { loadExtractorCursorLine, saveExtractorCursor } from "./SessionTracker.js";
+import { splitTranscriptLines } from "./TranscriptReader.js";
+
+const log = createLogger("ClaudeOwnerScan");
+
+/**
+ * A `cwd` → worktree-root resolver. Defaults to {@link resolveWorktreeRootOrNull},
+ * which realpaths and forward-slashes and returns null for a directory that is
+ * not inside any git worktree — so a scratch dir or `$HOME` a session merely
+ * `cd`-ed through is ignored rather than recorded as an owner root nobody will
+ * ever look up (which would be pure machine-global-ledger bloat, since a real
+ * worktree-root lookup can never match it). `resolveStateRoot` is deliberately
+ * NOT used here: it echoes a non-git cwd straight back, so every such line would
+ * become a phantom owner.
+ */
+export type RootResolver = (cwd: string) => string | null;
+
+function defaultResolveRoot(cwd: string): string | null {
+	try {
+		return resolveWorktreeRootOrNull(cwd);
+	} catch {
+		return null;
+	}
+}
+
+export function scanOwnerEdges(
+	lines: ReadonlyArray<string>,
+	fromLine: number,
+	resolveRoot: RootResolver = defaultResolveRoot,
+	now: () => string = () => new Date().toISOString(),
+): { edges: Map<string, ClaudeOwnerEdge>; lastLine: number } {
+	const edges = new Map<string, ClaudeOwnerEdge>();
+	// Resolving a root shells out to the filesystem, so cache within the pass:
+	// a long session stamps the same handful of directories on thousands of lines.
+	const rootCache = new Map<string, string | null>();
+
+	for (let i = Math.max(0, fromLine); i < lines.length; i++) {
+		const text = lines[i].trim();
+		if (!text.startsWith("{")) continue;
+		let raw: { cwd?: unknown; timestamp?: unknown };
+		try {
+			raw = JSON.parse(text) as typeof raw;
+		} catch {
+			continue;
+		}
+		const cwd = typeof raw.cwd === "string" ? raw.cwd : "";
+		if (cwd.length === 0) continue;
+
+		let root = rootCache.get(cwd);
+		if (root === undefined) {
+			root = resolveRoot(cwd);
+			rootCache.set(cwd, root);
+		}
+		if (root === null) continue;
+
+		const at = typeof raw.timestamp === "string" && raw.timestamp.length > 0 ? raw.timestamp : now();
+		const prior = edges.get(root);
+		edges.set(
+			root,
+			prior
+				? { ...prior, lastSeenAt: at, lastSeenCwd: cwd }
+				: { firstSeenAt: at, firstSeenLine: i, lastSeenAt: at, firstSeenCwd: cwd, lastSeenCwd: cwd },
+		);
+	}
+
+	return { edges, lastLine: lines.length };
+}
+
+/**
+ * Scan one transcript for owner edges against the `owners` extractor's OWN
+ * high-water mark, advancing it only when it moved forward — the same three-step
+ * protocol as `scanSkillsWithCursor`, and for the same reason: advancing a
+ * monotonic mark without scanning, or on a throw, strands those lines forever.
+ *
+ * Deliberately independent of the shared `lineNumber` the plan/reference pair
+ * ride, so a dist that predates this extractor cannot advance past the lines it
+ * needs.
+ *
+ * Never throws — the Stop hook must survive an unreadable transcript.
+ */
+export async function scanOwnersWithCursor(
+	transcriptPath: string,
+	sessionId: string,
+	cwd: string,
+	globalDir?: string,
+	record: (
+		input: { sessionId: string; transcriptPath: string; edges: ReadonlyMap<string, ClaudeOwnerEdge> },
+		globalDir?: string,
+	) => Promise<boolean> = recordClaudeOwners,
+): Promise<void> {
+	try {
+		const fromLine = await loadExtractorCursorLine(transcriptPath, "owners", cwd);
+		const lines = splitTranscriptLines(await readFile(transcriptPath, "utf-8"));
+		if (lines.length <= fromLine) return;
+		const { edges, lastLine } = scanOwnerEdges(lines, fromLine);
+		// Advance the owners mark ONLY when the ledger write was durable. A
+		// best-effort (unlocked) write may have been clobbered by a concurrent
+		// peer, and advancing past these lines would strand the dropped edge
+		// forever — the recovery `withClaudeOwnersLock` promises but cannot
+		// itself deliver. Leaving the mark put makes the next Stop hook re-scan
+		// from here and re-emit idempotently.
+		const durable = await record({ sessionId, transcriptPath, edges }, globalDir);
+		if (!durable) return;
+		/* v8 ignore start -- `lastLine` is unconditionally `lines.length` (see scanOwnerEdges),
+		 * and the guard above already proved `lines.length > fromLine`, so this is always true
+		 * once reached. Kept as an explicit check anyway to mirror scanSkillsWithCursor's
+		 * protocol, whose `toLine` CAN fall short of `fromLine` (its scanner may return 0). */
+		if (lastLine > fromLine) await saveExtractorCursor(transcriptPath, "owners", lastLine, cwd);
+		/* v8 ignore stop */
+	} catch (err) {
+		log.warn("Owner discovery failed for %s: %s", basename(transcriptPath), (err as Error).message);
+	}
+}

--- a/cli/src/core/ClaudeOwnerScan.ts
+++ b/cli/src/core/ClaudeOwnerScan.ts
@@ -13,8 +13,9 @@
  * notions of "line N" cannot drift apart.
  */
 
-import { readFile } from "node:fs/promises";
-import { basename } from "node:path";
+import { access, readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, dirname, isAbsolute, join } from "node:path";
 import { createLogger } from "../Logger.js";
 import { type ClaudeOwnerEdge, recordClaudeOwners } from "./ClaudeOwnership.js";
 import { resolveWorktreeRootOrNull } from "./GitOps.js";
@@ -43,6 +44,42 @@ function defaultResolveRoot(cwd: string): string | null {
 	}
 }
 
+/**
+ * Tool names that AUTHOR a file, so the worktree they wrote into is one the
+ * session owns even when its cwd stayed elsewhere. Read-only tools (`Read`,
+ * `Grep`, `Glob`) and `Bash` are deliberately excluded: merely reading — or
+ * `cd`-ing through — a directory is not authorship, and treating it as such
+ * would flood the ledger with roots the session only browsed. `NotebookEdit`
+ * names its target `notebook_path`; the others use `file_path`.
+ */
+const WRITE_TOOLS: ReadonlyMap<string, string> = new Map([
+	["Edit", "file_path"],
+	["Write", "file_path"],
+	["MultiEdit", "file_path"],
+	["NotebookEdit", "notebook_path"],
+]);
+
+/**
+ * File paths authored by the write-tool calls on one transcript line. Reads the
+ * assistant turn's `message.content` blocks; a non-array content (a plain user
+ * string) or a line with no write-tool call yields nothing.
+ */
+function authoredPaths(raw: { message?: unknown }): string[] {
+	const content = (raw.message as { content?: unknown } | undefined)?.content;
+	if (!Array.isArray(content)) return [];
+	const paths: string[] = [];
+	for (const block of content) {
+		if (!block || typeof block !== "object") continue;
+		const b = block as { type?: unknown; name?: unknown; input?: unknown };
+		if (b.type !== "tool_use" || typeof b.name !== "string") continue;
+		const key = WRITE_TOOLS.get(b.name);
+		if (key === undefined) continue;
+		const value = (b.input as Record<string, unknown> | undefined)?.[key];
+		if (typeof value === "string" && value.length > 0) paths.push(value);
+	}
+	return paths;
+}
+
 export function scanOwnerEdges(
 	lines: ReadonlyArray<string>,
 	fromLine: number,
@@ -53,11 +90,32 @@ export function scanOwnerEdges(
 	// Resolving a root shells out to the filesystem, so cache within the pass:
 	// a long session stamps the same handful of directories on thousands of lines.
 	const rootCache = new Map<string, string | null>();
+	const resolveCached = (dir: string): string | null => {
+		let root = rootCache.get(dir);
+		if (root === undefined) {
+			root = resolveRoot(dir);
+			rootCache.set(dir, root);
+		}
+		return root;
+	};
+	// First contributor to a root fixes its `firstSeen*`; later ones on higher
+	// lines only extend `lastSeen*`. `dir` is the directory that resolved to the
+	// root — the session cwd for a cwd edge, the edited file's directory for an
+	// authored edge — so `firstSeenCwd`/`lastSeenCwd` stay under `root` either way.
+	const recordEdge = (root: string, i: number, at: string, dir: string): void => {
+		const prior = edges.get(root);
+		edges.set(
+			root,
+			prior
+				? { ...prior, lastSeenAt: at, lastSeenCwd: dir }
+				: { firstSeenAt: at, firstSeenLine: i, lastSeenAt: at, firstSeenCwd: dir, lastSeenCwd: dir },
+		);
+	};
 
 	for (let i = Math.max(0, fromLine); i < lines.length; i++) {
 		const text = lines[i].trim();
 		if (!text.startsWith("{")) continue;
-		let raw: { cwd?: unknown; timestamp?: unknown };
+		let raw: { cwd?: unknown; timestamp?: unknown; message?: unknown };
 		try {
 			raw = JSON.parse(text) as typeof raw;
 		} catch {
@@ -66,21 +124,20 @@ export function scanOwnerEdges(
 		const cwd = typeof raw.cwd === "string" ? raw.cwd : "";
 		if (cwd.length === 0) continue;
 
-		let root = rootCache.get(cwd);
-		if (root === undefined) {
-			root = resolveRoot(cwd);
-			rootCache.set(cwd, root);
-		}
-		if (root === null) continue;
-
 		const at = typeof raw.timestamp === "string" && raw.timestamp.length > 0 ? raw.timestamp : now();
-		const prior = edges.get(root);
-		edges.set(
-			root,
-			prior
-				? { ...prior, lastSeenAt: at, lastSeenCwd: cwd }
-				: { firstSeenAt: at, firstSeenLine: i, lastSeenAt: at, firstSeenCwd: cwd, lastSeenCwd: cwd },
-		);
+
+		// (1) The directory the session was IN — its cwd.
+		const cwdRoot = resolveCached(cwd);
+		if (cwdRoot !== null) recordEdge(cwdRoot, i, at, cwd);
+
+		// (2) The directories the session WROTE INTO on this line. A cross-worktree
+		// or cross-repo edit is authorship of that root even though the cwd never
+		// left this one — the high-frequency case a cwd-only ledger misses.
+		for (const path of authoredPaths(raw)) {
+			const dir = dirname(isAbsolute(path) ? path : join(cwd, path));
+			const editRoot = resolveCached(dir);
+			if (editRoot !== null) recordEdge(editRoot, i, at, dir);
+		}
 	}
 
 	return { edges, lastLine: lines.length };
@@ -130,4 +187,58 @@ export async function scanOwnersWithCursor(
 	} catch (err) {
 		log.warn("Owner discovery failed for %s: %s", basename(transcriptPath), (err as Error).message);
 	}
+}
+
+/**
+ * Locates a Claude session's transcript by id: `<projectsDir>/<slug>/<id>.jsonl`.
+ * Claude keys the project directory by the launch cwd's encoded path, so the id
+ * alone does not name it — but a session id is globally unique, so the first
+ * `<slug>/<id>.jsonl` that exists is the one. Returns null when no directory
+ * holds it (rotated away, or a host with no such tree). Never throws.
+ */
+export async function resolveClaudeTranscriptPath(
+	sessionId: string,
+	projectsDir: string = join(homedir(), ".claude", "projects"),
+): Promise<string | null> {
+	let slugs: string[];
+	try {
+		slugs = (await readdir(projectsDir, { withFileTypes: true })).filter((d) => d.isDirectory()).map((d) => d.name);
+	} catch {
+		return null; // projectsDir absent — nothing to resolve
+	}
+	for (const slug of slugs) {
+		const candidate = join(projectsDir, slug, `${sessionId}.jsonl`);
+		try {
+			await access(candidate);
+			return candidate;
+		} catch {
+			// not in this project dir — keep looking
+		}
+	}
+	return null;
+}
+
+/**
+ * Ensures the ownership ledger reflects a session that EXECUTED a commit in this
+ * worktree, for the case the forward Stop hook has not recorded yet: the edit and
+ * the commit happened in one turn, so the commit's worker drains before the Stop
+ * hook that would have written the edge. Given the executing session id (from the
+ * commit's inherited `CLAUDE_CODE_SESSION_ID`), it scans that session's own
+ * transcript through the SAME {@link scanOwnersWithCursor} the Stop hook uses —
+ * so a file the session authored under this worktree becomes an owner edge here,
+ * while a session that only ran `git commit` without authoring under this root
+ * records nothing, leaving the downstream `claudeSessionsOwnedBy` lookup to
+ * attribute neither.
+ *
+ * A no-op when the transcript cannot be located. Never throws.
+ */
+export async function backfillExecutingSessionOwnership(
+	sessionId: string,
+	cwd: string,
+	globalDir?: string,
+	resolveTranscript: (id: string) => Promise<string | null> = resolveClaudeTranscriptPath,
+): Promise<void> {
+	const transcriptPath = await resolveTranscript(sessionId);
+	if (transcriptPath === null) return;
+	await scanOwnersWithCursor(transcriptPath, sessionId, cwd, globalDir);
 }

--- a/cli/src/core/ClaudeOwnership.test.ts
+++ b/cli/src/core/ClaudeOwnership.test.ts
@@ -1,0 +1,334 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import { withIsolatedHome } from "../testUtils/isolatedHome.js";
+import {
+	type ClaudeOwnedSession,
+	type ClaudeOwnerEdge,
+	capLedgerSessions,
+	claudeOwnersPath,
+	claudeSessionsOwnedBy,
+	loadClaudeOwners,
+	recordClaudeOwners,
+} from "./ClaudeOwnership.js";
+
+let dir: string;
+
+function edge(over: Partial<ClaudeOwnerEdge> = {}): ClaudeOwnerEdge {
+	return {
+		firstSeenAt: "2026-08-17T10:00:00.000Z",
+		firstSeenLine: 12,
+		lastSeenAt: "2026-08-17T10:05:00.000Z",
+		...over,
+	};
+}
+
+beforeEach(async () => {
+	dir = await mkdtemp(join(tmpdir(), "jolli-owners-"));
+});
+
+describe("ClaudeOwnership", () => {
+	it("returns an empty ledger when the file does not exist", async () => {
+		expect(await loadClaudeOwners(dir)).toEqual({ version: 1, sessions: {} });
+	});
+
+	it("returns an empty ledger for unparseable JSON rather than throwing", async () => {
+		await writeFile(join(dir, "claude-owners.json"), "{ not json", "utf-8");
+		expect(await loadClaudeOwners(dir)).toEqual({ version: 1, sessions: {} });
+	});
+
+	it("records one session under two owner roots", async () => {
+		await recordClaudeOwners(
+			{
+				sessionId: "s1",
+				transcriptPath: "/t/s1.jsonl",
+				edges: new Map([
+					["/repo/a", edge({ firstSeenLine: 0 })],
+					["/repo/b", edge({ firstSeenLine: 412 })],
+				]),
+			},
+			dir,
+		);
+		const ledger = await loadClaudeOwners(dir);
+		expect(Object.keys(ledger.sessions)).toEqual(["claude:s1"]);
+		expect(Object.keys(ledger.sessions["claude:s1"].owners).sort()).toEqual(["/repo/a", "/repo/b"]);
+	});
+
+	it("extends an existing edge without resetting its first-seen position", async () => {
+		await recordClaudeOwners(
+			{
+				sessionId: "s1",
+				transcriptPath: "/t/s1.jsonl",
+				edges: new Map([["/repo/a", edge({ firstSeenLine: 12 })]]),
+			},
+			dir,
+		);
+		await recordClaudeOwners(
+			{
+				sessionId: "s1",
+				transcriptPath: "/t/s1.jsonl",
+				edges: new Map([
+					[
+						"/repo/a",
+						edge({
+							firstSeenAt: "2026-08-17T11:00:00.000Z",
+							firstSeenLine: 900,
+							lastSeenAt: "2026-08-17T11:00:00.000Z",
+							lastSeenCwd: "/repo/a/sub",
+						}),
+					],
+				]),
+			},
+			dir,
+		);
+		const owners = (await loadClaudeOwners(dir)).sessions["claude:s1"].owners;
+		expect(owners["/repo/a"].firstSeenLine).toBe(12);
+		expect(owners["/repo/a"].firstSeenAt).toBe("2026-08-17T10:00:00.000Z");
+		expect(owners["/repo/a"].lastSeenAt).toBe("2026-08-17T11:00:00.000Z");
+		expect(owners["/repo/a"].lastSeenCwd).toBe("/repo/a/sub");
+	});
+
+	it("adds a new owner to a session that already has one", async () => {
+		await recordClaudeOwners(
+			{ sessionId: "s1", transcriptPath: "/t/s1.jsonl", edges: new Map([["/repo/a", edge()]]) },
+			dir,
+		);
+		await recordClaudeOwners(
+			{
+				sessionId: "s1",
+				transcriptPath: "/t/s1.jsonl",
+				edges: new Map([["/repo/b", edge({ firstSeenLine: 77 })]]),
+			},
+			dir,
+		);
+		const owners = (await loadClaudeOwners(dir)).sessions["claude:s1"].owners;
+		expect(Object.keys(owners).sort()).toEqual(["/repo/a", "/repo/b"]);
+		expect(owners["/repo/b"].firstSeenLine).toBe(77);
+	});
+
+	it("queries sessions by owner root and ignores other owners' sessions", async () => {
+		await recordClaudeOwners(
+			{
+				sessionId: "s1",
+				transcriptPath: "/t/s1.jsonl",
+				edges: new Map([["/repo/a", edge({ firstSeenLine: 5 })]]),
+			},
+			dir,
+		);
+		await recordClaudeOwners(
+			{ sessionId: "s2", transcriptPath: "/t/s2.jsonl", edges: new Map([["/repo/b", edge()]]) },
+			dir,
+		);
+		const mine = await claudeSessionsOwnedBy("/repo/a", dir);
+		expect(mine).toEqual([
+			{ sessionId: "s1", transcriptPath: "/t/s1.jsonl", edge: expect.objectContaining({ firstSeenLine: 5 }) },
+		]);
+	});
+
+	it("writes valid JSON that a second load round-trips", async () => {
+		await recordClaudeOwners(
+			{ sessionId: "s1", transcriptPath: "/t/s1.jsonl", edges: new Map([["/repo/a", edge()]]) },
+			dir,
+		);
+		const raw = await readFile(join(dir, "claude-owners.json"), "utf-8");
+		expect(JSON.parse(raw)).toEqual(await loadClaudeOwners(dir));
+	});
+
+	it("records nothing when the edge map is empty", async () => {
+		await recordClaudeOwners({ sessionId: "s1", transcriptPath: "/t/s1.jsonl", edges: new Map() }, dir);
+		expect(await loadClaudeOwners(dir)).toEqual({ version: 1, sessions: {} });
+	});
+
+	it("reports a durable write when the lock is free, and a durable no-op for an empty edge map", async () => {
+		expect(
+			await recordClaudeOwners(
+				{ sessionId: "s1", transcriptPath: "/t/s1.jsonl", edges: new Map([["/repo/a", edge()]]) },
+				dir,
+			),
+		).toBe(true);
+		expect(
+			await recordClaudeOwners({ sessionId: "s1", transcriptPath: "/t/s1.jsonl", edges: new Map() }, dir),
+		).toBe(true);
+	});
+
+	it.each([
+		["a bare JSON null", "null"],
+		["a JSON array", "[]"],
+		["a JSON number", "42"],
+		["an object with no sessions field", "{}"],
+		["an object whose sessions field is null", '{"sessions":null}'],
+		["an object whose sessions field is not an object", '{"sessions":"oops"}'],
+	])("returns an empty ledger for %s rather than throwing", async (_label, content) => {
+		await writeFile(join(dir, "claude-owners.json"), content, "utf-8");
+		expect(await loadClaudeOwners(dir)).toEqual({ version: 1, sessions: {} });
+	});
+
+	it("does not move lastSeenAt backward when a later scan reports an older timestamp", async () => {
+		await recordClaudeOwners(
+			{
+				sessionId: "s1",
+				transcriptPath: "/t/s1.jsonl",
+				edges: new Map([["/repo/a", edge({ lastSeenAt: "2026-08-17T12:00:00.000Z" })]]),
+			},
+			dir,
+		);
+		await recordClaudeOwners(
+			{
+				sessionId: "s1",
+				transcriptPath: "/t/s1.jsonl",
+				edges: new Map([["/repo/a", edge({ lastSeenAt: "2026-08-17T09:00:00.000Z" })]]),
+			},
+			dir,
+		);
+		const owners = (await loadClaudeOwners(dir)).sessions["claude:s1"].owners;
+		expect(owners["/repo/a"].lastSeenAt).toBe("2026-08-17T12:00:00.000Z");
+	});
+
+	it("keeps a prior lastSeenCwd when a later scan's edge carries none", async () => {
+		await recordClaudeOwners(
+			{
+				sessionId: "s1",
+				transcriptPath: "/t/s1.jsonl",
+				edges: new Map([["/repo/a", edge({ lastSeenCwd: "/repo/a/sub" })]]),
+			},
+			dir,
+		);
+		await recordClaudeOwners(
+			{ sessionId: "s1", transcriptPath: "/t/s1.jsonl", edges: new Map([["/repo/a", edge()]]) },
+			dir,
+		);
+		const owners = (await loadClaudeOwners(dir)).sessions["claude:s1"].owners;
+		expect(owners["/repo/a"].lastSeenCwd).toBe("/repo/a/sub");
+	});
+
+	it("drops a session with malformed owners but keeps a well-formed sibling intact", async () => {
+		const malformed = JSON.stringify({
+			version: 1,
+			sessions: {
+				"claude:null-owners": {
+					sessionId: "null-owners",
+					transcriptPath: "/t/null-owners.jsonl",
+					source: "claude",
+					owners: null,
+				},
+				"claude:string-owners": {
+					sessionId: "string-owners",
+					transcriptPath: "/t/string-owners.jsonl",
+					source: "claude",
+					owners: "oops",
+				},
+				"claude:array-owners": {
+					sessionId: "array-owners",
+					transcriptPath: "/t/array-owners.jsonl",
+					source: "claude",
+					owners: [],
+				},
+				"claude:missing-owners": {
+					sessionId: "missing-owners",
+					transcriptPath: "/t/missing-owners.jsonl",
+					source: "claude",
+				},
+				"claude:null-session": null,
+				"claude:array-session": [],
+				"claude:good": {
+					sessionId: "good",
+					transcriptPath: "/t/good.jsonl",
+					source: "claude",
+					owners: { "/repo/a": edge({ firstSeenLine: 5 }) },
+				},
+			},
+		});
+		await writeFile(join(dir, "claude-owners.json"), malformed, "utf-8");
+		const ledger = await loadClaudeOwners(dir);
+		expect(Object.keys(ledger.sessions)).toEqual(["claude:good"]);
+		expect(ledger.sessions["claude:good"].owners["/repo/a"]).toEqual(edge({ firstSeenLine: 5 }));
+	});
+
+	it("claudeSessionsOwnedBy does not throw against a ledger with malformed owners and returns only the valid owner", async () => {
+		const malformed = JSON.stringify({
+			version: 1,
+			sessions: {
+				"claude:null-owners": {
+					sessionId: "null-owners",
+					transcriptPath: "/t/null-owners.jsonl",
+					source: "claude",
+					owners: null,
+				},
+				"claude:missing-owners": {
+					sessionId: "missing-owners",
+					transcriptPath: "/t/missing-owners.jsonl",
+					source: "claude",
+				},
+				"claude:good": {
+					sessionId: "good",
+					transcriptPath: "/t/good.jsonl",
+					source: "claude",
+					owners: { "/repo/a": edge({ firstSeenLine: 5 }) },
+				},
+			},
+		});
+		await writeFile(join(dir, "claude-owners.json"), malformed, "utf-8");
+		const mine = await claudeSessionsOwnedBy("/repo/a", dir);
+		expect(mine).toEqual([
+			{ sessionId: "good", transcriptPath: "/t/good.jsonl", edge: expect.objectContaining({ firstSeenLine: 5 }) },
+		]);
+	});
+
+	it("resolves against the machine-global config dir when globalDir is omitted", async () => {
+		await withIsolatedHome(dir, async () => {
+			await recordClaudeOwners({
+				sessionId: "s1",
+				transcriptPath: "/t/s1.jsonl",
+				edges: new Map([["/repo/a", edge()]]),
+			});
+			const ledger = await loadClaudeOwners();
+			expect(Object.keys(ledger.sessions)).toEqual(["claude:s1"]);
+			expect(claudeOwnersPath()).toBe(join(dir, ".jolli", "jollimemory", "claude-owners.json"));
+		});
+	});
+});
+
+describe("capLedgerSessions", () => {
+	function session(id: string, lastSeenAt: string): ClaudeOwnedSession {
+		return {
+			sessionId: id,
+			transcriptPath: `/t/${id}.jsonl`,
+			source: "claude",
+			owners: { "/repo/a": edge({ lastSeenAt }) },
+		};
+	}
+
+	it("returns the sessions unchanged (as a copy) when under the cap", () => {
+		const sessions = {
+			"claude:a": session("a", "2026-08-17T10:00:00.000Z"),
+			"claude:b": session("b", "2026-08-17T11:00:00.000Z"),
+		};
+		const out = capLedgerSessions(sessions, "claude:b", 5);
+		expect(Object.keys(out).sort()).toEqual(["claude:a", "claude:b"]);
+		expect(out).not.toBe(sessions);
+	});
+
+	it("evicts the OLDEST sessions by lastSeenAt when over the cap", () => {
+		const sessions = {
+			"claude:old": session("old", "2026-08-17T08:00:00.000Z"),
+			"claude:mid": session("mid", "2026-08-17T09:00:00.000Z"),
+			"claude:new": session("new", "2026-08-17T10:00:00.000Z"),
+		};
+		// max 2, keeping "claude:mid" (the one just written this call).
+		const out = capLedgerSessions(sessions, "claude:mid", 2);
+		// Survivors: the kept one plus the single most-recent OTHER ("claude:new").
+		expect(Object.keys(out).sort()).toEqual(["claude:mid", "claude:new"]);
+	});
+
+	it("always retains `keep` even when it is the oldest", () => {
+		const sessions = {
+			"claude:keep": session("keep", "2026-08-17T08:00:00.000Z"),
+			"claude:a": session("a", "2026-08-17T09:00:00.000Z"),
+			"claude:b": session("b", "2026-08-17T10:00:00.000Z"),
+		};
+		const out = capLedgerSessions(sessions, "claude:keep", 1);
+		// max 1 leaves room for `keep` only; every other session is evicted.
+		expect(Object.keys(out)).toEqual(["claude:keep"]);
+	});
+});

--- a/cli/src/core/ClaudeOwnership.ts
+++ b/cli/src/core/ClaudeOwnership.ts
@@ -1,0 +1,236 @@
+/**
+ * Claude ownership ledger — which worktree roots a Claude session actually
+ * visited, and where in the transcript each of them first appeared.
+ *
+ * MACHINE-GLOBAL on purpose (`~/.jolli/jollimemory/claude-owners.json`). The
+ * question it answers is asked by a worktree that never ran the session: Claude
+ * was launched in checkout A, the user `cd`-ed into checkout B mid-conversation,
+ * and the commit lands in B. B's own `.jolli/jollimemory/` holds nothing about
+ * that session — its Stop hook never fired — so a per-worktree ledger would be
+ * a second copy of `sessions.json` and would fix nothing. One shared file lets
+ * A's hook record B's edge and B's post-commit read find it.
+ *
+ * Storage only. What counts as a `cwd`, and which line it was first seen on,
+ * is a later task's job.
+ */
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createLogger, errMsg } from "../Logger.js";
+import { atomicWriteFile } from "./AtomicWrite.js";
+import { withClaudeOwnersLock } from "./Locks.js";
+import { getGlobalConfigDir } from "./SessionTracker.js";
+
+const log = createLogger("ClaudeOwnership");
+
+const CLAUDE_OWNERS_FILE = "claude-owners.json";
+
+/** One worktree root's participation in one Claude session. */
+export interface ClaudeOwnerEdge {
+	readonly firstSeenAt: string;
+	/**
+	 * Line index (against `splitTranscriptLines`) of the first line whose `cwd`
+	 * belonged to this owner. Becomes a cursor lower bound, so it must never be
+	 * re-derived with a different notion of "line N".
+	 */
+	readonly firstSeenLine: number;
+	readonly lastSeenAt: string;
+	readonly firstSeenCwd?: string;
+	readonly lastSeenCwd?: string;
+}
+
+export interface ClaudeOwnedSession {
+	readonly sessionId: string;
+	readonly transcriptPath: string;
+	readonly source: "claude";
+	readonly owners: Readonly<Record<string, ClaudeOwnerEdge>>;
+}
+
+export interface ClaudeOwnersLedger {
+	readonly version: 1;
+	readonly sessions: Readonly<Record<string, ClaudeOwnedSession>>;
+}
+
+const EMPTY: ClaudeOwnersLedger = { version: 1, sessions: {} };
+
+/**
+ * Hard cap on how many sessions the machine-global ledger retains. The file is
+ * read, JSON-parsed and linearly scanned on the post-commit hot path and on
+ * every dashboard memory-detail render, and it is otherwise append-only — one
+ * entry per Claude session ever seen on this machine — so without a ceiling it
+ * grows unbounded and steadily slows both. When the cap is exceeded the oldest
+ * sessions (by their most recent `lastSeenAt`) are evicted: an old session's
+ * transcript file is the first thing the agent's own retention prunes, so its
+ * edge can no longer be acted on anyway. Generous enough that a still-relevant
+ * session is never evicted in practice.
+ */
+const MAX_LEDGER_SESSIONS = 2000;
+
+/** A session's recency = the newest `lastSeenAt` across its owner edges. */
+function sessionRecency(session: ClaudeOwnedSession): string {
+	let newest = "";
+	for (const e of Object.values(session.owners)) {
+		if (e.lastSeenAt > newest) newest = e.lastSeenAt;
+	}
+	return newest;
+}
+
+/**
+ * Keeps `sessions` within {@link MAX_LEDGER_SESSIONS}, always retaining `keep`
+ * (the session being written this call) plus the most-recent others. Exported
+ * so its eviction can be unit-tested with a small cap without seeding thousands
+ * of entries. ISO timestamps are compared with `<`/`>`, never `localeCompare`,
+ * which would reorder under some locales (generated-artifact lesson).
+ */
+export function capLedgerSessions(
+	sessions: Readonly<Record<string, ClaudeOwnedSession>>,
+	keep: string,
+	max: number = MAX_LEDGER_SESSIONS,
+): Record<string, ClaudeOwnedSession> {
+	const keys = Object.keys(sessions);
+	if (keys.length <= max) return { ...sessions };
+	const others = keys
+		.filter((k) => k !== keep)
+		.sort((a, b) => {
+			const ra = sessionRecency(sessions[a]);
+			const rb = sessionRecency(sessions[b]);
+			return ra < rb ? 1 : ra > rb ? -1 : 0;
+		});
+	const survivors = new Set<string>([keep, ...others.slice(0, Math.max(0, max - 1))]);
+	const out: Record<string, ClaudeOwnedSession> = {};
+	for (const k of keys) {
+		if (survivors.has(k)) out[k] = sessions[k];
+	}
+	return out;
+}
+
+export function claudeOwnersPath(globalDir?: string): string {
+	return join(globalDir ?? getGlobalConfigDir(), CLAUDE_OWNERS_FILE);
+}
+
+function sessionKey(sessionId: string): string {
+	return `claude:${sessionId}`;
+}
+
+/**
+ * True when `session` is structurally sound enough for `claudeSessionsOwnedBy`
+ * to walk its `owners` map safely — i.e. `owners` is itself a plain object
+ * (not null, not an array). A torn or hand-edited ledger can carry a session
+ * whose `owners` is missing, `null`, or a wrong-shaped value; that session is
+ * dropped rather than coerced, matching the "malformed reads as absent"
+ * posture the whole-file check already has.
+ */
+function hasValidOwners(session: unknown): session is ClaudeOwnedSession {
+	if (!session || typeof session !== "object" || Array.isArray(session)) return false;
+	const owners = (session as { owners?: unknown }).owners;
+	return !!owners && typeof owners === "object" && !Array.isArray(owners);
+}
+
+/**
+ * Reads the ledger. A missing or unparseable file reads as empty: this is
+ * consulted from the post-commit path, where throwing would take the whole
+ * summary down over a state file that the next Stop hook rewrites anyway.
+ * The same never-throw posture extends to each individual session: one whose
+ * `owners` field is missing or malformed is dropped rather than surfaced, so
+ * every session `loadClaudeOwners` returns is safe for a caller to index into
+ * without checking first.
+ */
+export async function loadClaudeOwners(globalDir?: string): Promise<ClaudeOwnersLedger> {
+	try {
+		const raw = JSON.parse(await readFile(claudeOwnersPath(globalDir), "utf-8")) as Partial<ClaudeOwnersLedger>;
+		if (!raw || typeof raw !== "object" || typeof raw.sessions !== "object" || raw.sessions === null) return EMPTY;
+		const sessions: Record<string, ClaudeOwnedSession> = {};
+		for (const [key, session] of Object.entries(raw.sessions)) {
+			if (hasValidOwners(session)) sessions[key] = session;
+		}
+		return { version: 1, sessions };
+	} catch (err) {
+		log.debug("claude-owners.json unreadable (%s) — treating as empty", errMsg(err));
+		return EMPTY;
+	}
+}
+
+/**
+ * Folds `edges` into the ledger. Set-union / max-progress ONLY: an existing
+ * edge keeps its `firstSeenAt` / `firstSeenLine` / `firstSeenCwd` and takes the
+ * newer `lastSeenAt` / `lastSeenCwd`. A later pass extends an edge; it never
+ * rewinds one, because the first-seen position is the lower bound a future
+ * commit will read from and moving it forward would silently skip that
+ * owner's earliest turns.
+ *
+ * Returns `true` when the write landed DURABLY (under the lock), `false` when
+ * the lock timed out and the merge ran best-effort — in which case a concurrent
+ * peer may have clobbered it, so the caller must not advance any cursor past the
+ * evidence these edges came from. An empty edge map is a durable no-op (`true`):
+ * there was nothing to lose, so the caller may advance freely.
+ */
+export async function recordClaudeOwners(
+	input: {
+		readonly sessionId: string;
+		readonly transcriptPath: string;
+		readonly edges: ReadonlyMap<string, ClaudeOwnerEdge>;
+	},
+	globalDir?: string,
+): Promise<boolean> {
+	if (input.edges.size === 0) return true;
+	return await withClaudeOwnersLock(
+		async (acquired) => {
+			// Read inside the lock: a snapshot taken before it would merge a peer's
+			// write away, which is the exact race the lock exists for.
+			const ledger = await loadClaudeOwners(globalDir);
+			const key = sessionKey(input.sessionId);
+			const existing = ledger.sessions[key];
+			const owners: Record<string, ClaudeOwnerEdge> = { ...(existing?.owners ?? {}) };
+			for (const [root, incoming] of input.edges) {
+				const prior = owners[root];
+				owners[root] = prior
+					? {
+							...prior,
+							lastSeenAt: incoming.lastSeenAt > prior.lastSeenAt ? incoming.lastSeenAt : prior.lastSeenAt,
+							...(incoming.lastSeenCwd !== undefined ? { lastSeenCwd: incoming.lastSeenCwd } : {}),
+						}
+					: incoming;
+			}
+			const next: ClaudeOwnersLedger = {
+				version: 1,
+				sessions: capLedgerSessions(
+					{
+						...ledger.sessions,
+						[key]: {
+							sessionId: input.sessionId,
+							transcriptPath: input.transcriptPath,
+							source: "claude",
+							owners,
+						},
+					},
+					key,
+				),
+			};
+			await atomicWriteFile(claudeOwnersPath(globalDir), JSON.stringify(next, null, "\t"));
+			return acquired;
+		},
+		globalDir === undefined ? {} : { globalDir },
+	);
+}
+
+/**
+ * Every Claude session this worktree root is an owner of, with that root's own
+ * edge. Callers MUST pass a `resolveStateRoot()`-normalised root — the keys
+ * were written that way, and a raw `process.cwd()` on macOS (`/var/…` vs
+ * `/private/var/…`) matches nothing while looking perfectly reasonable.
+ */
+export async function claudeSessionsOwnedBy(
+	ownerRoot: string,
+	globalDir?: string,
+): Promise<ReadonlyArray<{ sessionId: string; transcriptPath: string; edge: ClaudeOwnerEdge }>> {
+	const ledger = await loadClaudeOwners(globalDir);
+	const mine: { sessionId: string; transcriptPath: string; edge: ClaudeOwnerEdge }[] = [];
+	for (const session of Object.values(ledger.sessions)) {
+		// Optional chaining here is belt-and-suspenders: `loadClaudeOwners` already
+		// drops a session whose `owners` is malformed, but a future direct writer
+		// of the file must not be able to reopen this throw.
+		const edge = session.owners?.[ownerRoot];
+		if (edge) mine.push({ sessionId: session.sessionId, transcriptPath: session.transcriptPath, edge });
+	}
+	return mine;
+}

--- a/cli/src/core/GitOps.test.ts
+++ b/cli/src/core/GitOps.test.ts
@@ -71,6 +71,7 @@ import {
 	resetStateRootCache,
 	resolveGitHooksDir,
 	resolveStateRoot,
+	resolveWorktreeRootOrNull,
 	writeFileToBranch,
 	writeMultipleFilesToBranch,
 } from "./GitOps.js";
@@ -1902,6 +1903,40 @@ describe("GitOps", () => {
 			resetStateRootCache();
 			resolveStateRoot("/repo/root/z");
 			expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe("resolveWorktreeRootOrNull", () => {
+		beforeEach(() => {
+			mockExecFileSync.mockReset();
+			resetStateRootCache();
+		});
+
+		it("returns the worktree root for a directory inside a repo", () => {
+			mockExecFileSync.mockReturnValue("/repo/root\n");
+			expect(resolveWorktreeRootOrNull("/repo/root/sub")).toBe("/repo/root");
+		});
+
+		it("returns null (not the input path) for a directory outside any git worktree", () => {
+			mockExecFileSync.mockImplementation(() => {
+				throw new Error("fatal: not a git repository");
+			});
+			expect(resolveWorktreeRootOrNull("/tmp/scratch")).toBeNull();
+		});
+
+		it("returns null when git prints nothing", () => {
+			mockExecFileSync.mockReturnValue("   \n");
+			expect(resolveWorktreeRootOrNull("/tmp/empty-out")).toBeNull();
+		});
+
+		it("shares the memo with resolveStateRoot, which echoes the input for the null case", () => {
+			mockExecFileSync.mockImplementation(() => {
+				throw new Error("fatal: not a git repository");
+			});
+			expect(resolveWorktreeRootOrNull("/tmp/plain")).toBeNull();
+			// resolveStateRoot reads the cached null and falls back to the input.
+			expect(resolveStateRoot("/tmp/plain")).toBe("/tmp/plain");
+			expect(mockExecFileSync).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/cli/src/core/GitOps.ts
+++ b/cli/src/core/GitOps.ts
@@ -23,8 +23,12 @@ const NUL = "\x00";
 
 const log = createLogger("GitOps");
 
-/** Memoized git-worktree-root cache, keyed by the candidate directory. */
-const _stateRootCache = new Map<string, string>();
+/**
+ * Memoized git-worktree-root cache, keyed by the candidate directory. A `null`
+ * value is a real cached result — "this directory is not inside any git
+ * worktree" — distinct from `undefined` ("not resolved yet").
+ */
+const _stateRootCache = new Map<string, string | null>();
 
 /** Test-only: clears the memo so cases don't leak resolved roots into each other. */
 export function resetStateRootCache(): void {
@@ -55,6 +59,23 @@ export function resetStateRootCache(): void {
  * marker-gated concern, not this function's job.
  */
 export function resolveStateRoot(cwd: string): string {
+	// A directory outside any git worktree still needs *some* project dir, so
+	// echo the input back — see this function's contract above.
+	return resolveWorktreeRootOrNull(cwd) ?? cwd;
+}
+
+/**
+ * Like {@link resolveStateRoot}, but returns `null` for a directory that is not
+ * inside any git worktree instead of echoing the input path back.
+ *
+ * `resolveStateRoot` falls back to `cwd` so its caller always has a usable
+ * project dir; a caller that only wants a REAL worktree root — the Claude
+ * ownership ledger, whose keys must be roots a future commit can actually look
+ * up, never a scratch directory a session merely `cd`-ed through — needs the
+ * failure distinguishable from success, which the echoed cwd silently hides.
+ * Shares {@link resolveStateRoot}'s memo, so the two never disagree on a path.
+ */
+export function resolveWorktreeRootOrNull(cwd: string): string | null {
 	const cached = _stateRootCache.get(cwd);
 	if (cached !== undefined) return cached;
 	// Filesystem first: this is the SessionStart hook's very first call, where a
@@ -73,7 +94,7 @@ export function resolveStateRoot(cwd: string): string {
 		_stateRootCache.set(cwd, fsRoot);
 		return fsRoot;
 	}
-	let root = cwd;
+	let root: string | null = null;
 	try {
 		const out = execFileSyncHidden("git", ["rev-parse", "--show-toplevel"], {
 			cwd,
@@ -84,7 +105,7 @@ export function resolveStateRoot(cwd: string): string {
 		}).trim();
 		if (out) root = out; // git prints the toplevel in forward-slash form on every platform
 	} catch {
-		// Not a git repo / git missing — keep the input path.
+		// Not a git repo / git missing — no worktree root.
 	}
 	_stateRootCache.set(cwd, root);
 	return root;

--- a/cli/src/core/Locks.test.ts
+++ b/cli/src/core/Locks.test.ts
@@ -50,6 +50,7 @@ import {
 	releaseWorkerLock,
 	SESSIONS_LOCK_FILE,
 	WORKER_LOCK_FILE,
+	withClaudeOwnersLock,
 	withConfigLock,
 	withPlansLock,
 	withProfileLock,
@@ -870,6 +871,40 @@ describe("Locks", () => {
 			releaseFirst();
 			await second;
 			expect(order).toEqual(["first-enter", "first-exit", "second-enter"]);
+		});
+	});
+
+	describe("withClaudeOwnersLock — machine-global claude-owners.json RMW serialisation", () => {
+		it("acquires the lock and passes acquired:true to the body", async () => {
+			let seen: boolean | undefined;
+			const result = await withClaudeOwnersLock(
+				async (acquired) => {
+					seen = acquired;
+					return "ok";
+				},
+				{ globalDir: tempDir },
+			);
+			expect(result).toBe("ok");
+			expect(seen).toBe(true);
+			await expect(stat(join(tempDir, "claude-owners.lock"))).rejects.toThrow();
+		});
+
+		it("still runs the body with acquired:false when the lock can't be taken in time", async () => {
+			// Pre-hold the lock so the poll times out and the body runs unlocked —
+			// the best-effort path a caller keys off to avoid advancing a cursor.
+			await writeFile(join(tempDir, "claude-owners.lock"), String(process.pid), "utf-8");
+			let seen: boolean | undefined;
+			const result = await withClaudeOwnersLock(
+				async (acquired) => {
+					seen = acquired;
+					return "best-effort";
+				},
+				{ globalDir: tempDir, timeoutMs: 80, pollMs: 20 },
+			);
+			expect(result).toBe("best-effort");
+			expect(seen).toBe(false);
+			// The pre-existing lock is left intact (we never owned it).
+			await expect(stat(join(tempDir, "claude-owners.lock"))).resolves.toBeDefined();
 		});
 	});
 

--- a/cli/src/core/Locks.ts
+++ b/cli/src/core/Locks.ts
@@ -823,3 +823,47 @@ export async function withRepoRegistryLock<T>(fn: () => Promise<T>, opts: RepoRe
 		if (acquired) await releaseIfOwned(lockPath, REPO_REGISTRY_LOCK_FILE);
 	}
 }
+
+/** Serialises read-modify-write of the machine-global `claude-owners.json`. */
+const CLAUDE_OWNERS_LOCK_FILE = "claude-owners.lock";
+
+/**
+ * Serialises the read-modify-write of `claude-owners.json` across every repo's
+ * Stop hook on this machine. Same shape and same reasoning as
+ * {@link withRepoRegistryLock}: one machine-global JSON file whose whole-object
+ * overwrite would otherwise let a stale reader drop a peer's freshly-written
+ * owner edge.
+ *
+ * Best-effort — on timeout `fn` runs UNLOCKED (receiving `acquired: false`)
+ * rather than dropping the write entirely. Losing an edge is what this whole
+ * feature exists to prevent, so the recovery cannot be left to chance: `fn`
+ * gets the acquired flag and a caller that must not lose data keys off it.
+ * `recordClaudeOwners` propagates it so `scanOwnersWithCursor` advances its
+ * high-water mark ONLY on a durable (locked) write — a rare unlocked clobber
+ * then leaves the mark where it is and is re-emitted idempotently by the next
+ * Stop hook, which is the only thing that actually makes the recovery happen
+ * (advancing the mark past an unlocked write would strand the dropped edge).
+ */
+export async function withClaudeOwnersLock<T>(
+	fn: (acquired: boolean) => Promise<T>,
+	opts: RepoRegistryLockOpts = {},
+): Promise<T> {
+	const timeoutMs = opts.timeoutMs ?? DEFAULT_REPO_REGISTRY_LOCK_TIMEOUT_MS;
+	const pollMs = opts.pollMs ?? DEFAULT_PROFILE_LOCK_POLL_MS;
+	const dir = opts.globalDir ?? join(homedir(), ".jolli", "jollimemory");
+	await mkdir(dir, { recursive: true });
+	const lockPath = join(dir, CLAUDE_OWNERS_LOCK_FILE);
+	const acquired = await acquireWithPoll(lockPath, { timeoutMs, pollMs });
+	if (!acquired) {
+		log.warn(
+			"withClaudeOwnersLock: could not acquire %s within %d ms — proceeding best-effort",
+			CLAUDE_OWNERS_LOCK_FILE,
+			timeoutMs,
+		);
+	}
+	try {
+		return await fn(acquired);
+	} finally {
+		if (acquired) await releaseIfOwned(lockPath, CLAUDE_OWNERS_LOCK_FILE);
+	}
+}

--- a/cli/src/core/TranscriptRepair.test.ts
+++ b/cli/src/core/TranscriptRepair.test.ts
@@ -1,0 +1,348 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CommitSummary } from "../Types.js";
+import { recordClaudeOwners } from "./ClaudeOwnership.js";
+import { resolveStateRoot } from "./GitOps.js";
+import { createFolderStorageAtRoot } from "./StorageFactory.js";
+import { getSummary, setActiveStorage, storeSummary } from "./SummaryStore.js";
+import { repairSummaryTranscripts, transcriptRepairState } from "./TranscriptRepair.js";
+
+// Identity by default: these fixtures are plain temp dirs, not git worktrees,
+// and the real resolveStateRoot falls back to its input unchanged in that case
+// anyway (see GitOps.ts's non-repo fallback). A `vi.fn` wrapper so one test
+// below can override it to return a value DISTINCT from the raw cwd — without
+// that, every test here builds its ledger key via the same call the predicate
+// makes, so a mutant that dropped `resolveStateRoot(cwd)` from
+// TranscriptRepair.ts (calling `claudeSessionsOwnedBy(cwd, globalDir)`
+// directly) would pass unnoticed. Same pattern as QueueWorker.test.ts /
+// StopHook.test.ts / GeminiAfterAgentHook.test.ts.
+//
+// `getTreeHash` / `getDiffStats` are ALSO stubbed here (not just
+// `resolveStateRoot`): `repairSummaryTranscripts` writes through the real
+// `storeSummary`, whose index-flattening step calls both unconditionally.
+// Left real, each would shell out to `git` against a plain temp dir (not a
+// git repo) — a real subprocess spawn per test, which is exactly what would
+// force this file into `SLOW_TEST_FILES`. Stubbing them to the same values
+// the real calls degrade to on a non-repo cwd (`null` / all-zero stats) keeps
+// this file in the fast tier without changing what any assertion observes.
+vi.mock("./GitOps.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("./GitOps.js")>()),
+	resolveStateRoot: vi.fn((cwd: string) => cwd),
+	getTreeHash: vi.fn().mockResolvedValue(null),
+	getDiffStats: vi.fn().mockResolvedValue({ filesChanged: 0, insertions: 0, deletions: 0 }),
+}));
+
+// `storeSummary` also acquires `orphan-write.lock` via `acquireOrphanWriteLock`,
+// which (through `resolveSharedLockDir`) runs `git rev-parse --git-common-dir`
+// to find the lock directory — another real subprocess spawn on a non-repo
+// temp dir. Stubbed to always-succeed/no-op for the same fast-tier reason as
+// above. `withClaudeOwnersLock` (used by `recordClaudeOwners`) is untouched —
+// it is a plain file lock with no git dependency.
+vi.mock("./Locks.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("./Locks.js")>()),
+	acquireOrphanWriteLock: vi.fn().mockResolvedValue(true),
+	releaseOrphanWriteLock: vi.fn().mockResolvedValue(undefined),
+}));
+
+let globalDir: string;
+let repo: string;
+let transcript: string;
+
+const HASH = "a".repeat(40);
+const EDGE = { firstSeenAt: "2026-08-17T10:00:00.000Z", firstSeenLine: 0, lastSeenAt: "2026-08-17T10:00:00.000Z" };
+
+function summary(over: Partial<CommitSummary> = {}): CommitSummary {
+	return {
+		version: 5,
+		commitHash: "a".repeat(40),
+		commitMessage: "x",
+		commitAuthor: "a",
+		commitDate: "2026-08-17T11:00:00.000Z",
+		branch: "main",
+		generatedAt: "2026-08-17T11:00:05.000Z",
+		topics: [],
+		...over,
+	};
+}
+
+beforeEach(async () => {
+	globalDir = await mkdtemp(join(tmpdir(), "jolli-rep-g-"));
+	repo = await mkdtemp(join(tmpdir(), "jolli-rep-r-"));
+	transcript = join(globalDir, "s.jsonl");
+	// A single real user turn, not just a bare `{cwd, timestamp}` line: the
+	// `transcriptRepairState` tests above only check that this file EXISTS
+	// (`existsSync`), but `repairSummaryTranscripts` below actually parses it
+	// via `readTranscript` — a line with no `message` object yields zero
+	// entries under `parseTranscriptLine`, which would make every repair test
+	// misreport `no-entries-in-window`.
+	await writeFile(
+		transcript,
+		`${JSON.stringify({
+			cwd: repo,
+			timestamp: "2026-08-17T10:00:00.000Z",
+			message: { role: "user", content: "hello" },
+		})}\n`,
+		"utf-8",
+	);
+	// Storage seam (see TranscriptRepair.test.ts's task brief): a real
+	// FolderStorage rooted at the temp repo dir, set as the process-global
+	// override so `getSummary`/`storeSummary` inside `repairSummaryTranscripts`
+	// read/write it without needing a real git worktree or the orphan branch.
+	setActiveStorage(createFolderStorageAtRoot(repo));
+	// Baseline: a v5 summary with an empty transcript slice, exactly the shape
+	// `jolli doctor --repair-transcripts` would find. Individual tests seed
+	// their OWN summary at a distinct hash when they need a different shape
+	// (e.g. no upper bound, already-present, or no summary at all).
+	await storeSummary(summary({ transcripts: [] }), repo);
+});
+
+afterEach(() => {
+	setActiveStorage(undefined);
+});
+
+describe("transcriptRepairState", () => {
+	it("is present when the summary already references a transcript", async () => {
+		expect(await transcriptRepairState(summary({ transcripts: ["t1"] }), repo, globalDir)).toBe("present");
+	});
+
+	it("is repaired when the marker is set", async () => {
+		expect(
+			await transcriptRepairState(
+				summary({ transcripts: ["t1"], transcriptsRepairedAt: "2026-08-17T12:00:00.000Z" }),
+				repo,
+				globalDir,
+			),
+		).toBe("repaired");
+	});
+
+	it("is repairable when an owner edge and the transcript both exist", async () => {
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[resolveStateRoot(repo), EDGE]]) },
+			globalDir,
+		);
+		expect(await transcriptRepairState(summary({ transcripts: [] }), repo, globalDir)).toBe("repairable");
+	});
+
+	it("is unrepairable when no owner edge proves this checkout", async () => {
+		expect(await transcriptRepairState(summary({ transcripts: [] }), repo, globalDir)).toBe("unrepairable");
+	});
+
+	it("is unrepairable when the transcript file is gone", async () => {
+		await recordClaudeOwners(
+			{
+				sessionId: "s",
+				transcriptPath: join(globalDir, "vanished.jsonl"),
+				edges: new Map([[resolveStateRoot(repo), EDGE]]),
+			},
+			globalDir,
+		);
+		expect(await transcriptRepairState(summary({ transcripts: [] }), repo, globalDir)).toBe("unrepairable");
+	});
+
+	it("is unrepairable when the owner window holds no turns, despite the transcript existing", async () => {
+		// The exact over-promise the fix removes: a transcript file EXISTS, so the
+		// old `existsSync`-only predicate said "repairable" — but the owner joined
+		// past the file's only turn, so a real run reports no-entries-in-window and
+		// repairs nothing. The state query must agree with the engine.
+		await recordClaudeOwners(
+			{
+				sessionId: "s",
+				transcriptPath: transcript,
+				edges: new Map([[resolveStateRoot(repo), { ...EDGE, firstSeenLine: 99 }]]),
+			},
+			globalDir,
+		);
+		expect(await transcriptRepairState(summary({ transcripts: [] }), repo, globalDir)).toBe("unrepairable");
+	});
+
+	it("is unrepairable when the summary carries no upper bound, despite owner and transcript", async () => {
+		// Owner and a live transcript both present, but no generatedAt/commitDate to
+		// bound the window — the engine refuses with no-upper-bound, so the UI must
+		// not say "repairable".
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[resolveStateRoot(repo), EDGE]]) },
+			globalDir,
+		);
+		const state = await transcriptRepairState(
+			summary({ transcripts: [], generatedAt: "", commitDate: "" }),
+			repo,
+			globalDir,
+		);
+		expect(state).toBe("unrepairable");
+	});
+
+	it("looks the ledger up under resolveStateRoot's return value, not the raw cwd", async () => {
+		const anchoredRoot = "/anchored/repo/root";
+		vi.mocked(resolveStateRoot).mockReturnValueOnce(anchoredRoot);
+		await recordClaudeOwners(
+			{ sessionId: "anchored-1", transcriptPath: transcript, edges: new Map([[anchoredRoot, EDGE]]) },
+			globalDir,
+		);
+
+		const state = await transcriptRepairState(summary({ transcripts: [] }), repo, globalDir);
+
+		expect(resolveStateRoot).toHaveBeenCalledWith(repo);
+		expect(state).toBe("repairable");
+	});
+});
+
+describe("repairSummaryTranscripts", () => {
+	it("repairs an empty summary when transcript, owner edge and upper bound all exist", async () => {
+		// transcript holds one turn at 10:00; summary.generatedAt is 11:00:05.
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[repo, EDGE]]) },
+			globalDir,
+		);
+		const out = await repairSummaryTranscripts(HASH, repo, { apply: true, globalDir });
+		expect(out).toMatchObject({ repaired: true, reason: "repaired" });
+		const stored = await getSummary(HASH, repo);
+		expect(stored?.transcripts).toHaveLength(1);
+		expect(stored?.transcriptsRepairedAt).toBeTruthy();
+	});
+
+	it("is idempotent — a second run reports already-present and writes nothing", async () => {
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[repo, EDGE]]) },
+			globalDir,
+		);
+		await repairSummaryTranscripts(HASH, repo, { apply: true, globalDir });
+		const before = await getSummary(HASH, repo);
+		const out = await repairSummaryTranscripts(HASH, repo, { apply: true, globalDir });
+		expect(out.reason).toBe("already-present");
+		expect((await getSummary(HASH, repo))?.transcripts).toEqual(before?.transcripts);
+	});
+
+	it("refuses when the transcript file is gone", async () => {
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: join(globalDir, "gone.jsonl"), edges: new Map([[repo, EDGE]]) },
+			globalDir,
+		);
+		expect((await repairSummaryTranscripts(HASH, repo, { apply: true, globalDir })).reason).toBe(
+			"transcript-missing",
+		);
+	});
+
+	it("refuses when no owner edge proves this checkout", async () => {
+		expect((await repairSummaryTranscripts(HASH, repo, { apply: true, globalDir })).reason).toBe("no-owner-proof");
+	});
+
+	it("refuses when the bounded window yields no entries", async () => {
+		// Owner edge seeded past every line in the file.
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[repo, { ...EDGE, firstSeenLine: 99 }]]) },
+			globalDir,
+		);
+		expect((await repairSummaryTranscripts(HASH, repo, { apply: true, globalDir })).reason).toBe(
+			"no-entries-in-window",
+		);
+	});
+
+	it("skips a session whose transcript read throws, and still repairs from the others", async () => {
+		// A directory passes the `existsSync` liveness filter but `readFile`
+		// throws EISDIR on it — a genuine read fault distinct from the vanished-
+		// file case above. Proves a broken owner is skipped (not left to crash
+		// the whole repair) while a healthy owner's entries still land.
+		await recordClaudeOwners(
+			{ sessionId: "broken", transcriptPath: globalDir, edges: new Map([[repo, EDGE]]) },
+			globalDir,
+		);
+		await recordClaudeOwners(
+			{ sessionId: "good", transcriptPath: transcript, edges: new Map([[repo, EDGE]]) },
+			globalDir,
+		);
+		const out = await repairSummaryTranscripts(HASH, repo, { apply: true, globalDir });
+		expect(out).toMatchObject({ repaired: true, reason: "repaired", entries: 1 });
+	});
+
+	it("writes nothing when apply is false", async () => {
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[repo, EDGE]]) },
+			globalDir,
+		);
+		const out = await repairSummaryTranscripts(HASH, repo, { globalDir });
+		expect(out.repaired).toBe(true);
+		expect((await getSummary(HASH, repo))?.transcripts ?? []).toHaveLength(0);
+	});
+
+	it("stores a resolved session title alongside the repaired entries", async () => {
+		// resolveArchivedTitle falls back to the first human turn's content
+		// ("hello", from the beforeEach transcript) when there is no ai-title
+		// row — proves the engine resolves and PERSISTS a title rather than
+		// hand-building a StoredSession with the field left off entirely.
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[repo, EDGE]]) },
+			globalDir,
+		);
+		await repairSummaryTranscripts(HASH, repo, { apply: true, globalDir });
+		const stored = await getSummary(HASH, repo);
+		const id = stored?.transcripts?.[0];
+		expect(id).toBeTruthy();
+		const storage = createFolderStorageAtRoot(repo);
+		const raw = await storage.readFile(`transcripts/${id}.json`);
+		const data = JSON.parse(raw ?? "{}") as { sessions: ReadonlyArray<{ title?: string }> };
+		expect(data.sessions[0]?.title).toBe("hello");
+	});
+
+	it("prefers generatedAt over commitDate as the upper bound", async () => {
+		// commitDate is set BEFORE the transcript's one entry (10:00); generatedAt
+		// is AFTER it (11:00:05, same as the default fixture). The entry sits
+		// strictly between the two, so this is the one case that tells the two
+		// possible orderings apart: `before = generatedAt || commitDate` (correct)
+		// includes the entry, while the swapped `commitDate || generatedAt` cuts
+		// the window off at 09:00 and silently drops it — reporting
+		// "no-entries-in-window" instead of a successful repair. Asserting on
+		// `entries: 1` (not just `repaired: true`) is what makes the two orders
+		// actually disagree here.
+		const boundHash = "e".repeat(40);
+		await storeSummary(
+			summary({ commitHash: boundHash, transcripts: [], commitDate: "2026-08-17T09:00:00.000Z" }),
+			repo,
+		);
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[repo, EDGE]]) },
+			globalDir,
+		);
+		const out = await repairSummaryTranscripts(boundHash, repo, { apply: true, globalDir });
+		expect(out).toMatchObject({ reason: "repaired", entries: 1 });
+	});
+
+	it("refuses when the summary carries no capture timestamp to bound the window", async () => {
+		// Falls back to `commitDate` only when `generatedAt` is absent; forcing
+		// BOTH empty is the only way to reach "no-upper-bound" itself, rather
+		// than exercising the (already-covered) generatedAt-preferred path. No
+		// owner is recorded, so if the upper-bound check were ever skipped or
+		// reordered after the owner check, this would report "no-owner-proof"
+		// instead — which is exactly the mutant this test exists to catch.
+		const noBoundHash = "b".repeat(40);
+		await storeSummary(
+			summary({ commitHash: noBoundHash, transcripts: [], generatedAt: "", commitDate: "" }),
+			repo,
+		);
+		const out = await repairSummaryTranscripts(noBoundHash, repo, { apply: true, globalDir });
+		expect(out.reason).toBe("no-upper-bound");
+	});
+
+	it("refuses when no summary exists for the commit at all", async () => {
+		// Distinct from "no owner edge recorded" (both report "no-owner-proof",
+		// but via different branches: this one never even reaches the owner
+		// lookup because `getSummary` itself returns null).
+		const missingHash = "c".repeat(40);
+		const out = await repairSummaryTranscripts(missingHash, repo, { apply: true, globalDir });
+		expect(out.reason).toBe("no-owner-proof");
+	});
+
+	it("is already-present when the summary already lists a transcript, with no repaired marker set", async () => {
+		// Distinct from the idempotency test: that one proves a SECOND run of
+		// THIS engine is a no-op via `transcriptsRepairedAt`. This one proves a
+		// summary that was captured live (transcripts non-empty from the start,
+		// never touched by repair) is also refused — the other half of the
+		// `transcriptsRepairedAt !== undefined || getTranscriptIds(...).length > 0`
+		// condition.
+		const presentHash = "d".repeat(40);
+		await storeSummary(summary({ commitHash: presentHash, transcripts: ["existing-id"] }), repo);
+		const out = await repairSummaryTranscripts(presentHash, repo, { apply: true, globalDir });
+		expect(out.reason).toBe("already-present");
+	});
+});

--- a/cli/src/core/TranscriptRepair.ts
+++ b/cli/src/core/TranscriptRepair.ts
@@ -1,0 +1,180 @@
+/**
+ * Repair for summaries written with `transcripts: []`.
+ *
+ * Deliberately conservative (spec §8.3): every uncertainty resolves to "do not
+ * repair". A false negative leaves a memory looking exactly as it does today; a
+ * false positive staples someone else's conversation onto a commit, which is
+ * worse than the gap it would be papering over.
+ */
+
+import { existsSync } from "node:fs";
+import { createLogger, errMsg } from "../Logger.js";
+import type { CommitSummary, StoredSession, TranscriptReadResult } from "../Types.js";
+import { claudeSessionsOwnedBy } from "./ClaudeOwnership.js";
+import { resolveStateRoot } from "./GitOps.js";
+import { resolveArchivedTitle } from "./SessionTitleResolver.js";
+import { getSummary, storeSummary } from "./SummaryStore.js";
+import { getTranscriptIds } from "./SummaryTree.js";
+import { generateTranscriptId } from "./TranscriptId.js";
+import { getParserForSource } from "./TranscriptParser.js";
+import { readTranscript } from "./TranscriptReader.js";
+
+const log = createLogger("TranscriptRepair");
+
+/**
+ * What the memory-detail UI is allowed to claim about a summary's conversations:
+ *
+ * - `present`      — captured live; render the conversations.
+ * - `repaired`     — refilled from local transcript history after the fact.
+ * - `repairable`   — empty, but the evidence to rebuild it is still on this machine.
+ * - `unrepairable` — empty, and nothing local can fix it.
+ *
+ * The last two are the distinction spec §9 exists for: "No conversations linked
+ * yet" reads as "not yet", which is misleading for a capture that already failed
+ * and will never complete on its own.
+ */
+export type TranscriptRepairState = "present" | "repaired" | "repairable" | "unrepairable";
+
+export async function transcriptRepairState(
+	summary: CommitSummary,
+	cwd: string,
+	globalDir?: string,
+): Promise<TranscriptRepairState> {
+	if (summary.transcriptsRepairedAt !== undefined) return "repaired";
+	if (getTranscriptIds(summary).length > 0) return "present";
+	// Ask the repair engine itself, dry-run: "repairable" must mean exactly
+	// "a real run would repair this", or the UI promises a repair the engine
+	// then refuses. A looser predicate here (any owned transcript file exists)
+	// over-promises the two cases the engine still rejects — no upper bound to
+	// bound the window, or an owner window that holds no turns — which is the
+	// optimism spec §9's repairable/unrepairable split exists to remove. One
+	// code path with `repairSummaryTranscripts`, so the sentence and the
+	// behaviour cannot drift apart.
+	const outcome = await planRepair(summary, cwd, { apply: false, globalDir });
+	return outcome.repaired ? "repairable" : "unrepairable";
+}
+
+export interface RepairOutcome {
+	readonly commitHash: string;
+	/** True when a repair happened, or WOULD have happened under `apply: false`. */
+	readonly repaired: boolean;
+	readonly reason:
+		| "repaired"
+		| "already-present"
+		| "no-owner-proof"
+		| "transcript-missing"
+		| "no-entries-in-window"
+		| "no-upper-bound";
+	readonly entries?: number;
+}
+
+/**
+ * Rebuilds one summary's transcript slice from local history (spec §8.2).
+ *
+ * Bounds, both mandatory:
+ *   - LOWER — the owner edge's `firstSeenLine`, exactly as the live read path
+ *     seeds a first read (Task 5). Never 0-by-default: a summary whose owner
+ *     cannot be proven is refused outright, not silently read from the top of
+ *     a transcript that may hold turns belonging to a DIFFERENT worktree that
+ *     happened to share the same Claude session.
+ *   - UPPER — `generatedAt` (the instant capture actually ran), falling back
+ *     to `commitDate` only when absent. `generatedAt` is preferred because
+ *     capture can run well after the commit (queued, retried, or backfilled
+ *     later), so the commit's own timestamp can PRECEDE — and would then
+ *     wrongly truncate — the turns that actually produced it.
+ *
+ * `apply: false` performs every step except the final write, so the outcome a
+ * dry run reports is the outcome a real run would produce: there is exactly
+ * one code path, so the two cannot drift apart.
+ *
+ * Refusal is the default (spec §8.3): a missing summary, an unbounded window,
+ * no owner edge, a vanished transcript, or a bounded window with nothing in it
+ * all return without touching storage. A false negative leaves today's memory
+ * exactly as it is; a false positive would staple the wrong conversation onto
+ * a commit, which is strictly worse than the gap it would be papering over.
+ */
+export async function repairSummaryTranscripts(
+	commitHash: string,
+	cwd: string,
+	opts: { readonly apply?: boolean; readonly globalDir?: string } = {},
+): Promise<RepairOutcome> {
+	const summary = await getSummary(commitHash, cwd);
+	if (!summary) return { commitHash, repaired: false, reason: "no-owner-proof" };
+	return planRepair(summary, cwd, opts);
+}
+
+/**
+ * The engine's decision on ONE already-fetched summary — the single code path
+ * shared by {@link repairSummaryTranscripts} (which fetches then writes) and
+ * {@link transcriptRepairState} (which asks dry-run whether a repair is
+ * possible). Keeping both on this one function is what stops the UI's
+ * "repairable" sentence from drifting away from what a real run does.
+ */
+async function planRepair(
+	summary: CommitSummary,
+	cwd: string,
+	opts: { readonly apply?: boolean; readonly globalDir?: string },
+): Promise<RepairOutcome> {
+	const commitHash = summary.commitHash;
+	if (summary.transcriptsRepairedAt !== undefined || getTranscriptIds(summary).length > 0) {
+		return { commitHash, repaired: false, reason: "already-present" };
+	}
+
+	const before = summary.generatedAt || summary.commitDate;
+	if (!before) return { commitHash, repaired: false, reason: "no-upper-bound" };
+
+	const owned = await claudeSessionsOwnedBy(resolveStateRoot(cwd), opts.globalDir);
+	if (owned.length === 0) return { commitHash, repaired: false, reason: "no-owner-proof" };
+	const live = owned.filter((o) => existsSync(o.transcriptPath));
+	if (live.length === 0) return { commitHash, repaired: false, reason: "transcript-missing" };
+
+	const sessions: StoredSession[] = [];
+	for (const owner of live) {
+		let read: TranscriptReadResult;
+		try {
+			read = await readTranscript(
+				owner.transcriptPath,
+				{
+					transcriptPath: owner.transcriptPath,
+					lineNumber: owner.edge.firstSeenLine,
+					updatedAt: owner.edge.firstSeenAt,
+				},
+				getParserForSource("claude"),
+				before,
+			);
+		} catch (err) {
+			log.debug("repair: cannot read %s: %s", owner.transcriptPath, errMsg(err));
+			continue;
+		}
+		if (read.entries.length === 0) continue;
+		// Resolved here, not left off, per the archived-title contract every
+		// other stored-session writer follows (BackfillEngine.toStoredTranscript
+		// is the precedent for a writer outside QueueWorker's hot commit path):
+		// the transcript file this reads from is machine-local and pruned on the
+		// agent's own schedule, so a future reader re-deriving a title from
+		// `transcriptPath` is the one thing this repair cannot promise to work.
+		const title = await resolveArchivedTitle({
+			sessionId: owner.sessionId,
+			source: "claude",
+			transcriptPath: owner.transcriptPath,
+			entries: read.entries,
+		});
+		sessions.push({
+			sessionId: owner.sessionId,
+			transcriptPath: owner.transcriptPath,
+			source: "claude",
+			entries: read.entries,
+			...(title ? { title } : {}),
+		});
+	}
+	if (sessions.length === 0) return { commitHash, repaired: false, reason: "no-entries-in-window" };
+
+	const entries = sessions.reduce((n, s) => n + s.entries.length, 0);
+	if (opts.apply !== true) return { commitHash, repaired: true, reason: "repaired", entries };
+
+	const id = generateTranscriptId();
+	await storeSummary({ ...summary, transcripts: [id], transcriptsRepairedAt: new Date().toISOString() }, cwd, true, {
+		transcript: { id, data: { sessions } },
+	});
+	return { commitHash, repaired: true, reason: "repaired", entries };
+}

--- a/cli/src/dashboard/DashboardModel.ts
+++ b/cli/src/dashboard/DashboardModel.ts
@@ -14,6 +14,7 @@
  * talking to a server newer than its own assets.
  */
 
+import type { TranscriptRepairState } from "../core/TranscriptRepair.js";
 import type { KnowledgeGraph } from "../graph/GraphSchema.js";
 import type {
 	LocalAgentToolId,
@@ -959,6 +960,24 @@ export interface MemoryDetail {
 	 * type, so there is no second count here to pick the wrong one from.
 	 */
 	readonly conversations: ReadonlyArray<MemoryConversationRow>;
+	/**
+	 * Which of the three sentences spec §9 allows an EMPTY {@link conversations}
+	 * list to print — `transcriptRepairState` in
+	 * `cli/src/core/TranscriptRepair.ts`, the same predicate VS Code calls
+	 * in-process and IntelliJ reaches over the `transcript-repair-state` bridge
+	 * action, so one memory is never worded three different ways.
+	 *
+	 * OPTIONAL because it costs a filesystem read (the machine-global Claude
+	 * owners ledger, plus a stat per transcript it names) that only the DETAIL
+	 * view pays for, and because a page rendered before this shipped carries no
+	 * such field. `memories.js` treats an absent or unrecognised value as
+	 * `unrepairable`, the plainest wording — never as the optimistic one.
+	 *
+	 * It does NOT decide whether the empty block renders; `conversations` being
+	 * empty still does. `present` is not proof of renderable conversations: a
+	 * pre-v5 summary reads as `present` unconditionally.
+	 */
+	readonly transcriptRepairState?: TranscriptRepairState;
 	/** Plans, notes, references and the skills row — one ordered list, see {@link MemoryContextRow}. */
 	readonly context: ReadonlyArray<MemoryContextRow>;
 	readonly excluded: ReadonlyArray<MemoryExcludedRow>;

--- a/cli/src/dashboard/DashboardQuery.ts
+++ b/cli/src/dashboard/DashboardQuery.ts
@@ -20,6 +20,7 @@
 import { existsSync } from "node:fs";
 import { collectDisplayTopics } from "../core/SummaryTree.js";
 import { TOOL_RECORDING_SOURCES } from "../core/TranscriptParser.js";
+import type { TranscriptRepairState } from "../core/TranscriptRepair.js";
 import { createLogger, errMsg } from "../Logger.js";
 import type { CommitSummary } from "../Types.js";
 import type { DashboardDbHandle } from "./DashboardDb.js";
@@ -236,6 +237,15 @@ export interface QueryOptions {
 	 * Narrows the DETAIL only — see `buildMemories` for why this is not `scope`.
 	 */
 	readonly detailRepoIdentity?: string;
+	/**
+	 * Memories view: the async-read repair verdict for {@link hash}'s memory —
+	 * which of spec §9's three sentences an EMPTY conversations list prints. Read
+	 * by `readMemoryTranscriptRepairState` (it stats the machine-global Claude
+	 * owners ledger, which this synchronous layer cannot do) and threaded in the
+	 * same way {@link reachableCommits} and the three page models below are.
+	 * Absent leaves the client on the plainest wording.
+	 */
+	readonly transcriptRepairState?: TranscriptRepairState;
 	/**
 	 * The async-read per-repo git reachability sets, keyed by `repo_identity`.
 	 * Absent (or a repo missing from the map) renders every row unfiltered —
@@ -2238,6 +2248,7 @@ export function buildDashboardModel(db: DashboardDbHandle, opts: QueryOptions): 
 						options.hash,
 						options.reachableCommits,
 						options.detailRepoIdentity,
+						options.transcriptRepairState,
 					),
 				};
 			case "settings":

--- a/cli/src/dashboard/DashboardServer.test.ts
+++ b/cli/src/dashboard/DashboardServer.test.ts
@@ -56,6 +56,12 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 // as the other write handlers) — mocked so the server-layer tests stay hermetic.
 // Freshness is folder-wide aggregate; rebuild is the whole-folder compile sweep.
 vi.mock("../core/WikiFreshness.js", () => ({ getAggregateWikiFreshness: vi.fn() }));
+// Reads the machine-global Claude owners ledger, so a real call would answer
+// differently on every developer's machine. Its own cases are in
+// TranscriptRepair.test.ts.
+vi.mock("../core/TranscriptRepair.js", () => ({
+	transcriptRepairState: vi.fn().mockResolvedValue("repairable"),
+}));
 vi.mock("../core/MultiRepoCompile.js", () => ({
 	compileAllRepos: vi.fn(async () => ({ repos: [], totalIngested: 0, failed: 0 })),
 }));
@@ -72,6 +78,7 @@ import { compileAllRepos } from "../core/MultiRepoCompile.js";
 import { NEUTRAL_SOURCE_COLOR, SOURCE_META } from "../core/references/SourceLabels.js";
 import { initTelemetry, shutdownTelemetry } from "../core/Telemetry.js";
 import { readTelemetryEvents } from "../core/TelemetryBuffer.js";
+import { transcriptRepairState } from "../core/TranscriptRepair.js";
 import { TRANSCRIPT_SOURCE_LABELS } from "../core/TranscriptSourceLabel.js";
 import { getAggregateWikiFreshness } from "../core/WikiFreshness.js";
 import * as installer from "../install/Installer.js";
@@ -1679,6 +1686,57 @@ describe("defaultModelBuilder (no injected buildModel)", () => {
 		expect(body.view).toBe("memories");
 		expect(gitOps.listReachableCommits).toHaveBeenCalledWith("/w/jolli");
 		expect((body.memories?.items ?? []).map((item) => item.commitHash)).toEqual(["reachable-hash"]);
+	});
+
+	// The other async read the Memories view pays for, and the only one that is
+	// per-SELECTION rather than per-repo: which of spec §9's three sentences an
+	// empty conversations list is allowed to print. Nothing else in the payload
+	// fails when this stops being computed — the page just quietly reverts to the
+	// plainest wording — so this is the test that notices.
+	it("attaches the transcript repair state to the selected memory, and skips it with no selection", async () => {
+		const dbPath = join(dir, "memories-repair.db");
+		const configDir = join(dir, "config-repair");
+		const hash = "a".repeat(40);
+		await applyStatsEvents(
+			[
+				{
+					producerKind: "cli",
+					event: {
+						type: "repo.enabled",
+						repoIdentity: "repo-1",
+						repoName: "jolli",
+						worktreeRoot: "/w/jolli",
+						enabledAt: "t",
+					},
+				},
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		await withDashboardDb(
+			(db) => {
+				const { id } = db.prepare("SELECT id FROM repos WHERE repo_identity = ?").get("repo-1") as {
+					id: number;
+				};
+				db.prepare(
+					`INSERT INTO memories (repo_id, commit_hash, parent_hash, child_pos, root_hash, depth,
+					                       summary_json, first_seen_ms, written_at_ms, commit_date_ms)
+					 VALUES (?, ?, NULL, NULL, ?, 0, ?, 1, 1, 1)`,
+				).run(id, hash, hash, JSON.stringify({ commitHash: hash, topics: [] }));
+			},
+			{ dbPath },
+		);
+		// Reachability filters the tree ROWS, never the detail pane, so the stub's
+		// default answer is left alone here — the selected memory resolves by hash.
+		const port = await listen(createDashboardServer({ port: 0, assetsDir, dbPath, configDir }));
+
+		const selected = (await (await get(port, `/api/model?view=memories&hash=${hash}`)).json()) as DashboardModel;
+		expect(selected.memories?.selected?.transcriptRepairState).toBe("repairable");
+
+		// A tree render with no `?hash=` has no detail pane to word, so it must
+		// not pay the ledger read at all.
+		vi.mocked(transcriptRepairState).mockClear();
+		await get(port, "/api/model?view=memories");
+		expect(transcriptRepairState).not.toHaveBeenCalled();
 	});
 
 	// The `/` redirect builds no model at all now — it has one destination, so

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -139,7 +139,13 @@ import {
 	resolveKbRoot,
 	WIKI_FILE_PATTERN,
 } from "./KnowledgeQuery.js";
-import { buildMemoriesPage, type ReachableCommits, readContextDoc, readConversationEntries } from "./MemoriesQuery.js";
+import {
+	buildMemoriesPage,
+	type ReachableCommits,
+	readContextDoc,
+	readConversationEntries,
+	readMemoryTranscriptRepairState,
+} from "./MemoriesQuery.js";
 import { backupRepoRegistry, classifyRegistryEntry, forgetRepo, type RegistryEntryVerdict } from "./RepoForget.js";
 import { probeRepo } from "./RepoProbe.js";
 import { existingWorktrees, readRepoRegistry, recordedRepoPaths, registerRepo } from "./RepoRegistry.js";
@@ -706,6 +712,19 @@ async function defaultModelBuilder(
 							now,
 						)
 					: undefined;
+			// Which of spec §9's three sentences the memory detail's EMPTY
+			// conversations list prints. Async — it reads the machine-global Claude
+			// owners ledger and stats the transcripts it names — so it is computed
+			// here and threaded through `QueryOptions`, exactly like the reachability
+			// sets above. Without this the page would fall through to the plainest
+			// wording forever, with nothing failing to say so.
+			//
+			// Only the memories view, and only when a memory is actually selected: a
+			// tree render with no `?hash=` has no detail pane to word.
+			const transcriptRepairState =
+				request.view === "memories" && request.hash
+					? await readMemoryTranscriptRepairState(db, request.scope, request.hash, request.detailRepoIdentity)
+					: undefined;
 			// Every view is now served straight from the database. The stats view
 			// used to get one more step here — a display-time LLM call compressing
 			// the Decisions card's text — which is what made this builder async and
@@ -720,6 +739,7 @@ async function defaultModelBuilder(
 				...(graphModel ? { graphModel } : {}),
 				...(reachableCommits ? { reachableCommits } : {}),
 				...(authorIdentity ? { authorIdentity } : {}),
+				...(transcriptRepairState ? { transcriptRepairState } : {}),
 			});
 		},
 		{ dbPath },

--- a/cli/src/dashboard/MemoriesAsset.test.ts
+++ b/cli/src/dashboard/MemoriesAsset.test.ts
@@ -67,7 +67,13 @@ function render(
 	context: ReadonlyArray<Record<string, unknown>>,
 	conversations: ReadonlyArray<Record<string, unknown>> = [],
 	topics: ReadonlyArray<Record<string, unknown>> = [],
-	opts: { selected?: boolean; fetch?: FakeFetch; detail?: Record<string, unknown> } = {},
+	/** `extraSelected` adds server-attached `selected` fields (e.g. `transcriptRepairState`). */
+	opts: {
+		selected?: boolean;
+		fetch?: FakeFetch;
+		detail?: Record<string, unknown>;
+		extraSelected?: Record<string, unknown>;
+	} = {},
 ): {
 	rows: FakeRow[];
 	conversationRows: FakeRow[];
@@ -192,6 +198,7 @@ function render(
 							generatedAtMs: Date.parse("2026-08-14T03:22:00Z"),
 							e2e: [],
 							...opts.detail,
+							...(opts.extraSelected ?? {}),
 						},
 			tree: [],
 		},
@@ -314,7 +321,7 @@ describe("memories.js — empty states", () => {
 		// Both sections empty — the case that used to stack two 120px voids.
 		const { html } = render([], []);
 		expect(html).toContain('<div class="gd-empty">None.</div>');
-		expect(html).toContain('<div class="gd-empty">No conversations linked yet.</div>');
+		expect(html).toContain('<div class="gd-empty">No conversations were captured for this memory</div>');
 		expect(html).not.toContain("mem-empty-pane");
 	});
 });
@@ -775,6 +782,43 @@ describe("memories.js — conversation rows", () => {
 		const cli = render([], [conversation({ source: "cursor-cli" })]).html;
 		expect(cli).toContain('aria-label="cursor-cli"');
 		expect(cli).toContain("M8 1.5 14 5v6L8 14.5 2 11V5L8 1.5Z");
+	});
+});
+
+/**
+ * The three-state empty copy (spec §9). The old single sentence ("No
+ * conversations linked yet") read as *not yet* for a capture that already failed
+ * and will never complete on its own.
+ *
+ * Driven through the real renderer, so a branch that collapses back onto one
+ * sentence fails here — a `toContain` on the three strings would not. The
+ * degrade cases are the other half: the field arrives from the server, so an
+ * older payload, a state this build does not know, and `present` on a legacy
+ * summary must all land on the PLAINEST wording, never the optimistic one.
+ */
+describe("memories.js — empty conversations copy", () => {
+	const emptyFor = (state?: string) =>
+		render([], [], [], state === undefined ? {} : { extraSelected: { transcriptRepairState: state } }).html;
+
+	it("says the capture failed outright when nothing local can fix it", () => {
+		expect(emptyFor("unrepairable")).toContain("No conversations were captured for this memory");
+	});
+
+	it("offers repair only when the state says a repair is still possible", () => {
+		expect(emptyFor("repairable")).toContain("Conversation capture is missing but repair may still be possible");
+	});
+
+	it("says so when the capture was already repaired", () => {
+		expect(emptyFor("repaired")).toContain("Conversation capture was repaired from local transcript history");
+	});
+
+	it("degrades to the plainest copy for an absent or unrecognised state", () => {
+		for (const state of [undefined, "present", "something-new"]) {
+			const html = emptyFor(state);
+			expect(html).toContain("No conversations were captured for this memory");
+			expect(html).not.toContain("repair may still be possible");
+			expect(html).not.toContain("was repaired from");
+		}
 	});
 });
 

--- a/cli/src/dashboard/MemoriesQuery.test.ts
+++ b/cli/src/dashboard/MemoriesQuery.test.ts
@@ -2,7 +2,8 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { deflateSync } from "node:zlib";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { transcriptRepairState } from "../core/TranscriptRepair.js";
 import { withDashboardDb } from "./DashboardDb.js";
 import type { DashboardScope } from "./DashboardModel.js";
 import {
@@ -12,7 +13,17 @@ import {
 	buildMemoryDetail,
 	readContextDoc,
 	readConversationEntries,
+	readMemoryTranscriptRepairState,
 } from "./MemoriesQuery.js";
+
+// The predicate reads the machine-global `claude-owners.json` and stats every
+// transcript it names, so a real call would answer differently on each developer's
+// machine. Its own cases live in `TranscriptRepair.test.ts`; what these pin is the
+// wiring around it.
+vi.mock("../core/TranscriptRepair.js", () => ({
+	transcriptRepairState: vi.fn().mockResolvedValue("unrepairable"),
+}));
+
 import { applyStatsEvents } from "./StatsWriter.js";
 
 const ALL: DashboardScope = { kind: "all" };
@@ -1424,6 +1435,157 @@ describe("MemoriesQuery", () => {
 			// The source is half the key: the right session under the wrong agent is
 			// not a match.
 			expect(await read("codex", "sess-a")).toBeUndefined();
+		});
+	});
+
+	/**
+	 * The dashboard's half of the three-state memory-detail copy (spec §9).
+	 *
+	 * The predicate itself is covered by `TranscriptRepair.test.ts` and is stubbed
+	 * here: it reads the machine-global Claude owners ledger, so a real call would
+	 * make these cases answer differently on every developer's machine. What is
+	 * under test is the WIRING — that a state is produced at all, that it is
+	 * produced for the right repository, and that it reaches the payload the
+	 * client reads. Without a producer the page falls through to the plainest
+	 * sentence forever, and nothing else fails to say so.
+	 */
+	describe("readMemoryTranscriptRepairState", () => {
+		const HASH = "a".repeat(40);
+
+		beforeEach(() => {
+			vi.mocked(transcriptRepairState).mockReset();
+			vi.mocked(transcriptRepairState).mockResolvedValue("repairable");
+		});
+
+		it("answers the predicate's state for the selected memory", async () => {
+			await seedRepo(dbPath, "repo-1", "acme-api");
+			await seedMemory(dbPath, "repo-1", HASH, "feat: thing");
+
+			const state = await withDashboardDb((db) => readMemoryTranscriptRepairState(db, ALL, HASH), { dbPath });
+
+			expect(state).toBe("repairable");
+		});
+
+		it("asks about the OWNING repo's worktree, not the server's own cwd", async () => {
+			// The dashboard is machine-global: the process cwd names the wrong
+			// repository for every row but one, and the predicate resolves the
+			// Claude owner ledger against the root it is handed.
+			await seedRepo(dbPath, "repo-1", "acme-api");
+			await seedMemory(dbPath, "repo-1", HASH, "feat: thing");
+
+			await withDashboardDb((db) => readMemoryTranscriptRepairState(db, ALL, HASH), { dbPath });
+
+			expect(transcriptRepairState).toHaveBeenCalledWith(
+				expect.objectContaining({ commitHash: HASH }),
+				"/w/acme-api",
+			);
+		});
+
+		it("hands over the folded TREE, so an amended memory's children count", async () => {
+			// An amend/squash keeps its transcripts on the folded children, and the
+			// bare `memories.summary_json` row has `children` emptied — reading it
+			// alone would report a fully-captured consolidation as having none.
+			await seedRepo(dbPath, "repo-1", "acme-api");
+			const superseded = "b".repeat(40);
+			await seedMemory(dbPath, "repo-1", HASH, "feat: thing");
+			await seedMemory(dbPath, "repo-1", superseded, "feat: thing", { transcripts: ["t-1"] });
+			await withDashboardDb(
+				(db) => {
+					const { id: repoId } = db.prepare("SELECT id FROM repos WHERE repo_identity = ?").get("repo-1") as {
+						id: number;
+					};
+					db.prepare(
+						"UPDATE memories SET parent_hash = ?, child_pos = 0, root_hash = ?, depth = 1 WHERE repo_id = ? AND commit_hash = ?",
+					).run(HASH, HASH, repoId, superseded);
+					// `assembleSummary` fills `children` in place and never inserts the
+					// key, so the stored root has to carry the emptied array the import
+					// leaves behind — which is exactly what a real amended memory has.
+					db.prepare("UPDATE memories SET summary_json = ? WHERE repo_id = ? AND commit_hash = ?").run(
+						JSON.stringify({ commitHash: HASH, commitMessage: "feat: thing", children: [] }),
+						repoId,
+						HASH,
+					);
+				},
+				{ dbPath },
+			);
+
+			await withDashboardDb((db) => readMemoryTranscriptRepairState(db, ALL, HASH), { dbPath });
+
+			const summary = vi.mocked(transcriptRepairState).mock.calls[0]?.[0] as {
+				children?: ReadonlyArray<{ commitHash: string }>;
+			};
+			expect(summary.children?.map((c) => c.commitHash)).toEqual([superseded]);
+		});
+
+		it("falls back to the page scope for a stale detail-repo token", async () => {
+			// Same rule the detail pane itself follows: a token that resolves to no
+			// repo (removed, or renamed since the page rendered) must not narrow the
+			// lookup to a filter matching nothing — the hash still identifies the
+			// memory. The two must agree, or the page would word one memory's
+			// verdict onto another's conversations.
+			await seedRepo(dbPath, "repo-1", "acme-api");
+			await seedMemory(dbPath, "repo-1", HASH, "feat: thing");
+
+			const state = await withDashboardDb(
+				(db) => readMemoryTranscriptRepairState(db, ALL, HASH, "repo-that-was-removed"),
+				{ dbPath },
+			);
+
+			expect(state).toBe("repairable");
+		});
+
+		it("answers undefined for an unknown hash without asking the predicate", async () => {
+			await seedRepo(dbPath, "repo-1", "acme-api");
+
+			const state = await withDashboardDb((db) => readMemoryTranscriptRepairState(db, ALL, HASH), { dbPath });
+
+			expect(state).toBeUndefined();
+			expect(transcriptRepairState).not.toHaveBeenCalled();
+		});
+
+		it("answers undefined with no hash at all", async () => {
+			await seedRepo(dbPath, "repo-1", "acme-api");
+
+			const state = await withDashboardDb((db) => readMemoryTranscriptRepairState(db, ALL, undefined), {
+				dbPath,
+			});
+
+			expect(state).toBeUndefined();
+		});
+
+		it("answers undefined rather than throwing when the predicate fails", async () => {
+			// A wording detail must never take the memory detail page down with it,
+			// and undefined is the plainest sentence — not the optimistic one.
+			await seedRepo(dbPath, "repo-1", "acme-api");
+			await seedMemory(dbPath, "repo-1", HASH, "feat: thing");
+			vi.mocked(transcriptRepairState).mockRejectedValue(new Error("owners ledger unreadable"));
+
+			const state = await withDashboardDb((db) => readMemoryTranscriptRepairState(db, ALL, HASH), { dbPath });
+
+			expect(state).toBeUndefined();
+		});
+
+		it("attaches the state to the detail buildMemories selects", async () => {
+			// The end of the wire: `memories.js` reads exactly this field.
+			await seedRepo(dbPath, "repo-1", "acme-api");
+			await seedMemory(dbPath, "repo-1", HASH, "feat: thing");
+
+			const model = await withDashboardDb(
+				(db) => buildMemories(db, ALL, HASH, undefined, undefined, "repaired"),
+				{ dbPath },
+			);
+
+			expect(model.selected?.transcriptRepairState).toBe("repaired");
+		});
+
+		it("omits the field entirely when no state was computed", async () => {
+			await seedRepo(dbPath, "repo-1", "acme-api");
+			await seedMemory(dbPath, "repo-1", HASH, "feat: thing");
+
+			const model = await withDashboardDb((db) => buildMemories(db, ALL, HASH), { dbPath });
+
+			expect(model.selected).toBeDefined();
+			expect(model.selected).not.toHaveProperty("transcriptRepairState");
 		});
 	});
 });

--- a/cli/src/dashboard/MemoriesQuery.ts
+++ b/cli/src/dashboard/MemoriesQuery.ts
@@ -46,6 +46,7 @@ import {
 } from "../core/SummaryTree.js";
 import { estimateSummaryCostUsd } from "../core/TokenCost.js";
 import { TOOL_RECORDING_SOURCES } from "../core/TranscriptParser.js";
+import { type TranscriptRepairState, transcriptRepairState } from "../core/TranscriptRepair.js";
 import { createLogger, errMsg } from "../Logger.js";
 import type { CommitSummary, StoredTranscript } from "../Types.js";
 import type { DashboardDbHandle } from "./DashboardDb.js";
@@ -652,11 +653,23 @@ function buildContextRows(summary: CommitSummary): ReadonlyArray<MemoryContextRo
 	];
 }
 
-/** One memory's full detail, or undefined when `hash` does not resolve within `scope`. */
+/**
+ * One memory's full detail, or undefined when `hash` does not resolve within
+ * `scope`.
+ *
+ * `transcriptRepairState` is passed IN rather than derived here because the
+ * predicate is async (it reads the machine-global Claude owners ledger and stats
+ * the transcripts it names) while this whole query layer is synchronous —
+ * `buildDashboardModel` has hundreds of synchronous call sites. It is threaded
+ * from `defaultModelBuilder` exactly like `reachableCommits` and the settings /
+ * knowledge / graph models, which are async for the same reason.
+ * {@link readMemoryTranscriptRepairState} is what computes it.
+ */
 export function buildMemoryDetail(
 	db: DashboardDbHandle,
 	scope: DashboardScope,
 	hash: string,
+	transcriptRepairState?: TranscriptRepairState,
 ): MemoryDetail | undefined {
 	// Guard the empty string explicitly: with the prefix predicate below,
 	// `length("")=0` makes `substr(commit_hash,1,0)=""` true for EVERY row (the
@@ -861,6 +874,7 @@ export function buildMemoryDetail(
 		generatedAtMs,
 		...(summary.recap ? { recap: summary.recap } : {}),
 		conversations: buildConversations(db, row.repo_id, fullHash, summary),
+		...(transcriptRepairState ? { transcriptRepairState } : {}),
 		context,
 		excluded,
 		activity,
@@ -893,27 +907,107 @@ export function buildMemories(
 	hash: string | undefined,
 	reachable?: ReachableCommits,
 	detailRepoIdentity?: string,
+	transcriptRepairState?: TranscriptRepairState,
 ): MemoriesModel {
 	const list = buildMemoriesList(db, scope, reachable);
 	if (!hash) return list;
-	// Through `resolveScope`, because the link carries whatever `JD.repoToken`
-	// picked — usually the repo NAME, since that is the readable token. Handing a
-	// name straight to `buildMemoryDetail` resolves to repo id -1 (matches
-	// nothing), so the tree row navigated to a page whose detail pane stayed
-	// empty: the click looked like it did nothing at all.
-	// Always exactly ONE identity: this names the memory's owner, not the page
-	// scope, and a detail pane showing one memory has one owning repo.
+	const selected = buildMemoryDetail(
+		db,
+		resolveDetailScope(db, scope, detailRepoIdentity),
+		hash,
+		transcriptRepairState,
+	);
+	return selected ? { ...list, selected } : list;
+}
+
+/**
+ * Which repositories the DETAIL pane may resolve `hash` in.
+ *
+ * Through `resolveScope`, because the link carries whatever `JD.repoToken`
+ * picked — usually the repo NAME, since that is the readable token. Handing a
+ * name straight to `buildMemoryDetail` resolves to repo id -1 (matches nothing),
+ * so the tree row navigated to a page whose detail pane stayed empty: the click
+ * looked like it did nothing at all.
+ *
+ * Always exactly ONE identity: this names the memory's owner, not the page
+ * scope, and a detail pane showing one memory has one owning repo.
+ *
+ * A token that resolves to no repo means the link is stale (repo removed, or
+ * renamed since the page was rendered). Falls back to the page scope rather than
+ * to a filter that matches nothing — the hash still identifies the memory, and
+ * showing it is strictly better than showing an empty pane.
+ *
+ * Shared with {@link readMemoryTranscriptRepairState} rather than inlined twice:
+ * the two must resolve the SAME memory, or the page would print one memory's
+ * conversations under another's repair verdict.
+ */
+function resolveDetailScope(
+	db: DashboardDbHandle,
+	scope: DashboardScope,
+	detailRepoIdentity: string | undefined,
+): DashboardScope {
 	const detailScope: DashboardScope = detailRepoIdentity
 		? resolveScope(db, { kind: "repo", repoIdentities: [detailRepoIdentity] })
 		: scope;
-	// A token that resolves to no repo means the link is stale (repo removed, or
-	// renamed since the page was rendered). Fall back to the page scope rather
-	// than to a filter that matches nothing — the hash still identifies the
-	// memory, and showing it is strictly better than showing an empty pane.
 	const detailIds = scopeToRepoIds(db, detailScope).repoIds;
-	const detail = detailIds?.includes(-1) ? scope : detailScope;
-	const selected = buildMemoryDetail(db, detail, hash);
-	return selected ? { ...list, selected } : list;
+	return detailIds?.includes(-1) ? scope : detailScope;
+}
+
+/**
+ * The repair verdict for the memory {@link buildMemories} would select — the
+ * only ASYNC part of the Memories payload, computed by `defaultModelBuilder`
+ * and threaded back in.
+ *
+ * Why it cannot live in `buildMemoryDetail`: the predicate reads the
+ * machine-global Claude owners ledger and stats every transcript it names, while
+ * the whole query layer below `buildDashboardModel` is synchronous. The same
+ * shape `reachableCommits` and the settings / knowledge / graph models already
+ * use.
+ *
+ * The summary is assembled as a TREE, matching `buildMemoryDetail`: an
+ * amend/squash memory keeps its transcripts on the folded children, and the bare
+ * `memories.summary_json` row has `children` emptied — reading it alone would
+ * report a fully-captured consolidation as having no conversations at all.
+ *
+ * Every failure answers `undefined`, which `memories.js` renders as the plainest
+ * sentence. This is a wording detail on a page that must still open: a repo
+ * whose worktree has moved, an unparseable row, or an unreadable ledger must not
+ * take the memory detail down with it, and must not guess the optimistic way.
+ */
+export async function readMemoryTranscriptRepairState(
+	db: DashboardDbHandle,
+	scope: DashboardScope,
+	hash: string | undefined,
+	detailRepoIdentity?: string,
+): Promise<TranscriptRepairState | undefined> {
+	if (!hash) return undefined;
+	try {
+		const filter = scopeFilter(scopeToRepoIds(db, resolveDetailScope(db, scope, detailRepoIdentity)), "m.repo_id");
+		// Same predicate, ordering and LIMIT as `buildMemoryDetail`'s row query,
+		// so a short hash that resolves to one memory there resolves to the same
+		// one here. `worktree_root` is the cwd the predicate needs: the dashboard
+		// is machine-global, so the server's own cwd names the wrong repository
+		// for every row but one.
+		const row = db
+			.prepare(
+				`SELECT m.repo_id, m.commit_hash, m.summary_json, r.worktree_root
+				   FROM memories m
+				   JOIN repos r ON r.id = m.repo_id
+				  WHERE substr(m.commit_hash, 1, length(?)) = ?${filter.sql}
+				  ORDER BY m.repo_id, m.commit_hash
+				  LIMIT 1`,
+			)
+			.get(hash, hash, ...filter.params) as
+			| { repo_id: number; commit_hash: string; summary_json: string; worktree_root: string | null }
+			| undefined;
+		if (!row?.worktree_root) return undefined;
+		const summary = (assembleMemoryTree(db, row.repo_id, row.commit_hash) ??
+			JSON.parse(row.summary_json)) as CommitSummary;
+		return await transcriptRepairState(summary, row.worktree_root);
+	} catch (err) {
+		log.debug("transcript repair state unavailable for %s: %s", hash, errMsg(err));
+		return undefined;
+	}
 }
 
 /**

--- a/cli/src/dashboard/ProducerHooks.ts
+++ b/cli/src/dashboard/ProducerHooks.ts
@@ -26,6 +26,7 @@
  */
 
 import { dirname } from "node:path";
+import { currentAgentSessionId } from "../core/AgentSessionEnv.js";
 import { getCommitInfo, getCurrentBranch, getProjectRootDir } from "../core/GitOps.js";
 import { getSummary, readTranscriptsForCommits } from "../core/SummaryStore.js";
 import { getTranscriptIds } from "../core/SummaryTree.js";
@@ -212,58 +213,6 @@ export async function recordRecallReceipt(
 		],
 		dbPath,
 	);
-}
-
-/**
- * Environment variables that carry the id of the agent session this process is
- * running inside, most-specific first.
- *
- * **One entry, and that is a measured result rather than an unfinished list.**
- * Claude Code exports `CLAUDE_CODE_SESSION_ID`, and it is the same uuid
- * `sessions.session_id` carries, so a receipt written from it joins straight
- * onto the session row (verified against a live session). The other hosts were
- * checked the only way that settles it — reading `/proc/<pid>/environ` of a
- * running one — and they publish nothing usable:
- *
- *   - **codex**: the whole environment carries no session/conversation/thread
- *     variable; the only codex-specific entry is
- *     `CODEX_INTERNAL_ORIGINATOR_OVERRIDE`, which names the front-end, not the
- *     session. Its session id exists only inside its own rollout files.
- *
- * So a recall from those hosts writes no session id, and that is the honest
- * answer rather than a gap to paper over — see the note below on why the
- * tempting fallback is worse than the blank.
- *
- * Adding a host means measuring it the same way and appending its real variable
- * name here; nothing else changes.
- */
-const SESSION_ID_ENV_VARS: ReadonlyArray<string> = ["CLAUDE_CODE_SESSION_ID"];
-
-/**
- * The agent session this process is running inside, when one advertised itself
- * in the environment.
- *
- * Undefined for a plain terminal and for every host in the note above. That
- * costs real coverage — a recall from codex or cline can never be counted among
- * the sessions that got prior context — and it is still the right answer,
- * because the available fallback is to pick the most recently touched session
- * for this repo, which is a GUESS that looks exactly like a fact once stored.
- * Any figure derived from these receipts would then be wrong in the one
- * direction nobody can audit: attributing a call to a session that never made
- * it.
- *
- * A null is visible as a null; an invented id is not. Nothing reads that
- * distinction today — the dashboard's Recall card was removed (JOLLI-2193) and
- * with it the only consumer — but the receipts are still written, and a
- * fabricated id would be indistinguishable from a real one by the time anything
- * does.
- */
-function currentAgentSessionId(): string | undefined {
-	for (const name of SESSION_ID_ENV_VARS) {
-		const id = process.env[name]?.trim();
-		if (id) return id;
-	}
-	return undefined;
 }
 
 /**

--- a/cli/src/dashboard/assets/js/memories.js
+++ b/cli/src/dashboard/assets/js/memories.js
@@ -423,6 +423,25 @@ window.JD = window.JD || {};
 		return '<div class="gd-links">' + list.map(render).join("") + "</div>";
 	}
 
+	/**
+	 * Which of the three sentences spec §9 allows an empty Conversations list to
+	 * print, from the state the server attached to this detail
+	 * (`MemoryDetail.transcriptRepairState`, derived by the CLI's
+	 * `transcriptRepairState` predicate).
+	 *
+	 * Anything unrecognised — an absent field on an older payload, `present` on a
+	 * legacy summary that reads as captured while holding nothing — falls to the
+	 * plainest wording. "Repair may still be possible" is the one wrong direction
+	 * to guess in: it invites a repair with nothing to work from. The old copy
+	 * ("No conversations linked yet") read as *not yet*, which is exactly the lie
+	 * this replaces for a capture that already failed.
+	 */
+	function conversationsEmptyText(state) {
+		if (state === "repairable") return "Conversation capture is missing but repair may still be possible";
+		if (state === "repaired") return "Conversation capture was repaired from local transcript history";
+		return "No conversations were captured for this memory";
+	}
+
 	function conversationsSection(detail) {
 		var esc = JD.esc;
 		var body = rows(
@@ -471,7 +490,7 @@ window.JD = window.JD || {};
 				'<span class="mem-row-title">' +
 				esc(c.title || "(untitled)") +
 				'</span><span class="mem-row-meta">' + c.messageCount + " msgs</span></div>",
-			"No conversations linked yet.",
+			conversationsEmptyText(detail.transcriptRepairState),
 		);
 		return (
 			'<section class="mem-section mem-conversations"><div class="mem-section-head"><div class="gd-sec">' +

--- a/cli/src/hooks/PostCommitHook.helpers.test.ts
+++ b/cli/src/hooks/PostCommitHook.helpers.test.ts
@@ -138,6 +138,10 @@ vi.mock("../core/GitOps.js", () => ({
 	// via getTranscriptHashes → OrphanBranchStorage.listFiles. Empty listing is
 	// fine here — these tests don't assert on the resulting transcripts array.
 	listFilesInBranch: vi.fn().mockResolvedValue([]),
+	// Identity fake: loadSessionTranscripts keys the Claude ownership ledger
+	// lookup on this. This suite isn't exercising that lookup, so match
+	// QueueWorker.test.ts's convention rather than inventing a second one.
+	resolveStateRoot: vi.fn((cwd: string) => cwd),
 }));
 
 vi.mock("../core/SessionTracker.js", () => ({

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -38,6 +38,10 @@ vi.mock("../core/GitOps.js", () => ({
 	getLastReflogAction: vi.fn(),
 	readFileFromBranch: vi.fn(),
 	getProjectRootDir: vi.fn().mockImplementation((cwd: string) => Promise.resolve(cwd)),
+	// Identity fake: loadSessionTranscripts keys the Claude ownership ledger
+	// lookup on this. This suite isn't exercising that lookup, so match
+	// QueueWorker.test.ts's convention rather than inventing a second one.
+	resolveStateRoot: vi.fn((cwd: string) => cwd),
 }));
 
 vi.mock("../dashboard/CutoverRouter.js", () => ({

--- a/cli/src/hooks/PostCommitHook.ts
+++ b/cli/src/hooks/PostCommitHook.ts
@@ -13,6 +13,7 @@
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { currentAgentSessionId } from "../core/AgentSessionEnv.js";
 import { readManualDisableFlag } from "../core/RepoProfile.js";
 import { getCurrentTraceId, runWithTrace, traceIdFromEnv } from "../core/TraceContext.js";
 import { createLogger } from "../Logger.js";
@@ -112,6 +113,10 @@ export function postCommitEntry(cwd: string): { commitHash: string } | null {
 	// drains this commit — unifying the hook's logs, the worker's logs, and the
 	// outbound LLM/push calls under one id across the process boundary.
 	const traceId = getCurrentTraceId();
+	// The session that ran this commit, if the hook inherited its env. Stamped so
+	// the detached worker can attribute a cross-worktree commit to its authoring
+	// session even when the forward ledger has no cwd trace of it in this checkout.
+	const executingSessionId = currentAgentSessionId();
 	const op: GitOperation = {
 		type: opType,
 		commitHash,
@@ -120,6 +125,7 @@ export function postCommitEntry(cwd: string): { commitHash: string } | null {
 		commitSource,
 		createdAt: new Date().toISOString(),
 		...(traceId && { traceId }),
+		...(executingSessionId && { executingSessionId }),
 	};
 
 	// Write queue entry synchronously (post-commit hook must return quickly)

--- a/cli/src/hooks/QueueWorker.overlay.test.ts
+++ b/cli/src/hooks/QueueWorker.overlay.test.ts
@@ -32,6 +32,10 @@ vi.mock("../core/GitOps.js", () => ({
 	getCurrentBranch: vi.fn(),
 	getLastReflogAction: vi.fn(),
 	readFileFromBranch: vi.fn(),
+	// Identity fake: loadSessionTranscripts keys the Claude ownership ledger
+	// lookup on this. This suite isn't exercising that lookup, so match
+	// QueueWorker.test.ts's convention rather than inventing a second one.
+	resolveStateRoot: vi.fn((cwd: string) => cwd),
 }));
 
 vi.mock("../core/SessionTracker.js", async (importOriginal) => {

--- a/cli/src/hooks/QueueWorker.selection.test.ts
+++ b/cli/src/hooks/QueueWorker.selection.test.ts
@@ -47,6 +47,10 @@ vi.mock("../core/GitOps.js", () => ({
 	getCurrentBranch: vi.fn(),
 	getLastReflogAction: vi.fn(),
 	readFileFromBranch: vi.fn(),
+	// Identity fake: loadSessionTranscripts keys the Claude ownership ledger
+	// lookup on this. This suite isn't exercising that lookup, so match
+	// QueueWorker.test.ts's convention rather than inventing a second one.
+	resolveStateRoot: vi.fn((cwd: string) => cwd),
 }));
 
 vi.mock("../core/SessionTracker.js", async (importOriginal) => {

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -29,6 +29,15 @@ vi.mock("../core/GitOps.js", () => ({
 	resolveWorktreeRootOrNull: vi.fn((cwd: string) => cwd),
 }));
 
+// Keep `scanOwnerEdges` (used real below) and every other export, but stub the
+// executing-session backfill so the wiring tests can assert loadSessionTranscripts
+// calls it without driving a real ~/.claude/projects scan. Its own behavior is
+// covered directly in ClaudeOwnerScan.test.ts.
+vi.mock("../core/ClaudeOwnerScan.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../core/ClaudeOwnerScan.js")>()),
+	backfillExecutingSessionOwnership: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("../core/RepoProfile.js", () => ({
 	// Pre-cutover default: no fence (plain fn — survives mock resets).
 	readCutoverFence: async () => null,
@@ -585,7 +594,7 @@ import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { scanOwnerEdges } from "../core/ClaudeOwnerScan.js";
+import { backfillExecutingSessionOwnership, scanOwnerEdges } from "../core/ClaudeOwnerScan.js";
 import { type ClaudeOwnerEdge, claudeOwnersPath, recordClaudeOwners } from "../core/ClaudeOwnership.js";
 import { claudeSessionsForRepo } from "../core/ClaudeSessionDiscoverer.js";
 import { isClineCliInstalled } from "../core/ClineCliDetector.js";
@@ -5761,6 +5770,39 @@ describe("QueueWorker", () => {
 				const result = await __test__.loadSessionTranscripts(cwd, { claudeEnabled: false });
 
 				expect(result.allSessions.some((s) => s.sessionId === "off-1")).toBe(false);
+			});
+		});
+
+		// ─── Executing-session backfill (甲): a commit run by a Claude session that
+		// authored files in THIS worktree from another checkout leaves no cwd trace
+		// here, and if the edit + commit happened in one turn the Stop hook has not
+		// recorded it yet. loadSessionTranscripts backfills that session's ownership
+		// from `op.executingSessionId` before the owner lookup, so the commit is
+		// attributed to its author instead of nothing.
+		describe("executing-session backfill", () => {
+			beforeEach(() => {
+				vi.mocked(backfillExecutingSessionOwnership).mockClear().mockResolvedValue(undefined);
+			});
+
+			it("backfills the executing session's ownership before resolving owners", async () => {
+				await withLedgerHome(async () => {
+					await __test__.loadSessionTranscripts(cwd, {}, undefined, "exec-sid");
+					expect(backfillExecutingSessionOwnership).toHaveBeenCalledWith("exec-sid", cwd);
+				});
+			});
+
+			it("does not backfill when no executing session id is present", async () => {
+				await withLedgerHome(async () => {
+					await __test__.loadSessionTranscripts(cwd, {});
+					expect(backfillExecutingSessionOwnership).not.toHaveBeenCalled();
+				});
+			});
+
+			it("does not backfill when claudeEnabled is false", async () => {
+				await withLedgerHome(async () => {
+					await __test__.loadSessionTranscripts(cwd, { claudeEnabled: false }, undefined, "exec-sid");
+					expect(backfillExecutingSessionOwnership).not.toHaveBeenCalled();
+				});
 			});
 		});
 

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -16,6 +16,17 @@ vi.mock("../core/GitOps.js", () => ({
 	getLastReflogAction: vi.fn(),
 	readFileFromBranch: vi.fn(),
 	getProjectRootDir: vi.fn().mockImplementation((cwd: string) => Promise.resolve(cwd)),
+	// Identity fakes: this suite's fixtures are plain temp dirs, not git repos, and
+	// the real resolveStateRoot falls back to its input unchanged in that case
+	// anyway. What matters for these tests is that production and test build the
+	// ledger key the SAME way — the realpath/macOS-normalisation behavior itself
+	// is covered directly in GitOps.test.ts / ClaudeOwnerScan.test.ts.
+	// `resolveWorktreeRootOrNull` is what `scanOwnerEdges`' default resolver now
+	// uses; identity here so a temp-dir cwd still resolves to itself (in
+	// production it is a real worktree root, and a genuinely non-git cwd is
+	// correctly dropped — that path is covered in ClaudeOwnerScan.test.ts).
+	resolveStateRoot: vi.fn((cwd: string) => cwd),
+	resolveWorktreeRootOrNull: vi.fn((cwd: string) => cwd),
 }));
 
 vi.mock("../core/RepoProfile.js", () => ({
@@ -85,6 +96,11 @@ vi.mock("../core/SessionTracker.js", async (importOriginal) => {
 		detectActiveNotesForBranch: vi.fn().mockResolvedValue([]),
 		getReferenceEntriesForBranch: vi.fn().mockResolvedValue([]),
 		filterSessionsByEnabledIntegrations: actual.filterSessionsByEnabledIntegrations,
+		// Real implementation (pure `join(homedir(), …)`): the ledger merge tests
+		// isolate HOME via `withIsolatedHome` and need this to follow that redirect,
+		// the same way the production code's `claudeSessionsOwnedBy(ownerRoot)` call
+		// (no `globalDir` override) does.
+		getGlobalConfigDir: actual.getGlobalConfigDir,
 		dequeueAllGitOperations: vi.fn().mockResolvedValue([]),
 		peekAllGitOperations: vi.fn().mockResolvedValue([]),
 		deleteQueueEntry: vi.fn(),
@@ -177,6 +193,11 @@ vi.mock("../core/Locks.js", () => ({
 	// per-worktree lock contract itself is covered in Locks.test.ts.
 	withPlansLock: (_cwd: string | undefined, fn: () => Promise<unknown>) => fn(),
 	withCommitSelectionLock: (_cwd: string | undefined, fn: () => Promise<unknown>) => fn(),
+	// Passthrough, same reasoning as withPlansLock above: recordClaudeOwners (used
+	// directly, unmocked, by the ledger-merge tests to seed claude-owners.json)
+	// wraps its read-merge-write in this lock. The lock contract itself is
+	// covered in Locks.test.ts.
+	withClaudeOwnersLock: (fn: () => Promise<unknown>) => fn(),
 	INGEST_PHASE_FILE: "ingest-phase",
 }));
 
@@ -564,6 +585,9 @@ import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { scanOwnerEdges } from "../core/ClaudeOwnerScan.js";
+import { type ClaudeOwnerEdge, claudeOwnersPath, recordClaudeOwners } from "../core/ClaudeOwnership.js";
+import { claudeSessionsForRepo } from "../core/ClaudeSessionDiscoverer.js";
 import { isClineCliInstalled } from "../core/ClineCliDetector.js";
 import { discoverClineCliSessions } from "../core/ClineCliSessionDiscoverer.js";
 import { readClineCliTranscript } from "../core/ClineCliTranscriptReader.js";
@@ -585,7 +609,8 @@ import { discoverCursorSessions } from "../core/CursorSessionDiscoverer.js";
 import { readCursorTranscript } from "../core/CursorTranscriptReader.js";
 import { discoverDevinSessions, isDevinInstalled } from "../core/DevinSessionDiscoverer.js";
 import { readDevinTranscript } from "../core/DevinTranscriptReader.js";
-import { getCommitInfo, getCurrentBranch, getDiffContent, getDiffStats } from "../core/GitOps.js";
+import { readGeminiTranscript } from "../core/GeminiTranscriptReader.js";
+import { getCommitInfo, getCurrentBranch, getDiffContent, getDiffStats, resolveStateRoot } from "../core/GitOps.js";
 import { drainIngest } from "../core/IngestPipeline.js";
 import { appendCredentialMissingRun } from "../core/IngestRunStore.js";
 import { enqueueIngestOperation } from "../core/IngestTrigger.js";
@@ -600,6 +625,7 @@ import {
 	detectActiveNotesForBranch,
 	detectActivePlansForBranch,
 	detectUncommittedReferenceIds,
+	getGlobalConfigDir,
 	getReferenceEntriesForBranch,
 	loadAllSessions,
 	loadConfig,
@@ -632,6 +658,7 @@ import type {
 	ReferenceCommitRef,
 	SkillCommitRef,
 } from "../Types.js";
+import { withIsolatedHome } from "../testUtils/isolatedHome.js";
 import { __test__, buildWorkerStartupBanner, launchWorker, runWorker } from "./QueueWorker.js";
 
 describe("runWorker — manual disable guard", () => {
@@ -5561,6 +5588,379 @@ describe("QueueWorker", () => {
 			} finally {
 				rmSync(cwd, { recursive: true, force: true });
 			}
+		});
+	});
+
+	// ─── Claude ownership ledger merge: the post-commit read considers Claude
+	// sessions this worktree OWNS per the machine-global ledger, not only the
+	// ones its own sessions.json happened to record (multi-owner Claude session
+	// attribution — a session started in one checkout and continued in another).
+	describe("loadSessionTranscripts — Claude ownership ledger merge", () => {
+		const NOW = "2026-08-17T10:00:00.000Z";
+		const makeEdge = (): ClaudeOwnerEdge => ({ firstSeenAt: NOW, firstSeenLine: 0, lastSeenAt: NOW });
+		let cwd: string;
+		let transcript: string;
+
+		beforeEach(() => {
+			cwd = mkdtempSync(join(tmpdir(), "jolli-ledger-cwd-"));
+			transcript = join(cwd, "transcript.jsonl");
+			writeFileSync(transcript, "", "utf-8");
+			// A single well-formed slice: every test here has exactly one merged
+			// "claude" session pointed at `transcript`, so one shared resolved value
+			// covers all of them (the readAllTranscripts "claude" branch reads
+			// `result.newCursor.lineNumber` unguarded — an unmocked/undefined
+			// `readTranscript` result throws outside its own try/catch).
+			vi.mocked(readTranscript).mockResolvedValue({
+				entries: [{ role: "human", content: "hi", timestamp: NOW }],
+				newCursor: { transcriptPath: transcript, lineNumber: 1, updatedAt: NOW },
+				totalLinesRead: 1,
+			});
+		});
+
+		afterEach(() => {
+			rmSync(cwd, { recursive: true, force: true });
+		});
+
+		/**
+		 * Runs `fn` with HOME/USERPROFILE redirected to a scratch dir (via the
+		 * pre-existing `withIsolatedHome` — setting `process.env.HOME` alone is a
+		 * no-op on Windows) AND the file-wide `readFile` mock wired to serve the
+		 * REAL claude-owners.json from that scratch dir. Production's
+		 * `claudeSessionsOwnedBy(ownerRoot)` call inside `loadSessionTranscripts`
+		 * takes no `globalDir` override, so HOME isolation is the only way to keep
+		 * this suite off the developer's real `~/.jolli/jollimemory/`.
+		 *
+		 * Delegates to the REAL `readFile` (via `importActual`), not the
+		 * already-imported `readFileSync` — that one is ALSO mocked file-wide
+		 * (`mockReturnValue("")`, see the `node:fs` mock above) for the plan/note
+		 * fixtures this suite otherwise drives, and would silently make every
+		 * ledger read see an empty file.
+		 */
+		async function withLedgerHome(fn: (globalDir: string) => Promise<void>): Promise<void> {
+			const homeDir = mkdtempSync(join(tmpdir(), "jolli-ledger-home-"));
+			try {
+				await withIsolatedHome(homeDir, async () => {
+					const globalDir = getGlobalConfigDir();
+					mkdirSync(globalDir, { recursive: true });
+					const { readFile } = await import("node:fs/promises");
+					const { readFile: realReadFile } =
+						await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+					const ledgerPath = claudeOwnersPath(globalDir);
+					vi.mocked(readFile).mockImplementation(async (p: unknown) =>
+						String(p) === ledgerPath ? realReadFile(ledgerPath, "utf-8") : "",
+					);
+					await fn(globalDir);
+				});
+			} finally {
+				rmSync(homeDir, { recursive: true, force: true });
+			}
+		}
+
+		it("reads a Claude session this worktree owns even when sessions.json has none", async () => {
+			await withLedgerHome(async (globalDir) => {
+				await recordClaudeOwners(
+					{
+						sessionId: "foreign-1",
+						transcriptPath: transcript,
+						edges: new Map([[resolveStateRoot(cwd), makeEdge()]]),
+					},
+					globalDir,
+				);
+
+				const result = await __test__.loadSessionTranscripts(cwd, {});
+
+				expect(result.allSessions).toContainEqual(
+					expect.objectContaining({ sessionId: "foreign-1", transcriptPath: transcript, source: "claude" }),
+				);
+				// End-to-end: the ledger-contributed session actually got read, not just
+				// merged into the candidate list.
+				expect(result.sessionTranscripts.some((s) => s.sessionId === "foreign-1")).toBe(true);
+			});
+		});
+
+		// Regression guard for the exact failure mode the brief calls out: an
+		// unnormalised lookup (plain `cwd` instead of `resolveStateRoot(cwd)`)
+		// "matches nothing, silently, and the whole feature does nothing". Every
+		// other test in this block builds its edge key via `resolveStateRoot(cwd)`
+		// too, but under this file's identity mock (`resolveStateRoot: vi.fn((cwd)
+		// => cwd)`) that key is indistinguishable from the raw cwd — so those tests
+		// would keep passing even if production dropped the `resolveStateRoot` call
+		// entirely. This test breaks that tie: `resolveStateRoot` is stubbed to
+		// return something OTHER than `cwd` for exactly the production call, and
+		// the ledger edge is keyed under that distinct value. Same pattern as
+		// `StopHook.test.ts` ("anchors a subdirectory cwd…") and
+		// `GeminiAfterAgentHook.test.ts`.
+		it("looks the session up under resolveStateRoot's return value, not the raw cwd", async () => {
+			await withLedgerHome(async (globalDir) => {
+				const anchoredRoot = "/anchored/repo/root";
+				vi.mocked(resolveStateRoot).mockReturnValueOnce(anchoredRoot);
+				await recordClaudeOwners(
+					{
+						sessionId: "anchored-1",
+						transcriptPath: transcript,
+						edges: new Map([[anchoredRoot, makeEdge()]]),
+					},
+					globalDir,
+				);
+
+				const result = await __test__.loadSessionTranscripts(cwd, {});
+
+				expect(resolveStateRoot).toHaveBeenCalledWith(cwd);
+				expect(result.allSessions.some((s) => s.sessionId === "anchored-1")).toBe(true);
+			});
+		});
+
+		it("does not read a session owned only by a different worktree", async () => {
+			await withLedgerHome(async (globalDir) => {
+				await recordClaudeOwners(
+					{
+						sessionId: "other-1",
+						transcriptPath: transcript,
+						edges: new Map([["/somewhere/else", makeEdge()]]),
+					},
+					globalDir,
+				);
+
+				const result = await __test__.loadSessionTranscripts(cwd, {});
+
+				expect(result.allSessions.some((s) => s.sessionId === "other-1")).toBe(false);
+			});
+		});
+
+		it("does not duplicate a session present in both sessions.json and the ledger", async () => {
+			await withLedgerHome(async (globalDir) => {
+				vi.mocked(loadAllSessions).mockResolvedValue([
+					{ sessionId: "dup-1", transcriptPath: transcript, updatedAt: NOW, source: "claude" },
+				]);
+				await recordClaudeOwners(
+					{
+						sessionId: "dup-1",
+						transcriptPath: transcript,
+						edges: new Map([[resolveStateRoot(cwd), makeEdge()]]),
+					},
+					globalDir,
+				);
+
+				const result = await __test__.loadSessionTranscripts(cwd, {});
+
+				expect(result.allSessions.filter((s) => s.sessionId === "dup-1")).toHaveLength(1);
+			});
+		});
+
+		it("ignores the ledger when claudeEnabled is false", async () => {
+			await withLedgerHome(async (globalDir) => {
+				await recordClaudeOwners(
+					{
+						sessionId: "off-1",
+						transcriptPath: transcript,
+						edges: new Map([[resolveStateRoot(cwd), makeEdge()]]),
+					},
+					globalDir,
+				);
+
+				const result = await __test__.loadSessionTranscripts(cwd, { claudeEnabled: false });
+
+				expect(result.allSessions.some((s) => s.sessionId === "off-1")).toBe(false);
+			});
+		});
+
+		// ─── Owner-seeded lower bound (spec §7.3): with no cursor of its own for a
+		// transcript, this worktree's first read of a ledger-owned Claude session
+		// must start at the owner's OWN firstSeenLine, not at line 0 — otherwise a
+		// checkout that joined the conversation late absorbs every earlier turn,
+		// which belonged to whichever checkout was driving it at the time.
+		describe("owner-seeded lower bound", () => {
+			it("starts a first read from the owner's firstSeenLine, not from line 0", async () => {
+				await withLedgerHome(async (globalDir) => {
+					// loadCursorForTranscript() → null by the outer beforeEach: this
+					// worktree has never read this transcript before.
+					await recordClaudeOwners(
+						{
+							sessionId: "seeded-1",
+							transcriptPath: transcript,
+							edges: new Map([
+								[resolveStateRoot(cwd), { firstSeenAt: NOW, firstSeenLine: 3, lastSeenAt: NOW }],
+							]),
+						},
+						globalDir,
+					);
+
+					await __test__.loadSessionTranscripts(cwd, {});
+
+					// Kills: (a) "ownerSeeds is never consulted" — cursor would stay
+					// null/line-0 instead of 3; (b) the ternary picking the wrong
+					// branch of the seed condition. Inspect the call's positional
+					// args directly rather than `toHaveBeenCalledWith` — the 3rd
+					// (parser) arg comes from a mock reset to `undefined` by this
+					// file's global `vi.resetAllMocks()` and isn't this test's concern.
+					const call = vi.mocked(readTranscript).mock.calls[0];
+					expect(call[0]).toBe(transcript);
+					expect(call[1]).toMatchObject({ transcriptPath: transcript, lineNumber: 3 });
+					expect(call[3]).toBeUndefined();
+				});
+			});
+
+			it("resumes from this worktree's own cursor once it has one, ignoring the seed", async () => {
+				await withLedgerHome(async (globalDir) => {
+					// This worktree already has its OWN progress on this transcript —
+					// well past the owner's firstSeenLine (7). A seed must never win
+					// over an established cursor: that would rewind it and re-read
+					// spent lines.
+					vi.mocked(loadCursorForTranscript).mockResolvedValue({
+						transcriptPath: transcript,
+						lineNumber: 4,
+						updatedAt: NOW,
+					});
+					await recordClaudeOwners(
+						{
+							sessionId: "seeded-2",
+							transcriptPath: transcript,
+							edges: new Map([
+								[resolveStateRoot(cwd), { firstSeenAt: NOW, firstSeenLine: 7, lastSeenAt: NOW }],
+							]),
+						},
+						globalDir,
+					);
+
+					await __test__.loadSessionTranscripts(cwd, {});
+
+					// Kills: dropping (or weakening) the "only when saved === null"
+					// guard — that mutant would read from line 7 (the seed) instead
+					// of 4 (this worktree's own cursor).
+					const call = vi.mocked(readTranscript).mock.calls[0];
+					expect(call[0]).toBe(transcript);
+					expect(call[1]).toMatchObject({ transcriptPath: transcript, lineNumber: 4 });
+					expect(call[3]).toBeUndefined();
+				});
+			});
+
+			it("still honours beforeTimestamp as the upper bound when seeded", async () => {
+				await withLedgerHome(async (globalDir) => {
+					await recordClaudeOwners(
+						{
+							sessionId: "seeded-3",
+							transcriptPath: transcript,
+							edges: new Map([
+								[resolveStateRoot(cwd), { firstSeenAt: NOW, firstSeenLine: 2, lastSeenAt: NOW }],
+							]),
+						},
+						globalDir,
+					);
+					const upperBound = "2099-01-01T00:00:00.000Z";
+
+					await __test__.loadSessionTranscripts(cwd, {}, upperBound);
+
+					// Kills: the seeded path forgetting to thread `beforeTimestamp`
+					// through to the reader (e.g. a seed-only branch that hardcodes
+					// `undefined` instead of forwarding the caller's upper bound).
+					const call = vi.mocked(readTranscript).mock.calls[0];
+					expect(call[0]).toBe(transcript);
+					expect(call[1]).toMatchObject({ transcriptPath: transcript, lineNumber: 2 });
+					expect(call[3]).toBe(upperBound);
+				});
+			});
+
+			it("leaves a non-Claude source's first read at line 0", async () => {
+				await withLedgerHome(async (globalDir) => {
+					// A gemini session pointed at the SAME transcript path as a Claude
+					// ledger edge, so `ownerSeeds` genuinely holds a nonzero entry keyed
+					// by this exact path. If the seed branch were gated on the path
+					// alone (not on `source === "claude"`), this would wrongly seed the
+					// gemini read too.
+					vi.mocked(loadAllSessions).mockResolvedValue([
+						{ sessionId: "gemini-1", transcriptPath: transcript, updatedAt: NOW, source: "gemini" },
+					]);
+					vi.mocked(readGeminiTranscript).mockResolvedValue({
+						entries: [],
+						newCursor: { transcriptPath: transcript, lineNumber: 0, updatedAt: NOW },
+						totalLinesRead: 0,
+					});
+					await recordClaudeOwners(
+						{
+							sessionId: "claude-owner-of-same-path",
+							transcriptPath: transcript,
+							edges: new Map([
+								[resolveStateRoot(cwd), { firstSeenAt: NOW, firstSeenLine: 5, lastSeenAt: NOW }],
+							]),
+						},
+						globalDir,
+					);
+
+					await __test__.loadSessionTranscripts(cwd, {});
+
+					// Kills: gating the seed on `ownerSeeds.has(transcriptPath)` alone
+					// instead of `source === "claude"` — that mutant would pass a
+					// synthesized non-null cursor here instead of `null`.
+					expect(readGeminiTranscript).toHaveBeenCalledWith(transcript, null, undefined);
+				});
+			});
+		});
+
+		// ─── Regression coverage for spec §10.4 ("dashboard/backfill attribution and
+		// QueueWorker attribution agree for the same session-owner relation"). The
+		// other two §10.4 guarantees are already covered: same-worktree capture with
+		// an empty ledger is exercised throughout this file's plain `loadAllSessions`
+		// + `loadSessionTranscripts` tests (e.g. the C5 usage-only-conversation tests
+		// above), and linked-worktree capture is this describe block's own "reads a
+		// Claude session this worktree owns even when sessions.json has none" test.
+		//
+		// This one is deliberately NOT two independently hand-built fixtures that
+		// happen to agree by construction. Both routes derive their answer from ONE
+		// shared raw transcript line's `cwd`: `scanOwnerEdges` is the exact function
+		// the Stop hook uses to turn transcript lines into ledger edges, and
+		// `claudeSessionsForRepo` is the exact filter the dashboard back-fill uses to
+		// narrow a machine-wide disk scan to one repo. If the two routes' notion of
+		// "does this cwd belong to this repo" ever diverged, this test would fail
+		// while two hand-picked fixtures would not.
+		describe("cross-route agreement with the disk discoverer (spec §10.4)", () => {
+			it("attributes the same session to this repo via both the ownership ledger and claudeSessionsForRepo", async () => {
+				await withLedgerHome(async (globalDir) => {
+					const sessionId = "cross-route-1";
+					// The one shared fact both routes read: a single raw transcript line
+					// recording this worktree's cwd.
+					const rawLine = JSON.stringify({
+						type: "user",
+						cwd,
+						timestamp: NOW,
+						message: { role: "user", content: "hi" },
+					});
+
+					// QueueWorker / ledger route: scanOwnerEdges (ClaudeOwnerScan.ts) is
+					// the real production function that turns transcript lines into
+					// owner edges; recordClaudeOwners/claudeSessionsOwnedBy (via
+					// loadSessionTranscripts) is the real ledger round trip.
+					const { edges } = scanOwnerEdges([rawLine], 0);
+					await recordClaudeOwners({ sessionId, transcriptPath: transcript, edges }, globalDir);
+					const queueWorkerSide = await __test__.loadSessionTranscripts(cwd, {});
+
+					// Dashboard/backfill route: claudeSessionsForRepo is the real filter
+					// scanClaudeSessionsOnDisk narrows a machine-wide scan with, fed the
+					// SAME line's own `cwd` (parsed back out of `rawLine`, not a second
+					// hand-picked literal) as the session's one recorded directory.
+					const dirsFromSameLine = [(JSON.parse(rawLine) as { cwd: string }).cwd];
+					const backfillSide = claudeSessionsForRepo(
+						[
+							{
+								sessionId,
+								transcriptPath: transcript,
+								updatedAt: NOW,
+								dirs: dirsFromSameLine,
+								complete: true,
+							},
+						],
+						cwd,
+					);
+
+					// Kills: either route silently failing to attribute this session (a
+					// broken ledger merge on one side, or a broken/inverted
+					// claudeSessionsForRepo filter on the other) collapses one side to
+					// `[]` while the other still reports the session.
+					expect(
+						queueWorkerSide.allSessions.filter((s) => s.source === "claude").map((s) => s.sessionId),
+					).toEqual(backfillSide.map((s) => s.sessionId));
+					expect(backfillSide.map((s) => s.sessionId)).toEqual([sessionId]);
+				});
+			});
 		});
 	});
 

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -23,6 +23,7 @@ import { fileURLToPath } from "node:url";
 import { isAntigravityInstalled } from "../core/AntigravityDetector.js";
 import { discoverAntigravitySessions } from "../core/AntigravitySessionDiscoverer.js";
 import { readAntigravityTranscript } from "../core/AntigravityTranscriptReader.js";
+import { backfillExecutingSessionOwnership } from "../core/ClaudeOwnerScan.js";
 import { claudeSessionsOwnedBy } from "../core/ClaudeOwnership.js";
 import { resolveClientKind } from "../core/ClientHeader.js";
 import { isClineCliInstalled } from "../core/ClineCliDetector.js";
@@ -2035,7 +2036,7 @@ async function executePipeline(cwd: string, op: CommitGitOperation, force = fals
 				cwd,
 				pipelineStart,
 				{ fromRef: oldHash, toRef: op.commitHash },
-				{ commitType: "amend", commitSource },
+				{ commitType: "amend", commitSource, executingSessionId: op.executingSessionId },
 				op.createdAt,
 				op.branch,
 			);
@@ -2060,7 +2061,7 @@ async function executePipeline(cwd: string, op: CommitGitOperation, force = fals
 		conversationTokenBreakdown,
 		conversationModels,
 		consumedTranscripts,
-	} = await loadSessionTranscripts(cwd, config, op.createdAt);
+	} = await loadSessionTranscripts(cwd, config, op.createdAt, op.executingSessionId);
 
 	// Step 5: Get git diff and stats (moved before guard to enable diff-only summaries)
 	stepStart = now();
@@ -3342,7 +3343,11 @@ async function handleAmendPipeline(
 	cwd: string,
 	pipelineStart: number,
 	diffOverride?: { readonly fromRef: string; readonly toRef: string },
-	metadata?: { readonly commitType?: CommitType; readonly commitSource?: CommitSource },
+	metadata?: {
+		readonly commitType?: CommitType;
+		readonly commitSource?: CommitSource;
+		readonly executingSessionId?: string;
+	},
 	beforeTimestamp?: string,
 	branchHint?: string,
 ): Promise<void> {
@@ -3384,7 +3389,7 @@ async function handleAmendPipeline(
 		conversationTokenBreakdown,
 		conversationModels,
 		consumedTranscripts,
-	} = await loadSessionTranscripts(cwd, amendConfig, beforeTimestamp);
+	} = await loadSessionTranscripts(cwd, amendConfig, beforeTimestamp, metadata?.executingSessionId);
 
 	// Get git diff and stats. diffOverride (Scenario 1) provides oldHash->newHash
 	// (the actual amend delta); default HEAD~1..HEAD is the full amended diff.
@@ -3908,6 +3913,7 @@ async function loadSessionTranscripts(
 	cwd: string,
 	config: JolliMemoryConfig,
 	beforeTimestamp?: string,
+	executingSessionId?: string,
 ): Promise<{
 	allSessions: ReadonlyArray<{ sessionId: string; transcriptPath: string; source?: TranscriptSource }>;
 	sessionTranscripts: SessionTranscript[];
@@ -3940,6 +3946,16 @@ async function loadSessionTranscripts(
 	// wrote `/private/var/…` into the ledger. An unnormalised lookup matches
 	// nothing, silently, and the whole feature does nothing.
 	const ownerRoot = resolveStateRoot(cwd);
+	// (甲) A commit executed by a Claude session that authored files in THIS
+	// worktree from another checkout leaves no cwd trace here; when the edit and
+	// the commit happened in one turn, the Stop hook that would record it has not
+	// run yet either. Scan that session's own transcript now — through the same
+	// `scanOwnerEdges` the Stop hook uses — so the lookup below sees the authored
+	// edge. A session that only ran `git commit` without authoring under this root
+	// records nothing, and is correctly attributed to nothing.
+	if (executingSessionId && config.claudeEnabled !== false) {
+		await backfillExecutingSessionOwnership(executingSessionId, cwd);
+	}
 	const ledgerOwned = config.claudeEnabled === false ? [] : await claudeSessionsOwnedBy(ownerRoot);
 	// transcriptPath → this owner's lower bound, threaded into `readAllTranscripts`
 	// below. It seeds a session's first read (no saved cursor yet) instead of

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -23,6 +23,7 @@ import { fileURLToPath } from "node:url";
 import { isAntigravityInstalled } from "../core/AntigravityDetector.js";
 import { discoverAntigravitySessions } from "../core/AntigravitySessionDiscoverer.js";
 import { readAntigravityTranscript } from "../core/AntigravityTranscriptReader.js";
+import { claudeSessionsOwnedBy } from "../core/ClaudeOwnership.js";
 import { resolveClientKind } from "../core/ClientHeader.js";
 import { isClineCliInstalled } from "../core/ClineCliDetector.js";
 import { discoverClineCliSessions } from "../core/ClineCliSessionDiscoverer.js";
@@ -61,7 +62,7 @@ import { readCursorTranscript } from "../core/CursorTranscriptReader.js";
 import { discoverDevinSessions, isDevinInstalled } from "../core/DevinSessionDiscoverer.js";
 import { readDevinTranscript } from "../core/DevinTranscriptReader.js";
 import { readGeminiTranscript } from "../core/GeminiTranscriptReader.js";
-import { getCommitInfo, getCurrentBranch, getDiffContent, getDiffStats } from "../core/GitOps.js";
+import { getCommitInfo, getCurrentBranch, getDiffContent, getDiffStats, resolveStateRoot } from "../core/GitOps.js";
 import { enqueueIngestOperation } from "../core/IngestTrigger.js";
 import { discoverKimiConversations } from "../core/KimiDiscovery.js";
 import { discoverKimiSessions, isKimiInstalled } from "../core/KimiSessionDiscoverer.js";
@@ -3926,7 +3927,40 @@ async function loadSessionTranscripts(
 }> {
 	const trackedSessions = filterSessionsByEnabledIntegrations(await loadAllSessions(cwd), config);
 
-	let allSessions = trackedSessions;
+	// Claude candidates from the machine-global ownership ledger (multi-owner
+	// Claude session attribution). `sessions.json` only knows the sessions whose
+	// Stop hook fired against THIS checkout; the ledger knows every checkout a
+	// session's transcript proves it visited — a session started in one worktree
+	// and continued in another. Merged, not replaced: the local registry stays
+	// the cheap fast path and the fallback for a session the ledger never got
+	// (an older dist, a wiped global dir).
+	//
+	// The lookup key MUST be the anchored root, never the raw `cwd`: this `cwd`
+	// is git's hook cwd, and on macOS that is `/var/…` where `resolveStateRoot`
+	// wrote `/private/var/…` into the ledger. An unnormalised lookup matches
+	// nothing, silently, and the whole feature does nothing.
+	const ownerRoot = resolveStateRoot(cwd);
+	const ledgerOwned = config.claudeEnabled === false ? [] : await claudeSessionsOwnedBy(ownerRoot);
+	// transcriptPath → this owner's lower bound, threaded into `readAllTranscripts`
+	// below. It seeds a session's first read (no saved cursor yet) instead of
+	// starting at line 0 — see the seed comment there for why.
+	const ownerSeeds = new Map<string, number>();
+	for (const owned of ledgerOwned) ownerSeeds.set(owned.transcriptPath, owned.edge.firstSeenLine);
+
+	const seen = new Set(trackedSessions.map((s) => `${s.source ?? "claude"}:${s.sessionId}:${s.transcriptPath}`));
+	const ledgerSessions = ledgerOwned
+		.filter((o) => !seen.has(`claude:${o.sessionId}:${o.transcriptPath}`))
+		.map((o) => ({
+			sessionId: o.sessionId,
+			transcriptPath: o.transcriptPath,
+			updatedAt: o.edge.lastSeenAt,
+			source: "claude" as const,
+		}));
+	if (ledgerSessions.length > 0) {
+		log.info("Claude ownership ledger contributed %d session(s) for %s", ledgerSessions.length, ownerRoot);
+	}
+
+	let allSessions = [...trackedSessions, ...ledgerSessions];
 	if (config.codexEnabled !== false && (await isCodexInstalled())) {
 		const codexSessions = await discoverCodexSessions(cwd);
 		if (codexSessions.length > 0) {
@@ -4045,7 +4079,7 @@ async function loadSessionTranscripts(
 			.map((s) => conversationKey(s.source ?? "claude", s.sessionId)),
 	);
 
-	const rawAll = await readAllTranscripts(allSessions, cwd, beforeTimestamp);
+	const rawAll = await readAllTranscripts(allSessions, cwd, beforeTimestamp, ownerSeeds);
 	// Keep only checked conversations for the summary; excluded ones were read
 	// purely to advance their cursor (discard). Drop them at this SINGLE point from
 	// BOTH the entry stream and the per-session token map — the downstream token
@@ -4348,6 +4382,12 @@ async function readAllTranscripts(
 	sessions: ReadonlyArray<{ sessionId: string; transcriptPath: string; source?: TranscriptSource }>,
 	cwd: string,
 	beforeTimestamp?: string,
+	/**
+	 * Claude-only lower bounds from the ownership ledger, keyed by transcriptPath.
+	 * Consulted ONLY when this worktree has no cursor of its own for that
+	 * transcript — see the seed below.
+	 */
+	ownerSeeds?: ReadonlyMap<string, number>,
 ): Promise<{
 	sessionTranscripts: SessionTranscript[];
 	totalEntries: number;
@@ -4385,9 +4425,26 @@ async function readAllTranscripts(
 	const sessionIdentity = new Map<string, { sessionId: string; transcriptPath: string; source: TranscriptSource }>();
 
 	for (const session of sessions) {
-		const cursor = await loadCursorForTranscript(session.transcriptPath, cwd);
-		const startLine = cursor?.lineNumber ?? 0;
 		const source = session.source ?? "claude";
+		const saved = await loadCursorForTranscript(session.transcriptPath, cwd);
+		// THE load-bearing rule (spec §7.3). With no saved cursor the reader used to
+		// start at line 0 and stop only at `beforeTimestamp`, which for a session this
+		// checkout joined late means absorbing every earlier turn — turns that belong
+		// to whichever checkout was driving the conversation then. The ledger knows
+		// where this owner first appears, so that is the floor.
+		//
+		// Only when there is NO saved cursor: an established cursor is this owner's own
+		// progress and always wins, or a seed would rewind it and re-read spent lines.
+		// Claude-only, because the ledger has no other source in it (spec §2.2).
+		const seedLine = saved === null && source === "claude" ? ownerSeeds?.get(session.transcriptPath) : undefined;
+		const cursor =
+			seedLine !== undefined && seedLine > 0
+				? { transcriptPath: session.transcriptPath, lineNumber: seedLine, updatedAt: new Date().toISOString() }
+				: saved;
+		const startLine = cursor?.lineNumber ?? 0;
+		if (seedLine !== undefined && seedLine > 0) {
+			log.info("Seeding first read of %s from owner line %d", session.sessionId, seedLine);
+		}
 
 		// Fire ai_source_detected the first time this machine ever
 		// processes a transcript from `source` (markAiSourceSeen dedupes globally,

--- a/cli/src/hooks/StopHook.test.ts
+++ b/cli/src/hooks/StopHook.test.ts
@@ -30,6 +30,13 @@ vi.mock("../core/skills/TranscriptSkillDiscovery.js", () => ({
 	scanSkillsWithCursor: vi.fn().mockResolvedValue(undefined),
 }));
 
+// Mock the owner-ledger scan entry point for the same reason: the unit under
+// test here is the WIRING (the Stop hook is the ONLY writer of the machine-global
+// ownership ledger), and the scan itself is covered in ClaudeOwnerScan.test.ts.
+vi.mock("../core/ClaudeOwnerScan.js", () => ({
+	scanOwnersWithCursor: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("../core/RepoProfile.js", () => ({
 	// Pre-cutover default: no fence (plain fn — survives mock resets).
 	readCutoverFence: async () => null,
@@ -116,6 +123,7 @@ vi.spyOn(console, "error").mockImplementation(() => {});
 import { createReadStream, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
+import { scanOwnersWithCursor } from "../core/ClaudeOwnerScan.js";
 import { resolveStateRoot } from "../core/GitOps.js";
 import { readManualDisableFlag } from "../core/RepoProfile.js";
 import { extractReferencesFromTranscript } from "../core/references/ReferenceExtractor.js";
@@ -298,6 +306,17 @@ describe("StopHook", () => {
 			// session save + telemetry flush are surface-independent and still run
 			expect(saveSession).toHaveBeenCalled();
 			expect(flushTelemetryNow).toHaveBeenCalled();
+		});
+
+		it("skips owner discovery when it defers to the CLI hook", async () => {
+			vi.mocked(existsSync).mockReturnValue(true);
+			vi.mocked(isClaudeHookInstalled).mockResolvedValue(true);
+			process.env.CLAUDE_PLUGIN_ROOT = "/plugins/jolli";
+
+			mockStdin(hookJson());
+			await handleStopHook();
+
+			expect(scanOwnersWithCursor).not.toHaveBeenCalled();
 		});
 
 		it("runs discovery as the plugin hook when NO CLI Stop hook is installed (plugin-only install)", async () => {
@@ -618,6 +637,19 @@ describe("StopHook — plan discovery", () => {
 		await handleStopHook();
 
 		expect(scanSkillsWithCursor).toHaveBeenCalledWith(`${TRANSCRIPT_PATH}`, PROJECT_DIR, "claude");
+	});
+
+	it("runs owner discovery for the session's transcript", async () => {
+		// Fourth extractor, same turn-level site: this hook is the ONLY writer of
+		// the machine-global ownership ledger, so a missing call here means a
+		// session that moved checkouts mid-conversation never gets attributed.
+		vi.mocked(existsSync).mockReturnValue(true);
+		mockTranscriptWithLines(['{"role":"assistant","content":"Hello"}']);
+
+		mockStdin(hookJson(TRANSCRIPT_PATH, PROJECT_DIR));
+		await handleStopHook();
+
+		expect(scanOwnersWithCursor).toHaveBeenCalledWith(TRANSCRIPT_PATH, "test-session-123", PROJECT_DIR);
 	});
 
 	it("scans for skills even when the plan scan throws and holds the shared cursor", async () => {

--- a/cli/src/hooks/StopHook.ts
+++ b/cli/src/hooks/StopHook.ts
@@ -33,6 +33,7 @@ import { existsSync } from "node:fs";
 import { join, resolve as pathResolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isLocalAgentChild } from "../core/AgentReentry.js";
+import { scanOwnersWithCursor } from "../core/ClaudeOwnerScan.js";
 import { resolveStateRoot } from "../core/GitOps.js";
 import { scanPlansFrom } from "../core/plans/TranscriptPlanDiscovery.js";
 import { readManualDisableFlag } from "../core/RepoProfile.js";
@@ -277,6 +278,12 @@ async function discoverFromTranscript(sessionInfo: SessionInfo, cwd: string): Pr
 	// Own cursor, own error handling — a skill scan that throws must not hold the
 	// plan/reference cursor, and vice versa.
 	await scanSkillsWithCursor(transcriptPath, cwd, "claude");
+
+	// Fourth extractor, same protocol. This is the ONLY writer of the machine-global
+	// ownership ledger, and it is what lets a DIFFERENT checkout later prove it owns
+	// a slice of this session: the transcript's own `cwd` lines are the evidence, and
+	// they are only visible while the file is being scanned here.
+	await scanOwnersWithCursor(transcriptPath, sessionInfo.sessionId, cwd);
 
 	// Hold the cursor if the plan scan threw: advancing past its window (the
 	// reference scan reaching EOF) would lose those lines for plan discovery.

--- a/docs/superpowers/plans/2026-08-17-claude-multi-owner-session-attribution.md
+++ b/docs/superpowers/plans/2026-08-17-claude-multi-owner-session-attribution.md
@@ -1,0 +1,1558 @@
+# Claude Multi-Owner Session Attribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let one Claude session be attributed to several worktrees and repositories, so a commit made from a checkout the session merely *touched* still stores its own transcript slice instead of `transcripts: []` — plus a bounded repair path for summaries already written empty.
+
+**Architecture:** A machine-global Claude ownership ledger (`~/.jolli/jollimemory/claude-owners.json`) records, per session, one edge per worktree root the transcript's `cwd` lines prove it visited. The Stop hook fills it as a fourth `discovery-cursors.json` extractor (`owners`, its own high-water mark). QueueWorker merges ledger candidates for the current worktree root into `sessions.json`'s list, and — the load-bearing rule — seeds the *lower bound* of a first read from that owner's `firstSeenLine` instead of `0`. Phase 2 adds `jolli doctor --repair-transcripts`, which replays the same bounded window for historical empty summaries, and a three-state memory-detail copy across the four surfaces that render it.
+
+**Tech Stack:** TypeScript (ESM, Node ≥22.13), Vitest, Biome (tabs, 120 cols); Kotlin/Gradle for the IntelliJ copy string.
+
+**Spec:** [`docs/superpowers/specs/2026-08-17-claude-multi-owner-session-attribution-design.md`](../specs/2026-08-17-claude-multi-owner-session-attribution-design.md)
+
+## Global Constraints
+
+- **Ledger location is machine-global**, `~/.jolli/jollimemory/claude-owners.json`. Resolved via `getGlobalConfigDir()`. The spec's §5 phrase "under `.jolli/jollimemory`" is realised as the *global* dir, not the per-worktree one: a per-worktree ledger can only ever hold what that worktree's own Stop hook saw, which is the same information as its `sessions.json`, so it would fix nothing.
+- **Every owner root — written or looked up — goes through `resolveStateRoot()`** (`core/GitOps.ts`), which realpaths and forward-slashes. The Stop hook already anchors that way; QueueWorker's `cwd` is git's hook cwd and is NOT anchored, so on macOS it can read `/var/…` where the ledger holds `/private/var/…`. An unnormalised lookup misses every edge and the whole feature silently does nothing.
+- **Line numbers are counted by `splitTranscriptLines`** (`core/TranscriptReader.ts`) and nothing else. `firstSeenLine` becomes a cursor `lineNumber`, and `discovery-cursors.json` is monotonic — a definition that disagreed by one blank line strands records permanently rather than failing.
+- **The `owners` extractor rides its own high-water mark** in `discovery-cursors.json`, never the shared `lineNumber`. Follow `scanSkillsWithCursor`'s three-step protocol (load mark → scan → advance only when it moved) exactly; never advance on a throw.
+- **Ledger updates are set-union / max-progress only** (spec §6.1). A later pass may extend an edge; it may never reset `firstSeenAt` / `firstSeenLine`.
+- **Repair prefers a false negative** (spec §8.3). Every refusal rule returns "did not repair", never a partial write.
+- **No non-Claude source changes in this slice** (spec §2.2, §11).
+- **Coverage floor for `cli/src/`**: 97% statements / 96% branches / 97% functions / 97% lines ([`cli/vite.config.ts`](../../cli/vite.config.ts)). New modules need real tests, not smoke tests.
+- **Biome**: tabs, 4-wide, 120 columns, `noExplicitAny: error`, `noUnusedImports/Variables: error`. CI runs `biome check --error-on-warnings`.
+- **Commit discipline**: `git commit -s` (DCO). No `Co-Authored-By: Claude …`, no `🤖 Generated with …`.
+- **Per this repo's working preference, tasks below contain NO commit step and NO full-gate step.** Write the test, write the implementation, move on. Task 11 runs `npm run all` once and makes the commits. While iterating inside a task you may of course run that one test file (`npm run test -w @jolli.ai/cli -- <file>`); just don't wire it in as a plan step.
+
+---
+
+## File Structure
+
+**New (CLI):**
+- `cli/src/core/ClaudeOwnership.ts` — the ledger: types, load, upsert, per-owner query. Storage only; knows nothing about transcripts.
+- `cli/src/core/ClaudeOwnership.test.ts`
+- `cli/src/core/ClaudeOwnerScan.ts` — transcript-window → owner edges. Parsing only; knows nothing about JSON files.
+- `cli/src/core/ClaudeOwnerScan.test.ts`
+- `cli/src/core/TranscriptRepair.ts` — Phase 2 repair engine + the shared repairability predicate the four UI surfaces consume.
+- `cli/src/core/TranscriptRepair.test.ts`
+
+**Modified (CLI):**
+- `cli/src/Types.ts` — `DiscoveryExtractor` gains `"owners"`; `CommitSummary` gains `transcriptsRepairedAt?`.
+- `cli/src/core/Locks.ts` — `withClaudeOwnersLock`.
+- `cli/src/hooks/StopHook.ts` — call `scanOwnersWithCursor` in `discoverFromTranscript`.
+- `cli/src/hooks/QueueWorker.ts` — ledger candidate merge in `loadSessionTranscripts`; owner seed in `readAllTranscripts`.
+- `cli/src/commands/DoctorCommand.ts` — `--repair-transcripts`.
+- `cli/src/commands/IdeBridgeCommand.ts` — `transcript-repair-state` action.
+- `cli/src/dashboard/assets/js/memories.js` — three-state copy.
+
+**Modified (hosts):**
+- `vscode/src/views/SummaryScriptBuilder.ts` — three-state copy (2 sites).
+- `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryHtmlBuilder.kt` — three-state copy.
+- `intellij/src/main/kotlin/ai/jolli/jollimemory/core/TranscriptRepairState.kt` (new) — bridge adapter.
+
+Split rationale: the ledger's failure mode is concurrent JSON read-modify-write; the scan's is line counting and `cwd` attribution. They fail differently, are tested differently, and only the scan needs transcript fixtures — so they are separate files even though Phase 1 always uses them together.
+
+---
+
+## Phase 1 — Forward fix
+
+### Task 1: Ownership ledger storage
+
+**Files:**
+- Create: `cli/src/core/ClaudeOwnership.ts`
+- Create: `cli/src/core/ClaudeOwnership.test.ts`
+- Modify: `cli/src/core/Locks.ts` (add `withClaudeOwnersLock` beside `withRepoRegistryLock`)
+
+**Interfaces:**
+- Consumes: `getGlobalConfigDir()` from `core/SessionTracker.js`, `atomicWriteFile` from `core/AtomicWrite.js`, `resolveStateRoot` from `core/GitOps.js`.
+- Produces:
+  - `interface ClaudeOwnerEdge { readonly firstSeenAt: string; readonly firstSeenLine: number; readonly lastSeenAt: string; readonly firstSeenCwd?: string; readonly lastSeenCwd?: string }`
+  - `interface ClaudeOwnedSession { readonly sessionId: string; readonly transcriptPath: string; readonly source: "claude"; readonly owners: Readonly<Record<string, ClaudeOwnerEdge>> }`
+  - `interface ClaudeOwnersLedger { readonly version: 1; readonly sessions: Readonly<Record<string, ClaudeOwnedSession>> }`
+  - `claudeOwnersPath(globalDir?: string): string`
+  - `loadClaudeOwners(globalDir?: string): Promise<ClaudeOwnersLedger>`
+  - `recordClaudeOwners(input: { sessionId: string; transcriptPath: string; edges: ReadonlyMap<string, ClaudeOwnerEdge> }, globalDir?: string): Promise<void>`
+  - `claudeSessionsOwnedBy(ownerRoot: string, globalDir?: string): Promise<ReadonlyArray<{ sessionId: string; transcriptPath: string; edge: ClaudeOwnerEdge }>>`
+  - `withClaudeOwnersLock<T>(fn: () => Promise<T>, opts?: { timeoutMs?: number; pollMs?: number; globalDir?: string }): Promise<T>`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `cli/src/core/ClaudeOwnership.test.ts`:
+
+```typescript
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	type ClaudeOwnerEdge,
+	claudeSessionsOwnedBy,
+	loadClaudeOwners,
+	recordClaudeOwners,
+} from "./ClaudeOwnership.js";
+
+let dir: string;
+
+function edge(over: Partial<ClaudeOwnerEdge> = {}): ClaudeOwnerEdge {
+	return {
+		firstSeenAt: "2026-08-17T10:00:00.000Z",
+		firstSeenLine: 12,
+		lastSeenAt: "2026-08-17T10:05:00.000Z",
+		...over,
+	};
+}
+
+beforeEach(async () => {
+	dir = await mkdtemp(join(tmpdir(), "jolli-owners-"));
+});
+
+describe("ClaudeOwnership", () => {
+	it("returns an empty ledger when the file does not exist", async () => {
+		expect(await loadClaudeOwners(dir)).toEqual({ version: 1, sessions: {} });
+	});
+
+	it("returns an empty ledger for unparseable JSON rather than throwing", async () => {
+		await writeFile(join(dir, "claude-owners.json"), "{ not json", "utf-8");
+		expect(await loadClaudeOwners(dir)).toEqual({ version: 1, sessions: {} });
+	});
+
+	it("records one session under two owner roots", async () => {
+		await recordClaudeOwners(
+			{
+				sessionId: "s1",
+				transcriptPath: "/t/s1.jsonl",
+				edges: new Map([
+					["/repo/a", edge({ firstSeenLine: 0 })],
+					["/repo/b", edge({ firstSeenLine: 412 })],
+				]),
+			},
+			dir,
+		);
+		const ledger = await loadClaudeOwners(dir);
+		expect(Object.keys(ledger.sessions)).toEqual(["claude:s1"]);
+		expect(Object.keys(ledger.sessions["claude:s1"].owners).sort()).toEqual(["/repo/a", "/repo/b"]);
+	});
+
+	it("extends an existing edge without resetting its first-seen position", async () => {
+		await recordClaudeOwners(
+			{ sessionId: "s1", transcriptPath: "/t/s1.jsonl", edges: new Map([["/repo/a", edge({ firstSeenLine: 12 })]]) },
+			dir,
+		);
+		await recordClaudeOwners(
+			{
+				sessionId: "s1",
+				transcriptPath: "/t/s1.jsonl",
+				edges: new Map([
+					[
+						"/repo/a",
+						edge({
+							firstSeenAt: "2026-08-17T11:00:00.000Z",
+							firstSeenLine: 900,
+							lastSeenAt: "2026-08-17T11:00:00.000Z",
+							lastSeenCwd: "/repo/a/sub",
+						}),
+					],
+				]),
+			},
+			dir,
+		);
+		const owners = (await loadClaudeOwners(dir)).sessions["claude:s1"].owners;
+		expect(owners["/repo/a"].firstSeenLine).toBe(12);
+		expect(owners["/repo/a"].firstSeenAt).toBe("2026-08-17T10:00:00.000Z");
+		expect(owners["/repo/a"].lastSeenAt).toBe("2026-08-17T11:00:00.000Z");
+		expect(owners["/repo/a"].lastSeenCwd).toBe("/repo/a/sub");
+	});
+
+	it("adds a new owner to a session that already has one", async () => {
+		await recordClaudeOwners(
+			{ sessionId: "s1", transcriptPath: "/t/s1.jsonl", edges: new Map([["/repo/a", edge()]]) },
+			dir,
+		);
+		await recordClaudeOwners(
+			{ sessionId: "s1", transcriptPath: "/t/s1.jsonl", edges: new Map([["/repo/b", edge({ firstSeenLine: 77 })]]) },
+			dir,
+		);
+		const owners = (await loadClaudeOwners(dir)).sessions["claude:s1"].owners;
+		expect(Object.keys(owners).sort()).toEqual(["/repo/a", "/repo/b"]);
+		expect(owners["/repo/b"].firstSeenLine).toBe(77);
+	});
+
+	it("queries sessions by owner root and ignores other owners' sessions", async () => {
+		await recordClaudeOwners(
+			{ sessionId: "s1", transcriptPath: "/t/s1.jsonl", edges: new Map([["/repo/a", edge({ firstSeenLine: 5 })]]) },
+			dir,
+		);
+		await recordClaudeOwners(
+			{ sessionId: "s2", transcriptPath: "/t/s2.jsonl", edges: new Map([["/repo/b", edge()]]) },
+			dir,
+		);
+		const mine = await claudeSessionsOwnedBy("/repo/a", dir);
+		expect(mine).toEqual([{ sessionId: "s1", transcriptPath: "/t/s1.jsonl", edge: expect.objectContaining({ firstSeenLine: 5 }) }]);
+	});
+
+	it("writes valid JSON that a second load round-trips", async () => {
+		await recordClaudeOwners(
+			{ sessionId: "s1", transcriptPath: "/t/s1.jsonl", edges: new Map([["/repo/a", edge()]]) },
+			dir,
+		);
+		const raw = await readFile(join(dir, "claude-owners.json"), "utf-8");
+		expect(JSON.parse(raw)).toEqual(await loadClaudeOwners(dir));
+	});
+
+	it("records nothing when the edge map is empty", async () => {
+		await recordClaudeOwners({ sessionId: "s1", transcriptPath: "/t/s1.jsonl", edges: new Map() }, dir);
+		expect(await loadClaudeOwners(dir)).toEqual({ version: 1, sessions: {} });
+	});
+});
+```
+
+- [ ] **Step 2: Add the lock**
+
+In `cli/src/core/Locks.ts`, beside `withRepoRegistryLock`, add the constant with the other lock-file names and the function:
+
+```typescript
+/** Serialises read-modify-write of the machine-global `claude-owners.json`. */
+const CLAUDE_OWNERS_LOCK_FILE = "claude-owners.lock";
+
+/**
+ * Serialises the read-modify-write of `claude-owners.json` across every repo's
+ * Stop hook on this machine. Same shape and same reasoning as
+ * {@link withRepoRegistryLock}: one machine-global JSON file whose whole-object
+ * overwrite would otherwise let a stale reader drop a peer's freshly-written
+ * owner edge.
+ *
+ * Best-effort — on timeout `fn` runs unlocked rather than dropping an edge.
+ * Losing an edge is what this whole feature exists to prevent; a rare clobber
+ * is recovered by the next Stop hook, since the scan is idempotent from its own
+ * high-water mark.
+ */
+export async function withClaudeOwnersLock<T>(fn: () => Promise<T>, opts: RepoRegistryLockOpts = {}): Promise<T> {
+	const timeoutMs = opts.timeoutMs ?? DEFAULT_REPO_REGISTRY_LOCK_TIMEOUT_MS;
+	const pollMs = opts.pollMs ?? DEFAULT_PROFILE_LOCK_POLL_MS;
+	const dir = opts.globalDir ?? join(homedir(), ".jolli", "jollimemory");
+	await mkdir(dir, { recursive: true });
+	const lockPath = join(dir, CLAUDE_OWNERS_LOCK_FILE);
+	const acquired = await acquireWithPoll(lockPath, { timeoutMs, pollMs });
+	if (!acquired) {
+		log.warn(
+			"withClaudeOwnersLock: could not acquire %s within %d ms — proceeding best-effort",
+			CLAUDE_OWNERS_LOCK_FILE,
+			timeoutMs,
+		);
+	}
+	try {
+		return await fn();
+	} finally {
+		if (acquired) await releaseIfOwned(lockPath, CLAUDE_OWNERS_LOCK_FILE);
+	}
+}
+```
+
+- [ ] **Step 3: Write `ClaudeOwnership.ts`**
+
+```typescript
+/**
+ * Claude ownership ledger — which worktree roots a Claude session actually
+ * visited, and where in the transcript each of them first appeared.
+ *
+ * MACHINE-GLOBAL on purpose (`~/.jolli/jollimemory/claude-owners.json`). The
+ * question it answers is asked by a worktree that never ran the session: Claude
+ * was launched in checkout A, the user `cd`-ed into checkout B mid-conversation,
+ * and the commit lands in B. B's own `.jolli/jollimemory/` holds nothing about
+ * that session — its Stop hook never fired — so a per-worktree ledger would be
+ * a second copy of `sessions.json` and would fix nothing. One shared file lets
+ * A's hook record B's edge and B's post-commit read find it.
+ *
+ * Storage only. What counts as a `cwd`, and which line it was first seen on,
+ * is {@link ClaudeOwnerScan}'s job.
+ */
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createLogger, errMsg } from "../Logger.js";
+import { atomicWriteFile } from "./AtomicWrite.js";
+import { withClaudeOwnersLock } from "./Locks.js";
+import { getGlobalConfigDir } from "./SessionTracker.js";
+
+const log = createLogger("ClaudeOwnership");
+
+const CLAUDE_OWNERS_FILE = "claude-owners.json";
+
+/** One worktree root's participation in one Claude session. */
+export interface ClaudeOwnerEdge {
+	readonly firstSeenAt: string;
+	/**
+	 * Line index (against `splitTranscriptLines`) of the first line whose `cwd`
+	 * belonged to this owner. Becomes a cursor lower bound, so it must never be
+	 * re-derived with a different notion of "line N".
+	 */
+	readonly firstSeenLine: number;
+	readonly lastSeenAt: string;
+	readonly firstSeenCwd?: string;
+	readonly lastSeenCwd?: string;
+}
+
+export interface ClaudeOwnedSession {
+	readonly sessionId: string;
+	readonly transcriptPath: string;
+	readonly source: "claude";
+	readonly owners: Readonly<Record<string, ClaudeOwnerEdge>>;
+}
+
+export interface ClaudeOwnersLedger {
+	readonly version: 1;
+	readonly sessions: Readonly<Record<string, ClaudeOwnedSession>>;
+}
+
+const EMPTY: ClaudeOwnersLedger = { version: 1, sessions: {} };
+
+export function claudeOwnersPath(globalDir?: string): string {
+	return join(globalDir ?? getGlobalConfigDir(), CLAUDE_OWNERS_FILE);
+}
+
+function sessionKey(sessionId: string): string {
+	return `claude:${sessionId}`;
+}
+
+/**
+ * Reads the ledger. A missing or unparseable file reads as empty: this is
+ * consulted from the post-commit path, where throwing would take the whole
+ * summary down over a state file that the next Stop hook rewrites anyway.
+ */
+export async function loadClaudeOwners(globalDir?: string): Promise<ClaudeOwnersLedger> {
+	try {
+		const raw = JSON.parse(await readFile(claudeOwnersPath(globalDir), "utf-8")) as Partial<ClaudeOwnersLedger>;
+		if (!raw || typeof raw !== "object" || typeof raw.sessions !== "object" || raw.sessions === null) return EMPTY;
+		return { version: 1, sessions: raw.sessions };
+	} catch (err) {
+		log.debug("claude-owners.json unreadable (%s) — treating as empty", errMsg(err));
+		return EMPTY;
+	}
+}
+
+/**
+ * Folds `edges` into the ledger. Set-union / max-progress ONLY (spec §6.1): an
+ * existing edge keeps its `firstSeenAt` / `firstSeenLine` / `firstSeenCwd` and
+ * takes the newer `lastSeenAt` / `lastSeenCwd`. A later pass extends an edge; it
+ * never rewinds one, because the first-seen position is the lower bound a future
+ * commit will read from and moving it forward would silently skip that owner's
+ * earliest turns.
+ */
+export async function recordClaudeOwners(
+	input: {
+		readonly sessionId: string;
+		readonly transcriptPath: string;
+		readonly edges: ReadonlyMap<string, ClaudeOwnerEdge>;
+	},
+	globalDir?: string,
+): Promise<void> {
+	if (input.edges.size === 0) return;
+	await withClaudeOwnersLock(async () => {
+		// Read inside the lock: a snapshot taken before it would merge a peer's
+		// write away, which is the exact race the lock exists for.
+		const ledger = await loadClaudeOwners(globalDir);
+		const key = sessionKey(input.sessionId);
+		const existing = ledger.sessions[key];
+		const owners: Record<string, ClaudeOwnerEdge> = { ...(existing?.owners ?? {}) };
+		for (const [root, incoming] of input.edges) {
+			const prior = owners[root];
+			owners[root] = prior
+				? {
+						...prior,
+						lastSeenAt: incoming.lastSeenAt > prior.lastSeenAt ? incoming.lastSeenAt : prior.lastSeenAt,
+						...(incoming.lastSeenCwd !== undefined ? { lastSeenCwd: incoming.lastSeenCwd } : {}),
+					}
+				: incoming;
+		}
+		const next: ClaudeOwnersLedger = {
+			version: 1,
+			sessions: {
+				...ledger.sessions,
+				[key]: { sessionId: input.sessionId, transcriptPath: input.transcriptPath, source: "claude", owners },
+			},
+		};
+		await atomicWriteFile(claudeOwnersPath(globalDir), JSON.stringify(next, null, "\t"));
+	}, globalDir === undefined ? {} : { globalDir });
+}
+
+/**
+ * Every Claude session this worktree root is an owner of, with that root's own
+ * edge. Callers MUST pass a `resolveStateRoot()`-normalised root — the keys were
+ * written that way, and a raw `process.cwd()` on macOS (`/var/…` vs
+ * `/private/var/…`) matches nothing while looking perfectly reasonable.
+ */
+export async function claudeSessionsOwnedBy(
+	ownerRoot: string,
+	globalDir?: string,
+): Promise<ReadonlyArray<{ sessionId: string; transcriptPath: string; edge: ClaudeOwnerEdge }>> {
+	const ledger = await loadClaudeOwners(globalDir);
+	const mine: { sessionId: string; transcriptPath: string; edge: ClaudeOwnerEdge }[] = [];
+	for (const session of Object.values(ledger.sessions)) {
+		const edge = session.owners[ownerRoot];
+		if (edge) mine.push({ sessionId: session.sessionId, transcriptPath: session.transcriptPath, edge });
+	}
+	return mine;
+}
+```
+
+---
+
+### Task 2: Transcript window → owner edges
+
+**Files:**
+- Create: `cli/src/core/ClaudeOwnerScan.ts`
+- Create: `cli/src/core/ClaudeOwnerScan.test.ts`
+
+**Interfaces:**
+- Consumes: `splitTranscriptLines` from `core/TranscriptReader.js`, `resolveStateRoot` from `core/GitOps.js`, `ClaudeOwnerEdge` from Task 1.
+- Produces: `scanOwnerEdges(lines: ReadonlyArray<string>, fromLine: number, resolveRoot?: (cwd: string) => string | null): { edges: Map<string, ClaudeOwnerEdge>; lastLine: number }`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `cli/src/core/ClaudeOwnerScan.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import { scanOwnerEdges } from "./ClaudeOwnerScan.js";
+
+/** One transcript line carrying a cwd and a timestamp. */
+function line(cwd: string, ts: string): string {
+	return JSON.stringify({ cwd, timestamp: ts, message: { role: "user", content: "hi" } });
+}
+
+// Identity roots: each cwd's first path segment pair is its "worktree root".
+const roots = (cwd: string): string | null => (cwd.startsWith("/repo/") ? `/repo/${cwd.split("/")[2]}` : null);
+
+describe("scanOwnerEdges", () => {
+	it("records one edge per distinct worktree root", () => {
+		const lines = [
+			line("/repo/a", "2026-08-17T10:00:00.000Z"),
+			line("/repo/b/sub", "2026-08-17T10:01:00.000Z"),
+			line("/repo/a/deep", "2026-08-17T10:02:00.000Z"),
+		];
+		const { edges } = scanOwnerEdges(lines, 0, roots);
+		expect([...edges.keys()].sort()).toEqual(["/repo/a", "/repo/b"]);
+		expect(edges.get("/repo/a")?.firstSeenLine).toBe(0);
+		expect(edges.get("/repo/b")?.firstSeenLine).toBe(1);
+	});
+
+	it("keeps the FIRST line of a root and the LAST timestamp/cwd", () => {
+		const lines = [
+			line("/repo/a", "2026-08-17T10:00:00.000Z"),
+			line("/repo/a/sub", "2026-08-17T10:09:00.000Z"),
+		];
+		const edge = scanOwnerEdges(lines, 0, roots).edges.get("/repo/a");
+		expect(edge?.firstSeenLine).toBe(0);
+		expect(edge?.firstSeenAt).toBe("2026-08-17T10:00:00.000Z");
+		expect(edge?.firstSeenCwd).toBe("/repo/a");
+		expect(edge?.lastSeenAt).toBe("2026-08-17T10:09:00.000Z");
+		expect(edge?.lastSeenCwd).toBe("/repo/a/sub");
+	});
+
+	it("numbers lines against the WHOLE file, not the scanned window", () => {
+		const lines = [
+			line("/repo/a", "2026-08-17T10:00:00.000Z"),
+			line("/repo/a", "2026-08-17T10:01:00.000Z"),
+			line("/repo/b", "2026-08-17T10:02:00.000Z"),
+		];
+		const { edges, lastLine } = scanOwnerEdges(lines, 2, roots);
+		expect([...edges.keys()]).toEqual(["/repo/b"]);
+		expect(edges.get("/repo/b")?.firstSeenLine).toBe(2);
+		expect(lastLine).toBe(3);
+	});
+
+	it("returns the line count as lastLine so the caller can advance its mark", () => {
+		expect(scanOwnerEdges([line("/repo/a", "2026-08-17T10:00:00.000Z")], 0, roots).lastLine).toBe(1);
+	});
+
+	it("skips lines with no cwd, an empty cwd, or unparseable JSON", () => {
+		const lines = [
+			"not json",
+			JSON.stringify({ timestamp: "2026-08-17T10:00:00.000Z" }),
+			JSON.stringify({ cwd: "", timestamp: "2026-08-17T10:00:00.000Z" }),
+			line("/repo/a", "2026-08-17T10:03:00.000Z"),
+		];
+		const { edges } = scanOwnerEdges(lines, 0, roots);
+		expect([...edges.keys()]).toEqual(["/repo/a"]);
+		expect(edges.get("/repo/a")?.firstSeenLine).toBe(3);
+	});
+
+	it("skips a cwd that resolves to no worktree root", () => {
+		const { edges } = scanOwnerEdges([line("/tmp/scratch", "2026-08-17T10:00:00.000Z")], 0, roots);
+		expect(edges.size).toBe(0);
+	});
+
+	it("falls back to a caller-supplied instant when a line carries no timestamp", () => {
+		const lines = [JSON.stringify({ cwd: "/repo/a" })];
+		const edge = scanOwnerEdges(lines, 0, roots, () => "2026-08-17T12:00:00.000Z").edges.get("/repo/a");
+		expect(edge?.firstSeenAt).toBe("2026-08-17T12:00:00.000Z");
+	});
+
+	it("returns no edges for an empty window", () => {
+		const { edges, lastLine } = scanOwnerEdges([], 0, roots);
+		expect(edges.size).toBe(0);
+		expect(lastLine).toBe(0);
+	});
+});
+```
+
+- [ ] **Step 2: Write `ClaudeOwnerScan.ts`**
+
+```typescript
+/**
+ * Turns a window of Claude transcript lines into owner edges.
+ *
+ * `cwd` is read off the RAW line object, never off `parseTranscriptLine`: Claude
+ * stamps it on records that are not conversation turns at all (`attachment`,
+ * `queue-operation`), and gating on the turn parser throws away most of the
+ * directories a session ever visited. This mirrors `ClaudeSessionDiscoverer`'s
+ * `scanSlice`, which learned the same lesson against 64 real transcripts.
+ *
+ * The index a line reports is its index in the WHOLE file, because it becomes a
+ * cursor lower bound — the caller passes the file's full `splitTranscriptLines`
+ * output plus the line to start at, rather than a pre-sliced window, so the two
+ * notions of "line N" cannot drift apart.
+ */
+
+import { resolveStateRoot } from "./GitOps.js";
+import type { ClaudeOwnerEdge } from "./ClaudeOwnership.js";
+
+/**
+ * A `cwd` → worktree-root resolver. Defaults to {@link resolveStateRoot}, which
+ * realpaths and forward-slashes; returns null for a directory that resolves to
+ * nothing usable, so the line is ignored rather than creating an owner nobody
+ * will ever look up.
+ */
+export type RootResolver = (cwd: string) => string | null;
+
+function defaultResolveRoot(cwd: string): string | null {
+	try {
+		const root = resolveStateRoot(cwd);
+		return root.length > 0 ? root : null;
+	} catch {
+		return null;
+	}
+}
+
+export function scanOwnerEdges(
+	lines: ReadonlyArray<string>,
+	fromLine: number,
+	resolveRoot: RootResolver = defaultResolveRoot,
+	now: () => string = () => new Date().toISOString(),
+): { edges: Map<string, ClaudeOwnerEdge>; lastLine: number } {
+	const edges = new Map<string, ClaudeOwnerEdge>();
+	// Resolving a root shells out to the filesystem, so cache within the pass:
+	// a long session stamps the same handful of directories on thousands of lines.
+	const rootCache = new Map<string, string | null>();
+
+	for (let i = Math.max(0, fromLine); i < lines.length; i++) {
+		const text = lines[i].trim();
+		if (!text.startsWith("{")) continue;
+		let raw: { cwd?: unknown; timestamp?: unknown };
+		try {
+			raw = JSON.parse(text) as typeof raw;
+		} catch {
+			continue;
+		}
+		const cwd = typeof raw.cwd === "string" ? raw.cwd : "";
+		if (cwd.length === 0) continue;
+
+		let root = rootCache.get(cwd);
+		if (root === undefined) {
+			root = resolveRoot(cwd);
+			rootCache.set(cwd, root);
+		}
+		if (root === null) continue;
+
+		const at = typeof raw.timestamp === "string" && raw.timestamp.length > 0 ? raw.timestamp : now();
+		const prior = edges.get(root);
+		edges.set(
+			root,
+			prior
+				? { ...prior, lastSeenAt: at, lastSeenCwd: cwd }
+				: { firstSeenAt: at, firstSeenLine: i, lastSeenAt: at, firstSeenCwd: cwd, lastSeenCwd: cwd },
+		);
+	}
+
+	return { edges, lastLine: lines.length };
+}
+```
+
+---
+
+### Task 3: Stop hook writes the ledger
+
+**Files:**
+- Modify: `cli/src/Types.ts` (`DiscoveryExtractor`)
+- Modify: `cli/src/core/ClaudeOwnerScan.ts` (add the cursor-protocol wrapper)
+- Modify: `cli/src/hooks/StopHook.ts:279` (`discoverFromTranscript`)
+- Modify: `cli/src/core/ClaudeOwnerScan.test.ts` (append the wrapper's tests)
+- Modify: `cli/src/hooks/StopHook.test.ts`
+
+**Interfaces:**
+- Consumes: `loadExtractorCursorLine` / `saveExtractorCursor` from `core/SessionTracker.js`, `recordClaudeOwners` (Task 1), `scanOwnerEdges` (Task 2).
+- Produces: `scanOwnersWithCursor(transcriptPath: string, sessionId: string, cwd: string, globalDir?: string): Promise<void>`
+
+- [ ] **Step 1: Widen `DiscoveryExtractor`**
+
+In `cli/src/Types.ts:65`:
+
+```typescript
+export type DiscoveryExtractor = "plans" | "references" | "skills" | "owners";
+```
+
+Leave `LEGACY_COVERED_EXTRACTORS` in `SessionTracker.ts` untouched — `owners` is new, so a legacy bare `lineNumber` must NOT be credited to it (that is exactly the stranding the per-extractor marks exist to prevent).
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `cli/src/core/ClaudeOwnerScan.test.ts`:
+
+```typescript
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadClaudeOwners } from "./ClaudeOwnership.js";
+import { loadExtractorCursorLine, saveExtractorCursor } from "./SessionTracker.js";
+import { scanOwnersWithCursor } from "./ClaudeOwnerScan.js";
+
+describe("scanOwnersWithCursor", () => {
+	it("records edges and advances only the owners mark", async () => {
+		const global = await mkdtemp(join(tmpdir(), "jolli-owners-g-"));
+		const repo = await mkdtemp(join(tmpdir(), "jolli-owners-r-"));
+		const transcript = join(global, "s1.jsonl");
+		await writeFile(transcript, `${JSON.stringify({ cwd: repo, timestamp: "2026-08-17T10:00:00.000Z" })}\n`, "utf-8");
+
+		await scanOwnersWithCursor(transcript, "s1", repo, global);
+
+		const ledger = await loadClaudeOwners(global);
+		expect(Object.keys(ledger.sessions)).toEqual(["claude:s1"]);
+		expect(await loadExtractorCursorLine(transcript, "owners", repo)).toBe(1);
+		expect(await loadExtractorCursorLine(transcript, "plans", repo)).toBe(0);
+	});
+
+	it("re-scans nothing once the mark has passed the file", async () => {
+		const global = await mkdtemp(join(tmpdir(), "jolli-owners-g2-"));
+		const repo = await mkdtemp(join(tmpdir(), "jolli-owners-r2-"));
+		const transcript = join(global, "s2.jsonl");
+		await writeFile(transcript, `${JSON.stringify({ cwd: repo, timestamp: "2026-08-17T10:00:00.000Z" })}\n`, "utf-8");
+		await saveExtractorCursor(transcript, "owners", 1, repo);
+
+		await scanOwnersWithCursor(transcript, "s2", repo, global);
+
+		expect(await loadClaudeOwners(global)).toEqual({ version: 1, sessions: {} });
+	});
+
+	it("never throws when the transcript is missing", async () => {
+		const global = await mkdtemp(join(tmpdir(), "jolli-owners-g3-"));
+		const repo = await mkdtemp(join(tmpdir(), "jolli-owners-r3-"));
+		await expect(scanOwnersWithCursor(join(repo, "gone.jsonl"), "s3", repo, global)).resolves.toBeUndefined();
+	});
+});
+```
+
+- [ ] **Step 3: Add the wrapper to `ClaudeOwnerScan.ts`**
+
+```typescript
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { createLogger } from "../Logger.js";
+import { recordClaudeOwners } from "./ClaudeOwnership.js";
+import { loadExtractorCursorLine, saveExtractorCursor } from "./SessionTracker.js";
+import { splitTranscriptLines } from "./TranscriptReader.js";
+
+const log = createLogger("ClaudeOwnerScan");
+
+/**
+ * Scan one transcript for owner edges against the `owners` extractor's OWN
+ * high-water mark, advancing it only when it moved forward — the same three-step
+ * protocol as `scanSkillsWithCursor`, and for the same reason: advancing a
+ * monotonic mark without scanning, or on a throw, strands those lines forever.
+ *
+ * Deliberately independent of the shared `lineNumber` the plan/reference pair
+ * ride, so a dist that predates this extractor cannot advance past the lines it
+ * needs.
+ *
+ * Never throws — the Stop hook must survive an unreadable transcript.
+ */
+export async function scanOwnersWithCursor(
+	transcriptPath: string,
+	sessionId: string,
+	cwd: string,
+	globalDir?: string,
+): Promise<void> {
+	try {
+		const fromLine = await loadExtractorCursorLine(transcriptPath, "owners", cwd);
+		const lines = splitTranscriptLines(await readFile(transcriptPath, "utf-8"));
+		if (lines.length <= fromLine) return;
+		const { edges, lastLine } = scanOwnerEdges(lines, fromLine);
+		await recordClaudeOwners({ sessionId, transcriptPath, edges }, globalDir);
+		if (lastLine > fromLine) await saveExtractorCursor(transcriptPath, "owners", lastLine, cwd);
+	} catch (err) {
+		log.warn("Owner discovery failed for %s: %s", basename(transcriptPath), (err as Error).message);
+	}
+}
+```
+
+- [ ] **Step 4: Call it from the Stop hook**
+
+In `cli/src/hooks/StopHook.ts`, inside `discoverFromTranscript`, immediately after the `scanSkillsWithCursor` call (line ~279):
+
+```typescript
+	// Own cursor, own error handling — see scanSkillsWithCursor above.
+	await scanSkillsWithCursor(transcriptPath, cwd, "claude");
+
+	// Fourth extractor, same protocol. This is the ONLY writer of the machine-global
+	// ownership ledger, and it is what lets a DIFFERENT checkout later prove it owns
+	// a slice of this session: the transcript's own `cwd` lines are the evidence, and
+	// they are only visible while the file is being scanned here.
+	await scanOwnersWithCursor(transcriptPath, sessionInfo.sessionId, cwd);
+```
+
+Add the import:
+
+```typescript
+import { scanOwnersWithCursor } from "../core/ClaudeOwnerScan.js";
+```
+
+- [ ] **Step 5: Assert the hook wiring**
+
+Add to `cli/src/hooks/StopHook.test.ts`, following the file's existing mocking style for `../core/skills/TranscriptSkillDiscovery.js`:
+
+```typescript
+vi.mock("../core/ClaudeOwnerScan.js", () => ({ scanOwnersWithCursor: vi.fn(async () => undefined) }));
+
+it("runs owner discovery for the session's transcript", async () => {
+	// …arrange the same happy-path stdin payload the neighbouring cases use…
+	await handleStopHook();
+	const { scanOwnersWithCursor } = await import("../core/ClaudeOwnerScan.js");
+	expect(scanOwnersWithCursor).toHaveBeenCalledWith(expect.stringContaining(".jsonl"), "test-session", expect.any(String));
+});
+
+it("skips owner discovery when it defers to the CLI hook", async () => {
+	// …set CLAUDE_PLUGIN_ROOT + an installed CLI hook, as the existing defer test does…
+	await handleStopHook();
+	const { scanOwnersWithCursor } = await import("../core/ClaudeOwnerScan.js");
+	expect(scanOwnersWithCursor).not.toHaveBeenCalled();
+});
+```
+
+---
+
+### Task 4: QueueWorker merges ledger candidates
+
+**Files:**
+- Modify: `cli/src/hooks/QueueWorker.ts:3907` (`loadSessionTranscripts`)
+- Modify: `cli/src/hooks/QueueWorker.test.ts`
+
+**Interfaces:**
+- Consumes: `claudeSessionsOwnedBy` (Task 1), `resolveStateRoot` from `core/GitOps.js`.
+- Produces: a private `claudeLedgerCandidates(cwd, config)` returning `{ sessions, seeds }`, where `seeds` is `Map<string, number>` keyed by `transcriptPath` — Task 5 consumes it.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `cli/src/hooks/QueueWorker.test.ts` (the file already fakes `sessions.json`; add a fake global dir via the ledger's own writer):
+
+```typescript
+it("reads a Claude session this worktree owns even when sessions.json has none", async () => {
+	// repoDir is a git worktree fixture; transcript records a cwd inside it.
+	await writeFile(transcript, `${JSON.stringify({ cwd: repoDir, timestamp: "2026-08-17T10:00:00.000Z", message: { role: "user", content: [{ type: "text", text: "why is X like this" }] } })}\n`, "utf-8");
+	await recordClaudeOwners(
+		{
+			sessionId: "foreign-1",
+			transcriptPath: transcript,
+			edges: new Map([[resolveStateRoot(repoDir), { firstSeenAt: "2026-08-17T10:00:00.000Z", firstSeenLine: 0, lastSeenAt: "2026-08-17T10:00:00.000Z" }]]),
+		},
+		globalDir,
+	);
+
+	const summary = await runCommitPipelineForTest(repoDir);
+
+	expect(summary.transcripts ?? []).not.toHaveLength(0);
+});
+
+it("does not read a session owned only by a different worktree", async () => {
+	await recordClaudeOwners(
+		{
+			sessionId: "other-1",
+			transcriptPath: transcript,
+			edges: new Map([["/somewhere/else", { firstSeenAt: "2026-08-17T10:00:00.000Z", firstSeenLine: 0, lastSeenAt: "2026-08-17T10:00:00.000Z" }]]),
+		},
+		globalDir,
+	);
+
+	const summary = await runCommitPipelineForTest(repoDir);
+
+	expect(summary.transcripts ?? []).toHaveLength(0);
+});
+
+it("does not duplicate a session present in both sessions.json and the ledger", async () => {
+	await saveSession({ sessionId: "dup-1", transcriptPath: transcript, updatedAt: NOW, source: "claude" }, repoDir);
+	await recordClaudeOwners(
+		{ sessionId: "dup-1", transcriptPath: transcript, edges: new Map([[resolveStateRoot(repoDir), edge]]) },
+		globalDir,
+	);
+
+	const summary = await runCommitPipelineForTest(repoDir);
+
+	expect(summary.transcriptEntries).toBe(1);
+});
+
+it("ignores the ledger when claudeEnabled is false", async () => {
+	await saveConfig({ claudeEnabled: false });
+	await recordClaudeOwners(
+		{ sessionId: "off-1", transcriptPath: transcript, edges: new Map([[resolveStateRoot(repoDir), edge]]) },
+		globalDir,
+	);
+
+	const summary = await runCommitPipelineForTest(repoDir);
+
+	expect(summary.transcripts ?? []).toHaveLength(0);
+});
+```
+
+- [ ] **Step 2: Implement the merge**
+
+In `cli/src/hooks/QueueWorker.ts`, replace line 3907's single assignment with the merge, and thread the seeds out of the function:
+
+```typescript
+	const trackedSessions = filterSessionsByEnabledIntegrations(await loadAllSessions(cwd), config);
+
+	// Claude candidates from the machine-global ownership ledger (spec §7.1).
+	// `sessions.json` only knows the sessions whose Stop hook fired against THIS
+	// checkout; the ledger knows every checkout a session's transcript proves it
+	// visited, which is the whole point of the fix. Merged, not replaced — the
+	// local registry stays the cheap fast path and the fallback for a session the
+	// ledger never got (an older dist, a wiped global dir).
+	//
+	// The lookup key MUST be the anchored root: this `cwd` is git's hook cwd, and
+	// on macOS that is `/var/…` where `resolveStateRoot` wrote `/private/var/…`.
+	const ownerRoot = resolveStateRoot(cwd);
+	const ledgerOwned = config.claudeEnabled === false ? [] : await claudeSessionsOwnedBy(ownerRoot);
+	/** transcriptPath → this owner's lower bound, for a first read (see readAllTranscripts). */
+	const ownerSeeds = new Map<string, number>();
+	for (const owned of ledgerOwned) ownerSeeds.set(owned.transcriptPath, owned.edge.firstSeenLine);
+
+	const seen = new Set(
+		trackedSessions.map((s) => `${s.source ?? "claude"} ${s.sessionId} ${s.transcriptPath}`),
+	);
+	const ledgerSessions = ledgerOwned
+		.filter((o) => !seen.has(`claude ${o.sessionId} ${o.transcriptPath}`))
+		.map((o) => ({
+			sessionId: o.sessionId,
+			transcriptPath: o.transcriptPath,
+			updatedAt: o.edge.lastSeenAt,
+			source: "claude" as const,
+		}));
+	if (ledgerSessions.length > 0) {
+		log.info("Claude ownership ledger contributed %d session(s) for %s", ledgerSessions.length, ownerRoot);
+	}
+
+	let allSessions: ReadonlyArray<SessionInfo> = [...trackedSessions, ...ledgerSessions];
+```
+
+Add the imports:
+
+```typescript
+import { claudeSessionsOwnedBy } from "../core/ClaudeOwnership.js";
+```
+
+(`resolveStateRoot` is already imported in this module; confirm before adding a duplicate.)
+
+---
+
+### Task 5: Owner-seeded lower bound (the load-bearing rule)
+
+**Files:**
+- Modify: `cli/src/hooks/QueueWorker.ts:4327` (`readAllTranscripts`) and its call site at 4028
+- Modify: `cli/src/hooks/QueueWorker.test.ts`
+
+**Interfaces:**
+- Consumes: `ownerSeeds` from Task 4.
+- Produces: `readAllTranscripts(sessions, cwd, beforeTimestamp?, ownerSeeds?)` — a fourth optional parameter, so every existing caller and test is untouched.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `cli/src/hooks/QueueWorker.test.ts`:
+
+```typescript
+it("starts a first read from the owner's firstSeenLine, not from line 0", async () => {
+	// 3 turns from another checkout, then 1 turn from this one.
+	await writeFile(transcript, [foreignTurn(0), foreignTurn(1), foreignTurn(2), localTurn(3)].join("\n"), "utf-8");
+	await recordClaudeOwners(
+		{
+			sessionId: "seeded-1",
+			transcriptPath: transcript,
+			edges: new Map([[resolveStateRoot(repoDir), { firstSeenAt: T3, firstSeenLine: 3, lastSeenAt: T3 }]]),
+		},
+		globalDir,
+	);
+
+	const summary = await runCommitPipelineForTest(repoDir);
+
+	expect(summary.transcriptEntries).toBe(1);
+});
+
+it("resumes from this worktree's own cursor once it has one", async () => {
+	await saveCursor({ transcriptPath: transcript, lineNumber: 4, updatedAt: NOW }, repoDir);
+	await recordClaudeOwners(
+		{ sessionId: "seeded-2", transcriptPath: transcript, edges: new Map([[resolveStateRoot(repoDir), { firstSeenAt: T0, firstSeenLine: 0, lastSeenAt: T0 }]]) },
+		globalDir,
+	);
+
+	const summary = await runCommitPipelineForTest(repoDir);
+
+	// The seed must NOT rewind an established cursor.
+	expect(summary.transcriptEntries ?? 0).toBe(0);
+});
+
+it("still honours beforeTimestamp as the upper bound when seeded", async () => {
+	await writeFile(transcript, [localTurn(0, T0), localTurn(1, "2099-01-01T00:00:00.000Z")].join("\n"), "utf-8");
+	await recordClaudeOwners(
+		{ sessionId: "seeded-3", transcriptPath: transcript, edges: new Map([[resolveStateRoot(repoDir), { firstSeenAt: T0, firstSeenLine: 0, lastSeenAt: T0 }]]) },
+		globalDir,
+	);
+
+	const summary = await runCommitPipelineForTest(repoDir);
+
+	expect(summary.transcriptEntries).toBe(1);
+});
+
+it("leaves a non-Claude source's first read at line 0", async () => {
+	// A gemini session with an owner seed present for the same path must ignore it.
+	// (Nothing writes such a seed today; the assertion pins that the branch is
+	// source-gated rather than path-gated.)
+});
+```
+
+- [ ] **Step 2: Implement the seed**
+
+In `readAllTranscripts`, widen the signature and replace the cursor load:
+
+```typescript
+async function readAllTranscripts(
+	sessions: ReadonlyArray<{ sessionId: string; transcriptPath: string; source?: TranscriptSource }>,
+	cwd: string,
+	beforeTimestamp?: string,
+	/**
+	 * Claude-only lower bounds from the ownership ledger, keyed by transcriptPath.
+	 * Consulted ONLY when this worktree has no cursor of its own for that
+	 * transcript — see the seed below.
+	 */
+	ownerSeeds?: ReadonlyMap<string, number>,
+): Promise<{
+```
+
+then, at the top of the per-session loop (replacing lines 4368-4370):
+
+```typescript
+		const source = session.source ?? "claude";
+		const saved = await loadCursorForTranscript(session.transcriptPath, cwd);
+		// THE load-bearing rule (spec §7.3). With no saved cursor the reader used to
+		// start at line 0 and stop only at `beforeTimestamp`, which for a session this
+		// checkout joined late means absorbing every earlier turn — turns that belong
+		// to whichever checkout was driving the conversation then. The ledger knows
+		// where this owner first appears, so that is the floor.
+		//
+		// Only when there is NO saved cursor: an established cursor is this owner's own
+		// progress and always wins, or a seed would rewind it and re-read spent lines.
+		// Claude-only, because the ledger has no other source in it (spec §2.2).
+		const seedLine = saved === null && source === "claude" ? ownerSeeds?.get(session.transcriptPath) : undefined;
+		const cursor =
+			seedLine !== undefined && seedLine > 0
+				? { transcriptPath: session.transcriptPath, lineNumber: seedLine, updatedAt: new Date().toISOString() }
+				: saved;
+		const startLine = cursor?.lineNumber ?? 0;
+		if (seedLine !== undefined && seedLine > 0) {
+			log.info("Seeding first read of %s from owner line %d", session.sessionId, seedLine);
+		}
+```
+
+- [ ] **Step 3: Pass the seeds through the call site**
+
+At line 4028 in `loadSessionTranscripts`:
+
+```typescript
+	const rawAll = await readAllTranscripts(allSessions, cwd, beforeTimestamp, ownerSeeds);
+```
+
+---
+
+## Phase 2 — Bounded repair
+
+### Task 6: Repair marker and the shared repairability predicate
+
+**Files:**
+- Modify: `cli/src/Types.ts` (`CommitSummary`)
+- Create: `cli/src/core/TranscriptRepair.ts` (predicate half only; the engine lands in Task 7)
+- Create: `cli/src/core/TranscriptRepair.test.ts`
+
+**Interfaces:**
+- Consumes: `getTranscriptIds` from `core/SummaryTree.js`, `claudeSessionsOwnedBy` (Task 1).
+- Produces:
+  - `type TranscriptRepairState = "present" | "repaired" | "repairable" | "unrepairable"`
+  - `transcriptRepairState(summary: CommitSummary, cwd: string): Promise<TranscriptRepairState>`
+
+- [ ] **Step 1: Add the marker field**
+
+In `cli/src/Types.ts`, inside `CommitSummary`, after `transcripts`:
+
+```typescript
+	/**
+	 * Set by `jolli doctor --repair-transcripts --fix` when this summary's empty
+	 * `transcripts` was refilled from local transcript history. Purely additive —
+	 * no schema bump, matching how `skills` / `excludedContext` shipped.
+	 *
+	 * Two jobs. It is the repair's idempotency key: a summary carrying it is never
+	 * a candidate again, so a repeated run cannot create a second artifact for the
+	 * same evidence window (spec §8.2). And it is what lets the memory-detail UI
+	 * say "repaired from local transcript history" rather than implying the
+	 * conversation was captured live.
+	 */
+	readonly transcriptsRepairedAt?: string;
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `cli/src/core/TranscriptRepair.test.ts`:
+
+```typescript
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { CommitSummary } from "../Types.js";
+import { recordClaudeOwners } from "./ClaudeOwnership.js";
+import { transcriptRepairState } from "./TranscriptRepair.js";
+
+let globalDir: string;
+let repo: string;
+let transcript: string;
+
+const EDGE = { firstSeenAt: "2026-08-17T10:00:00.000Z", firstSeenLine: 0, lastSeenAt: "2026-08-17T10:00:00.000Z" };
+
+function summary(over: Partial<CommitSummary> = {}): CommitSummary {
+	return {
+		commitHash: "a".repeat(40),
+		commitMessage: "x",
+		commitAuthor: "a",
+		commitDate: "2026-08-17T11:00:00.000Z",
+		branch: "main",
+		generatedAt: "2026-08-17T11:00:05.000Z",
+		topics: [],
+		...over,
+	} as CommitSummary;
+}
+
+beforeEach(async () => {
+	globalDir = await mkdtemp(join(tmpdir(), "jolli-rep-g-"));
+	repo = await mkdtemp(join(tmpdir(), "jolli-rep-r-"));
+	transcript = join(globalDir, "s.jsonl");
+	await writeFile(transcript, `${JSON.stringify({ cwd: repo, timestamp: "2026-08-17T10:00:00.000Z" })}\n`, "utf-8");
+});
+
+describe("transcriptRepairState", () => {
+	it("is present when the summary already references a transcript", async () => {
+		expect(await transcriptRepairState(summary({ transcripts: ["t1"] }), repo, globalDir)).toBe("present");
+	});
+
+	it("is repaired when the marker is set", async () => {
+		expect(
+			await transcriptRepairState(summary({ transcripts: ["t1"], transcriptsRepairedAt: "2026-08-17T12:00:00.000Z" }), repo, globalDir),
+		).toBe("repaired");
+	});
+
+	it("is repairable when an owner edge and the transcript both exist", async () => {
+		await recordClaudeOwners({ sessionId: "s", transcriptPath: transcript, edges: new Map([[repo, EDGE]]) }, globalDir);
+		expect(await transcriptRepairState(summary({ transcripts: [] }), repo, globalDir)).toBe("repairable");
+	});
+
+	it("is unrepairable when no owner edge proves this checkout", async () => {
+		expect(await transcriptRepairState(summary({ transcripts: [] }), repo, globalDir)).toBe("unrepairable");
+	});
+
+	it("is unrepairable when the transcript file is gone", async () => {
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: join(globalDir, "vanished.jsonl"), edges: new Map([[repo, EDGE]]) },
+			globalDir,
+		);
+		expect(await transcriptRepairState(summary({ transcripts: [] }), repo, globalDir)).toBe("unrepairable");
+	});
+});
+```
+
+- [ ] **Step 3: Write the predicate**
+
+Create `cli/src/core/TranscriptRepair.ts` with the predicate (the engine is appended in Task 7):
+
+```typescript
+/**
+ * Repair for summaries written with `transcripts: []`.
+ *
+ * Deliberately conservative (spec §8.3): every uncertainty resolves to "do not
+ * repair". A false negative leaves a memory looking exactly as it does today; a
+ * false positive staples someone else's conversation onto a commit, which is
+ * worse than the gap it would be papering over.
+ */
+
+import { existsSync } from "node:fs";
+import { resolveStateRoot } from "./GitOps.js";
+import type { CommitSummary } from "../Types.js";
+import { claudeSessionsOwnedBy } from "./ClaudeOwnership.js";
+import { getTranscriptIds } from "./SummaryTree.js";
+
+/**
+ * What the memory-detail UI is allowed to claim about a summary's conversations:
+ *
+ * - `present`     — captured live; render the conversations.
+ * - `repaired`    — refilled from local transcript history after the fact.
+ * - `repairable`  — empty, but the evidence to rebuild it is still on this machine.
+ * - `unrepairable`— empty, and nothing local can fix it.
+ *
+ * The last two are the distinction spec §9 exists for: "No conversations linked
+ * yet" reads as "not yet", which is misleading for a capture that already failed
+ * and will never complete on its own.
+ */
+export type TranscriptRepairState = "present" | "repaired" | "repairable" | "unrepairable";
+
+export async function transcriptRepairState(
+	summary: CommitSummary,
+	cwd: string,
+	globalDir?: string,
+): Promise<TranscriptRepairState> {
+	if (summary.transcriptsRepairedAt !== undefined) return "repaired";
+	if (getTranscriptIds(summary).length > 0) return "present";
+	const owned = await claudeSessionsOwnedBy(resolveStateRoot(cwd), globalDir);
+	return owned.some((o) => existsSync(o.transcriptPath)) ? "repairable" : "unrepairable";
+}
+```
+
+---
+
+### Task 7: Repair engine
+
+**Files:**
+- Modify: `cli/src/core/TranscriptRepair.ts`
+- Modify: `cli/src/core/TranscriptRepair.test.ts`
+
+**Interfaces:**
+- Consumes: `readTranscript` from `core/TranscriptReader.js`, `getParserForSource` from `core/TranscriptParser.js`, `generateTranscriptId` from `core/TranscriptId.js`, `getSummary` / `storeSummary` from `core/SummaryStore.js`.
+- Produces:
+  - `interface RepairOutcome { readonly commitHash: string; readonly repaired: boolean; readonly reason: "repaired" | "already-present" | "no-owner-proof" | "transcript-missing" | "no-entries-in-window" | "no-upper-bound" }`
+  - `repairSummaryTranscripts(commitHash: string, cwd: string, opts?: { apply?: boolean; globalDir?: string }): Promise<RepairOutcome>`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `cli/src/core/TranscriptRepair.test.ts`:
+
+```typescript
+describe("repairSummaryTranscripts", () => {
+	it("repairs an empty summary when transcript, owner edge and upper bound all exist", async () => {
+		// transcript holds one turn at 10:00; summary.generatedAt is 11:00:05.
+		await recordClaudeOwners({ sessionId: "s", transcriptPath: transcript, edges: new Map([[repo, EDGE]]) }, globalDir);
+		const out = await repairSummaryTranscripts(HASH, repo, { apply: true, globalDir });
+		expect(out).toMatchObject({ repaired: true, reason: "repaired" });
+		const stored = await getSummary(HASH, repo);
+		expect(stored?.transcripts).toHaveLength(1);
+		expect(stored?.transcriptsRepairedAt).toBeTruthy();
+	});
+
+	it("is idempotent — a second run reports already-present and writes nothing", async () => {
+		await recordClaudeOwners({ sessionId: "s", transcriptPath: transcript, edges: new Map([[repo, EDGE]]) }, globalDir);
+		await repairSummaryTranscripts(HASH, repo, { apply: true, globalDir });
+		const before = await getSummary(HASH, repo);
+		const out = await repairSummaryTranscripts(HASH, repo, { apply: true, globalDir });
+		expect(out.reason).toBe("already-present");
+		expect((await getSummary(HASH, repo))?.transcripts).toEqual(before?.transcripts);
+	});
+
+	it("refuses when the transcript file is gone", async () => {
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: join(globalDir, "gone.jsonl"), edges: new Map([[repo, EDGE]]) },
+			globalDir,
+		);
+		expect((await repairSummaryTranscripts(HASH, repo, { apply: true, globalDir })).reason).toBe("transcript-missing");
+	});
+
+	it("refuses when no owner edge proves this checkout", async () => {
+		expect((await repairSummaryTranscripts(HASH, repo, { apply: true, globalDir })).reason).toBe("no-owner-proof");
+	});
+
+	it("refuses when the bounded window yields no entries", async () => {
+		// Owner edge seeded past every line in the file.
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[repo, { ...EDGE, firstSeenLine: 99 }]]) },
+			globalDir,
+		);
+		expect((await repairSummaryTranscripts(HASH, repo, { apply: true, globalDir })).reason).toBe("no-entries-in-window");
+	});
+
+	it("writes nothing when apply is false", async () => {
+		await recordClaudeOwners({ sessionId: "s", transcriptPath: transcript, edges: new Map([[repo, EDGE]]) }, globalDir);
+		const out = await repairSummaryTranscripts(HASH, repo, { globalDir });
+		expect(out.repaired).toBe(true);
+		expect((await getSummary(HASH, repo))?.transcripts ?? []).toHaveLength(0);
+	});
+});
+```
+
+- [ ] **Step 2: Implement the engine**
+
+Append to `cli/src/core/TranscriptRepair.ts`:
+
+```typescript
+export interface RepairOutcome {
+	readonly commitHash: string;
+	/** True when a repair happened, or WOULD have happened under `apply: false`. */
+	readonly repaired: boolean;
+	readonly reason:
+		| "repaired"
+		| "already-present"
+		| "no-owner-proof"
+		| "transcript-missing"
+		| "no-entries-in-window"
+		| "no-upper-bound";
+	readonly entries?: number;
+}
+
+/**
+ * Rebuilds one summary's transcript slice from local history (spec §8.2).
+ *
+ * Bounds, both mandatory:
+ *   - LOWER — the owner edge's `firstSeenLine`, exactly as the live read path
+ *     seeds a first read. Never 0-by-default: a summary whose owner cannot be
+ *     proven is refused, not read from the top.
+ *   - UPPER — `generatedAt` (the capture instant), falling back to `commitDate`.
+ *     `generatedAt` is preferred because it is when capture actually ran; the
+ *     commit's own timestamp can precede the turns that produced it.
+ *
+ * `apply: false` performs every step except the write, so the outcome a dry run
+ * reports is the outcome the real run produces — the reasons cannot drift,
+ * because there is one code path.
+ */
+export async function repairSummaryTranscripts(
+	commitHash: string,
+	cwd: string,
+	opts: { readonly apply?: boolean; readonly globalDir?: string } = {},
+): Promise<RepairOutcome> {
+	const summary = await getSummary(commitHash, cwd);
+	if (!summary) return { commitHash, repaired: false, reason: "no-owner-proof" };
+	if (summary.transcriptsRepairedAt !== undefined || getTranscriptIds(summary).length > 0) {
+		return { commitHash, repaired: false, reason: "already-present" };
+	}
+
+	const before = summary.generatedAt || summary.commitDate;
+	if (!before) return { commitHash, repaired: false, reason: "no-upper-bound" };
+
+	const owned = await claudeSessionsOwnedBy(resolveStateRoot(cwd), opts.globalDir);
+	if (owned.length === 0) return { commitHash, repaired: false, reason: "no-owner-proof" };
+	const live = owned.filter((o) => existsSync(o.transcriptPath));
+	if (live.length === 0) return { commitHash, repaired: false, reason: "transcript-missing" };
+
+	const sessions: StoredSession[] = [];
+	for (const owner of live) {
+		let read: TranscriptReadResult;
+		try {
+			read = await readTranscript(
+				owner.transcriptPath,
+				{
+					transcriptPath: owner.transcriptPath,
+					lineNumber: owner.edge.firstSeenLine,
+					updatedAt: owner.edge.firstSeenAt,
+				},
+				getParserForSource("claude"),
+				before,
+			);
+		} catch (err) {
+			log.debug("repair: cannot read %s: %s", owner.transcriptPath, errMsg(err));
+			continue;
+		}
+		if (read.entries.length === 0) continue;
+		sessions.push({
+			sessionId: owner.sessionId,
+			transcriptPath: owner.transcriptPath,
+			source: "claude",
+			entries: read.entries,
+		});
+	}
+	if (sessions.length === 0) return { commitHash, repaired: false, reason: "no-entries-in-window" };
+
+	const entries = sessions.reduce((n, s) => n + s.entries.length, 0);
+	if (opts.apply !== true) return { commitHash, repaired: true, reason: "repaired", entries };
+
+	const id = generateTranscriptId();
+	await storeSummary(
+		{ ...summary, transcripts: [id], transcriptsRepairedAt: new Date().toISOString() },
+		cwd,
+		true,
+		{ transcript: { id, data: { sessions } } },
+	);
+	return { commitHash, repaired: true, reason: "repaired", entries };
+}
+```
+
+---
+
+### Task 8: `jolli doctor --repair-transcripts`
+
+**Files:**
+- Modify: `cli/src/commands/DoctorCommand.ts:715` (registration) + a new `runRepairTranscripts`
+- Modify: `cli/src/commands/DoctorCommand.test.ts`
+
+**Interfaces:**
+- Consumes: `listSummaries` from `core/SummaryStore.js`, `repairSummaryTranscripts` (Task 7).
+- Produces: `runRepairTranscripts(cwd: string, apply: boolean): Promise<void>`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `cli/src/commands/DoctorCommand.test.ts`:
+
+```typescript
+it("lists repair candidates without writing when --fix is absent", async () => {
+	const out = await captureStdout(() => runRepairTranscripts(repo, false));
+	expect(out).toContain("would repair");
+	expect((await getSummary(HASH, repo))?.transcripts ?? []).toHaveLength(0);
+});
+
+it("repairs and reports per-summary reasons with --fix", async () => {
+	const out = await captureStdout(() => runRepairTranscripts(repo, true));
+	expect(out).toContain("repaired");
+	expect((await getSummary(HASH, repo))?.transcripts).toHaveLength(1);
+});
+
+it("reports a clean result when no summary has an empty transcript list", async () => {
+	const out = await captureStdout(() => runRepairTranscripts(repoWithFullSummaries, true));
+	expect(out).toContain("No summaries need transcript repair");
+});
+```
+
+- [ ] **Step 2: Implement the runner**
+
+```typescript
+/**
+ * Scans this repo's summaries for an empty `transcripts` list and offers, or
+ * performs, the bounded repair.
+ *
+ * List-then-act like `--recover`: the bare flag reports what it WOULD do and
+ * `--fix` performs it. Repair rewrites stored memories from evidence that may be
+ * days old, so it is never something a diagnostic command does on its own.
+ */
+export async function runRepairTranscripts(cwd: string, apply: boolean): Promise<void> {
+	const summaries = await listSummaries(Number.MAX_SAFE_INTEGER, cwd);
+	const candidates = summaries.filter((s) => s.transcriptsRepairedAt === undefined && getTranscriptIds(s).length === 0);
+	if (candidates.length === 0) {
+		console.log("No summaries need transcript repair.");
+		return;
+	}
+
+	let repaired = 0;
+	for (const candidate of candidates) {
+		const out = await repairSummaryTranscripts(candidate.commitHash, cwd, { apply });
+		const hash = candidate.commitHash.substring(0, 8);
+		if (out.repaired) {
+			repaired++;
+			console.log(`  ${hash}  ${apply ? "repaired" : "would repair"} — ${out.entries} entr(ies)`);
+		} else {
+			console.log(`  ${hash}  skipped — ${out.reason}`);
+		}
+	}
+	console.log(
+		apply
+			? `Repaired ${repaired} of ${candidates.length} summar(ies).`
+			: `${repaired} of ${candidates.length} summar(ies) can be repaired. Re-run with --fix to apply.`,
+	);
+}
+```
+
+- [ ] **Step 3: Register the flag**
+
+In `registerDoctorCommand`, add the option and dispatch it BEFORE `runDoctor` (and after `--recover`, matching the existing precedence comments):
+
+```typescript
+		.option("--repair-transcripts", "Refill summaries written with no conversation from local transcript history")
+```
+
+```typescript
+				if (options.repairTranscripts === true) {
+					await runRepairTranscripts(options.cwd, options.fix === true);
+					return;
+				}
+```
+
+and widen the action's option type with `repairTranscripts?: boolean`.
+
+---
+
+### Task 9: Three-state memory-detail copy
+
+**Files:**
+- Modify: `cli/src/commands/IdeBridgeCommand.ts` (new `transcript-repair-state` action)
+- Modify: `cli/src/dashboard/assets/js/memories.js:456`
+- Modify: `vscode/src/views/SummaryScriptBuilder.ts:2278` and `:2462`
+- Create: `intellij/src/main/kotlin/ai/jolli/jollimemory/core/TranscriptRepairState.kt`
+- Modify: `intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryHtmlBuilder.kt:278`
+- Modify: `cli/src/commands/IdeBridgeCommand.test.ts`
+
+**Interfaces:**
+- Consumes: `transcriptRepairState` (Task 6).
+- Produces: bridge action `{ action: "transcript-repair-state", commitHash }` → `{ state: TranscriptRepairState }`.
+
+The three strings, verbatim from spec §9 — use these exact words on every surface:
+
+| state | copy |
+|---|---|
+| `unrepairable` | `No conversations were captured for this memory` |
+| `repairable` | `Conversation capture is missing but repair may still be possible` |
+| `repaired` | `Conversation capture was repaired from local transcript history` |
+
+- [ ] **Step 1: Add the bridge action**
+
+IntelliJ has no in-process access to `cli/src` (unlike VS Code, which bundles it), so a predicate with no bridge operation is silently "VS Code only". In `IdeBridgeCommand.ts`, beside the other read actions:
+
+```typescript
+		case "transcript-repair-state": {
+			const summary = await getSummary(String(request.commitHash ?? ""), cwd);
+			if (!summary) return { state: "unrepairable" satisfies TranscriptRepairState };
+			return { state: await transcriptRepairState(summary, cwd) };
+		}
+```
+
+- [ ] **Step 2: Write the bridge test**
+
+```typescript
+it("answers transcript-repair-state for a summary with no conversations", async () => {
+	const res = await dispatch({ action: "transcript-repair-state", commitHash: HASH }, repo);
+	expect(res).toEqual({ state: "unrepairable" });
+});
+
+it("answers unrepairable for an unknown commit rather than throwing", async () => {
+	const res = await dispatch({ action: "transcript-repair-state", commitHash: "f".repeat(40) }, repo);
+	expect(res).toEqual({ state: "unrepairable" });
+});
+```
+
+- [ ] **Step 3: VS Code copy**
+
+At both sites in `SummaryScriptBuilder.ts`, replace the fixed string with a state lookup the panel already has (the summary payload carries `transcriptsRepairedAt`; the `repairable` split comes from the extension calling `transcriptRepairState` in-process and putting it on the payload as `transcriptRepairState`):
+
+```javascript
+      conversationsBody.innerHTML =
+        '<p class="conv-empty">' +
+        (summary.transcriptRepairState === 'repairable'
+          ? 'Conversation capture is missing but repair may still be possible'
+          : 'No conversations were captured for this memory') +
+        '</p>';
+```
+
+Remember this webview runs under a strict CSP — no inline `style=`, no inline handlers.
+
+- [ ] **Step 4: Dashboard copy**
+
+`cli/src/dashboard/assets/js/memories.js:456` — same three-way branch, reading the state the page's own server-side render attaches to each row.
+
+- [ ] **Step 5: IntelliJ copy**
+
+Create `TranscriptRepairState.kt` as the thin bridge adapter (follow `FileDiscarder`'s shape — parse defensively, treat an unparseable body as the mildest verdict, `unrepairable`), and branch `SummaryHtmlBuilder.kt:278`'s `conversationsEmpty` paragraph on it.
+
+---
+
+### Task 10: Regression coverage for the spec's §10.4 list
+
+**Files:**
+- Modify: `cli/src/hooks/QueueWorker.test.ts`
+
+- [ ] **Step 1: Write the three regression tests**
+
+```typescript
+it("same-worktree Claude capture is unchanged when the ledger is empty", async () => {
+	await saveSession({ sessionId: "plain", transcriptPath: transcript, updatedAt: NOW, source: "claude" }, repoDir);
+	const summary = await runCommitPipelineForTest(repoDir);
+	expect(summary.transcriptEntries).toBeGreaterThan(0);
+});
+
+it("linked-worktree capture works when the session was first seen elsewhere", async () => {
+	// Edge written for worktree B by A's hook; the commit runs in B, which has no
+	// sessions.json row at all.
+	await recordClaudeOwners(
+		{ sessionId: "cross", transcriptPath: transcript, edges: new Map([[resolveStateRoot(worktreeB), EDGE_AT_LINE_3]]) },
+		globalDir,
+	);
+	const summary = await runCommitPipelineForTest(worktreeB);
+	expect(summary.transcripts ?? []).not.toHaveLength(0);
+});
+
+it("agrees with claudeSessionsForRepo about which sessions belong to this repo", async () => {
+	// The disk discoverer and the ledger must not disagree for the same session.
+	const scanned = claudeSessionsForRepo([{ sessionId: "cross", transcriptPath: transcript, updatedAt: NOW, dirs: [repoDir], complete: true }], repoDir);
+	const owned = await claudeSessionsOwnedBy(resolveStateRoot(repoDir), globalDir);
+	expect(owned.map((o) => o.sessionId)).toEqual(scanned.map((s) => s.sessionId));
+});
+```
+
+---
+
+### Task 11: Gate and commit
+
+- [ ] **Step 1: Run the fast tier**
+
+```bash
+npm run test:fast
+```
+
+- [ ] **Step 2: Run the full gate**
+
+```bash
+npm run all
+```
+
+Triage by failure SHAPE first: a `Test timed out in NNNNms` in one of the real-`git` files is contention under `--coverage`, not a regression — re-run that file alone with the stock timeout to confirm. An assertion or thrown error is a real break.
+
+- [ ] **Step 3: Build the IntelliJ side**
+
+```bash
+cd intellij && ./gradlew build
+```
+
+- [ ] **Step 4: Commit in two logical commits**
+
+```bash
+git add cli/src/core/ClaudeOwnership.ts cli/src/core/ClaudeOwnership.test.ts \
+        cli/src/core/ClaudeOwnerScan.ts cli/src/core/ClaudeOwnerScan.test.ts \
+        cli/src/core/Locks.ts cli/src/Types.ts \
+        cli/src/hooks/StopHook.ts cli/src/hooks/StopHook.test.ts \
+        cli/src/hooks/QueueWorker.ts cli/src/hooks/QueueWorker.test.ts
+git commit -s -m "fix(capture): attribute one Claude session to every worktree it visited
+
+Claude capture read candidates only from the current worktree's sessions.json,
+so a session that started in another checkout — or moved between repositories
+mid-conversation — produced a summary with no transcript at all. Record the
+worktree roots each session's transcript proves it visited in a machine-global
+ownership ledger, and seed a first read from that owner's own first-seen line
+so a newly-attributed checkout takes its slice rather than the whole history."
+
+git add cli/src/core/TranscriptRepair.ts cli/src/core/TranscriptRepair.test.ts \
+        cli/src/commands/DoctorCommand.ts cli/src/commands/DoctorCommand.test.ts \
+        cli/src/commands/IdeBridgeCommand.ts cli/src/commands/IdeBridgeCommand.test.ts \
+        cli/src/dashboard/assets/js/memories.js \
+        vscode/src/views/SummaryScriptBuilder.ts \
+        intellij/src/main/kotlin/ai/jolli/jollimemory/core/TranscriptRepairState.kt \
+        intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryHtmlBuilder.kt
+git commit -s -m "feat(doctor): repair summaries written with no conversation
+
+Adds jolli doctor --repair-transcripts, which refills an empty transcript list
+from local history bounded below by the owner's first-seen line and above by the
+capture instant, refusing whenever either bound cannot be established. The memory
+detail now distinguishes a capture that never happened from one that can still be
+repaired and from one that was."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** §4 ownership semantics → Task 1's edge shape and Task 2's root resolution. §5 storage → Task 1 (global, per the answered question). §6.1 Stop-hook write path → Task 3. §6.2 `firstSeenLine` from transcript evidence → Task 2 (`firstSeenLine` is the line index of the first matching `cwd`, never a wall clock). §7.1 candidate selection → Task 4. §7.2 owner-specific cursor → satisfied structurally: `cursors.json` already lives in `<worktree>/.jolli/jollimemory/`, so `(cwd, transcriptPath)` IS `(ownerRoot, transcriptPath)` and no new file is needed; Task 5 adds the only missing half, the seed. §7.3 first read from a foreign owner → Task 5. §8 repair → Tasks 6-8. §9 UI copy → Task 9. §10.1/§10.2/§10.3 → Tasks 3/5/7. §10.4 → Task 10. §11 risk limits → non-Claude sources untouched (Task 5's branch is source-gated), the lower bound lives outside the parser (a synthesized cursor, not a reader change).
+
+**Deviation to flag.** The spec's §7.2 implies a NEW owner-keyed cursor store. This plan does not add one, because the existing store is already keyed by owner through its directory; adding a second would create two owners of one fact with no tie-breaker. The behavioural contract §7.2 states — first read starts at `firstSeenLine`, subsequent reads resume from this owner's cursor, owners never advance one another — holds exactly as written.
+
+**Type consistency.** `ClaudeOwnerEdge` is produced by `scanOwnerEdges` (Task 2), stored by `recordClaudeOwners` (Task 1), and read by `claudeSessionsOwnedBy` (Task 1) / `repairSummaryTranscripts` (Task 7) — one shape throughout. `firstSeenLine` is a line index against `splitTranscriptLines` at every one of those sites and at the `TranscriptCursor.lineNumber` it becomes in Task 5. `TranscriptRepairState`'s four values are spelled identically in Tasks 6, 8 and 9.
+
+**Known gap left open deliberately.** A ledger edge is only ever written by a Stop hook that fired, so a session from before this ships has no edges and is `unrepairable` even when its transcript is on disk. Seeding the ledger from `scanClaudeSessionsOnDisk` (which already computes exactly this `dirs` set) would close it, and is a natural follow-up — but it is a machine-wide disk sweep and spec §2.1 rules it out of the commit path, so it belongs behind the `doctor` flag rather than in this slice.

--- a/docs/superpowers/specs/2026-08-17-claude-multi-owner-session-attribution-design.md
+++ b/docs/superpowers/specs/2026-08-17-claude-multi-owner-session-attribution-design.md
@@ -1,0 +1,277 @@
+# Claude multi-owner session attribution - design
+
+**Date:** 2026-08-17
+**Scope:** fix Claude conversation capture so one Claude session may be attributed to multiple worktrees and repositories without falling back to whole-session ownership, and add a bounded repair path for historical summaries that were written with `transcripts: []`.
+**Depends on:** the current post-commit QueueWorker pipeline, the Claude Stop hook, and the existing Claude disk discoverer.
+
+---
+
+## 1. Problem
+
+Claude capture currently has two different attribution paths:
+
+- The post-commit summary path reads Claude sessions from the current worktree's `.jolli/jollimemory/sessions.json`.
+- The dashboard and backfill paths can discover Claude transcripts from disk and attribute one session to multiple directories and repositories.
+
+That split creates a correctness gap. A Claude session that was seen from a different worktree, or that touched multiple repositories during one conversation, can still appear in dashboard storage while the post-commit summary for a later commit writes `transcripts: []`.
+
+The obvious patch, scanning sibling worktrees' `sessions.json`, is not sufficient. It only helps linked worktrees in one repository, does not cover cross-repo sessions, and still throws away the real evidence already present in the transcript: the set of working directories the session touched.
+
+The second trap is cursor ownership. The current cursor model is keyed by `transcriptPath` inside one worktree's `cursors.json`. If a foreign-attributed Claude session is first consumed from a different owner with no local cursor, the reader starts from line 0 and only stops at `beforeTimestamp`. That would wrongly attribute the entire earlier portion of the session to the current commit.
+
+## 2. Goals and non-goals
+
+### 2.1 Goals
+
+- Let one Claude session be attributed to more than one worktree and more than one repository.
+- Keep commit summaries slice-based rather than whole-session based.
+- Prevent a newly-attributed owner from consuming transcript history that predates that owner's first participation in the session.
+- Keep the fast forward-capture path; do not make every post-commit summarization depend on a full transcript disk sweep.
+- Add a repair path for historical summaries written with `transcripts: []`, but only when the missing transcript still exists locally and can be bounded safely.
+
+### 2.2 Non-goals
+
+- Do not redefine ownership for non-Claude sources in this slice.
+- Do not rewrite the stored-transcript schema or the existing `summary.transcripts` contract.
+- Do not promise recovery of transcripts that the host has already rotated or deleted.
+- Do not collapse attribution to a machine-global "repo" cursor. Cursor advancement must remain isolated between worktrees.
+
+## 3. Chosen model
+
+The fix is a mixed model:
+
+- Keep the Stop hook as the fast forward-capture entry.
+- Introduce a Claude ownership ledger that records owner-specific evidence for each session.
+- Use worktree-root ownership edges, not a single worktree-local session registry, to decide whether a commit may consume a Claude session.
+- Seed an owner-specific cursor from the owner's first-seen position so the first consumption from that owner does not start at line 0.
+- Use the Claude disk discoverer only for repair and for recovery when forward-capture evidence is missing.
+
+This deliberately preserves the existing summary pipeline shape: a commit still stores only its own derived transcript slice, and `summary.transcripts` still points at a stored artifact generated at capture time.
+
+## 4. Ownership semantics
+
+### 4.1 Owner identity
+
+The owner key is the current git worktree root, the same root `resolveStateRoot()` already resolves for hook entrypoints.
+
+This is stricter than repository identity on purpose. Two linked worktrees of the same repository may be on different branches and may consume different parts of one long Claude session. Sharing a single repo-level cursor would let one worktree advance the other and recreate the current bug in a new form.
+
+Cross-repo sessions are therefore represented as multiple ownership edges, one per worktree root that the session touched.
+
+### 4.2 Ownership edge
+
+Each Claude session may have zero or more ownership edges. An edge records:
+
+- `ownerRoot`
+- `firstSeenAt`
+- `firstSeenLine`
+- `lastSeenAt`
+- optional `firstSeenCwd`
+- optional `lastSeenCwd`
+
+The edge is not just a yes/no relation. It is also the seed for owner-local consumption.
+
+### 4.3 Session identity
+
+The session key remains Claude-session identity, not owner identity:
+
+- `source = "claude"`
+- `sessionId`
+- `transcriptPath`
+
+Multiple owners may attach to the same session key.
+
+## 5. Data storage
+
+Add a Claude ownership ledger under `.jolli/jollimemory`, separate from `sessions.json`.
+
+Suggested shape:
+
+```json
+{
+  "version": 1,
+  "sessions": {
+    "claude:<sessionId>": {
+      "sessionId": "...",
+      "transcriptPath": "...",
+      "source": "claude",
+      "owners": {
+        "/abs/worktree/root": {
+          "firstSeenAt": "...",
+          "firstSeenLine": 123,
+          "lastSeenAt": "...",
+          "firstSeenCwd": "...",
+          "lastSeenCwd": "..."
+        }
+      }
+    }
+  }
+}
+```
+
+This is intentionally parallel to, not a replacement for, `sessions.json`:
+
+- `sessions.json` remains the cheap "recent sessions seen from here" registry.
+- The Claude ownership ledger is the cross-owner truth for Claude attribution.
+
+## 6. Forward capture
+
+### 6.1 Stop hook write path
+
+The Claude Stop hook continues to save the lightweight `SessionInfo` row into the current worktree's `sessions.json` for compatibility and cheap local reads.
+
+In the same turn, it also updates the Claude ownership ledger:
+
+- resolve `projectDir` to the current worktree root
+- identify the Claude session by `sessionId` and `transcriptPath`
+- scan only the newly-seen transcript range
+- if this owner has not appeared before, write `firstSeenAt` and `firstSeenLine`
+- always update `lastSeenAt`
+- update `lastSeenCwd` from the latest matching line
+
+The update is set-union / max-progress only. A later Stop hook may extend the edge but may not reset it.
+
+### 6.2 Determining `firstSeenLine`
+
+`firstSeenLine` must come from transcript evidence, not from "time the hook ran". The hook already has the transcript path and already maintains discovery cursors. The ownership update should therefore use the same newly-scanned line window and record the first line within that window whose `cwd` belongs to the current worktree root.
+
+If no such line is present in the window, the owner edge is not created on that pass.
+
+## 7. QueueWorker read path
+
+### 7.1 Session candidate selection
+
+For Claude only, QueueWorker should no longer rely exclusively on `loadAllSessions(cwd)`.
+
+Instead:
+
+1. read Claude candidates from the ownership ledger whose `owners` map contains the current worktree root
+2. merge in the current worktree's `sessions.json` entries as a fallback / recent-session fast path
+3. dedupe by `(source, sessionId, transcriptPath)`
+
+Other sources keep their current behavior in this slice.
+
+### 7.2 Owner-specific cursor
+
+The current cursor key, effectively `(cwd, transcriptPath)`, is not enough for shared Claude sessions. Introduce owner-specific Claude consumption state keyed by:
+
+- `ownerRoot`
+- `transcriptPath`
+
+This may live in a new file or in an extended cursor schema, but the logical rule is:
+
+- the first read for owner `X` starts at `firstSeenLine`
+- subsequent reads for owner `X` resume from owner `X`'s own cursor
+- owner `A` and owner `B` never advance one another
+
+### 7.3 First read from a foreign owner
+
+This is the load-bearing rule of the design:
+
+If the current owner has no saved consumption cursor for a Claude session, the reader must start from that owner's `firstSeenLine`, not from `0`.
+
+`beforeTimestamp` is still used as the upper bound, exactly as today. The fix only changes the lower bound.
+
+That preserves the desired semantics:
+
+- ownership is shared
+- stored commit transcripts remain slices
+- the first commit in a newly-attributed owner does not absorb all earlier transcript history
+
+## 8. Historical repair
+
+### 8.1 Scope
+
+Repair is bounded and conservative. It only attempts to fix summaries where:
+
+- `summary.transcripts` is empty
+- the missing conversation's transcript still exists locally
+- an ownership edge exists for the current owner
+- the edge has a safe lower bound
+- the commit has a safe upper bound
+
+### 8.2 Repair algorithm
+
+For each candidate summary:
+
+1. find Claude sessions whose ownership ledger contains the summary's owner root
+2. seed the lower bound from the owner edge's `firstSeenLine`
+3. seed the upper bound from the commit capture timestamp; fall back to commit time only if nothing more precise exists
+4. read the slice with the owner-specific lower bound and the commit upper bound
+5. if the slice yields no entries, do not repair
+6. if the slice yields entries, store a derived transcript artifact and patch `summary.transcripts`
+
+Repair must be idempotent. A summary already repaired should not create a second transcript artifact for the same evidence window.
+
+### 8.3 Refusal rules
+
+Repair must refuse to act when:
+
+- the transcript file is gone
+- the current owner cannot be proven
+- only whole-session evidence exists and no owner-local lower bound can be established
+- no safe upper bound can be established without risking inclusion of later turns
+
+The system should prefer a false negative over a false positive.
+
+## 9. UI and copy
+
+The memory detail UI should distinguish three states:
+
+- `No conversations were captured for this memory`
+- `Conversation capture is missing but repair may still be possible`
+- `Conversation capture was repaired from local transcript history`
+
+`No conversations linked yet` is misleading for a memory whose capture already failed and will never complete automatically.
+
+## 10. Testing
+
+### 10.1 Forward capture
+
+- creates an ownership edge when a Claude session first touches a worktree
+- extends, but does not reset, an existing edge
+- allows one Claude session to attach to two worktree owners
+- allows one Claude session to attach to two repository owners
+- keeps `sessions.json` local behavior unchanged for the current worktree
+
+### 10.2 Owner-specific consumption
+
+- first read from owner A starts at A's `firstSeenLine`
+- first read from owner B starts at B's `firstSeenLine`
+- owner A advancing its cursor does not advance owner B
+- a foreign owner with no seed never falls back to `startLine = 0`
+- `beforeTimestamp` still gates the upper bound correctly
+
+### 10.3 Repair
+
+- repairs a `transcripts: []` summary when transcript + owner edge + upper bound all exist
+- refuses repair when transcript is missing
+- refuses repair when owner proof is absent
+- is idempotent across repeated repair runs
+
+### 10.4 Regression coverage
+
+- same-worktree Claude capture still works
+- linked-worktree Claude capture now works even when the session was first seen elsewhere
+- dashboard/backfill attribution and QueueWorker attribution agree for the same session-owner relation
+
+## 11. Rollout and risk
+
+The main risk is introducing a second cursor semantics that drifts from the current QueueWorker reader contract. To limit that risk:
+
+- keep non-Claude sources unchanged in this slice
+- reuse the existing transcript readers and `beforeTimestamp` logic
+- add the owner-specific lower-bound logic outside the parser, as a Claude attribution concern
+
+The second risk is over-repairing history. That is why repair is explicitly conservative and may refuse many summaries that are missing enough evidence.
+
+## 12. Recommendation
+
+Implement this in two phases on one branch:
+
+1. forward fix
+   add the ownership ledger, owner-specific Claude cursoring, and QueueWorker Claude reads through the new model
+2. bounded repair
+   add an explicit repair path for historical empty summaries and the UI copy distinction
+
+The forward fix is the correctness blocker. Repair is valuable, but only after new captures are trustworthy.

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/TranscriptRepairState.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/TranscriptRepairState.kt
@@ -1,0 +1,123 @@
+package ai.jolli.jollimemory.core
+
+import ai.jolli.jollimemory.bridge.CliIntegrations
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonObject
+
+/**
+ * Thin JVM adapter over the CLI-owned transcript-repair verdict.
+ *
+ * One `transcript-repair-state` bridge round-trip into
+ * `transcriptRepairState` (`cli/src/core/TranscriptRepair.ts`) — the same
+ * predicate the VS Code extension calls in-process, and the same one the
+ * dashboard's server-side render attaches to its memory detail. This file must
+ * stay an adapter: it sends a commit hash and reads back a string, and decides
+ * nothing.
+ *
+ * Do NOT reintroduce a Kotlin restatement of "can this memory's conversations
+ * still be rebuilt?". That question is answered from the machine-global Claude
+ * owners ledger plus the summary's own shape, and a second implementation of it
+ * cannot be checked against the TypeScript one — nothing on the JSON wire fails
+ * when the two disagree, so the user just gets a different sentence in the IDE
+ * than on the dashboard about the same memory.
+ *
+ * What DOES live here is presentation: [emptyConversationsText] is the wording,
+ * which is the host's job. The three sentences are identical on all four
+ * surfaces (spec §9).
+ */
+object TranscriptRepairState {
+
+    private val gson: Gson = GsonBuilder().serializeNulls().create()
+    private const val ACTION = "transcript-repair-state"
+
+    /**
+     * The CLI's `TranscriptRepairState` union, as it arrives on the wire.
+     *
+     * `state` has a default, so this class keeps the no-arg constructor Gson
+     * prefers and an omitted field arrives as [UNREPAIRABLE] — the mildest
+     * verdict, which is the safe way to be wrong about a body we could not read.
+     * See `FileDiscarder.DiscardOutcome.additionalPaths` for why that regime is
+     * a property of the class rather than of Gson.
+     */
+    private data class StateResponse(val state: String = UNREPAIRABLE)
+
+    const val PRESENT: String = "present"
+    const val REPAIRED: String = "repaired"
+    const val REPAIRABLE: String = "repairable"
+    const val UNREPAIRABLE: String = "unrepairable"
+
+    /**
+     * The webview message `SummaryPanel`'s deferred hydrate posts to correct the
+     * empty-Conversations sentence in place, and the command
+     * `SummaryScriptBuilder`'s handler matches on.
+     *
+     * A cross-language name with no compiler between its two ends: rename it on
+     * one side only and the hydrate silently stops arriving, leaving the
+     * server-rendered plainest sentence on a memory that deserved a different
+     * one. Pinned from both directions — the producer goes through
+     * [hydrateMessage] rather than spelling the string, and
+     * `SummaryScriptBuilderTest` asserts the handler still carries this literal.
+     */
+    const val HYDRATE_COMMAND: String = "conversationsEmptyText"
+
+    /** Payload key of [hydrateMessage] — the SENTENCE, not the state. */
+    const val HYDRATE_TEXT_KEY: String = "text"
+
+    /**
+     * The hydrate message for [state], or null when there is nothing to correct.
+     *
+     * Null in, null out: a verdict that has not been fetched yet is exactly what
+     * the server-rendered HTML already prints, so posting would be a no-op that
+     * still costs a `executeJavaScript` round trip.
+     *
+     * Carries the SENTENCE rather than the state, so the three strings live in
+     * one place instead of being restated in the webview's JS where nothing
+     * would notice a drift.
+     */
+    fun hydrateMessage(state: String?): Pair<String, Map<String, Any>>? =
+        state?.let { HYDRATE_COMMAND to mapOf(HYDRATE_TEXT_KEY to emptyConversationsText(it)) }
+
+    /**
+     * Which of spec §9's three sentences this memory's EMPTY conversations panel
+     * is allowed to print.
+     *
+     * Every failure answers [UNREPAIRABLE], and none of them raises: an
+     * unreadable body, a null state, a bridge that is down, a missing runtime.
+     * "Repair may still be possible" is the one wrong direction to guess in — it
+     * invites a repair that has nothing to work from — and a memory tab must not
+     * fail to open over a wording detail. Same rule, same reason, as
+     * `FileDiscarder.preview` returning an empty set.
+     *
+     * Blocking I/O — call OFF the EDT.
+     */
+    fun fetch(cwd: String, commitHash: String): String {
+        if (cwd.isEmpty() || commitHash.isEmpty()) return UNREPAIRABLE
+        val request = JsonObject().apply { addProperty("commitHash", commitHash) }
+        return try {
+            val response = CliIntegrations.runIdeBridge(cwd, ACTION, gson.toJson(request))
+            val state = gson.fromJson(response, StateResponse::class.java)?.state
+            @Suppress("SENSELESS_COMPARISON")
+            if (state == null || state.isEmpty()) UNREPAIRABLE else state
+        } catch (_: Exception) {
+            UNREPAIRABLE
+        }
+    }
+
+    /**
+     * The sentence for [state]. Verbatim from spec §9 and identical on the CLI
+     * dashboard, the VS Code memory detail and here.
+     *
+     * Anything unrecognised — a null this build never fetched, [PRESENT] on a
+     * legacy summary that reads as captured while holding nothing, a state a
+     * newer CLI added — falls to the plainest wording. The copy this replaced
+     * ("No conversation transcripts saved for this commit") read as a *not yet*,
+     * which is misleading for a capture that already failed and will never
+     * complete on its own.
+     */
+    fun emptyConversationsText(state: String?): String = when (state) {
+        REPAIRABLE -> "Conversation capture is missing but repair may still be possible"
+        REPAIRED -> "Conversation capture was repaired from local transcript history"
+        else -> "No conversations were captured for this memory"
+    }
+}

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/SummaryPanel.kt
@@ -15,6 +15,7 @@ import ai.jolli.jollimemory.core.SummaryTree
 import ai.jolli.jollimemory.core.TopicUpdates
 import ai.jolli.jollimemory.core.TraceContext
 import ai.jolli.jollimemory.core.TranscriptEntry
+import ai.jolli.jollimemory.core.TranscriptRepairState
 import ai.jolli.jollimemory.core.WorkingContext
 import ai.jolli.jollimemory.core.references.SourceId
 import ai.jolli.jollimemory.services.JolliApiClient
@@ -223,6 +224,13 @@ class SummaryPanel(
     // ConcurrentModificationException under rapid memory-tab switches.
     private val transcriptHashSet = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
     private val planTranslateSet = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
+    // The CLI's repair verdict for THIS memory ([TranscriptRepairState]), which
+    // picks the empty Conversations sentence. Written on the loadDeferredSets pool
+    // thread, read on the EDT in doRefreshNow / maybeSendDeferredHydrate, cleared
+    // on the EDT in setSummary — hence @Volatile, like every other field on that
+    // path. Null means "not answered yet", which prints the plainest sentence.
+    @Volatile
+    private var transcriptRepairState: String? = null
     private val cwd: String
     private val service = project.getService(JolliMemoryService::class.java)
     // Refresh when a PR is created/updated or a memory is shared elsewhere (the Create PR
@@ -292,10 +300,44 @@ class SummaryPanel(
             refreshTranscriptHashes(myGen)
             if (myGen != summaryGeneration) return@executeOnPooledThread
             refreshPlanTranslateSet(myGen)
+            if (myGen != summaryGeneration) return@executeOnPooledThread
+            // Which of spec §9's three sentences an EMPTY Conversations panel is
+            // allowed to print. Asked HERE and not in [doRefreshNow] for the same
+            // reason the two sets above moved off the EDT: a bridge call is 1-30 ms
+            // warm but 100-700 ms right after IDE start, and doRefreshNow's pool
+            // task is what the first paint waits on. Hydrated in place below rather
+            // than triggering a second loadHTML.
+            //
+            // The RULE stays in the CLI; this only asks, and takes `unrepairable`
+            // for every failure rather than raising.
+            val fetched = TranscriptRepairState.fetch(cwd, currentSummary.commitHash)
+            // Re-checked AFTER the slow call and BEFORE the write, exactly as
+            // [refreshTranscriptHashes] does around its own store read — the gen
+            // test at the top of this block only proves nothing had changed when
+            // the call STARTED. This one is load-bearing precisely because the
+            // call is the slow one: memory A's cold fetch (~400 ms) can still be
+            // in flight when the user switches to memory B, whose warm fetch
+            // (~10 ms) lands first — and an unguarded write would then leave A's
+            // verdict in the field while B is on screen. The stale invokeLater
+            // below drops its own hydrate, but the FIELD survives it and is read
+            // again by `doRefreshNow`'s snapshot on any later full reload and by
+            // [maybeSendDeferredHydrate] when a save ack re-drains the pending
+            // flag. That is how "repair may still be possible" would end up on a
+            // memory where repair is impossible — the one direction this whole
+            // sentence exists to avoid, and what `setSummary`'s clear() means.
+            if (myGen != summaryGeneration) return@executeOnPooledThread
+            transcriptRepairState = fetched
             ApplicationManager.getApplication().invokeLater {
                 if (disposed) return@invokeLater
                 if (myGen != summaryGeneration) return@invokeLater
-                if (transcriptHashSet.isEmpty() && planTranslateSet.isEmpty()) return@invokeLater
+                // `transcriptRepairState` counts as new data on its own: a memory
+                // with NO transcripts and no translatable plans is exactly the one
+                // whose empty-state sentence has to be corrected, so the old
+                // both-sets-empty early return would have skipped every case this
+                // wording exists for.
+                if (transcriptHashSet.isEmpty() && planTranslateSet.isEmpty() && transcriptRepairState == null) {
+                    return@invokeLater
+                }
                 // Arm the pending flag even when the webview is currently dirty.
                 // [maybeSendDeferredHydrate] holds it back while dirty and
                 // [postToWebview] re-fires it once a persisted-save ack clears the
@@ -335,6 +377,13 @@ class SummaryPanel(
         }
         if (planTranslateSet.isNotEmpty()) {
             postToWebview("planTranslateAvailable", mapOf("slugs" to planTranslateSet.toList()))
+        }
+        // Command name and payload built by [TranscriptRepairState.hydrateMessage],
+        // never spelled here: the matching handler is a JS string in
+        // SummaryScriptBuilder with no compiler between the two, so the name lives
+        // in one constant that a test pins against the script.
+        TranscriptRepairState.hydrateMessage(transcriptRepairState)?.let { (command, data) ->
+            postToWebview(command, data)
         }
     }
 
@@ -968,6 +1017,10 @@ class SummaryPanel(
         val planTranslateSnapshot = planTranslateSet.toSet()
         val bridgeScriptSnapshot = bridgeScript
         val readOnlySnapshot = readOnly
+        // Null until [loadDeferredSets]' background pass answers, so the FIRST
+        // render prints the plainest sentence and the hydrate corrects it. Every
+        // later full reload (a memory-state event, a theme change) already has it.
+        val repairStateSnapshot = transcriptRepairState
         val pageBg = editorBackground()
         val isDark = pageBg.isDarkByLuma()
         val pageBgHex = pageBg.toCssHex()
@@ -989,6 +1042,7 @@ class SummaryPanel(
                     bridgeScriptSnapshot,
                     readOnlySnapshot,
                     pageBgHex,
+                    repairStateSnapshot,
                 )
             } catch (e: Exception) {
                 jmLog.warn("doRefreshNow: buildHtml failed: %s", e.message ?: e.toString())
@@ -1059,6 +1113,9 @@ class SummaryPanel(
         // the previous memory's transcript / plan-translate UI into the new page.
         transcriptHashSet.clear()
         planTranslateSet.clear()
+        // Same reason, and it is a per-MEMORY verdict: reusing the outgoing
+        // memory's would tell the user a repair is possible for a different commit.
+        transcriptRepairState = null
         currentSummary = newSummary
         // If the read-only mode flipped, re-run the memory-state listener
         // decision (registered only when editable) so a read-only tab reused

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryHtmlBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryHtmlBuilder.kt
@@ -7,6 +7,7 @@ import ai.jolli.jollimemory.core.ModelPricing
 import ai.jolli.jollimemory.core.PlanReference
 import ai.jolli.jollimemory.core.SummaryTree
 import ai.jolli.jollimemory.core.TopicCategory
+import ai.jolli.jollimemory.core.TranscriptRepairState
 import ai.jolli.jollimemory.core.references.ReferenceCommitRef
 import ai.jolli.jollimemory.toolwindow.CommitMemoryFormat
 import ai.jolli.jollimemory.core.references.SourceDisplay
@@ -43,6 +44,11 @@ object SummaryHtmlBuilder {
      * @param isDark Whether to use dark theme colours
      * @param transcriptHashSet Set of commit hashes that have transcript files
      * @param planTranslateSet Set of plan slugs that support translation
+     * @param transcriptRepairState The CLI's repair verdict for this memory
+     *   ([ai.jolli.jollimemory.core.TranscriptRepairState]), which picks the
+     *   empty Conversations sentence. Null — the default, what the FIRST render
+     *   has before `loadDeferredSets` answers, and what a failed fetch yields —
+     *   prints the plainest one; the deferred hydrate corrects it in place.
      */
     fun buildHtml(
         summary: CommitSummary,
@@ -52,6 +58,7 @@ object SummaryHtmlBuilder {
         bridgeScript: String = "",
         readOnly: Boolean = false,
         pageBgHex: String = "#1e1e1e",
+        transcriptRepairState: String? = null,
     ): String {
         val (allTopics, sourceNodes) = collectSortedTopics(summary)
         val stats = SummaryTree.aggregateStats(summary)
@@ -92,7 +99,7 @@ ${buildMemoryPanel(summary, allTopics, topicsHtml, topicsTitle, topicsLabel)}
 ${buildE2ePanel(summary)}
 ${buildAttachmentsPanel(summary.plans, planTranslateSet, sourceNodes, summary.references)}
 ${buildExcludedContextSection(summary)}
-${buildPrivateDrawer(transcriptHashSet)}
+${buildPrivateDrawer(transcriptHashSet, transcriptRepairState)}
 ${buildFooter(summary)}
 </div>
 ${buildShareModal()}
@@ -264,11 +271,16 @@ ${if (bridgeScript.isNotEmpty()) "<script>$bridgeScript</script>" else ""}
      * populated. See `SummaryPanel.loadDeferredSets` for why the deferred hydration flips
      * `hidden` attributes in place rather than triggering a second `loadHTML`.
      */
-    private fun buildAllConversationsSection(transcriptHashSet: Set<String>): String {
+    private fun buildAllConversationsSection(transcriptHashSet: Set<String>, transcriptRepairState: String?): String {
         val count = transcriptHashSet.size
         val hasTranscripts = count > 0
         val emptyHidden = if (hasTranscripts) " hidden" else ""
         val populatedHidden = if (hasTranscripts) "" else " hidden"
+        // Which of spec §9's three sentences the empty branch carries. The set
+        // being empty is still what decides whether that branch SHOWS — the state
+        // only picks the wording, because `present` is not proof of renderable
+        // conversations (a pre-v5 summary reads as `present` unconditionally).
+        val emptyText = TranscriptRepairState.emptyConversationsText(transcriptRepairState)
         return """
 <div class="private-zone" id="conversationsSection" data-transcript-count="$count">
   <div class="private-zone-watermark">PRIVATE</div>
@@ -276,7 +288,7 @@ ${if (bridgeScript.isNotEmpty()) "<script>$bridgeScript</script>" else ""}
     <div class="section-title">&#x1F4AC; All Conversations</div>
     <button class="action-btn" id="openTranscriptsBtn"$populatedHidden>Manage</button>
   </div>
-  <p class="empty" id="conversationsEmpty"$emptyHidden>No conversation transcripts saved for this commit.</p>
+  <p class="empty" id="conversationsEmpty"$emptyHidden>$emptyText</p>
   <p class="conversations-description" id="conversationsDescription"$populatedHidden>Raw AI conversation transcripts captured during development.</p>
   <p class="conversations-stats" id="conversationsStats"$populatedHidden>
     <span class="stats-loading">Loading stats...</span>
@@ -686,7 +698,7 @@ $listItems
      * `loadHTML`. The `data-transcript-count` attribute lets the JS check the initial
      * count without re-reading the badge.
      */
-    private fun buildPrivateDrawer(transcriptHashSet: Set<String>): String {
+    private fun buildPrivateDrawer(transcriptHashSet: Set<String>, transcriptRepairState: String?): String {
         val count = transcriptHashSet.size
         val countText = "$count session${if (count != 1) "s" else ""}"
         val countHidden = if (count > 0) "" else " hidden"
@@ -699,7 +711,7 @@ $listItems
     <span class="private-count" id="privateCount"$countHidden>$countText</span>
     <span class="attach-arrow">&#x25BC;</span>
   </div>
-  <div class="private-body">${buildAllConversationsSection(transcriptHashSet)}</div>
+  <div class="private-body">${buildAllConversationsSection(transcriptHashSet, transcriptRepairState)}</div>
 </div>"""
     }
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryScriptBuilder.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryScriptBuilder.kt
@@ -1690,6 +1690,16 @@ ${buildPrMessageScript()}
     if (msg.command === 'transcriptsAvailable') {
       applyTranscriptCount(msg.count);
     }
+    // The empty-Conversations sentence, corrected once the panel's background
+    // pass has the CLI's repair verdict (spec §9). The server-rendered HTML ships
+    // the plainest wording, because the verdict costs a bridge call this page
+    // must not wait on. Text, not the state: the three strings live once, in
+    // TranscriptRepairState.emptyConversationsText. textContent, never innerHTML.
+    if (msg.command === 'conversationsEmptyText') {
+      if (conversationsEmpty && typeof msg.text === 'string' && msg.text) {
+        conversationsEmpty.textContent = msg.text;
+      }
+    }
     if (msg.command === 'planTranslateAvailable') {
       var slugs = msg.slugs || [];
       for (var si = 0; si < slugs.length; si++) {

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/TranscriptRepairStateTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/TranscriptRepairStateTest.kt
@@ -1,0 +1,84 @@
+package ai.jolli.jollimemory.core
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+/**
+ * The JVM host's half of the three-state memory-detail copy (spec §9).
+ *
+ * Two things are pinned here. The WORDING — three sentences that must read
+ * identically on the CLI dashboard, the VS Code memory detail and this host, so
+ * one memory is never described three different ways — and the DEGRADE, which is
+ * the whole reason a wrong answer here matters: "repair may still be possible"
+ * invites the user to run a repair that has nothing to work from, so every
+ * unknown must land on the plainest sentence instead.
+ *
+ * [TranscriptRepairState.fetch]'s bridge round-trip is not exercised: it goes
+ * through [ai.jolli.jollimemory.bridge.CliIntegrations.runIdeBridge], which has
+ * no injectable seam, and the JVM-global-state rule forbids stubbing a Kotlin
+ * singleton — the same limit [FileDiscarderTest] documents. What is reachable is
+ * the guard that answers before any I/O, plus the deserialization default the
+ * catch-all leans on.
+ *
+ * Pure in-memory: no Project, no VFS, no JVM globals.
+ */
+class TranscriptRepairStateTest {
+
+    @Test
+    fun `a repairable memory says a repair is still possible`() {
+        TranscriptRepairState.emptyConversationsText("repairable") shouldBe
+            "Conversation capture is missing but repair may still be possible"
+    }
+
+    @Test
+    fun `a repaired memory says where its conversations came from`() {
+        TranscriptRepairState.emptyConversationsText("repaired") shouldBe
+            "Conversation capture was repaired from local transcript history"
+    }
+
+    @Test
+    fun `an unrepairable memory says the capture failed outright`() {
+        // Not "no conversations linked YET" — that reads as a capture still in
+        // flight, which is exactly the lie this replaces.
+        TranscriptRepairState.emptyConversationsText("unrepairable") shouldBe
+            "No conversations were captured for this memory"
+    }
+
+    @Test
+    fun `an unknown state degrades to the plainest sentence, never the optimistic one`() {
+        // `present` is deliberately in this bucket: a pre-v5 summary reads as
+        // `present` unconditionally, so it is no evidence that anything was
+        // captured. `null` is what a failed fetch yields, and a state string this
+        // build has never heard of is what a newer CLI can send.
+        for (state in listOf(null, "present", "", "REPAIRABLE", "something-new")) {
+            TranscriptRepairState.emptyConversationsText(state) shouldBe
+                "No conversations were captured for this memory"
+        }
+    }
+
+    @Test
+    fun `the hydrate message carries the sentence under the key the webview reads`() {
+        // The producer end of a cross-language pair with no compiler between it
+        // and `SummaryScriptBuilder`'s handler. `SummaryScriptBuilderTest` pins
+        // the other end against the same literals.
+        TranscriptRepairState.hydrateMessage("repairable") shouldBe
+            ("conversationsEmptyText" to mapOf("text" to "Conversation capture is missing but repair may still be possible"))
+    }
+
+    @Test
+    fun `no hydrate is posted before a verdict has been fetched`() {
+        // Null is what the panel holds until its background pass answers, and it
+        // is exactly what the server-rendered HTML already prints — posting would
+        // be an executeJavaScript round trip that changes nothing.
+        TranscriptRepairState.hydrateMessage(null) shouldBe null
+    }
+
+    @Test
+    fun `fetch answers unrepairable without touching the bridge when it has nothing to ask about`() {
+        // The one branch reachable without a live CLI. Both arguments are
+        // required to identify a memory, so an absent one is not a reason to
+        // guess the hopeful answer.
+        TranscriptRepairState.fetch("", "abc123") shouldBe "unrepairable"
+        TranscriptRepairState.fetch("/repo", "") shouldBe "unrepairable"
+    }
+}

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryHtmlBuilderTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryHtmlBuilderTest.kt
@@ -206,7 +206,65 @@ class SummaryHtmlBuilderTest {
         fun `renders empty conversations section when no transcripts`() {
             val html = SummaryHtmlBuilder.buildHtml(makeSummary(), transcriptHashSet = emptySet())
             html shouldContain "All Conversations"
-            html shouldContain "No conversation transcripts"
+            html shouldContain "No conversations were captured for this memory"
+        }
+
+        // ── the three-state empty copy (spec §9) ─────────────────────────
+        //
+        // The old single sentence read as a *not yet*, which is misleading for a
+        // capture that already failed and will never complete on its own. Each
+        // case below fails if the branch collapses back onto one sentence.
+
+        @Test
+        fun `offers repair only when the state says a repair is still possible`() {
+            val html = SummaryHtmlBuilder.buildHtml(
+                makeSummary(),
+                transcriptHashSet = emptySet(),
+                transcriptRepairState = "repairable",
+            )
+            html shouldContain "Conversation capture is missing but repair may still be possible"
+            html shouldNotContain "No conversations were captured for this memory"
+        }
+
+        @Test
+        fun `says so when the capture was already repaired`() {
+            val html = SummaryHtmlBuilder.buildHtml(
+                makeSummary(),
+                transcriptHashSet = emptySet(),
+                transcriptRepairState = "repaired",
+            )
+            html shouldContain "Conversation capture was repaired from local transcript history"
+        }
+
+        @Test
+        fun `degrades to the plainest copy for an unknown or present state`() {
+            // `present` is deliberately in this bucket: a pre-v5 summary reads as
+            // `present` even when nothing was ever captured, so it must not claim
+            // a repair happened or is possible.
+            for (state in listOf(null, "present", "unrepairable", "something-new")) {
+                val html = SummaryHtmlBuilder.buildHtml(
+                    makeSummary(),
+                    transcriptHashSet = emptySet(),
+                    transcriptRepairState = state,
+                )
+                html shouldContain "No conversations were captured for this memory"
+                html shouldNotContain "repair may still be possible"
+                html shouldNotContain "was repaired from"
+            }
+        }
+
+        @Test
+        fun `the state picks the wording, never whether the empty branch shows`() {
+            // A memory WITH transcripts still ships the empty paragraph hidden —
+            // the deferred hydrate flips `hidden` in place — so the state must not
+            // become a second gate on rendering it.
+            val html = SummaryHtmlBuilder.buildHtml(
+                makeSummary(),
+                transcriptHashSet = setOf("abc123"),
+                transcriptRepairState = "repairable",
+            )
+            html shouldContain """id="conversationsEmpty" hidden"""
+            html shouldContain "Conversation capture is missing but repair may still be possible"
         }
     }
 

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryScriptBuilderTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/toolwindow/views/SummaryScriptBuilderTest.kt
@@ -1,0 +1,47 @@
+package ai.jolli.jollimemory.toolwindow.views
+
+import ai.jolli.jollimemory.core.TranscriptRepairState
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the webview end of the deferred-hydrate contract.
+ *
+ * The script is a JS string; the panel that posts to it is Kotlin. Nothing
+ * between them is compiled together, so a message renamed on one side is a
+ * silent no-op — the handler simply never runs. That failure is invisible here
+ * in the worst possible way: the server-rendered HTML already carries the
+ * PLAINEST empty-Conversations sentence, so a memory whose capture is still
+ * repairable just keeps being described as one that was never captured.
+ *
+ * The producer side goes through [TranscriptRepairState.hydrateMessage] rather
+ * than spelling the command, so it cannot drift from the constant on its own —
+ * and the assertion below is against the LITERAL rather than the constant, so
+ * changing the constant's value without updating the handler fails here instead
+ * of passing tautologically.
+ *
+ * `SummaryPanel` itself needs a `Project` and has no unit seam, so "the panel
+ * still posts this at all" stays unpinned; see the task report.
+ *
+ * Pure in-memory: no Project, no VFS, no JVM globals.
+ */
+class SummaryScriptBuilderTest {
+
+    private val script = SummaryScriptBuilder.buildScript()
+
+    @Test
+    fun `handles the empty-conversations hydrate message the panel posts`() {
+        script shouldContain "msg.command === 'conversationsEmptyText'"
+        // Deliberately textContent, not innerHTML: the sentence is ours, but this
+        // element must never become an HTML sink.
+        script shouldContain "conversationsEmpty.textContent = msg.text"
+    }
+
+    @Test
+    fun `the handler matches the command and payload key the producer sends`() {
+        // The other direction of the same pair. Both ends are strings; this is
+        // what makes a one-sided rename fail rather than go quiet.
+        script shouldContain "'${TranscriptRepairState.HYDRATE_COMMAND}'"
+        script shouldContain "msg.${TranscriptRepairState.HYDRATE_TEXT_KEY}"
+    }
+}

--- a/vscode/src/views/SummaryScriptBuilder.test.ts
+++ b/vscode/src/views/SummaryScriptBuilder.test.ts
@@ -559,6 +559,132 @@ describe("SummaryScriptBuilder", () => {
 			expect(script).toContain("source: row.getAttribute('data-source')");
 		});
 
+		// ── the three-state empty copy (spec §9) ─────────────────────────────
+		//
+		// Driven through the real message listener rather than asserted as text:
+		// the branch is the point, and a `toContain` on the sentences passes just
+		// as happily when every state prints the same one. `renderEmptyFor` runs
+		// the emitted script against a stub document, posts `conversationsData`
+		// with no items, and reads back what the panel wrote.
+		describe("empty-state copy", () => {
+			const renderEmptyFor = (
+				state: string | undefined,
+				opts: { readonly detachToEmpty?: boolean } = {},
+			): string => {
+				const messageListeners: Array<(event: { data: unknown }) => void> = [];
+				const conversationsBody = {
+					innerHTML: "",
+					querySelector: () => null,
+					querySelectorAll: () => [] as ReadonlyArray<never>,
+				};
+				const stub = (): Record<string, unknown> => ({
+					innerHTML: "",
+					textContent: "",
+					value: "",
+					style: {} as Record<string, string>,
+					dataset: {} as Record<string, string>,
+					children: [] as ReadonlyArray<never>,
+					classList: {
+						add: () => undefined,
+						remove: () => undefined,
+						toggle: () => undefined,
+						contains: () => false,
+					},
+					querySelector: () => null,
+					querySelectorAll: () => [] as ReadonlyArray<never>,
+					addEventListener: () => undefined,
+					removeEventListener: () => undefined,
+					setAttribute: () => undefined,
+					removeAttribute: () => undefined,
+					getAttribute: () => null,
+					appendChild: () => undefined,
+					insertAdjacentHTML: () => undefined,
+					remove: () => undefined,
+					focus: () => undefined,
+					click: () => undefined,
+					closest: () => null,
+					scrollIntoView: () => undefined,
+					getBoundingClientRect: () => ({ top: 0, left: 0, width: 0, height: 0 }),
+				});
+				const doc: Record<string, unknown> = {
+					getElementById: (id: string) => (id === "conversationsBody" ? conversationsBody : stub()),
+					querySelector: () => stub(),
+					querySelectorAll: () => [] as ReadonlyArray<never>,
+					addEventListener: () => undefined,
+					createElement: stub,
+					body: stub(),
+					head: stub(),
+					documentElement: stub(),
+				};
+				const win: Record<string, unknown> = {
+					document: doc,
+					addEventListener: (type: string, fn: (event: { data: unknown }) => void) => {
+						if (type === "message") messageListeners.push(fn);
+					},
+					removeEventListener: () => undefined,
+					matchMedia: () => ({ matches: false, addEventListener: () => undefined }),
+				};
+				const acquireVsCodeApi = () => ({
+					postMessage: () => undefined,
+					getState: () => ({}),
+					setState: () => undefined,
+				});
+				new Function("window", "document", "acquireVsCodeApi", script)(win, doc, acquireVsCodeApi);
+				const post = (data: unknown): void => {
+					for (const fn of messageListeners) fn({ data });
+				};
+				post(
+					state === undefined
+						? { command: "conversationsData", items: [] }
+						: { command: "conversationsData", items: [], transcriptRepairState: state },
+				);
+				if (opts.detachToEmpty) {
+					// The panel had rows and the user detached the last one; the host
+					// sends no second `conversationsData`, so this path has to reuse
+					// the state latched above.
+					conversationsBody.innerHTML = "";
+					post({ command: "conversationDetached", sessionId: "s1", source: "claude" });
+				}
+				return conversationsBody.innerHTML;
+			};
+
+			it("says the capture failed outright when nothing local can fix it", () => {
+				expect(renderEmptyFor("unrepairable")).toContain(
+					"No conversations were captured for this memory",
+				);
+			});
+
+			it("offers repair only when the state says a repair is still possible", () => {
+				expect(renderEmptyFor("repairable")).toContain(
+					"Conversation capture is missing but repair may still be possible",
+				);
+			});
+
+			it("says so when the capture was already repaired", () => {
+				expect(renderEmptyFor("repaired")).toContain(
+					"Conversation capture was repaired from local transcript history",
+				);
+			});
+
+			it("degrades to the plainest copy for an absent or unknown state", () => {
+				// `present` is deliberately in this bucket: a legacy summary reads as
+				// `present` even when nothing was ever captured, so it must not claim
+				// a repair happened or is possible.
+				for (const state of [undefined, "present", "something-new"]) {
+					const html = renderEmptyFor(state);
+					expect(html).toContain("No conversations were captured for this memory");
+					expect(html).not.toContain("repair may still be possible");
+					expect(html).not.toContain("was repaired from");
+				}
+			});
+
+			it("keeps the state for the empty panel the last detach leaves behind", () => {
+				expect(renderEmptyFor("repairable", { detachToEmpty: true })).toContain(
+					"Conversation capture is missing but repair may still be possible",
+				);
+			});
+		});
+
 		it("renders each row with a data-source attribute so detach can match the source:sessionId composite key", () => {
 			// Two different sources can mint the same raw sessionId, so
 			// matching detach by sessionId alone risks resolving to (or

--- a/vscode/src/views/SummaryScriptBuilder.ts
+++ b/vscode/src/views/SummaryScriptBuilder.ts
@@ -2268,6 +2268,26 @@ export function buildScript(options: SummaryScriptOptions = {}): string {
   // Cursor CLI (cursor-agent) reuses Cursor's brand mark, same pairing pattern.
   SOURCE_ICON_SVG['cursor-cli'] = SOURCE_ICON_SVG.cursor;
 
+  // Which of the three sentences spec §9 allows the empty Conversations panel to
+  // print. Set from every conversationsData payload; the host derives it from
+  // the CLI's transcriptRepairState predicate, so this side only picks wording.
+  //
+  // Starts undefined and STAYS the mildest verdict for anything it does not
+  // recognise: an unknown or absent state means we cannot claim a repair is
+  // possible, and "repair may still be possible" is the one wrong direction to
+  // guess in — it invites a repair that has nothing to work from.
+  var transcriptRepairState;
+
+  function conversationsEmptyHtml() {
+    var text = 'No conversations were captured for this memory';
+    if (transcriptRepairState === 'repairable') {
+      text = 'Conversation capture is missing but repair may still be possible';
+    } else if (transcriptRepairState === 'repaired') {
+      text = 'Conversation capture was repaired from local transcript history';
+    }
+    return '<p class="conv-empty">' + text + '</p>';
+  }
+
   // Render inline conversation rows from the host's conversationsData payload.
   // Interpolated host-supplied strings (title/source/ids) go through esc(),
   // the same HTML-escape helper used for markdown rendering below.
@@ -2275,7 +2295,7 @@ export function buildScript(options: SummaryScriptOptions = {}): string {
     if (!conversationsBody) return;
     items = items || [];
     if (items.length === 0) {
-      conversationsBody.innerHTML = '<p class="conv-empty">No conversations linked to this memory.</p>';
+      conversationsBody.innerHTML = conversationsEmptyHtml();
       return;
     }
     var html = '';
@@ -2444,6 +2464,10 @@ ${buildSourceLabelScript()}
   window.addEventListener('message', function(event) {
     var msg = event.data;
     if (msg.command === 'conversationsData') {
+      // Latched BEFORE the render, and kept for the detach path below: the last
+      // detach empties the panel long after this message arrived, and the host
+      // sends no second one.
+      transcriptRepairState = msg.transcriptRepairState;
       renderConversations(msg.items || []);
       var cnt = detachCountEl();
       if (cnt) cnt.textContent = String((msg.items || []).length);
@@ -2459,7 +2483,7 @@ ${buildSourceLabelScript()}
         var cntEl = detachCountEl();
         if (cntEl) cntEl.textContent = String(remaining);
         if (remaining === 0) {
-          conversationsBody.innerHTML = '<p class="conv-empty">No conversations linked to this memory.</p>';
+          conversationsBody.innerHTML = conversationsEmptyHtml();
         }
       }
       // The detached conversation's tokens no longer belong to this memory, so

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -248,6 +248,18 @@ vi.mock("../../../cli/src/core/SessionTitleResolver.js", () => ({
 	resolveSessionTitle: mockResolveSessionTitle,
 }));
 
+// The predicate's own cases live in the CLI's TranscriptRepair.test.ts. Stubbed
+// here because the real one reads the machine-global `claude-owners.json` and
+// stats every transcript path it names — a per-developer answer this suite must
+// not depend on.
+const { mockTranscriptRepairState } = vi.hoisted(() => ({
+	mockTranscriptRepairState: vi.fn().mockResolvedValue("unrepairable"),
+}));
+
+vi.mock("../../../cli/src/core/TranscriptRepair.js", () => ({
+	transcriptRepairState: mockTranscriptRepairState,
+}));
+
 const { mockDeleteTopicInTree, mockUpdateTopicInTree } = vi.hoisted(() => ({
 	mockDeleteTopicInTree: vi.fn(),
 	mockUpdateTopicInTree: vi.fn(),
@@ -830,6 +842,10 @@ describe("SummaryWebviewPanel", () => {
 			SummaryWebviewPanel as unknown as { commitPanels: Map<string, unknown> }
 		).commitPanels.clear();
 		mockGetTranscriptHashes.mockResolvedValue(new Set<string>());
+		// `clearAllMocks` drops the implementation set at declaration, so the
+		// default verdict is restored here rather than left as `undefined` for
+		// every suite that never touches it.
+		mockTranscriptRepairState.mockResolvedValue("unrepairable");
 		mockReadPlanFromBranch.mockResolvedValue(null);
 		mockLoadConfig.mockResolvedValue({
 			apiKey: "test-key",
@@ -5197,7 +5213,92 @@ describe("SummaryWebviewPanel", () => {
 				expect(postMessage).toHaveBeenCalledWith({
 					command: "conversationsData",
 					items: [],
+					transcriptRepairState: "unrepairable",
 				});
+			});
+
+			// ── the three-state empty copy (spec §9) ─────────────────────────
+			//
+			// The webview picks its empty-state sentence from this field alone, so
+			// a producer that stops attaching it degrades the panel to the plainest
+			// wording forever — silently, with nothing else failing. These are what
+			// fail in that case.
+
+			it("attaches the CLI predicate's state to conversationsData", async () => {
+				mockTranscriptRepairState.mockResolvedValue("repairable");
+				mockGetTranscriptHashes.mockResolvedValue(new Set());
+				mockReadTranscriptsForCommits.mockResolvedValue(new Map());
+				await SummaryWebviewPanel.show(
+					makeSummary(),
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "loadConversations" });
+				await flushPromises();
+
+				const call = postMessage.mock.calls.find(
+					(c) => c[0]?.command === "conversationsData",
+				);
+				expect(call?.[0].transcriptRepairState).toBe("repairable");
+				// The rule stays in the CLI: this host forwards the summary it is
+				// showing and its workspace root, and restates nothing.
+				expect(mockTranscriptRepairState).toHaveBeenCalledWith(
+					expect.objectContaining({ commitHash: makeSummary().commitHash }),
+					workspaceRoot,
+				);
+			});
+
+			it("falls back to unrepairable when the panel holds no summary to ask about", async () => {
+				mockTranscriptRepairState.mockResolvedValue("repairable");
+				mockGetTranscriptHashes.mockResolvedValue(new Set());
+				mockReadTranscriptsForCommits.mockResolvedValue(new Map());
+				await SummaryWebviewPanel.show(
+					makeSummary(),
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
+				firstCommitPanel().currentSummary = undefined;
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "loadConversations" });
+				await flushPromises();
+
+				const call = postMessage.mock.calls.find(
+					(c) => c[0]?.command === "conversationsData",
+				);
+				expect(call?.[0].transcriptRepairState).toBe("unrepairable");
+				expect(mockTranscriptRepairState).not.toHaveBeenCalled();
+			});
+
+			it("falls back to unrepairable when the predicate throws", async () => {
+				// The mildest verdict, silently. An unusable answer must never
+				// become the optimistic "repair may still be possible", and it must
+				// never cost the user the conversation rows either.
+				mockTranscriptRepairState.mockRejectedValue(new Error("owners ledger unreadable"));
+				mockGetTranscriptHashes.mockResolvedValue(new Set());
+				mockReadTranscriptsForCommits.mockResolvedValue(new Map());
+				await SummaryWebviewPanel.show(
+					makeSummary(),
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "loadConversations" });
+				await flushPromises();
+
+				const call = postMessage.mock.calls.find(
+					(c) => c[0]?.command === "conversationsData",
+				);
+				expect(call?.[0].transcriptRepairState).toBe("unrepairable");
 			});
 		});
 

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -42,6 +42,10 @@ import {
 	groupArchivedSessions,
 } from "../../../cli/src/core/ArchivedConversations.js";
 import { resolveSessionTitle } from "../../../cli/src/core/SessionTitleResolver.js";
+import {
+	type TranscriptRepairState,
+	transcriptRepairState,
+} from "../../../cli/src/core/TranscriptRepair.js";
 import { track } from "../../../cli/src/core/Telemetry.js";
 import { runWithTrace } from "../../../cli/src/core/TraceContext.js";
 import {
@@ -3963,7 +3967,49 @@ export class SummaryWebviewPanel {
 			}),
 		);
 
-		this.panel.webview.postMessage({ command: "conversationsData", items });
+		this.panel.webview.postMessage({
+			command: "conversationsData",
+			items,
+			transcriptRepairState: await this.readTranscriptRepairState(),
+		});
+	}
+
+	/**
+	 * Which of the three sentences spec §9 allows the empty Conversations panel
+	 * to print — `transcriptRepairState` in `cli/src/core/TranscriptRepair.ts`,
+	 * called in-process because this host bundles the CLI. The rule stays there:
+	 * IntelliJ asks the same predicate over the `transcript-repair-state` bridge
+	 * action, so the two surfaces cannot word the same memory differently.
+	 *
+	 * Rides on `conversationsData` rather than the build-time HTML because both
+	 * places the client prints that sentence are client-side — the initial render
+	 * and the last detach — and only a live answer is right for the second.
+	 *
+	 * Every failure answers `unrepairable`, the MILDEST verdict, and never
+	 * propagates: the conversations list is what the user came for, so an
+	 * unreadable owners ledger must not cost them the rows. Guessing the other
+	 * way would invite a repair that has nothing to work from.
+	 *
+	 * `this.workspaceRoot` is the cwd even in foreign-storage mode, matching
+	 * every other read in this class. A foreign memory's owner edges are keyed by
+	 * ITS worktree root, which this panel does not have, so such a memory falls to
+	 * `unrepairable` — the conservative answer, and the honest one: the repair
+	 * itself is per-repo and could not run from here either.
+	 */
+	private async readTranscriptRepairState(): Promise<TranscriptRepairState> {
+		const summary = this.currentSummary;
+		if (!summary) {
+			return "unrepairable";
+		}
+		try {
+			return await transcriptRepairState(summary, this.workspaceRoot);
+		} catch (err) {
+			log.warn(
+				"Transcript repair state unavailable: %s",
+				err instanceof Error ? err.message : String(err),
+			);
+			return "unrepairable";
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Problem

The conversation-ownership ledger only knew a session's **cwd**, so a Claude session running in worktree A that authored and committed changes into worktree B left no trace B could find. B's drain attributed the commit to nothing and wrote an empty transcript. This is the common shape that cwd-only attribution misses: cross-worktree work, and work committed from a different checkout than the one the agent sat in.

## Fix

Add a second class of authorship evidence, captured two ways that cover each other's timing gap:

- **Forward (edited files).** `scanOwnerEdges` now derives an owner edge from the worktree root of every file a session *wrote* (Edit / Write / MultiEdit / NotebookEdit), not just from its cwd. Read-only tools author nothing, so a browsed directory never becomes an owner. The Stop hook already drives this scanner, so a session that edits B's files is recorded as a B owner before it ever commits — covering commits a human or GUI later makes from B.

- **Commit-time (executing session).** The post-commit hook stamps the inherited `CLAUDE_CODE_SESSION_ID` onto the queue entry, and the worker backfills that session's ownership from its own transcript before resolving owners. This covers the case the forward path cannot: an edit and commit in one turn, where the commit's worker drains before the Stop hook runs. A session that only ran `git commit` without authoring under the root records nothing and is correctly attributed to nothing.

Both feed the existing multi-owner ledger and owner-seeded lower bound, so the slice stays bounded and no session absorbs another's history.

## Scope & notes

- Covers **commit / cherry-pick / revert / amend** (the fresh-summary pipelines). Squash and rebase consolidate existing summaries and need no fresh attribution.
- **Claude only** — no other host advertises a session id in the environment (measured). The reader lives in the shared `AgentSessionEnv`, extracted from `ProducerHooks` so both callers share one measured list.
- Includes the corresponding transcript-repair surfacing across the dashboard, VS Code, and IntelliJ hosts.
