### PR TITLE
Deinline wiki bodies from graph schema, fetch on demand via /graph-wiki

### DIFF
--- a/cli/src/dashboard/DashboardServer.test.ts
+++ b/cli/src/dashboard/DashboardServer.test.ts
@@ -664,6 +664,30 @@ describe("routes", () => {
 			expect(body).toContain('<option value="repoB">repoB</option>');
 		});
 
+		it("serves a topic's RAW markdown body over /graph-wiki (utf-8, no-store) for the graph reader", async () => {
+			const configDir = writeMemoryBank(dir, [
+				{ dir: "repoA", wiki: { "topic--auth.md": "# Auth\n\nbody text" } },
+			]);
+			const port = await listen(testServer({ configDir }));
+			const res = await get(port, "/graph-wiki?kb=repoA&slug=auth");
+			expect(res.status).toBe(200);
+			expect(res.headers.get("content-type")).toBe("text/markdown; charset=utf-8");
+			expect(res.headers.get("cache-control")).toBe("no-store");
+			// Raw markdown (the viz renders it client-side) — not a framed HTML document.
+			expect(await res.text()).toBe("# Auth\n\nbody text");
+		});
+
+		it("/graph-wiki 400s missing params + a traversal slug, 404s an unknown repo / missing topic", async () => {
+			const configDir = writeMemoryBank(dir, [{ dir: "repoA", wiki: { "topic--auth.md": "# x\n" } }]);
+			const port = await listen(testServer({ configDir }));
+			expect((await get(port, "/graph-wiki?kb=repoA")).status).toBe(400); // missing slug
+			expect((await get(port, "/graph-wiki?slug=auth")).status).toBe(400); // missing kb
+			expect((await get(port, "/graph-wiki?kb=repoA&slug=..")).status).toBe(400); // traversal
+			expect((await get(port, "/graph-wiki?kb=repoA&slug=Bad_Slug")).status).toBe(400); // wrong shape
+			expect((await get(port, "/graph-wiki?kb=nope&slug=auth")).status).toBe(404); // unknown repo
+			expect((await get(port, "/graph-wiki?kb=repoA&slug=missing")).status).toBe(404); // missing topic
+		});
+
 		it("classes the REAL <body> for light theme (not the CSS comment's literal <body>)", async () => {
 			const configDir = writeMemoryBank(dir, [{ dir: "repoA", graph: '{"schemaVersion":4,"nodes":[]}' }]);
 			const port = await listen(testServer({ configDir }));

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -1436,6 +1436,37 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 			return;
 		}
 
+		// The Graph page's on-demand wiki body: RAW markdown for ONE topic, fetched
+		// when the user opens a full wiki page in the graph. The graph iframe is a
+		// `sandbox="allow-scripts"` opaque-origin frame and cannot fetch same-origin
+		// itself, so the parent `/graph` page relays the request here (see the
+		// `jolli-graph-wiki-request` handler in `graph.js`). Public GET like the
+		// other viewer routes; the viz renders the markdown client-side. The body is
+		// NOT inlined into graph.json (schema v5) — this is what replaces it.
+		if (url.pathname === "/graph-wiki") {
+			const kb = url.searchParams.get("kb");
+			const slug = url.searchParams.get("slug");
+			if (!kb || !slug) {
+				sendText(res, 400, "kb and slug are required");
+				return;
+			}
+			// Slug is the lowercase-hyphen `stableSlug`; the strict shape also blocks
+			// path traversal before the filename is built (readWikiBody re-checks).
+			if (!/^[a-z0-9][a-z0-9-]*$/.test(slug)) {
+				sendText(res, 400, "invalid slug");
+				return;
+			}
+			const repo = await resolveKbRepo(configDir, kb);
+			const body = repo ? readWikiBody(repo.kbRoot, `topic--${slug}.md`) : undefined;
+			if (body === undefined) {
+				sendText(res, 404, "wiki page not found");
+				return;
+			}
+			res.writeHead(200, { "Content-Type": "text/markdown; charset=utf-8", "Cache-Control": "no-store" });
+			res.end(body);
+			return;
+		}
+
 		// The Graph page's iframe: the repo's knowledge graph inlined into the
 		// self-contained viz (reusing `GraphExport.buildStandaloneHtml`), served
 		// into a `sandbox="allow-scripts"` iframe. Same public-GET + isolation model.

--- a/cli/src/dashboard/assets/js/graph.js
+++ b/cli/src/dashboard/assets/js/graph.js
@@ -23,6 +23,10 @@ window.JD = window.JD || {};
 	 * known repos, and it drives nothing but the address bar (no token, no mutation).
 	 */
 
+	// The repo currently shown in the frame (initial pick, then updated on an
+	// in-frame switch). Used to scope the on-demand wiki-body relay below.
+	let currentKb = null;
+
 	function availableRepos(model) {
 		return ((model.graph && model.graph.repos) || []).filter((r) => r.graphAvailable);
 	}
@@ -46,13 +50,14 @@ window.JD = window.JD || {};
 			return;
 		}
 		var kb = initialKb(available);
+		currentKb = kb;
 		var src = "/graph-viewer?kb=" + encodeURIComponent(kb) + "&theme=" + JD.currentTheme();
 		document.getElementById("app").innerHTML =
 			'<section class="graph-page"><iframe class="graph-frame" sandbox="allow-scripts" ' +
 			'title="Knowledge graph" src="' +
 			src +
 			'"></iframe></section>';
-		syncUrlWithFrame(available);
+		wireFrameMessages(available);
 		// wiki/graph freshness + on-demand Rebuild (folder-wide aggregate).
 		if (JD.mountWikiFreshness) JD.mountWikiFreshness();
 	}
@@ -62,20 +67,56 @@ window.JD = window.JD || {};
 	// makes sense. The banner is folder-wide: it reports how far behind ALL Memory
 	// Bank repos are (aggregate), and its `never`/`fresh`/`behind` states cover that.
 
