### PR TITLE
Drop zero-turn conversations uniformly from archives

### DIFF
--- a/cli/src/core/ArchivedConversations.test.ts
+++ b/cli/src/core/ArchivedConversations.test.ts
@@ -109,11 +109,15 @@ describe("groupArchivedSessions", () => {
 		expect(result.grouped.has("claude:s1")).toBe(false);
 	});
 
-	it("keeps a real empty conversation (empty entries, no usage)", () => {
+	it("drops an overlay-emptied shell (empty entries, no usage)", () => {
+		// A "Mark All as Deleted" overlay empties a session's entries after it was
+		// read, leaving a zero-turn shell with no usage. It would render as a
+		// `0 msgs` noise row, so the display rule hides it uniformly alongside the
+		// usage-only carrier above.
 		const empty = session({ sessionId: "s1", source: "claude", entries: [] });
 		const result = groupArchivedSessions([["c1", transcript([empty])]]);
-		expect(result.order).toEqual(["claude:s1"]);
-		expect(result.grouped.get("claude:s1")?.entries).toEqual([]);
+		expect(result.order).toEqual([]);
+		expect(result.grouped.has("claude:s1")).toBe(false);
 	});
 
 	it("shows a conversation entry-less in one commit but real in another, even with usage", () => {
@@ -136,12 +140,13 @@ describe("groupArchivedSessions", () => {
 		expect(result.grouped.get("claude:s1")?.entries.map((e) => e.content)).toEqual(["real"]);
 	});
 
-	it("treats an absent entries field as an empty slice", () => {
+	it("treats an absent entries field as an empty slice and drops it", () => {
 		// Legacy/malformed stored session with `entries` omitted (cast around the
-		// required field to mimic on-disk data the reader tolerates).
+		// required field to mimic on-disk data the reader tolerates). It coalesces to
+		// an empty slice, so it is a zero-turn conversation and hidden like any other.
 		const legacy = { sessionId: "s1", source: "claude" } as unknown as StoredSession;
 		const result = groupArchivedSessions([["c1", transcript([legacy])]]);
-		// No usage recorded, so it stays as a real (empty) conversation.
-		expect(result.grouped.get("claude:s1")?.entries).toEqual([]);
+		expect(result.order).toEqual([]);
+		expect(result.grouped.has("claude:s1")).toBe(false);
 	});
 });

--- a/cli/src/core/ArchivedConversations.ts
+++ b/cli/src/core/ArchivedConversations.ts
@@ -105,22 +105,20 @@ export function groupArchivedSessions(
 			return ta - tb;
 		});
 		const entries = sorted.flat();
-		// Hide a usage-only conversation: it exists on disk only so `detach` has a
-		// per-session subtrahend (the queue worker persists a zero-entry carrier for
-		// a conversation that spent tokens without producing a readable turn), so a
-		// row for it would render as an empty conversation.
-		//
-		// The `usage` half of the predicate is load-bearing. "No entries at all" is a
-		// DIFFERENT case: a legacy/malformed stored session can omit `entries`
-		// entirely, and those are real conversations this deliberately still lists
-		// (turn count 0). Only a carrier is identifiable by empty-entries AND a
-		// recorded `usage`.
+		// Hide every zero-turn conversation, uniformly. Two disk shapes produce one:
+		// a usage-only carrier (empty entries + recorded usage) the queue worker
+		// persists so `detach` has a per-session subtrahend, and an overlay-emptied
+		// shell (empty entries + no usage) a "Mark All as Deleted" edit left behind
+		// on memories written before the storage-layer drop (buildStoredTranscript)
+		// existed. Neither has a readable turn, so a row for either would render as
+		// an empty `0 msgs` conversation — noise the user asked us to suppress. This
+		// also cleans up already-generated memories with no data migration.
 		//
 		// Filtered on the MERGED entries, not per slice: a conversation split across
 		// commits can legitimately be entry-less in one transcript and real in
 		// another, and that one must still show. Detach reads `transcript.sessions`
 		// directly and is deliberately NOT filtered — the record stays subtractable.
-		if (entries.length === 0 && g.session.usage !== undefined) continue;
+		if (entries.length === 0) continue;
 		grouped.set(key, { session: g.session, hash: g.hash, entries });
 	}
 	// Keep `order` in sync with `grouped` so callers can zip the two without

--- a/cli/src/core/RegenerateContext.test.ts
+++ b/cli/src/core/RegenerateContext.test.ts
@@ -94,8 +94,8 @@ describe("loadRegenerateContext", () => {
 		vi.mocked(SummaryStore.readTranscriptsForCommits).mockResolvedValue(
 			singleHashMap(baseSummary.commitHash, {
 				sessions: [
-					{ sessionId: "a", source: "claude", entries: [] },
-					{ sessionId: "b", source: "claude", entries: [] },
+					{ sessionId: "a", source: "claude", entries: [{ role: "human", content: "hi" }] },
+					{ sessionId: "b", source: "claude", entries: [{ role: "human", content: "yo" }] },
 				],
 			}),
 		);
@@ -103,24 +103,26 @@ describe("loadRegenerateContext", () => {
 		expect(ctx.sources).toEqual(["Claude"]);
 	});
 
-	it("excludes a usage-only carrier from sessionCount but keeps an entries-less legacy session", async () => {
-		// A carrier is a zero-entry session that carries `usage` — stored only so a
-		// later detach has a token subtrahend, and hidden from every Conversations
-		// surface. Counting it would make the confirm dialog promise a conversation the
-		// user cannot see, and it contributes nothing to the regenerate prompt anyway.
-		// A session that merely omits/empties `entries` WITHOUT `usage` is legacy data
-		// and must keep counting.
+	it("excludes every zero-turn conversation from sessionCount, matching the Conversations list", async () => {
+		// The count must agree with `groupArchivedSessions`, which drops EVERY
+		// zero-turn conversation uniformly — both the usage-only carrier (stored so a
+		// later detach has a token subtrahend) and the overlay-emptied shell (a
+		// "Mark All as Deleted" edit left an entry-less, usage-less session behind).
+		// Counting either would make the confirm dialog promise a conversation the
+		// user cannot see. Only the one session with a readable turn survives.
 		vi.mocked(SummaryStore.readTranscriptsForCommits).mockResolvedValue(
 			singleHashMap(baseSummary.commitHash, {
 				sessions: [
 					{ sessionId: "carrier", source: "claude", entries: [], usage: { input: 6, output: 3, cached: 0 } },
-					{ sessionId: "legacy", source: "claude", entries: [] },
+					{ sessionId: "shell", source: "claude", entries: [] },
+					{ sessionId: "real", source: "claude", entries: [{ role: "human", content: "hi" }] },
 				],
 			}),
 		);
 
 		const ctx = await loadRegenerateContext(baseSummary, "/repo");
 		expect(ctx.sessionCount).toBe(1);
+		expect(ctx.entryCount).toBe(1);
 	});
 
 	it("defaults missing session.source to 'claude' for sessionId dedup keys", async () => {
@@ -131,8 +133,8 @@ describe("loadRegenerateContext", () => {
 		vi.mocked(SummaryStore.readTranscriptsForCommits).mockResolvedValue(
 			singleHashMap(baseSummary.commitHash, {
 				sessions: [
-					{ sessionId: "dup", entries: [] },
-					{ sessionId: "dup", entries: [] },
+					{ sessionId: "dup", entries: [{ role: "human", content: "h1" }] },
+					{ sessionId: "dup", entries: [{ role: "assistant", content: "a1" }] },
 				],
 			}),
 		);

--- a/cli/src/core/RegenerateContext.ts
+++ b/cli/src/core/RegenerateContext.ts
@@ -1,4 +1,5 @@
 import type { CommitSummary, SourceId } from "../Types.js";
+import { groupArchivedSessions } from "./ArchivedConversations.js";
 import type { StorageProvider } from "./StorageProvider.js";
 import { normalizeToV4, readTranscriptsForCommits } from "./SummaryStore.js";
 import { getTranscriptIds } from "./SummaryTree.js";
@@ -58,28 +59,26 @@ export async function loadRegenerateContext(
 	// entries even when the user can see them in the All Conversations card.
 	const transcriptMap = await readTranscriptsForCommits(transcriptIds, cwd, storage);
 
+	// Collapse the transcript files into the SAME conversation rows the user sees
+	// in the All Conversations card by reusing `groupArchivedSessions` — one row
+	// per `source:sessionId`, slices merged across an amend/squash chain, and
+	// every zero-turn conversation dropped uniformly (usage-only carriers AND
+	// overlay-emptied shells alike). Deriving the counts from that shared rule is
+	// what keeps this confirm dialog from promising a conversation the list does
+	// not render; a private re-implementation of the merge is exactly what drifted
+	// before. entryCount/humanTurns are unaffected by the drop — a zero-turn
+	// conversation contributes no entries either way.
+	const { order, grouped } = groupArchivedSessions(transcriptMap);
 	let entryCount = 0;
 	let humanTurns = 0;
-	const seenSessions = new Set<string>();
 	const sourceSet = new Set<string>();
-	for (const stored of transcriptMap.values()) {
-		for (const session of stored.sessions) {
-			entryCount += session.entries.length;
-			for (const entry of session.entries) {
-				if (entry.role === "human") humanTurns++;
-			}
-			// Skip a usage-only carrier: the queue worker stores a zero-entry session
-			// carrying `usage` purely so `detach` has a token subtrahend, and the
-			// Conversations surfaces hide it. Counting it here would make the confirm
-			// dialog promise a conversation the user cannot see (and which contributes
-			// nothing to the regenerate prompt — buildMultiSessionContext emits no block
-			// for an entry-less session). A session that merely omits `entries` is legacy
-			// data, not a carrier, and still counts — hence the `usage` half.
-			if (session.entries.length === 0 && session.usage !== undefined) continue;
-			const sourceKey = session.source ?? "claude";
-			seenSessions.add(`${sourceKey}:${session.sessionId}`);
-			sourceSet.add(transcriptSourceLabel(session.source));
+	for (const key of order) {
+		const { session, entries } = grouped.get(key) as NonNullable<ReturnType<typeof grouped.get>>;
+		entryCount += entries.length;
+		for (const entry of entries) {
+			if (entry.role === "human") humanTurns++;
 		}
+		sourceSet.add(transcriptSourceLabel(session.source));
 	}
 
 	// Bucket references by source in one pass instead of N filter() scans.
@@ -90,7 +89,7 @@ export async function loadRegenerateContext(
 
 	return {
 		entryCount,
-		sessionCount: seenSessions.size,
+		sessionCount: order.length,
 		sources: Array.from(sourceSet),
 		humanTurns,
 		plansCount: normalized.plans?.length ?? 0,

--- a/cli/src/dashboard/MemoriesQuery.test.ts
+++ b/cli/src/dashboard/MemoriesQuery.test.ts
@@ -1085,7 +1085,7 @@ describe("MemoriesQuery", () => {
 			]);
 		});
 
-		it("drops a usage-only carrier session, the way the editor's conversation list does", async () => {
+		it("drops every zero-turn session — usage-only carrier and overlay-emptied shell alike", async () => {
 			await seedRepo(dbPath, "repo-1", "acme-api");
 			const hash = "a".repeat(40);
 			await seedMemory(dbPath, "repo-1", hash, "feat: x");
@@ -1106,7 +1106,8 @@ describe("MemoriesQuery", () => {
 										entries: [],
 										usage: { input: 1, output: 2, cached: 0 },
 									},
-									// Entry-less WITHOUT usage is legacy data and stays visible.
+									// Entry-less WITHOUT usage is an overlay-emptied shell ("Mark All
+									// as Deleted") — a zero-turn `0 msgs` noise row, now hidden too.
 									{ sessionId: "legacy", source: "claude", entries: [] },
 								],
 							}),
@@ -1123,9 +1124,7 @@ describe("MemoriesQuery", () => {
 			);
 
 			const detail = await withDashboardDb((db) => buildMemoryDetail(db, ALL, hash), { dbPath });
-			expect(detail?.conversations).toEqual([
-				{ source: "claude", title: "(untitled session)", messageCount: 0, sessionId: "legacy" },
-			]);
+			expect(detail?.conversations).toEqual([]);
 		});
 	});
 
@@ -1409,7 +1408,18 @@ describe("MemoriesQuery", () => {
 						id: number;
 					};
 					const blob = deflateSync(
-						Buffer.from(JSON.stringify({ sessions: [{ sessionId: "sess-old", entries: [] }] })),
+						// One real turn so the session survives the zero-turn drop; the
+						// point of the test is the source-less → "claude" key resolution.
+						Buffer.from(
+							JSON.stringify({
+								sessions: [
+									{
+										sessionId: "sess-old",
+										entries: [{ role: "human", content: "hi", timestamp: "2026-08-19T10:00:00Z" }],
+									},
+								],
+							}),
+						),
 					);
 					db.prepare("UPDATE transcripts SET sessions_blob = ? WHERE repo_id = ?").run(blob, repoId);
 				},

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -2824,8 +2824,16 @@ describe("QueueWorker", () => {
 		it("omits title rather than storing a sentinel when no title can be resolved", async () => {
 			// Absence is what lets a reader fall back; a stored "(untitled session)"
 			// would be indistinguishable from a real title and pin the wrong answer.
+			// A carrier (usage>0, no live file, no archived entries) has no resolvable
+			// title and survives the shell drop, so it exercises the omission path.
 			const stored = await __test__.buildStoredTranscript([
-				{ sessionId: "s1", transcriptPath: "/gone/s1.jsonl", source: "claude", entries: [] },
+				{
+					sessionId: "s1",
+					transcriptPath: "/gone/s1.jsonl",
+					source: "claude",
+					entries: [],
+					usage: { input: 10, output: 5, cached: 0 },
+				},
 			]);
 
 			expect(stored.sessions[0]).not.toHaveProperty("title");
@@ -2838,6 +2846,9 @@ describe("QueueWorker", () => {
 					transcriptPath: "/claude/legacy.jsonl",
 					// source intentionally omitted — pre-multi-source data shape
 					entries: [],
+					// usage>0 keeps this carrier alive past the shell drop; the test is
+					// about source preservation on serialize, not the drop.
+					usage: { input: 10, output: 5, cached: 0 },
 				},
 			]);
 
@@ -2873,12 +2884,14 @@ describe("QueueWorker", () => {
 			// A stored zero would read as "this session used nothing", which detach would
 			// treat as a valid no-op subtraction; absent means "cannot attribute" and
 			// leaves the memory's totals alone. Sources with no usage must land on absent.
+			// Entries are present so the all-zero usage does not read as a droppable
+			// shell — the point here is the usage-field gate, not the shell drop.
 			const stored = await __test__.buildStoredTranscript([
 				{
 					sessionId: "s1",
 					transcriptPath: "/gemini/s1.json",
 					source: "gemini",
-					entries: [],
+					entries: [{ role: "human", content: "hi", timestamp: "2026-08-19T10:00:00Z" }],
 					usage: { input: 0, output: 0, cached: 0 },
 					usageByModel: [],
 				},
@@ -2895,6 +2908,10 @@ describe("QueueWorker", () => {
 					transcriptPath: "/claude/s1.jsonl",
 					source: "claude",
 					entries: [],
+					// A carrier (usage>0) — toolUse rides the same usage gate as its
+					// usage in production, so an entry-less toolUse session always has
+					// usage. usage>0 also keeps it past the shell drop.
+					usage: { input: 10, output: 5, cached: 0 },
 					toolUse: [
 						{ name: "Bash", kind: "builtin", calls: 3 },
 						{ name: "jollimemory.recall", kind: "mcp", server: "jollimemory", calls: 1 },
@@ -2915,7 +2932,16 @@ describe("QueueWorker", () => {
 			// `[]` replaces stored rows, absent leaves them alone. Length-gating this
 			// the way `usageByModel` is gated would collapse them.
 			const stored = await __test__.buildStoredTranscript([
-				{ sessionId: "s1", transcriptPath: "/claude/s1.jsonl", source: "claude", entries: [], toolUse: [] },
+				{
+					sessionId: "s1",
+					transcriptPath: "/claude/s1.jsonl",
+					source: "claude",
+					entries: [],
+					// usage>0 keeps this carrier past the shell drop; the assertion is
+					// about the empty-vs-absent toolUse distinction.
+					usage: { input: 10, output: 5, cached: 0 },
+					toolUse: [],
+				},
 			]);
 
 			expect(stored.sessions[0].toolUse).toEqual([]);
@@ -2923,10 +2949,53 @@ describe("QueueWorker", () => {
 
 		it("omits toolUse for a source whose parser cannot report tool calls", async () => {
 			const stored = await __test__.buildStoredTranscript([
-				{ sessionId: "s1", transcriptPath: "/gemini/s1.json", source: "gemini", entries: [] },
+				{
+					sessionId: "s1",
+					transcriptPath: "/gemini/s1.json",
+					source: "gemini",
+					entries: [],
+					// A carrier (usage>0) so it survives the shell drop; the point of the
+					// test — that gemini reports no toolUse — is unchanged.
+					usage: { input: 10, output: 5, cached: 0 },
+				},
 			]);
 
 			expect(stored.sessions[0]).not.toHaveProperty("toolUse");
+		});
+
+		it("drops overlay-emptied shells (no entries and no usage) but keeps real sessions and usage-only carriers", async () => {
+			// Repro for the "Mark All as Deleted" bug: a delete-all overlay empties a
+			// session's entries AFTER it was read with real content, so it reaches here
+			// with entries:[] and no usage — a shell whose only effect is a `0 msgs`
+			// noise row in the CONVERSATIONS list. A legitimate carrier (entries:[] but
+			// usage>0, appended by appendUsageOnlyCarriers) must survive: detach reads
+			// it as a per-session subtrahend. A present-but-all-zero usage counts as no
+			// usage — the same predicate the serialize step uses to gate the field.
+			const stored = await __test__.buildStoredTranscript([
+				{
+					sessionId: "real",
+					transcriptPath: "/claude/real.jsonl",
+					source: "claude",
+					entries: [{ role: "human", content: "hi", timestamp: "2026-08-19T10:00:00Z" }],
+				},
+				{ sessionId: "shell-no-usage", transcriptPath: "/claude/a.jsonl", source: "claude", entries: [] },
+				{
+					sessionId: "shell-zero-usage",
+					transcriptPath: "/claude/b.jsonl",
+					source: "claude",
+					entries: [],
+					usage: { input: 0, output: 0, cached: 0 },
+				},
+				{
+					sessionId: "carrier",
+					transcriptPath: "/claude/carrier.jsonl",
+					source: "claude",
+					entries: [],
+					usage: { input: 10, output: 5, cached: 0 },
+				},
+			]);
+
+			expect(stored.sessions.map((s) => s.sessionId)).toEqual(["real", "carrier"]);
 		});
 	});
 

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -4675,6 +4675,26 @@ function appendUsageOnlyCarriers(
  * the later session's metadata onto the earlier one on serialize.
  */
 async function buildStoredTranscript(sessionTranscripts: ReadonlyArray<SessionTranscript>): Promise<StoredTranscript> {
+	// Drop overlay-emptied shells before anything else. A "Mark All as Deleted"
+	// overlay empties a session's entries AFTER it was read with real content, so
+	// the session slips past readAllTranscripts' read-time `entries.length > 0`
+	// gate and appendUsageOnlyCarriers' `usage > 0` gate, then applyOverlaysToSessions
+	// prunes its entries to `[]` — landing here with neither entries nor usage.
+	// attachPerSessionUsage sees `post < pre` and deliberately withholds usage
+	// (avoiding over-subtraction on detach), so nothing re-fills it. Such a session
+	// contributes nothing to the summary body, the token accounting, or detach — its
+	// only effect would be a `0 msgs` noise row in the CONVERSATIONS list. Filtering
+	// it here restores the "a stored session has entries OR usage" invariant.
+	//
+	// The predicate keeps a legitimate usage-only carrier (empty entries but
+	// usage > 0, appended by appendUsageOnlyCarriers) — detach subtracts its
+	// `StoredSession.usage`. It is the SAME `input+output+cached > 0` test the
+	// serialize step below gates the `usage` field on, so a carrier that survives
+	// here always keeps its usage on disk (and a present-but-all-zero usage is
+	// treated as no usage, exactly as it is there).
+	const kept = sessionTranscripts.filter(
+		(st) => st.entries.length > 0 || (st.usage != null && st.usage.input + st.usage.output + st.usage.cached > 0),
+	);
 	// Titles are resolved HERE rather than attached upstream like `usage` and
 	// `toolUse`, even though that is the established pattern for this array: there
 	// are two call sites (commit and amend) plus the backfill's own writer, and an
@@ -4682,9 +4702,9 @@ async function buildStoredTranscript(sessionTranscripts: ReadonlyArray<SessionTr
 	// well-formed archive. Serializing is the one thing no writer can skip. The
 	// cost is that this stops being a pure function — see `resolveArchivedTitle`
 	// for why commit time is the only moment the answer is available at all.
-	const titles = await Promise.all(sessionTranscripts.map((st) => resolveArchivedTitle(st)));
+	const titles = await Promise.all(kept.map((st) => resolveArchivedTitle(st)));
 	return {
-		sessions: sessionTranscripts.map((st, i) => ({
+		sessions: kept.map((st, i) => ({
 			sessionId: st.sessionId,
 			source: st.source,
 			transcriptPath: st.transcriptPath,

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/SummaryReader.kt
@@ -240,6 +240,15 @@ class SummaryReader(
                     val source = session.notNull("source")?.asString ?: "ai"
                     val entries = session.arrayOrNull("entries")
                     val messageCount = entries?.size() ?: 0
+                    // Drop zero-turn conversations uniformly, mirroring the CLI-owned
+                    // rule in core/ArchivedConversations.ts (`groupArchivedSessions`):
+                    // both a usage-only carrier (empty entries + recorded usage, kept on
+                    // disk so `detach` has a per-session subtrahend) and an overlay-emptied
+                    // shell (empty entries, no usage) archive with no readable turn and
+                    // would otherwise render as a `0 msgs` noise row here. VS Code and the
+                    // dashboard already suppress these; this keeps the JVM host in step
+                    // rather than re-implementing the visibility rule without the filter.
+                    if (messageCount == 0) return@mapNotNull null
                     ConversationBrief(
                         source = source,
                         title = deriveTitle(entries, source),

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/SummaryReaderConversationsTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/SummaryReaderConversationsTest.kt
@@ -66,13 +66,33 @@ class SummaryReaderConversationsTest {
             val json = """
                 {"sessions":[
                   {"sessionId":"s1","source":"claude","entries":[{"role":"human","content":"first"}]},
-                  {"sessionId":"s2","source":"cursor","entries":[]}
+                  {"sessionId":"s2","source":"cursor","entries":[{"role":"human","content":"second"}]}
                 ]}
             """.trimIndent()
             val rows = SummaryReader.parseConversations(json)
             rows.map { it.source } shouldBe listOf("claude", "cursor")
-            rows[1].messageCount shouldBe 0
-            rows[1].title shouldBe "Cursor session"
+            rows[1].messageCount shouldBe 1
+            rows[1].title shouldBe "second"
+        }
+
+        /**
+         * Zero-turn sessions are dropped uniformly, matching the CLI-owned
+         * `groupArchivedSessions` rule: a usage-only carrier or an overlay-emptied
+         * shell (both archived with `entries:[]`) has no readable turn, so it must
+         * not surface as a `0 msgs` row on the JVM host any more than it does on
+         * VS Code or the dashboard.
+         */
+        @Test
+        fun `drops zero-turn sessions but keeps their non-empty siblings`() {
+            val json = """
+                {"sessions":[
+                  {"sessionId":"s1","source":"claude","entries":[{"role":"human","content":"first"}]},
+                  {"sessionId":"s2","source":"cursor","entries":[]}
+                ]}
+            """.trimIndent()
+            val rows = SummaryReader.parseConversations(json)
+            rows.size shouldBe 1
+            rows[0].sessionId shouldBe "s1"
         }
 
         /**
@@ -100,7 +120,10 @@ class SummaryReaderConversationsTest {
 
         @Test
         fun `an explicit null source or sessionId falls back instead of dropping the row`() {
-            val json = """{"sessions":[{"sessionId":null,"source":null,"entries":[]}]}"""
+            // A real turn so the zero-turn filter keeps the row — this case is about
+            // null source/sessionId falling back, not about empty-session survival.
+            val json =
+                """{"sessions":[{"sessionId":null,"source":null,"entries":[{"role":"human","content":"hi"}]}]}"""
             val rows = SummaryReader.parseConversations(json)
             rows.size shouldBe 1
             rows[0].source shouldBe "ai"

--- a/vscode/src/views/SidebarWebviewProvider.test.ts
+++ b/vscode/src/views/SidebarWebviewProvider.test.ts
@@ -4456,12 +4456,11 @@ describe("SidebarWebviewProvider", () => {
 	});
 
 	describe("kb:expandMemory → kb:memoryEvidence", () => {
-		it("omits a usage-only carrier from the conversations evidence, keeps entries-less legacy sessions", async () => {
+		it("omits every zero-turn session from the conversations evidence (carrier and legacy shell alike)", async () => {
 			// A carrier (empty `entries` + a recorded `usage`) is stored only so `detach`
-			// has a token subtrahend; an evidence row for it would read as an empty
-			// conversation. A session that merely OMITS `entries` is legacy data, not a
-			// carrier, and must still surface with a turn count of 0 — hence the `usage`
-			// half of the predicate.
+			// has a token subtrahend; a legacy/overlay-emptied session merely OMITS
+			// `entries`. Both are zero-turn and would read as empty `0 msgs` rows, so the
+			// evidence list drops both uniformly — only a session with real turns lists.
 			const view = makeMockView();
 			const fakeSummary = {
 				version: 5,
@@ -4512,10 +4511,7 @@ describe("SidebarWebviewProvider", () => {
 			const sent = await flushUntilMessage(view, "kb:memoryEvidence");
 			const evidenceMsg = sent.find((m) => m.type === "kb:memoryEvidence");
 
-			expect(evidenceMsg.evidence.conversations.map((c: { id: string }) => c.id)).toEqual([
-				"sess-real",
-				"sess-legacy",
-			]);
+			expect(evidenceMsg.evidence.conversations.map((c: { id: string }) => c.id)).toEqual(["sess-real"]);
 		});
 
 		it("shows the title the ARCHIVE recorded, without re-deriving it from the live transcript", async () => {
@@ -4593,7 +4589,14 @@ describe("SidebarWebviewProvider", () => {
 			};
 			const fakeTranscript = {
 				sessions: [
-					{ sessionId: "sess-abc", source: "claude" as const, transcriptPath: "/tmp/claude.jsonl" },
+					{
+						sessionId: "sess-abc",
+						source: "claude" as const,
+						transcriptPath: "/tmp/claude.jsonl",
+						// One real turn so the session is not a zero-turn row the evidence
+						// list now drops — this test is about the plan/note/ref/file projection.
+						entries: [{ role: "human" as const, content: "hi" }],
+					},
 				],
 			};
 			const getSummaryByHash = vi.fn().mockResolvedValue(fakeSummary);
@@ -4627,8 +4630,7 @@ describe("SidebarWebviewProvider", () => {
 				id: "sess-abc",
 				source: "claude",
 				transcriptPath: "/tmp/claude.jsonl",
-				// No `entries` on the fake session → archived turn count falls back to 0.
-				messageCount: 0,
+				messageCount: 1,
 			});
 			// context: plan + note + reference
 			expect(evidenceMsg.evidence.context).toHaveLength(3);
@@ -5106,7 +5108,18 @@ describe("SidebarWebviewProvider", () => {
 			};
 			const getSummaryByHash = vi.fn().mockResolvedValue(fakeSummary);
 			const readTranscriptById = vi.fn()
-				.mockResolvedValueOnce({ sessions: [{ sessionId: "s1", source: "claude" as const, transcriptPath: "/tmp/a.jsonl" }] })
+				.mockResolvedValueOnce({
+					sessions: [
+						{
+							sessionId: "s1",
+							source: "claude" as const,
+							transcriptPath: "/tmp/a.jsonl",
+							// A real turn so the surviving transcript's session is not dropped
+							// as a zero-turn row — this test is about the inner-catch skip.
+							entries: [{ role: "human" as const, content: "hi" }],
+						},
+					],
+				})
 				.mockRejectedValueOnce(new Error("read failed"));
 			const provider = new SidebarWebviewProvider({
 				executeCommand: vi.fn(),
@@ -5182,7 +5195,14 @@ describe("SidebarWebviewProvider", () => {
 			};
 			const foreignTranscript = {
 				sessions: [
-					{ sessionId: "foreign-sess-1", source: "claude" as const, transcriptPath: "/other-repo/claude.jsonl" },
+					{
+						sessionId: "foreign-sess-1",
+						source: "claude" as const,
+						transcriptPath: "/other-repo/claude.jsonl",
+						// A real turn so the session is not dropped as a zero-turn row —
+						// this test is about reading conversations from foreign-repo storage.
+						entries: [{ role: "human" as const, content: "hi" }],
+					},
 				],
 			};
 			// getSummaryAnyRepoWithSource returns the summary with sourceRepoName set (foreign repo)

--- a/vscode/src/views/SidebarWebviewProvider.ts
+++ b/vscode/src/views/SidebarWebviewProvider.ts
@@ -1657,15 +1657,16 @@ export class SidebarWebviewProvider
 					});
 					return { ...base, entries: sorted.flat() };
 				})
-				// Drop usage-only carriers: stored so `detach` has a per-session
-				// subtrahend, but with no readable turn to show — an evidence/branch row
-				// for one would render as an empty conversation. Applied to the MERGED
-				// entries so a conversation that is a carrier in one transcript and real in
-				// another still surfaces. A session that merely OMITS `entries` (legacy /
-				// malformed stored data) is not a carrier and is deliberately kept: those
-				// are real conversations, rendered with a turn count of 0 — hence the
-				// `usage` half of the predicate.
-				.filter((session) => session.entries.length > 0 || session.usage === undefined)
+				// Drop every zero-turn conversation, uniformly — the same rule the
+				// CLI owns in core/ArchivedConversations.ts (`groupArchivedSessions`):
+				// a usage-only carrier (stored so `detach` has a per-session subtrahend)
+				// and an overlay-emptied shell both archive with no readable turn and
+				// would render as an empty `0 msgs` row. Applied to the MERGED entries so
+				// a conversation that is a carrier in one transcript and real in another
+				// still surfaces. This is the sole visibility filter for both callers of
+				// readArchivedSessions (evidence rows and openEvidenceConversation), so
+				// neither re-filters.
+				.filter((session) => session.entries.length > 0)
 		);
 	}
 
@@ -1730,6 +1731,9 @@ export class SidebarWebviewProvider
 			// merged-entries fallback) — identical to the previous behavior, so a
 			// deleted transcript is no worse than before, never a throw. `?? []`
 			// guards a malformed transcript JSON missing `entries`.
+			// readArchivedSessions already drops zero-turn conversations (overlay
+			// shells and usage-only carriers), matching the dashboard's
+			// groupArchivedSessions rule, so this path does not re-filter.
 			const archivedSessions = await this.readArchivedSessions(summary, sourceRepoName, sourceRemoteUrl);
 			const conversations: MemoryEvidenceItem[] = await Promise.all(
 				archivedSessions.map(async (session) => ({

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -4646,6 +4646,55 @@ describe("SummaryWebviewPanel", () => {
 				expect(msg.totalEntries).toBe(1);
 			});
 
+			it("excludes an overlay-emptied zero-turn shell (empty entries, no usage) from sessionCounts", async () => {
+				// A "Mark All as Deleted" edit leaves a session with empty entries and NO
+				// usage. `groupArchivedSessions` drops it uniformly alongside usage-only
+				// carriers, so the conversation list renders nothing for it — the stats
+				// subtitle must match, or it reports "1 conversation" over an empty list.
+				mockGetTranscriptHashes.mockResolvedValue(new Set(["abc123"]));
+				const transcriptMap = new Map([
+					[
+						"abc123",
+						{
+							sessions: [
+								// Overlay-emptied shell: no entries, no usage — must be dropped.
+								{ sessionId: "shell", source: "claude" as const, entries: [] },
+								// A real conversation that must still count.
+								{
+									sessionId: "real",
+									source: "claude" as const,
+									entries: [{ role: "human" as const, content: "hi" }],
+								},
+							],
+						},
+					],
+				]);
+				mockReadTranscriptsForCommits.mockResolvedValue(transcriptMap as never);
+
+				await SummaryWebviewPanel.show(
+					makeSummary(),
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+				);
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "loadTranscriptStats" });
+				await flushPromises();
+
+				const call = postMessage.mock.calls.find(
+					(c) => (c[0] as { command?: string })?.command === "transcriptStatsLoaded",
+				);
+				const msg = call?.[0] as {
+					totalEntries: number;
+					sessionCounts: Record<string, number>;
+				};
+				// Only the real conversation counts; the shell contributes to neither.
+				expect(msg.sessionCounts).toEqual({ claude: 1 });
+				expect(msg.totalEntries).toBe(1);
+			});
+
 			it("deduplicates sessions and counts codex sessions separately", async () => {
 				mockGetTranscriptHashes.mockResolvedValue(
 					new Set(["abc123", "def456"]),
@@ -13041,7 +13090,7 @@ describe("SummaryWebviewPanel", () => {
 				);
 			});
 
-			it("tolerates source-less / entries-less sessions and merges duplicates", async () => {
+			it("tolerates source-less / entries-less sessions, merges duplicates, then drops the zero-turn result", async () => {
 				mockGetTranscriptHashes.mockResolvedValue(new Set(["c1", "c2"]));
 				const map = new Map<
 					string,
@@ -13066,20 +13115,17 @@ describe("SummaryWebviewPanel", () => {
 					source: string;
 					messageCount: number;
 				}>;
-				expect(items).toHaveLength(1);
-				expect(items[0]).toMatchObject({
-					sessionId: "su",
-					source: "claude",
-					messageCount: 0,
-				});
+				// The merge still runs (both slices coalesce onto "claude:su"), but the
+				// merged conversation has zero turns, so groupArchivedSessions drops it.
+				expect(items).toHaveLength(0);
 			});
 
-			it("hides a usage-only carrier but keeps a real conversation that shares the transcript", async () => {
+			it("hides every zero-turn session (usage-only carrier and legacy shell), keeps the real conversation", async () => {
 				// The queue worker persists a zero-entry session carrying `usage` when a
 				// conversation spent tokens without producing a readable turn — it exists
-				// only so `detach` has a subtrahend. Listing it would render an empty
-				// conversation row, so the reader drops it. The sibling with real turns,
-				// and an entries-less LEGACY session (no `usage`), both still list.
+				// only so `detach` has a subtrahend. An entries-less LEGACY session (no
+				// `usage`) is an overlay-emptied shell. Both render as empty `0 msgs`
+				// rows, so the reader drops both; only the sibling with real turns lists.
 				mockGetTranscriptHashes.mockResolvedValue(new Set(["c1"]));
 				const map = new Map<
 					string,
@@ -13098,8 +13144,8 @@ describe("SummaryWebviewPanel", () => {
 							sessions: [
 								{ sessionId: "real", entries: [{ role: "human", content: "hi" }] },
 								{ sessionId: "carrier", entries: [], usage: { input: 600, output: 300, cached: 0 } },
-								// Legacy/malformed: omits `entries`, carries no `usage` → NOT a
-								// carrier, still listed with a turn count of 0.
+								// Legacy/malformed: omits `entries`, carries no `usage` → an
+								// overlay-emptied shell, a zero-turn row, now dropped too.
 								{ sessionId: "legacy" },
 							],
 						},
@@ -13115,7 +13161,7 @@ describe("SummaryWebviewPanel", () => {
 					(c) => (c[0] as { command?: string })?.command === "conversationsData",
 				);
 				const items = call?.[0].items as Array<{ sessionId: string; messageCount: number }>;
-				expect(items.map((i) => i.sessionId)).toEqual(["real", "legacy"]);
+				expect(items.map((i) => i.sessionId)).toEqual(["real"]);
 			});
 
 			it("keeps a conversation whose carrier slice is joined by real turns in another transcript", async () => {

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -3884,31 +3884,23 @@ export class SummaryWebviewPanel {
 		// whether a source is *captured going forward*, not whether already-archived
 		// history is shown. Filtering here under-counted disabled-source sessions and
 		// — paired with the save path — was the visible half of a silent data-loss bug.
-		const seen = new Set<string>();
+		//
+		// The counts MUST agree with the Conversations list, which renders exactly
+		// `groupArchivedSessions`' rows. Deriving them from that same rule — rather
+		// than re-implementing the `source:sessionId` merge here — is what keeps the
+		// subtitle from reporting a conversation the list drops: every zero-turn
+		// conversation (usage-only carrier and overlay-emptied shell alike) is hidden
+		// uniformly, on the MERGED slices, so a conversation that is real in another
+		// transcript still counts. `totalEntries` is unchanged by the drop — a
+		// zero-turn conversation contributes no entries either way.
+		const { order, grouped } = groupArchivedSessions(transcriptMap);
 		let totalEntries = 0;
 		const sessionCounts: Record<string, number> = {};
-		for (const [, transcript] of transcriptMap) {
-			for (const session of transcript.sessions) {
-				const source = session.source ?? "claude";
-				const key = `${source}:${session.sessionId}`;
-				totalEntries += session.entries.length;
-				if (seen.has(key)) {
-					continue;
-				}
-				// Skip a usage-only carrier slice WITHOUT marking the key seen: such a
-				// conversation must not be counted (its row is hidden, so a count of 1
-				// against an empty list reads as a bug), but a conversation whose slice in
-				// THIS transcript happens to be a carrier still gets counted when a later
-				// transcript carries its real turns. Same merged-view semantics as
-				// readGroupedArchivedSessions, reached without a second grouping pass, and
-				// the same narrow predicate — a session that merely omits `entries` is
-				// legacy data, not a carrier, and still counts.
-				if ((session.entries ?? []).length === 0 && session.usage !== undefined) {
-					continue;
-				}
-				seen.add(key);
-				sessionCounts[source] = (sessionCounts[source] ?? 0) + 1;
-			}
+		for (const key of order) {
+			const { session, entries } = grouped.get(key) as NonNullable<ReturnType<typeof grouped.get>>;
+			totalEntries += entries.length;
+			const source = session.source ?? "claude";
+			sessionCounts[source] = (sessionCounts[source] ?? 0) + 1;
 		}
 
 		this.panel.webview.postMessage({


### PR DESCRIPTION
## What

A "Mark All as Deleted" overlay empties a session's `entries` after it was read, leaving a zero-turn shell (no entries, no usage) that slipped past the read-time and usage gates and rendered as a `0 msgs` noise row. Legitimate usage-only carriers (empty entries + `usage > 0`, kept so `detach` has a per-session subtrahend) must still survive on disk.

This drops zero-turn shells at the storage layer (`buildStoredTranscript`) and hides **every** zero-turn conversation uniformly across all display surfaces — with no data migration for already-generated memories.

## Surfaces aligned to the CLI-owned rule

The visibility rule lives in `core/ArchivedConversations.ts` (`groupArchivedSessions`: `if (entries.length === 0) continue`). Every surface now matches it:

- **Storage** — `buildStoredTranscript` drops shells, keeps usage carriers.
- **Dashboard** — `groupArchivedSessions`.
- **VS Code** — `SidebarWebviewProvider.readArchivedSessions` is now the single authoritative filter (`entries.length > 0`); the redundant caller-side re-filter in the evidence path was removed. The two filters previously encoded contradictory intent (internal kept legacy `usage === undefined` shells, caller dropped them).
- **IntelliJ** — `SummaryReader.parseConversations` now drops zero-turn sessions too, instead of re-implementing the visibility rule without the filter and rendering `0 msgs` rows the other surfaces suppress.

## Tests

- VS Code: full suite green with coverage (110 files / 4654 passed). The existing `omits every zero-turn session (carrier and legacy shell alike)` test proves the single filter is now authoritative.
- IntelliJ: `SummaryReaderConversationsTest` green (updated two tests that encoded keep-empty behavior; added `drops zero-turn sessions but keeps their non-empty siblings`).
- typecheck + biome lint clean.