-	// Mirror the frame's in-iframe repo switch into this page's /graph?kb= URL.
-	// Re-registered per render with the current repo list; the previous handler
-	// is removed so repeated renders don't stack listeners.
-	function syncUrlWithFrame(available) {
-		if (JD._graphRepoHandler) window.removeEventListener("message", JD._graphRepoHandler);
-		JD._graphRepoHandler = function (ev) {
+	// Relay messages from the (sandboxed, opaque-origin) graph frame:
+	//   - `jolli-graph-repo`: mirror the in-frame repo switch into this page's
+	//     `/graph?kb=` URL (so refresh / bookmark / share reopens the same repo),
+	//     and track `currentKb` for the wiki relay below.
+	//   - `jolli-graph-wiki-request`: the frame cannot fetch same-origin itself
+	//     (opaque origin), so this same-origin parent fetches the topic's wiki body
+	//     from `/graph-wiki` and posts it back. Body text is NOT inlined into the
+	//     graph (schema v5) — this is the dashboard's on-demand path.
+	// Re-registered per render with the current repo list; the previous handler is
+	// removed so repeated renders don't stack listeners.
+	function wireFrameMessages(available) {
+		if (JD._graphFrameHandler) window.removeEventListener("message", JD._graphFrameHandler);
+		JD._graphFrameHandler = function (ev) {
 			var d = ev && ev.data;
-			if (!d || d.type !== "jolli-graph-repo" || typeof d.kb !== "string") return;
-			if (!available.some((r) => r.kb === d.kb)) return;
-			try {
-				window.history.replaceState(null, "", "/graph?kb=" + encodeURIComponent(d.kb));
-			} catch (e) {}
+			if (!d) return;
+			// Only trust messages from THIS page's own graph iframe. Without this, a
+			// hostile page that window.open()s the dashboard's /graph can postMessage
+			// the relay below and exfiltrate wiki content cross-origin (the relay's
+			// own fetch to /graph-wiki is same-origin, so it bypasses the server's
+			// Origin allowlist — a confused deputy). The sandboxed frame posts via
+			// window.parent.postMessage, so its messages arrive with ev.source ===
+			// the frame's contentWindow; an opener window's do not. Re-query live so
+			// it still matches after an in-frame repo-switch navigation.
+			var frame = document.querySelector(".graph-frame");
+			if (!frame || ev.source !== frame.contentWindow) return;
+			if (d.type === "jolli-graph-repo" && typeof d.kb === "string") {
+				if (!available.some((r) => r.kb === d.kb)) return;
+				currentKb = d.kb;
+				try {
+					window.history.replaceState(null, "", "/graph?kb=" + encodeURIComponent(d.kb));
+				} catch (e) {}
+				return;
+			}
+			if (d.type === "jolli-graph-wiki-request" && typeof d.requestId === "string" && typeof d.slug === "string") {
+				var source = ev.source;
+				if (!source || !currentKb) return;
+				var requestId = d.requestId;
+				var slug = d.slug;
+				fetch("/graph-wiki?kb=" + encodeURIComponent(currentKb) + "&slug=" + encodeURIComponent(slug))
+					.then((res) => (res.ok ? res.text() : Promise.reject(new Error("wiki " + res.status))))
+					.then((markdown) =>
+						source.postMessage({ type: "jolli-graph-wiki-body", requestId: requestId, slug: slug, markdown: markdown }, "*"),
+					)
+					.catch(() =>
+						source.postMessage({ type: "jolli-graph-wiki-body", requestId: requestId, slug: slug, error: "load-failed" }, "*"),
+					);
+				return;
+			}
 		};
-		window.addEventListener("message", JD._graphRepoHandler);
+		window.addEventListener("message", JD._graphFrameHandler);
 	}
 
 	JD.renderGraph = (model) => render(model);

--- a/cli/src/graph/GraphBuilder.test.ts
+++ b/cli/src/graph/GraphBuilder.test.ts
@@ -135,8 +135,8 @@ describe("buildKnowledgeGraph", () => {
 		// The full-build exit stamps the repo name (breadcrumb root) — basename("/kb") === "kb".
 		expect(graphArg.repoName).toBe("kb");
 		const t1 = graphArg.topics.find((t: { slug: string }) => t.slug === "t1");
-		expect(t1.fullBody).toBe("page body\n\nsecond para");
 		expect(t1.overview).toBe("page body"); // first non-heading paragraph
+		expect(t1.wikiFile).toBe("topic--t1.md"); // body fetched on demand, not inlined
 		expect(t1.sourceBranches).toEqual(["main"]);
 		expect(t1.sourceCommits).toEqual([{ hash: "abcdef12", message: "" }]);
 	});
@@ -269,7 +269,7 @@ describe("buildKnowledgeGraph", () => {
 	// tests cannot silently go green if the separator/algorithm ever changes.
 	const fpOf = topicFingerprint;
 	const metaOf = (sourceBranches: string[], sourceCommits: { hash: string; message: string }[]) =>
-		topicMetaFingerprint({ sourceBranches, sourceCommits, overview: "", fullBody: "" });
+		topicMetaFingerprint({ sourceBranches, sourceCommits, overview: "" });
 
 	/** A field-valid baseline that actually carries a distilled t1 topic + unit, so a
 	 *  no-LLM reassemble (metadata drift) and an empty-on-delete have something to act on. */

--- a/cli/src/graph/GraphBuilder.ts
+++ b/cli/src/graph/GraphBuilder.ts
@@ -76,8 +76,8 @@ export function topicFingerprint(title: string, summary: string, content: string
  * LLM inputs, so they can change while {@link topicFingerprint} stays put — and
  * the rolled-up `commitCount` is derived from them. When the content diff is a
  * no-op but this changes, GraphBuilder does a NO-LLM reassemble instead of
- * skipping, so the on-disk metadata never goes stale. (`overview` / `fullBody`
- * are derived from `content`, already covered by the content fingerprint.)
+ * skipping, so the on-disk metadata never goes stale. (`overview` is derived
+ * from `content`, already covered by the content fingerprint.)
  */
 export function topicMetaFingerprint(meta: TopicSourceMeta): string {
 	const branches = meta.sourceBranches.join(",");
@@ -208,7 +208,6 @@ export async function buildKnowledgeGraph(
 			sourceBranches: page?.relatedBranches ?? entry.relatedBranches ?? [],
 			sourceCommits: commitRefs(page?.sourceRefs ?? entry.sourceRefs ?? []),
 			overview: firstParagraph(content),
-			fullBody: content,
 		};
 		sources.set(entry.stableSlug, meta);
 		metaFingerprints[entry.stableSlug] = topicMetaFingerprint(meta);

--- a/cli/src/graph/GraphExport.test.ts
+++ b/cli/src/graph/GraphExport.test.ts
@@ -67,6 +67,21 @@ describe("assembleGraphHtml", () => {
 		expect(html.indexOf("__EMBEDDED_GRAPH__")).toBeLessThan(html.indexOf("/* data */"));
 	});
 
+	it("inlines __EMBEDDED_WIKI__ (escaped) after the graph and before the app scripts when embeddedWiki is given", () => {
+		const html = assembleGraphHtml({ ...PARTS, embeddedWiki: { auth: "# Auth\n</script>x" } });
+		expect(html).toContain("window.__EMBEDDED_WIKI__ = ");
+		// The body's </script> is escaped like the graph global.
+		expect(html).toContain("\\u003c/script");
+		expect(html).not.toContain("</script>x");
+		// Both globals precede the app scripts; the wiki map follows the graph.
+		expect(html.indexOf("__EMBEDDED_GRAPH__")).toBeLessThan(html.indexOf("__EMBEDDED_WIKI__"));
+		expect(html.indexOf("__EMBEDDED_WIKI__")).toBeLessThan(html.indexOf("/* data */"));
+	});
+
+	it("omits __EMBEDDED_WIKI__ when no embeddedWiki is given (served surfaces fetch on demand)", () => {
+		expect(assembleGraphHtml(PARTS)).not.toContain("__EMBEDDED_WIKI__");
+	});
+
 	it("preserves $-sequences verbatim (no String.replace $$/$&/$' corruption)", () => {
 		const html = assembleGraphHtml({
 			...PARTS,
@@ -153,6 +168,12 @@ describe("exportGraphHtml", () => {
 		const html = readFileSync(file, "utf8");
 		expect(html).toContain("window.__EMBEDDED_GRAPH__");
 		expect(html).not.toContain("styles/main.css"); // stylesheet inlined (real assets)
+		// host-bridge.js MUST be bundled: it defines WikiHost.requestWikiBody, the
+		// on-demand body source for the dashboard iframe (which shares this builder).
+		// Dropping it from SCRIPT_FILES would silently break "Open full wiki page"
+		// there, so pin its presence and its load-order before data.js.
+		expect(html).toContain("requestWikiBody");
+		expect(html.indexOf("requestWikiBody")).toBeLessThan(html.indexOf("WikiDataLoader"));
 	});
 
 	it("honors an explicit *.html output path", async () => {
@@ -178,5 +199,94 @@ describe("exportGraphHtml", () => {
 		await expect(exportGraphHtml({ cwd: kbRoot, out: tmp("kg-out4-") })).rejects.toThrow(
 			/No knowledge graph found.*jolli compile/s,
 		);
+	});
+
+	it("re-inlines each topic's _wiki page as __EMBEDDED_WIKI__ (skips missing file / non-basename)", async () => {
+		const kbRoot = tmp("kg-wiki-");
+		mkdirSync(join(kbRoot, ".jolli", "graph"), { recursive: true });
+		mkdirSync(join(kbRoot, "_wiki"), { recursive: true });
+		const graphJson = JSON.stringify({
+			stats: { categories: 1 },
+			categories: [],
+			units: [],
+			edges: [],
+			topics: [
+				{ slug: "auth", wikiFile: "topic--auth.md" },
+				{ slug: "gone", wikiFile: "topic--gone.md" }, // no file on disk → omitted
+				{ slug: "evil", wikiFile: "../escape.md" }, // basename guard → skipped
+				{ slug: "nofield" }, // no wikiFile → skipped (non-string guard)
+			],
+		});
+		writeFileSync(join(kbRoot, ".jolli", "graph", "graph.json"), graphJson, "utf8");
+		writeFileSync(join(kbRoot, "_wiki", "topic--auth.md"), "# Auth page body", "utf8");
+		// Plant a file at the traversal TARGET of `../escape.md` (join(kbRoot,"_wiki","../escape.md")
+		// = <kbRoot>/escape.md). This is what makes the basename guard load-bearing: without a file
+		// here, `evil` would be dropped by existsSync alone and the guard would be untested.
+		writeFileSync(join(kbRoot, "escape.md"), "SECRET-TRAVERSAL-CONTENT", "utf8");
+		createStorage.mockResolvedValue({ kbRoot });
+
+		const file = await exportGraphHtml({ cwd: kbRoot, out: tmp("kg-wiki-out-") });
+		const html = readFileSync(file, "utf8");
+		// Extract and parse the embedded wiki map (ASCII bodies → escape is a no-op → valid JSON).
+		const m = html.match(/window\.__EMBEDDED_WIKI__ = (\{.*?\});/s);
+		expect(m).toBeTruthy();
+		expect(JSON.parse((m as RegExpMatchArray)[1])).toEqual({ auth: "# Auth page body" });
+		// The WIKI_FILE_RE basename guard blocked the traversal: escape.md's content
+		// never reached the export. (Deleting the guard would read it into `evil`.)
+		expect(html).not.toContain("SECRET-TRAVERSAL-CONTENT");
+	});
+
+	it("still exports (empty wiki map) when graph.json is malformed JSON", async () => {
+		const kbRoot = tmp("kg-badjson-");
+		mkdirSync(join(kbRoot, ".jolli", "graph"), { recursive: true });
+		writeFileSync(join(kbRoot, ".jolli", "graph", "graph.json"), "{not valid json", "utf8");
+		createStorage.mockResolvedValue({ kbRoot });
+
+		const file = await exportGraphHtml({ cwd: kbRoot, out: tmp("kg-badjson-out-") });
+		const html = readFileSync(file, "utf8");
+		// readWikiBodies swallows the parse error → empty map; the export still opens.
+		const m = html.match(/window\.__EMBEDDED_WIKI__ = (\{.*?\});/s);
+		expect(m).toBeTruthy();
+		expect(JSON.parse((m as RegExpMatchArray)[1])).toEqual({});
+	});
+
+	it("tolerates a graph.json whose `topics` is present but not an array", async () => {
+		const kbRoot = tmp("kg-notopics-");
+		mkdirSync(join(kbRoot, ".jolli", "graph"), { recursive: true });
+		writeFileSync(
+			join(kbRoot, ".jolli", "graph", "graph.json"),
+			JSON.stringify({ stats: {}, topics: "oops" }),
+			"utf8",
+		);
+		createStorage.mockResolvedValue({ kbRoot });
+
+		const file = await exportGraphHtml({ cwd: kbRoot, out: tmp("kg-notopics-out-") });
+		const m = readFileSync(file, "utf8").match(/window\.__EMBEDDED_WIKI__ = (\{.*?\});/s);
+		expect(m).toBeTruthy();
+		expect(JSON.parse((m as RegExpMatchArray)[1])).toEqual({});
+	});
+
+	it("omits a topic whose _wiki entry is present but unreadable (a directory in its place)", async () => {
+		const kbRoot = tmp("kg-unreadable-");
+		mkdirSync(join(kbRoot, ".jolli", "graph"), { recursive: true });
+		// A DIRECTORY where the topic page file is expected: existsSync passes, readFileSync throws.
+		mkdirSync(join(kbRoot, "_wiki", "topic--dir.md"), { recursive: true });
+		writeFileSync(
+			join(kbRoot, ".jolli", "graph", "graph.json"),
+			JSON.stringify({
+				stats: {},
+				categories: [],
+				units: [],
+				edges: [],
+				topics: [{ slug: "dir", wikiFile: "topic--dir.md" }],
+			}),
+			"utf8",
+		);
+		createStorage.mockResolvedValue({ kbRoot });
+
+		const file = await exportGraphHtml({ cwd: kbRoot, out: tmp("kg-unreadable-out-") });
+		const m = readFileSync(file, "utf8").match(/window\.__EMBEDDED_WIKI__ = (\{.*?\});/s);
+		expect(m).toBeTruthy();
+		expect(JSON.parse((m as RegExpMatchArray)[1])).toEqual({});
 	});
 });

--- a/cli/src/graph/GraphExport.ts
+++ b/cli/src/graph/GraphExport.ts
@@ -4,8 +4,13 @@
  * (vendor + app), and the repo's `graph.json` (as `window.__EMBEDDED_GRAPH__`),
  * so the file opens directly from `file://` — no server, no `fetch` (CORS-safe).
  *
- * The full `_wiki` pages need no external files: each topic's markdown is
- * embedded as `fullBody` inside graph.json and rendered in-panel by `panel.js`.
+ * graph.json no longer carries the topic bodies (v5 dropped `fullBody`). To keep
+ * the exported file self-contained and offline (`file://`, no fetch), each
+ * topic's `_wiki/topic--<slug>.md` page is re-inlined here as a
+ * `window.__EMBEDDED_WIKI__` map keyed by topic slug; `panel.js` reads it when
+ * the user opens the full wiki page. The SERVED surfaces (dashboard / VS Code /
+ * web) instead fetch the body on demand over a host bridge and pass no
+ * `embeddedWiki`, so they never carry the bodies inline.
  *
  * Mirrors the VS Code webview's `KnowledgeGraphPanel.renderGraphHtml`, with one
  * shared hazard to respect: replacements are passed as FUNCTIONS, never strings.
@@ -24,6 +29,10 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 /** Vendor + app scripts, in the same order as the viz `index.html` loads them. */
 const VENDOR_FILES = ["panzoom.min.js", "elk.bundled.js", "marked.min.js"] as const;
 const SCRIPT_FILES = [
+	// host-bridge.js first (as in the template) so `window.WikiHost` exists before
+	// data.js runs. It is inert in a standalone export (not framed), but the
+	// dashboard iframe needs its `requestWikiBody` bridge to fetch bodies on click.
+	"host-bridge.js",
 	"data.js",
 	"state.js",
 	"edges.js",
@@ -41,6 +50,12 @@ export interface GraphHtmlParts {
 	readonly vendorJs: ReadonlyArray<string>; // vendor/*.js, in load order
 	readonly appJs: ReadonlyArray<string>; // js/*.js, in load order
 	readonly graphJson: string; // the repo's graph.json (verbatim)
+	/**
+	 * Optional `{ slug → markdown }` map re-inlined as `window.__EMBEDDED_WIKI__`
+	 * so a self-contained offline export renders wiki bodies with no fetch. Omitted
+	 * by the served surfaces (dashboard / VS Code), which fetch bodies on demand.
+	 */
+	readonly embeddedWiki?: Record<string, string>;
 }
 
 /**
@@ -70,10 +85,17 @@ function replaceMarker(html: string, marker: RegExp, replacement: () => string, 
 export function assembleGraphHtml(parts: GraphHtmlParts, bodyClass?: string): string {
 	const safeGraph = escapeForInlineScript(parts.graphJson);
 	const scriptTag = (js: string) => `<script>\n${js}\n</script>`;
+	// Optional inlined wiki bodies (`{ slug → markdown }`) for a self-contained
+	// export; omitted by the served surfaces, which fetch on demand.
+	const wikiScript = parts.embeddedWiki
+		? `<script>window.__EMBEDDED_WIKI__ = ${escapeForInlineScript(JSON.stringify(parts.embeddedWiki))};</script>\n`
+		: "";
 	// Vendor first, then the embedded data (data.js reads it), then app scripts.
+	// Both globals precede the app scripts (host-bridge.js / data.js read them).
 	const scripts =
 		`${parts.vendorJs.map(scriptTag).join("\n")}\n` +
 		`<script>window.__EMBEDDED_GRAPH__ = ${safeGraph};</script>\n` +
+		wikiScript +
 		parts.appJs.map(scriptTag).join("\n");
 
 	// Real `<body>` first (CSS with its comment `<body>` is not inlined yet).
@@ -104,7 +126,12 @@ export function resolveAssetsDir(baseDir: string = HERE): string {
 }
 
 /** Read the viz assets from `assetsDir` and assemble the standalone HTML. */
-export function buildStandaloneHtml(assetsDir: string, graphJson: string, bodyClass?: string): string {
+export function buildStandaloneHtml(
+	assetsDir: string,
+	graphJson: string,
+	bodyClass?: string,
+	embeddedWiki?: Record<string, string>,
+): string {
 	const read = (...p: string[]) => readFileSync(join(assetsDir, ...p), "utf8");
 	return assembleGraphHtml(
 		{
@@ -113,9 +140,43 @@ export function buildStandaloneHtml(assetsDir: string, graphJson: string, bodyCl
 			vendorJs: VENDOR_FILES.map((f) => read("vendor", f)),
 			appJs: SCRIPT_FILES.map((f) => read("js", f)),
 			graphJson,
+			embeddedWiki,
 		},
 		bodyClass,
 	);
+}
+
+/** A topic wiki filename is always `topic--<lowercase-hyphen-slug>.md` (see GraphSchema). */
+const WIKI_FILE_RE = /^topic--[a-z0-9]+(?:-[a-z0-9]+)*\.md$/;
+
+/**
+ * Read each topic's `_wiki/<wikiFile>` page into a `{ slug → markdown }` map for
+ * a self-contained export. Best-effort: a topic whose file is missing/unreadable
+ * is omitted (the viz shows a placeholder). The `wikiFile` is validated to be a
+ * bare `topic--<slug>.md` basename before it is joined to `<kbRoot>/_wiki/`, so a
+ * tampered graph.json can't drive a path traversal.
+ */
+function readWikiBodies(kbRoot: string, graphJson: string): Record<string, string> {
+	const map: Record<string, string> = {};
+	let topics: Array<{ slug?: unknown; wikiFile?: unknown }>;
+	try {
+		const parsed = JSON.parse(graphJson) as { topics?: unknown };
+		topics = Array.isArray(parsed.topics) ? (parsed.topics as Array<{ slug?: unknown; wikiFile?: unknown }>) : [];
+	} catch {
+		return map; // malformed graph.json → export still opens, just without bodies
+	}
+	for (const t of topics) {
+		if (typeof t.slug !== "string" || typeof t.wikiFile !== "string") continue;
+		if (!WIKI_FILE_RE.test(t.wikiFile)) continue; // basename guard (no separators / traversal)
+		const file = join(kbRoot, "_wiki", t.wikiFile);
+		if (!existsSync(file)) continue;
+		try {
+			map[t.slug] = readFileSync(file, "utf8");
+		} catch {
+			// unreadable → omit; the viz placeholder covers it
+		}
+	}
+	return map;
 }
 
 export interface ExportGraphOptions {
@@ -137,7 +198,9 @@ export async function exportGraphHtml(opts: ExportGraphOptions): Promise<string>
 	if (!existsSync(graphPath)) {
 		throw new Error(`No knowledge graph found at ${graphPath}. Run "jolli compile --cwd ${opts.cwd}" first.`);
 	}
-	const html = buildStandaloneHtml(resolveAssetsDir(), readFileSync(graphPath, "utf8"));
+	const graphJson = readFileSync(graphPath, "utf8");
+	const embeddedWiki = readWikiBodies(kbRoot, graphJson);
+	const html = buildStandaloneHtml(resolveAssetsDir(), graphJson, undefined, embeddedWiki);
 
 	const outFile = opts.out.toLowerCase().endsWith(".html")
 		? opts.out

--- a/cli/src/graph/GraphSchema.test.ts
+++ b/cli/src/graph/GraphSchema.test.ts
@@ -256,7 +256,6 @@ describe("assembleGraph", () => {
 					{ hash: "def67890", message: "" },
 				],
 				overview: "T1 overview",
-				fullBody: "# body 1",
 			},
 		],
 		// t2 deliberately absent → empty source metadata
@@ -270,14 +269,13 @@ describe("assembleGraph", () => {
 
 		const t1 = graph.topics.find((t) => t.slug === "t1");
 		expect(t1?.sourceBranches).toEqual(["main", "feature/x"]);
-		expect(t1?.fullBody).toBe("# body 1");
 		expect(t1?.wikiFile).toBe("topic--t1.md");
 		expect(t1?.unitCount).toBe(2);
 		expect(t1?.commitCount).toBe(2);
 
 		const t2 = graph.topics.find((t) => t.slug === "t2");
 		expect(t2?.sourceBranches).toEqual([]);
-		expect(t2?.fullBody).toBe("");
+		expect(t2?.wikiFile).toBe("topic--t2.md");
 		expect(t2?.unitCount).toBe(1);
 		expect(t2?.commitCount).toBe(0);
 

--- a/cli/src/graph/GraphSchema.ts
+++ b/cli/src/graph/GraphSchema.ts
@@ -112,8 +112,13 @@ export function isCanonicalKinds(v: unknown): v is UnitKind[] {
  * written under v3 lacks it; the version mismatch forces a one-time full rebuild
  * that regenerates graph.json in the v4 shape (no migration script — the array
  * is recomputed deterministically every build, never reused from the baseline).
+ * Bumped 4→5 when `fullBody` (the verbatim topic body) was REMOVED from every
+ * `GraphTopic`. The viz no longer inlines wiki bodies into graph.json; it
+ * fetches `_wiki/topic--<slug>.md` on demand (`wikiFile` names it). Dropping an
+ * output field is a breaking shape change ⇒ the version mismatch forces a
+ * one-time full rebuild that regenerates graph.json in the leaner v5 shape.
  */
-export const GRAPH_SCHEMA_VERSION = 4;
+export const GRAPH_SCHEMA_VERSION = 5;
 
 /** Category id for topics not grouped into any real category. Shared by the full
  * distiller (backfill) and the incremental merge so both bucket the same way. */
@@ -209,8 +214,6 @@ export interface TopicSourceMeta {
 	readonly sourceBranches: string[];
 	readonly sourceCommits: SourceCommitRef[];
 	readonly overview: string;
-	/** Verbatim topic page body, rendered in the viz reader drawer. */
-	readonly fullBody: string;
 }
 
 // -- Final merged graph (what the viz consumes) -------------------------------
@@ -225,7 +228,12 @@ export interface GraphTopic extends DistilledTopic {
 	readonly sourceBranches: string[];
 	readonly sourceCommits: SourceCommitRef[];
 	readonly overview: string;
-	readonly fullBody: string;
+	/**
+	 * Basename of the human-browsable topic page under `<kbRoot>/_wiki/`
+	 * (`topic--<slug>.md`). The viz fetches this on demand when the user opens
+	 * the full wiki page — the body is NOT inlined into graph.json (see the
+	 * v5 note on {@link GRAPH_SCHEMA_VERSION}).
+	 */
 	readonly wikiFile: string;
 	unitCount: number;
 	commitCount: number;
@@ -491,7 +499,6 @@ export function assembleGraph(
 			sourceBranches: src ? src.sourceBranches : [],
 			sourceCommits: src ? src.sourceCommits : [],
 			overview: src ? src.overview : "",
-			fullBody: src ? src.fullBody : "",
 			wikiFile: `topic--${t.slug}.md`,
 			unitCount: 0,
 			commitCount: 0,

--- a/cli/src/graph/assets/js/data.js
+++ b/cli/src/graph/assets/js/data.js
@@ -5,14 +5,20 @@
 (function () {
   "use strict";
 
-  // The schema version this viewer is built for. MUST stay in lockstep with
-  // GRAPH_SCHEMA_VERSION in cli/src/graph/GraphSchema.ts — same "thin mirror,
-  // keep in sync" contract as the symmetric-edge dedup below. A loaded graph.json
-  // whose schemaVersion is a NUMBER strictly below this was written by an older
-  // build; the viewer still renders it (every new-field read is guarded), but
-  // main.js surfaces a "regenerate for the full experience" notice. A missing or
-  // non-numeric schemaVersion is NOT treated as stale (no false positive on data
-  // that predates the field or is hand-authored).
+  // Oldest schema whose graphs still render FULLY in this viewer. A loaded
+  // graph.json whose schemaVersion is a NUMBER strictly below this was written by
+  // a build old enough to be missing something the viewer needs; main.js then
+  // surfaces a "regenerate for the full experience" notice (the viewer still
+  // renders it — every new-field read is guarded). A missing/non-numeric
+  // schemaVersion is NOT stale (no false positive on pre-field or hand-authored
+  // data).
+  //
+  // Deliberately NOT equal to GRAPH_SCHEMA_VERSION (now 5): the v4→v5 bump only
+  // REMOVED `fullBody`, a field this viewer no longer reads (it fetches
+  // `_wiki/topic--<slug>.md` on demand via `wikiBody` below). A v4 graph still
+  // carries `wikiFile` and every other field, so it renders fully here — flagging
+  // it stale would be a false positive. Advance this only when a NEW version adds
+  // something the viewer actually depends on.
   const SUPPORTED_SCHEMA_VERSION = 4;
 
   // Muted jewel-tone palette for categories — deliberately avoids pure red/blue
@@ -21,6 +27,32 @@
     "#7d99c4", "#a3b577", "#cc977c", "#a995cf", "#c8a06b", "#7eb0b0",
     "#c99898", "#b5c47a", "#bc8e5c", "#9d8cc4", "#8aaab8", "#a0a0a0",
   ];
+
+  // --- Lazy per-topic wiki body -------------------------------------------
+  // graph.json no longer inlines topic bodies (schema v5). The reader fetches
+  // `_wiki/topic--<slug>.md` on demand: from window.__EMBEDDED_WIKI__ in a
+  // self-contained export, else over the host bridge (dashboard / VS Code / web).
+  // The PROMISE is cached per slug so concurrent opens dedupe and a resolved body
+  // is reused; a rejection is evicted so a later open can retry.
+  const _bodyCache = new Map();
+  function wikiBody(slug) {
+    if (_bodyCache.has(slug)) return _bodyCache.get(slug);
+    const p = resolveWikiBody(slug);
+    _bodyCache.set(slug, p);
+    p.catch(() => _bodyCache.delete(slug));
+    return p;
+  }
+  function resolveWikiBody(slug) {
+    // ① Self-contained export: bodies inlined as a { slug -> markdown } map.
+    const inlined = window.__EMBEDDED_WIKI__;
+    if (inlined && typeof inlined[slug] === "string") return Promise.resolve(inlined[slug]);
+    // ② Framed host (dashboard / VS Code / web app): fetch on demand.
+    if (window.WikiHost && typeof window.WikiHost.requestWikiBody === "function") {
+      return window.WikiHost.requestWikiBody(slug);
+    }
+    // ③ No source available (e.g. a standalone file opened with no inlined bodies).
+    return Promise.reject(new Error("no wiki body source"));
+  }
 
   async function load() {
     let graph;
@@ -204,6 +236,8 @@
       coChangeCategoryAgg: [...coChangeCategoryAgg.values()],
       // Relationship types with no direction — drawn as a single line, no arrow.
       symmetricTypes: SYMMETRIC,
+      // Lazy per-topic wiki body loader (fetches `_wiki/topic--<slug>.md`). See above.
+      wikiBody,
     };
     return window.WikiData;
   }

--- a/cli/src/graph/assets/js/host-bridge.js
+++ b/cli/src/graph/assets/js/host-bridge.js
@@ -167,10 +167,81 @@
     postToHost("jolli-graph-rendered");
   }
 
+  // --- Lazy wiki body request/response -------------------------------------
+  // graph.json no longer inlines topic bodies (schema v5). When the user opens a
+  // full wiki page, the viz asks the host for `_wiki/topic--<slug>.md` and the
+  // host (which holds any auth / disk / network access) posts it back. This
+  // generalises the one-shot requestGraph handshake into a keyed request/response
+  // so multiple topic pages can be in flight at once.
+  //
+  // Two transports, picked at call time:
+  //   - VS Code webview: `acquireVsCodeApi()` (its messages do NOT arrive with
+  //     `event.source === window.parent`, so the response is matched purely by
+  //     requestId, not the `fromHost` gate).
+  //   - framed host (web app / dashboard iframe): `window.parent.postMessage`,
+  //     with the response gated by `fromHost` like the theme/host channel.
+  var WIKI_TIMEOUT_MS = 15000;
+  var vscodeApi = null;
+  try {
+    // May be called exactly once per webview; nothing else in the viz calls it.
+    if (typeof acquireVsCodeApi === "function") vscodeApi = acquireVsCodeApi();
+  } catch (e) {
+    vscodeApi = null; // already acquired elsewhere, or not a VS Code webview
+  }
+  var wikiSeq = 0;
+  var wikiPending = new Map(); // requestId -> { resolve, reject, timer }
+  var wikiListenerBound = false;
+
+  function onWikiMessage(event) {
+    // VS Code: accept by requestId (source is not window.parent). Framed host:
+    // require the `fromHost` gate so a sibling/other-origin frame can't answer.
+    if (!vscodeApi && !fromHost(event)) return;
+    var data = event.data;
+    if (!data || data.type !== "jolli-graph-wiki-body") return;
+    var entry = wikiPending.get(data.requestId);
+    if (!entry) return;
+    wikiPending.delete(data.requestId);
+    clearTimeout(entry.timer);
+    if (typeof data.error === "string" && data.error) {
+      entry.reject(new Error(data.error));
+    } else if (typeof data.markdown === "string") {
+      entry.resolve(data.markdown);
+    } else {
+      entry.reject(new Error("wiki body response carried no markdown"));
+    }
+  }
+
+  function requestWikiBody(slug) {
+    return new Promise(function (resolve, reject) {
+      if (!wikiListenerBound) {
+        window.addEventListener("message", onWikiMessage);
+        wikiListenerBound = true;
+      }
+      var requestId = "wiki-" + ++wikiSeq;
+      var timer = setTimeout(function () {
+        wikiPending.delete(requestId);
+        reject(new Error("host did not provide wiki body within " + WIKI_TIMEOUT_MS / 1000 + "s"));
+      }, WIKI_TIMEOUT_MS);
+      wikiPending.set(requestId, { resolve: resolve, reject: reject, timer: timer });
+      var msg = { type: "jolli-graph-wiki-request", requestId: requestId, slug: slug };
+      if (vscodeApi) {
+        vscodeApi.postMessage(msg);
+      } else if (embedded) {
+        var target = hostOrigin && hostOrigin !== "null" ? hostOrigin : "*";
+        window.parent.postMessage(msg, target);
+      } else {
+        wikiPending.delete(requestId);
+        clearTimeout(timer);
+        reject(new Error("no host to request a wiki body from"));
+      }
+    });
+  }
+
   // rootLabel: breadcrumb root override (repo name), set from the host handshake.
   window.WikiHost = {
     embedded: embedded,
     requestGraph: requestGraph,
+    requestWikiBody: requestWikiBody,
     notifyRendered: notifyRendered,
     applyTheme: applyTheme,
     rootLabel: null,

--- a/cli/src/graph/assets/js/panel.js
+++ b/cli/src/graph/assets/js/panel.js
@@ -109,7 +109,9 @@
 
     // Full wiki page opens in-panel (kind: "wiki"); Back returns to this topic.
     // Sits right under the description, mirroring the "Open category" button.
-    if (t.fullBody) {
+    // Gated on `wikiFile` (every topic has one) — the body is fetched on open,
+    // not inlined into the graph (schema v5), so `fullBody` no longer exists here.
+    if (t.wikiFile) {
       html += `<button type="button" class="wiki-open" data-open-wiki="${esc(slug)}">📖 Open full wiki page</button>`;
     }
 
@@ -143,19 +145,70 @@
     return html;
   }
 
-  // Full markdown wiki page, rendered inside the panel (reading mode widens it).
+  // Full wiki page, rendered inside the panel (reading mode widens it). The body
+  // is NOT inlined into the graph (schema v5) — it is fetched on demand, so this
+  // returns a heading + loading placeholder synchronously and `loadWikiInto`
+  // fills `.wiki-body` once `WikiData.wikiBody(slug)` resolves. Keeping the render
+  // synchronous lets the existing state→render pipeline stay unchanged.
   function renderWiki(slug) {
     const D = window.WikiData;
     const t = D.topicsBySlug.get(slug);
     if (!t) return renderEmpty();
-    const md = (window.marked && window.marked.parse)
-      ? window.marked.parse(t.fullBody || "")
-      : `<pre>${esc(t.fullBody || "")}</pre>`;
     let html = "";
     html += `<h2>${esc(t.shortTitle)}</h2>`;
     html += `<div class="p-meta">${esc(t.title)}</div>`;
-    html += `<div class="wiki-body">${md}</div>`; // marked output is our own wiki HTML
+    html += `<div class="wiki-body" id="wiki-body"><div class="wiki-loading">Loading…</div></div>`;
     return html;
+  }
+
+  // Neutralise the wiki page's relative links: `_wiki` pages link to sibling
+  // topic pages and per-commit files by RELATIVE path, which do not resolve
+  // inside the graph panel. Turn any non-absolute (or in-page anchor) link into
+  // inert text; keep real http(s) links but open them in a new tab.
+  function neutralizeRelativeLinks(htmlString) {
+    const tmp = document.createElement("div");
+    tmp.innerHTML = htmlString; // marked output is our own wiki HTML
+    tmp.querySelectorAll("a[href]").forEach((a) => {
+      const href = a.getAttribute("href") || "";
+      if (/^https?:\/\//i.test(href)) {
+        a.setAttribute("target", "_blank");
+        a.setAttribute("rel", "noopener noreferrer");
+        return;
+      }
+      const span = document.createElement("span");
+      span.className = "wiki-inert-link";
+      span.textContent = a.textContent || "";
+      a.replaceWith(span);
+    });
+    return tmp.innerHTML;
+  }
+
+  // Fetch the wiki body for `slug` and render it into the live `.wiki-body`
+  // container. Guards staleness: the user may navigate away while the fetch is in
+  // flight, so re-check the current selection before patching the DOM.
+  function loadWikiInto(slug) {
+    const D = window.WikiData;
+    if (!D || typeof D.wikiBody !== "function") return;
+    const stillShowing = () => {
+      const s = window.WikiState.get();
+      return !!(s.selected && s.selected.kind === "wiki" && s.selected.id === slug);
+    };
+    D.wikiBody(slug).then(
+      (md) => {
+        if (!stillShowing()) return;
+        const live = document.getElementById("wiki-body");
+        if (!live) return;
+        live.innerHTML =
+          window.marked && window.marked.parse
+            ? neutralizeRelativeLinks(window.marked.parse(md || ""))
+            : `<pre>${esc(md || "")}</pre>`;
+      },
+      () => {
+        if (!stillShowing()) return;
+        const live = document.getElementById("wiki-body");
+        if (live) live.innerHTML = `<div class="wiki-error">${esc("The full wiki page isn’t available right now.")}</div>`;
+      },
+    );
   }
 
   function renderCategoryPair(pairId) {
@@ -227,6 +280,9 @@
     // Opening the full wiki page: jump to the top so reading starts at the
     // beginning, not wherever the previous panel content was scrolled.
     if (panelEl && sel && sel.kind === "wiki") panelEl.scrollTop = 0;
+    // The wiki body is fetched lazily (not inlined). renderWiki emitted a loading
+    // placeholder; fill it once the body resolves (or show an error).
+    if (sel && sel.kind === "wiki") loadWikiInto(sel.id);
 
     const back = document.getElementById("panel-back");
     if (back) back.addEventListener("click", () => S.goBack());

--- a/cli/src/graph/assets/styles/main.css
+++ b/cli/src/graph/assets/styles/main.css
@@ -482,6 +482,11 @@ body {
 /* ── Rendered wiki page (marked output) ─────────────────── */
 .wiki-body { font-size: 12.5px; color: var(--prose); line-height: 1.7; }
 .wiki-body > :first-child { margin-top: 0; }
+/* Lazy-load states for the on-demand wiki body (schema v5 — body fetched, not inlined). */
+.wiki-loading { color: var(--muted); font-style: italic; padding: 8px 0; }
+.wiki-error { color: var(--muted); padding: 8px 0; }
+/* Relative links in a wiki page don't resolve inside the panel; rendered inert. */
+.wiki-inert-link { color: inherit; }
 .wiki-body h1, .wiki-body h2, .wiki-body h3, .wiki-body h4 {
   color: var(--ink); line-height: 1.3; margin: 18px 0 8px;
 }

--- a/cli/src/sync/AllowList.test.ts
+++ b/cli/src/sync/AllowList.test.ts
@@ -267,6 +267,28 @@ describe("isAllowedPath — .jolli/graph/", () => {
 	});
 });
 
+describe("isAllowedPath — _wiki/ (explicit, additive over the generic .md rule)", () => {
+	const opts = { syncTranscripts: false };
+
+	it("explicitly guarantees the two named wiki shapes are allowed", () => {
+		// The additive branch returns true for these regardless of the generic rule,
+		// so a future tightening of the generic `.md` rule can't drop them.
+		expect(isAllowedPath("myrepo/_wiki/_index.md", opts)).toBe(true);
+		expect(isAllowedPath("myrepo/_wiki/topic--auth.md", opts)).toBe(true);
+		expect(isAllowedPath("myrepo/_wiki/topic--ai-context-relevance-filtering.md", opts)).toBe(true);
+	});
+
+	it("lets other _wiki entries fall through to the generic rules (no hard reject / no regression)", () => {
+		// A non-conforming leaf is NOT hard-rejected — it rides the generic `.md`
+		// rule exactly as before this branch existed, so LegacyMigration keeps
+		// migrating arbitrary content under a folder literally named `_wiki`.
+		expect(isAllowedPath("myrepo/_wiki/topic--Bad_Slug.md", opts)).toBe(true); // generic .md
+		expect(isAllowedPath("myrepo/_wiki/notes.md", opts)).toBe(true); // generic .md
+		// Non-markdown is still rejected by the generic extension check.
+		expect(isAllowedPath("myrepo/_wiki/topic--auth.txt", opts)).toBe(false);
+	});
+});
+
 describe("isAllowedPath — windows-style separators", () => {
 	const opts = { syncTranscripts: true };
 

--- a/cli/src/sync/AllowList.ts
+++ b/cli/src/sync/AllowList.ts
@@ -92,6 +92,9 @@ const SUMMARY_HASH_REGEX = /^[0-9a-f]{7,64}\.json$/;
  */
 const PLAN_OR_NOTE_REGEX = /^[A-Za-z0-9][A-Za-z0-9._-]{0,254}\.md$/;
 const PLAN_PROGRESS_REGEX = /^[A-Za-z0-9][A-Za-z0-9._-]{0,254}\.json$/;
+// `<repoFolder>/_wiki/` leaves: the topic index `_index.md` and per-topic
+// `topic--<slug>.md` pages (slug is the lowercase-hyphen `stableSlug`).
+const WIKI_LEAF_REGEX = /^(?:_index|topic--[a-z0-9]+(?:-[a-z0-9]+)*)\.md$/;
 
 export interface AllowListOpts {
 	readonly syncTranscripts: boolean;
@@ -155,6 +158,20 @@ export function isAllowedPath(relPath: string, opts: AllowListOpts): boolean {
 			return segments[2] === "graph.json";
 		}
 		return false;
+	}
+
+	// `<repoFolder>/_wiki/...` — the human-browsable topic pages the knowledge-
+	// graph reader fetches on click (`topic--<slug>.md`) plus the `_index.md`
+	// index. The two named shapes are allowed EXPLICITLY (additively) so a future
+	// tightening of the generic `.md` rule below can't silently stop the Space
+	// graph reader's bodies from being allowed. Anything else under `_wiki/` falls
+	// through to the generic rules unchanged — additive, never a hard reject, so
+	// arbitrary legacy content under a `_wiki/` folder still migrates as before,
+	// staying symmetric with `classifyVaultPath`'s `user-content` fallthrough.
+	// (Sync staging is gated by `classifyVaultPath`, not this function — its only
+	// runtime caller is LegacyMigration — so the tight `wiki` kind lives there.)
+	if (segments.length === 3 && segments[1] === "_wiki" && WIKI_LEAF_REGEX.test(segments[2] as string)) {
+		return true;
 	}
 
 	// Reject any other dot-prefixed segment (hidden file or hidden directory).

--- a/cli/src/sync/OwnedPathKind.ts
+++ b/cli/src/sync/OwnedPathKind.ts
@@ -43,6 +43,14 @@ export type OwnedPathKind =
 	// viz renders. Regenerable (rebuilt by `jolli compile`), so a torn/stale
 	// copy self-heals; synced so the Space renders the graph without a rebuild.
 	| "graph"
+	// <repoFolder>/_wiki/topic--<slug>.md and <repoFolder>/_wiki/_index.md — the
+	// human-browsable topic pages the knowledge-graph reader fetches on click.
+	// Regenerable (rewritten by `jolli compile`); synced so the Space graph can
+	// serve wiki bodies on demand instead of inlining them into graph.json. Was
+	// only ever staged via the `user-content` fallthrough before; named
+	// explicitly so a future tightening of that fallthrough can't silently stop
+	// syncing the bodies the graph reader depends on.
+	| "wiki"
 	// Per-repo visible markdown (under <repoFolder>/<branch>/...):
 	| "visible-summary" // <repoFolder>/<branch>/<slug>-<hex8>.md
 	| "visible-plan" // <repoFolder>/<branch>/plan--<slug>.md

--- a/cli/src/sync/VaultPathClassifier.test.ts
+++ b/cli/src/sync/VaultPathClassifier.test.ts
@@ -27,6 +27,8 @@ describe("classifyVaultPath — positive cases", () => {
 		["myrepo/.jolli/plan-progress/my-feature.json", "plan-progress"],
 		["myrepo/.jolli/notes/note-xyz.md", "note"],
 		["myrepo/.jolli/graph/graph.json", "graph"],
+		["myrepo/_wiki/_index.md", "wiki"],
+		["myrepo/_wiki/topic--fix-auth.md", "wiki"],
 		[`myrepo/main/fix-auth-${HASH8}.md`, "visible-summary"],
 		["myrepo/main/plan--my-feature.md", "visible-plan"],
 		["myrepo/main/note--note-xyz.md", "visible-note"],
@@ -153,6 +155,21 @@ describe("classifyVaultPath — negative cases", () => {
 		expect(classifyVaultPath("myrepo/.jolli/graph/other.json")).toBeNull();
 		expect(classifyVaultPath("myrepo/.jolli/graph/graph.txt")).toBeNull();
 		expect(classifyVaultPath("myrepo/.jolli/graph/nested/x.json")).toBeNull();
+	});
+
+	it("classifies `_wiki/_index.md` and `_wiki/topic--<slug>.md` as `wiki`, strict on the leaf shape", () => {
+		// The knowledge-graph reader fetches these on click. They are named
+		// explicitly rather than riding the `user-content` fallthrough, so a
+		// future tightening of that fallthrough can't silently stop syncing them.
+		expect(classifyVaultPath("myrepo/_wiki/_index.md")).toBe("wiki");
+		expect(classifyVaultPath("myrepo/_wiki/topic--auth.md")).toBe("wiki");
+		expect(classifyVaultPath("myrepo/_wiki/topic--ai-context-relevance-filtering.md")).toBe("wiki");
+		// Wrong shapes under _wiki still SYNC (they fall back to the safe-segment
+		// `user-content` fallthrough) — they just don't earn the strict `wiki`
+		// kind. This keeps the canary tight without ever dropping a real file.
+		expect(classifyVaultPath("myrepo/_wiki/readme.md")).toBe("user-content");
+		expect(classifyVaultPath("myrepo/_wiki/topic--Bad_Slug.md")).toBe("user-content");
+		expect(classifyVaultPath("myrepo/_wiki/sub/topic--x.md")).toBe("user-content");
 	});
 
 	it("rejects shadow-status.json (per-device dirty-write recovery state — never synced)", () => {

--- a/cli/src/sync/VaultPathClassifier.ts
+++ b/cli/src/sync/VaultPathClassifier.ts
@@ -45,6 +45,9 @@
  *       │   ├── plan-progress/<slug>.json       ← plan-progress
  *       │   ├── notes/<id>.md                   ← note (markdown)
  *       │   └── graph/graph.json                ← graph (regenerable KB-graph data)
+ *       ├── _wiki/
+ *       │   ├── _index.md                       ← wiki (topic index page)
+ *       │   └── topic--<slug>.md                ← wiki (topic page; fetched on click)
  *       └── <branch>/
  *           ├── <slug>-<hex8>.md                ← visible-summary
  *           ├── plan--<slug>.md                 ← visible-plan
@@ -263,6 +266,21 @@ function classifyStrict(relPath: string): OwnedPathKind | null {
 		const branch = segments[1];
 		const file = segments[2];
 		if (branch === undefined || file === undefined) return null;
+
+		// `<repoFolder>/_wiki/...` — the human-browsable topic pages the knowledge-
+		// graph reader fetches on click: `topic--<slug>.md` (slug is the same
+		// lowercase-hyphen `stableSlug` a summary uses) plus the `_index.md` index.
+		// Named explicitly (rather than left to the `user-content` fallthrough) so a
+		// future tightening of that fallthrough can't silently stop syncing them.
+		if (branch === "_wiki") {
+			if (file === "_index.md") return "wiki";
+			if (file.startsWith("topic--") && file.endsWith(".md")) {
+				const slug = file.slice("topic--".length, -".md".length);
+				return SUMMARY_SLUG_RE.test(slug) ? "wiki" : null;
+			}
+			return null;
+		}
+
 		if (!BRANCH_FOLDER_RE.test(branch)) return null;
 
 		// plan--<slug>.md

--- a/vscode/src/views/KnowledgeGraphPanel.test.ts
+++ b/vscode/src/views/KnowledgeGraphPanel.test.ts
@@ -25,7 +25,13 @@ vi.mock("vscode", () => ({
 	ViewColumn: { One: 1 },
 }));
 
-import { buildGraphHtml, KnowledgeGraphPanel, openKnowledgeGraph, renderGraphHtml } from "./KnowledgeGraphPanel.js";
+import {
+	buildGraphHtml,
+	KnowledgeGraphPanel,
+	openKnowledgeGraph,
+	readGraphWikiBody,
+	renderGraphHtml,
+} from "./KnowledgeGraphPanel.js";
 
 const TEMPLATE = `<!doctype html><html><head>
   <meta charset="utf-8" />
@@ -62,19 +68,29 @@ beforeEach(() => {
 	showInformationMessage.mockReset();
 	showErrorMessage.mockReset();
 	disposeCbs = [];
-	createWebviewPanel.mockImplementation((_viewType: string, title: string) => ({
-		webview: {
+	createWebviewPanel.mockImplementation((_viewType: string, title: string) => {
+		// biome-ignore lint/suspicious/noExplicitAny: loose webview mock, cast at call sites
+		const webview: any = {
 			asWebviewUri: (u: { toString: () => string }) => ({ toString: () => `vsc:${u.toString()}` }),
 			cspSource: "vscode-resource:",
 			html: "",
-		},
-		onDidDispose: (cb: () => void) => {
-			disposeCbs.push(cb);
-		},
-		reveal: vi.fn(),
-		title,
-		dispose: vi.fn(),
-	}));
+			postMessage: vi.fn(),
+			// Capture the handler so tests can drive it, and hand back a disposable.
+			onDidReceiveMessage: (cb: (m: unknown) => void) => {
+				webview._onMessage = cb;
+				return { dispose: vi.fn() };
+			},
+		};
+		return {
+			webview,
+			onDidDispose: (cb: () => void) => {
+				disposeCbs.push(cb);
+			},
+			reveal: vi.fn(),
+			title,
+			dispose: vi.fn(),
+		};
+	});
 });
 
 afterEach(() => {
@@ -146,6 +162,11 @@ describe("buildGraphHtml", () => {
 		expect(html).toContain("window.__EMBEDDED_GRAPH__ = {\"a\":1};");
 		expect(html).toContain("/assets/graph/vendor/panzoom.min.js");
 		expect(html).toContain("/assets/graph/styles/main.css");
+		// host-bridge.js MUST be loaded (defines WikiHost.requestWikiBody, the webview's
+		// on-demand body source) and BEFORE data.js. Dropping it from SCRIPT_FILES would
+		// silently break "Open full wiki page" in the webview.
+		expect(html).toContain("/assets/graph/js/host-bridge.js");
+		expect(html.indexOf("/js/host-bridge.js")).toBeLessThan(html.indexOf("/js/data.js"));
 	});
 
 	it("throws a clear error when the shipped template is missing from the build", () => {
@@ -162,37 +183,37 @@ describe("KnowledgeGraphPanel.show", () => {
 	it("opens one tab per repo, reuses a repo's tab on re-show, and recreates after dispose", () => {
 		const extensionUri = makeExtensionDir() as never;
 
-		KnowledgeGraphPanel.show(extensionUri, "repo-a", '{"a":1}');
+		KnowledgeGraphPanel.show(extensionUri, "/kb", "repo-a", '{"a":1}');
 		expect(createWebviewPanel).toHaveBeenCalledTimes(1);
 		const panelA = createWebviewPanel.mock.results[0].value;
 		expect(panelA.title).toBe("Knowledge Graph — repo-a");
 
 		// A different repo gets its own tab — it does NOT overwrite repo-a's.
-		KnowledgeGraphPanel.show(extensionUri, "repo-b", '{"b":2}');
+		KnowledgeGraphPanel.show(extensionUri, "/kb", "repo-b", '{"b":2}');
 		expect(createWebviewPanel).toHaveBeenCalledTimes(2);
 		const panelB = createWebviewPanel.mock.results[1].value;
 		expect(panelB.title).toBe("Knowledge Graph — repo-b");
 		expect(panelA.title).toBe("Knowledge Graph — repo-a"); // untouched
 
 		// Re-showing repo-a reveals its existing tab, no new panel.
-		KnowledgeGraphPanel.show(extensionUri, "repo-a", '{"a":11}');
+		KnowledgeGraphPanel.show(extensionUri, "/kb", "repo-a", '{"a":11}');
 		expect(createWebviewPanel).toHaveBeenCalledTimes(2);
 		expect(panelA.reveal).toHaveBeenCalled();
 
 		// After repo-a's tab is disposed, the next show for repo-a creates a fresh panel.
 		disposeCbs[0]();
-		KnowledgeGraphPanel.show(extensionUri, "repo-a", '{"a":111}');
+		KnowledgeGraphPanel.show(extensionUri, "/kb", "repo-a", '{"a":111}');
 		expect(createWebviewPanel).toHaveBeenCalledTimes(3);
 	});
 
 	it("ignores a late dispose for an already-recreated repo tab (stale-instance guard)", () => {
 		const extensionUri = makeExtensionDir() as never;
-		KnowledgeGraphPanel.show(extensionUri, "a", "{}"); // panel A1 (disposeCbs[0]), panels[a]=A1
+		KnowledgeGraphPanel.show(extensionUri, "/kb", "a", "{}"); // panel A1 (disposeCbs[0]), panels[a]=A1
 		disposeCbs[0](); // dispose A1 -> panels[a] cleared (panels.get(a) === this TRUE)
-		KnowledgeGraphPanel.show(extensionUri, "a", "{}"); // panel A2 (disposeCbs[1]), panels[a]=A2
+		KnowledgeGraphPanel.show(extensionUri, "/kb", "a", "{}"); // panel A2 (disposeCbs[1]), panels[a]=A2
 		expect(createWebviewPanel).toHaveBeenCalledTimes(2);
 		disposeCbs[0](); // A1's dispose fires again -> panels.get(a)(A2) !== A1 -> no-op (FALSE branch)
-		KnowledgeGraphPanel.show(extensionUri, "a", "{}"); // A2 still live -> reused, no 3rd panel
+		KnowledgeGraphPanel.show(extensionUri, "/kb", "a", "{}"); // A2 still live -> reused, no 3rd panel
 		expect(createWebviewPanel).toHaveBeenCalledTimes(2);
 	});
 });
@@ -255,5 +276,95 @@ describe("openKnowledgeGraph", () => {
 		}
 		expect(showErrorMessage).toHaveBeenCalledTimes(1);
 		expect(showErrorMessage.mock.calls[0][0]).toContain("raw-string-failure");
+	});
+});
+
+describe("readGraphWikiBody", () => {
+	it("reads a valid slug's page and rejects missing / malformed / traversal slugs", () => {
+		const kbParent = mkdtempSync(join(tmpdir(), "kg-rb-"));
+		tmpDirs.push(kbParent);
+		mkdirSync(join(kbParent, "repo-a", "_wiki"), { recursive: true });
+		writeFileSync(join(kbParent, "repo-a", "_wiki", "topic--auth.md"), "BODY", "utf8");
+		expect(readGraphWikiBody(kbParent, "repo-a", "auth")).toBe("BODY");
+		expect(readGraphWikiBody(kbParent, "repo-a", "missing")).toBeUndefined();
+		expect(readGraphWikiBody(kbParent, "repo-a", "../secret")).toBeUndefined();
+		expect(readGraphWikiBody(kbParent, "repo-a", "Bad_Slug")).toBeUndefined();
+	});
+});
+
+describe("KnowledgeGraphPanel — wiki body request handler", () => {
+	it("serves _wiki/topic--<slug>.md over postMessage, error-answers a miss, ignores junk", () => {
+		const extensionUri = makeExtensionDir() as never;
+		const kbParent = mkdtempSync(join(tmpdir(), "kg-msg-"));
+		tmpDirs.push(kbParent);
+		mkdirSync(join(kbParent, "repo-a", "_wiki"), { recursive: true });
+		writeFileSync(join(kbParent, "repo-a", "_wiki", "topic--auth.md"), "# Auth\n\nbody", "utf8");
+
+		KnowledgeGraphPanel.show(extensionUri, kbParent, "repo-a", "{}");
+		const panel = createWebviewPanel.mock.results[0].value;
+		const onMessage = panel.webview._onMessage as (m: unknown) => void;
+		const post = panel.webview.postMessage as ReturnType<typeof vi.fn>;
+
+		// A hit → the body is posted back, keyed by the request id.
+		onMessage({ type: "jolli-graph-wiki-request", requestId: "r1", slug: "auth" });
+		expect(post).toHaveBeenLastCalledWith({
+			type: "jolli-graph-wiki-body",
+			requestId: "r1",
+			slug: "auth",
+			markdown: "# Auth\n\nbody",
+		});
+
+		// A missing topic → error, never a body.
+		onMessage({ type: "jolli-graph-wiki-request", requestId: "r2", slug: "missing" });
+		expect(post).toHaveBeenLastCalledWith({
+			type: "jolli-graph-wiki-body",
+			requestId: "r2",
+			slug: "missing",
+			error: "not-found",
+		});
+
+		// A traversal slug is blocked before it reaches disk → error.
+		onMessage({ type: "jolli-graph-wiki-request", requestId: "r3", slug: "../secret" });
+		expect(post).toHaveBeenLastCalledWith({
+			type: "jolli-graph-wiki-body",
+			requestId: "r3",
+			slug: "../secret",
+			error: "not-found",
+		});
+
+		// Unrelated / malformed messages are ignored (no extra posts).
+		const before = post.mock.calls.length;
+		onMessage({ type: "jolli-graph-other" });
+		onMessage({ type: "jolli-graph-wiki-request", requestId: "r4" }); // no slug
+		onMessage(null);
+		expect(post.mock.calls.length).toBe(before);
+	});
+
+	it("re-reads _wiki from the NEW kbParent after the folder is re-targeted on re-show", () => {
+		const extensionUri = makeExtensionDir() as never;
+		const kb1 = mkdtempSync(join(tmpdir(), "kg-kb1-"));
+		const kb2 = mkdtempSync(join(tmpdir(), "kg-kb2-"));
+		tmpDirs.push(kb1, kb2);
+		mkdirSync(join(kb1, "repo-a", "_wiki"), { recursive: true });
+		mkdirSync(join(kb2, "repo-a", "_wiki"), { recursive: true });
+		writeFileSync(join(kb1, "repo-a", "_wiki", "topic--auth.md"), "OLD FOLDER BODY", "utf8");
+		writeFileSync(join(kb2, "repo-a", "_wiki", "topic--auth.md"), "NEW FOLDER BODY", "utf8");
+
+		KnowledgeGraphPanel.show(extensionUri, kb1, "repo-a", "{}");
+		// Re-show the SAME repo after the Memory Bank folder was re-targeted (kb1 → kb2).
+		KnowledgeGraphPanel.show(extensionUri, kb2, "repo-a", "{}");
+		expect(createWebviewPanel).toHaveBeenCalledTimes(1); // same panel reused
+		const panel = createWebviewPanel.mock.results[0].value;
+		const onMessage = panel.webview._onMessage as (m: unknown) => void;
+		const post = panel.webview.postMessage as ReturnType<typeof vi.fn>;
+
+		onMessage({ type: "jolli-graph-wiki-request", requestId: "r1", slug: "auth" });
+		// Must serve from kb2 (the re-targeted folder), not the stale kb1.
+		expect(post).toHaveBeenLastCalledWith({
+			type: "jolli-graph-wiki-body",
+			requestId: "r1",
+			slug: "auth",
+			markdown: "NEW FOLDER BODY",
+		});
 	});
 });

--- a/vscode/src/views/KnowledgeGraphPanel.ts
+++ b/vscode/src/views/KnowledgeGraphPanel.ts
@@ -22,7 +22,39 @@ import * as vscode from "vscode";
 import { escapeForInlineScript } from "../../../cli/src/core/InlineScript.js";
 
 const VENDOR_FILES = ["panzoom.min.js", "elk.bundled.js", "marked.min.js"];
-const SCRIPT_FILES = ["data.js", "state.js", "edges.js", "camera.js", "drag.js", "views.js", "panel.js", "main.js"];
+// host-bridge.js first (as in the template) so `window.WikiHost` exists before
+// data.js runs. In the webview it provides `requestWikiBody`, which fetches a
+// topic's `_wiki/topic--<slug>.md` from the extension host over `acquireVsCodeApi`
+// (the body is NOT inlined into graph.json — schema v5). The requestGraph
+// handshake stays inert here because `window.__EMBEDDED_GRAPH__` short-circuits it.
+const SCRIPT_FILES = [
+	"host-bridge.js",
+	"data.js",
+	"state.js",
+	"edges.js",
+	"camera.js",
+	"drag.js",
+	"views.js",
+	"panel.js",
+	"main.js",
+];
+
+/** A topic wiki slug is the lowercase-hyphen `stableSlug`; the shape also blocks traversal. */
+const WIKI_SLUG_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+/**
+ * Read one topic's wiki page from `<kbParent>/<repoName>/_wiki/topic--<slug>.md`.
+ * The slug shape is validated first, so a malicious `slug` cannot escape `_wiki/`.
+ * Returns undefined when the slug is malformed or the file is missing/unreadable.
+ */
+export function readGraphWikiBody(kbParent: string, repoName: string, slug: string): string | undefined {
+	if (!WIKI_SLUG_RE.test(slug)) return undefined;
+	try {
+		return readFileSync(join(kbParent, repoName, "_wiki", `topic--${slug}.md`), "utf8");
+	} catch {
+		return undefined;
+	}
+}
 
 /** Resolved asset URIs + nonce for one render. */
 export interface GraphHtmlAssets {
@@ -105,20 +137,26 @@ export class KnowledgeGraphPanel {
 	 */
 	private static panels: Map<string, KnowledgeGraphPanel> = new Map();
 	private readonly panel: vscode.WebviewPanel;
+	private readonly repoName: string;
+	/** Memory Bank parent dir; mutable because the folder can be re-targeted between opens. */
+	private kbParent: string;
 	private disposed = false;
 
 	/** Opens (or re-uses) the graph panel for `repoName`, rendering `graphJson`. */
-	static show(extensionUri: vscode.Uri, repoName: string, graphJson: string): void {
+	static show(extensionUri: vscode.Uri, kbParent: string, repoName: string, graphJson: string): void {
 		const existing = KnowledgeGraphPanel.panels.get(repoName);
 		if (existing && !existing.disposed) {
+			existing.kbParent = kbParent; // the Memory Bank folder may have been re-targeted
 			existing.panel.webview.html = buildGraphHtml(existing.panel.webview, extensionUri, graphJson);
 			existing.panel.reveal(vscode.ViewColumn.One);
 			return;
 		}
-		KnowledgeGraphPanel.panels.set(repoName, new KnowledgeGraphPanel(extensionUri, repoName, graphJson));
+		KnowledgeGraphPanel.panels.set(repoName, new KnowledgeGraphPanel(extensionUri, kbParent, repoName, graphJson));
 	}
 
-	private constructor(extensionUri: vscode.Uri, repoName: string, graphJson: string) {
+	private constructor(extensionUri: vscode.Uri, kbParent: string, repoName: string, graphJson: string) {
+		this.kbParent = kbParent;
+		this.repoName = repoName;
 		this.panel = vscode.window.createWebviewPanel(
 			"jollimemory.knowledgeGraph",
 			`Knowledge Graph — ${repoName}`,
@@ -130,10 +168,29 @@ export class KnowledgeGraphPanel {
 			},
 		);
 		this.panel.webview.html = buildGraphHtml(this.panel.webview, extensionUri, graphJson);
+		// The viz fetches a topic's wiki body on demand (schema v5 — not inlined).
+		// host-bridge.js posts a `jolli-graph-wiki-request`; read the file from disk
+		// (only the host can) and post the body back keyed by requestId.
+		const sub = this.panel.webview.onDidReceiveMessage((msg: unknown) => this.onMessage(msg));
 		this.panel.onDidDispose(() => {
 			this.disposed = true;
+			sub.dispose();
 			if (KnowledgeGraphPanel.panels.get(repoName) === this) KnowledgeGraphPanel.panels.delete(repoName);
 		});
+	}
+
+	private onMessage(msg: unknown): void {
+		if (!msg || typeof msg !== "object") return;
+		const m = msg as { type?: unknown; requestId?: unknown; slug?: unknown };
+		if (m.type !== "jolli-graph-wiki-request" || typeof m.requestId !== "string" || typeof m.slug !== "string") {
+			return;
+		}
+		const markdown = readGraphWikiBody(this.kbParent, this.repoName, m.slug);
+		void this.panel.webview.postMessage(
+			markdown === undefined
+				? { type: "jolli-graph-wiki-body", requestId: m.requestId, slug: m.slug, error: "not-found" }
+				: { type: "jolli-graph-wiki-body", requestId: m.requestId, slug: m.slug, markdown },
+		);
 	}
 }
 
@@ -157,7 +214,7 @@ export async function openKnowledgeGraph(
 		return;
 	}
 	try {
-		KnowledgeGraphPanel.show(extensionUri, repoName, readFileSync(graphPath, "utf8"));
+		KnowledgeGraphPanel.show(extensionUri, kbParent, repoName, readFileSync(graphPath, "utf8"));
 	} catch (err) {
 		await vscode.window.showErrorMessage(
 			`Could not open the knowledge graph: ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Quick recap

This batch of commits removed wiki body inlining from the knowledge graph schema and implemented on-demand fetching across all four consumption surfaces (standalone export, dashboard, VS Code, and web frontend). The graph.json file is now significantly leaner because it no longer carries the full markdown text of every topic; instead, the viz fetches `_wiki/topic--<slug>.md` files when the user opens a full wiki page. Each surface implements its own fetch mechanism: the standalone export re-inlines bodies at build time for offline use, the dashboard relays requests through a parent-page route, VS Code reads from the extension's file system, and the web frontend calls a new backend endpoint. A security issue in the dashboard's message relay was fixed by adding source verification, and comprehensive test coverage was added for the new wiki-body request paths across all three web-based surfaces.

---

## Topics (3)
<details>
<summary><strong>01 · Remove wiki body inlining from graph schema and implement on-demand fetching across four surfaces</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The knowledge graph was embedding the full markdown body of every topic directly into graph.json, making the file unnecessarily large and causing churn during sync. Users needed a way to view full wiki pages without carrying all that text in memory or over the network.

**💡 Decisions Behind the Code**

- **Design 2 (viz never reads fullBody)**: The viz was changed to ignore `fullBody` entirely and always fetch from `_wiki` on demand. This ensures content is consistent across all surfaces and allows graph.json to be genuinely lean. The trade-off is that a topic whose `_wiki` file is missing will show a placeholder instead of falling back to an inlined body, but this is acceptable because `_wiki` files are already being written and synced as part of the normal compile process.
- **Dual transport for wiki requests**: The host-bridge needed to work in three different execution contexts (VS Code webview with `acquireVsCodeApi`, framed hosts with `window.parent.postMessage`, and standalone exports with inlined data). Rather than duplicating the request/response logic, a single `requestWikiBody` method detects the environment at call time and picks the right transport. This keeps the viz code simple and lets each surface implement its own fetch mechanism independently.
- **Re-inline for standalone export**: The standalone HTML export re-reads `_wiki` files at build time and injects them as `window.__EMBEDDED_WIKI__` so the exported file can open offline without any fetch. This preserves the self-contained property of the export while keeping graph.json itself lean. The export gracefully skips missing or unreadable files rather than failing the entire build.

**✅ What Was Implemented**

- **Schema and generation**: Removed the `fullBody` field from `GraphTopic` in GraphSchema.ts, bumped `GRAPH_SCHEMA_VERSION` from 4 to 5, and updated GraphBuilder.ts to stop populating it. The `wikiFile` field (which names the corresponding `_wiki/topic--<slug>.md` file) is now the sole reference to the body.
- **Viz layer**: Modified panel.js to gate the "Open full wiki page" button on `wikiFile` instead of `fullBody`, and made `renderWiki` async so it fetches the body on demand via a new `wikiBody(slug)` resolver in data.js. Added link neutralization to strip relative links that don't resolve inside the panel. Extended host-bridge.js with a `requestWikiBody(slug)` method that uses dual transports: `acquireVsCodeApi` for VS Code webviews and `window.parent.postMessage` for framed hosts.
- **Per-surface implementation**: Dashboard gained a `/graph-wiki` route that reads `_wiki/topic--<slug>.md` from disk and returns raw markdown; graph.js relays wiki requests from the sandboxed iframe to this route. VSCode's KnowledgeGraphPanel added an `onDidReceiveMessage` handler to serve wiki bodies from the extension's file system. The standalone export re-inlines wiki bodies into a `window.__EMBEDDED_WIKI__` map at build time so the exported file remains self-contained.
- **Sync allowlist**: Added an explicit `wiki` kind to OwnedPathKind.ts and VaultPathClassifier.ts so `_wiki/topic--<slug>.md` files are synced with deliberate protection rather than relying on a generic fallback rule.

**📁 FILES**
- `cli/src/graph/GraphSchema.ts`
- `cli/src/graph/GraphBuilder.ts`
- `cli/src/graph/GraphExport.ts`
- `cli/src/graph/assets/js/data.js`
- `cli/src/graph/assets/js/host-bridge.js`

</blockquote>
</details>
<details>
<summary><strong>02 · Implement wiki body endpoint and request handler in E:\jolli web frontend</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The web frontend (E:\jolli) is deployed independently from the CLI and needs its own way to serve wiki bodies on demand. The backend must provide a route to fetch individual topic pages from the vault mirror, and the frontend pane must handle the request/response flow.

**💡 Decisions Behind the Code**

- **Reply to event.source, not current iframe**: When the user switches repos, the old iframe is unmounted and a new one is mounted with a reset request-ID counter. If responses were posted to the current iframe, a stale response from the old repo could match the new iframe's request ID and render the wrong content. By replying to the exact window that made the request, stale responses harmlessly target the now-detached requester and never leak into a different repo's view.
- **Re-vendor viz assets from jollimemory**: Rather than duplicating the viz code, the E:\jolli frontend pulls the built assets (data.js, host-bridge.js, panel.js, etc.) from jollimemory's build output. This ensures the two repos stay in sync and avoids maintaining two copies of the same logic. The README.md in the vendored directory is preserved to document the postMessage protocol.

**✅ What Was Implemented**

- **Backend route**: Added `GET /:id/graph/wiki?repo=<repoPath>&slug=<slug>` to KnowledgeGraphRouter.ts. The route reuses existing vault-space resolution and adds `sanitizeSlug` to validate the slug shape before constructing the file path, preventing traversal attacks. It returns raw markdown with `text/markdown; charset=utf-8` and `Cache-Control: no-store` headers.
- **Common client**: Extended SpaceClient.ts with `getRepoWikiPage(spaceId, repo, slug)` that calls the new backend route and returns the markdown string.
- **Frontend pane**: Modified KnowledgeGraphPane.tsx to capture `event.source` when handling `jolli-graph-wiki-request` messages and post the response directly to that source (not to the current iframe). This prevents stale responses from a previous repo from being delivered to a newly-mounted iframe after a repo switch. The pane also threads `kbParent` through the panel lifecycle so it can be re-targeted when the Memory Bank folder changes.

**📁 FILES**
- `backend/src/router/KnowledgeGraphRouter.ts`
- `common/src/core/SpaceClient.ts`
- `frontend/src/ui/spaces/KnowledgeGraphPane.tsx`
- `frontend/public/graph/README.md`

</blockquote>
</details>
<details>
<summary><strong>03 · Fix security issue in dashboard graph relay and add test coverage for wiki body requests</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The dashboard's message relay from the sandboxed graph iframe was accepting messages from any source without verifying they came from the actual graph frame, allowing a hostile page to drive the relay and exfiltrate wiki content cross-origin.

**💡 Decisions Behind the Code**

The source check was placed at the entry point of the handler so it gates both the repo-switch message and the new wiki-request message uniformly. This is simpler and more maintainable than adding the check inside each branch. The check re-queries the frame element live so it still matches after an in-frame navigation (e.g., when the user switches repos within the graph).

**✅ What Was Implemented**

- **Security fix in graph.js**: Added an `ev.source === frame.contentWindow` check at the top of the message handler so both `jolli-graph-repo` and `jolli-graph-wiki-request` messages are only trusted when they originate from the real graph iframe. A hostile page that opens the dashboard via `window.open` can no longer drive the relay to fetch and return wiki content.
- **Test coverage**: Added comprehensive tests for the `/graph-wiki` route (valid/invalid slugs, missing repos, traversal attempts), the `SpaceClient.getRepoWikiPage` method, the VSCode `readGraphWikiBody` function, and the KnowledgeGraphPane message handler (including the re-target-on-re-show scenario).

**📁 FILES**
- `cli/src/dashboard/assets/js/graph.js`
- `cli/src/dashboard/DashboardServer.test.ts`
- `vscode/src/views/KnowledgeGraphPanel.test.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 19, 2026 at 8:16 PM · via Anthropic*
<!-- jollimemory-summary-end -->