### PR TITLE
Give skill usage its own page in the dashboard

### DIFF
--- a/claude-plugin/scripts/_publish-lib.sh
+++ b/claude-plugin/scripts/_publish-lib.sh
@@ -45,6 +45,7 @@ PUBLISH_REQUIRED_DIST=(
 	dashboard-assets/js/charts.js
 	dashboard-assets/js/shell.js
 	dashboard-assets/js/stats.js
+	dashboard-assets/js/skills.js
 	dashboard-assets/js/standup.js
 	dashboard-assets/js/memories.js
 	dashboard-assets/js/knowledge.js

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -211,6 +211,19 @@ export interface ToolCallCount {
 	readonly kind: ToolCallKind;
 	/** MCP server the tool belongs to. Present only when `kind` is `"mcp"`. */
 	readonly server?: string;
+	/**
+	 * Plugin that provides the skill. Present only when `kind` is `"skill"`.
+	 *
+	 * A separate field from {@link server} rather than a reuse of it, even though both
+	 * name "where the tool came from": they are indexed and queried differently (the
+	 * MCP card rolls up by `server`), so a plugin label stored there would join those
+	 * roll-ups as a phantom server.
+	 *
+	 * Absent means the skill has no namespace, which is the common case — not that its
+	 * namespace is unknown. A name two plugins both claim is also absent rather than
+	 * attributed to whichever was seen first; see `observeSkillEntry`.
+	 */
+	readonly plugin?: string;
 	readonly calls: number;
 	/**
 	 * When the LAST call in this bucket was made, from the transcript line that
@@ -236,6 +249,52 @@ export interface ToolCallCount {
 	 * rather than treat absence as "never called".
 	 */
 	readonly lastCallAtMs?: number;
+	/**
+	 * Tokens spent under this bucket, when the source can attribute them.
+	 *
+	 * Only ever set on `kind: "skill"` buckets: a skill owns a bounded stretch of
+	 * the conversation that attribution can delimit, while a builtin or MCP call is
+	 * one step inside a turn whose spend belongs to the turn, not to the tool. So an
+	 * absent value here is the normal case, not a gap to be filled later.
+	 *
+	 * Absent, NEVER a zeroed {@link SkillUsage}: the sources divide into ones that
+	 * attribute (Claude), ones that estimate (OpenCode) and ones that report nothing
+	 * at all (Codex, Kimi, Cursor), and a stored zero would claim the third group's
+	 * skills were free. `confidence` carries which of the first two produced a value.
+	 */
+	readonly usage?: SkillUsage;
+	/**
+	 * The individual entries behind {@link calls}, for the per-invocation record.
+	 *
+	 * Only ever set on `kind: "skill"` buckets, for the same reason {@link usage} is:
+	 * a skill entry is an event with its own timestamp, outcome and injected body,
+	 * while a builtin or MCP call is one step inside a turn that carries none of
+	 * those separately.
+	 *
+	 * `calls` is NOT derivable from this array's length and must stay independent.
+	 * Two reasons, both real: a Codex CLI bucket deliberately reports one invocation
+	 * per session no matter how many paged reads produced it (see
+	 * `scanCodexSkillLines`), and a bucket recovered from an already-archived commit
+	 * carries a count with no invocations at all.
+	 *
+	 * Absent means "this bucket has no per-invocation record", which is the normal
+	 * state for a count merged in from a `SkillCommitRef` — never "it ran zero times".
+	 */
+	readonly invocations?: ReadonlyArray<SkillInvocation>;
+	/**
+	 * Whether the invocations in this bucket were OBSERVED or inferred.
+	 *
+	 * Skill-level rather than per-invocation, matching {@link SkillUse.detection},
+	 * and copying it down to each invocation is lossless: one scan pass emits a
+	 * single nature per skill (`scanCodexSkillLines` drops its inferred entry
+	 * outright when an observed one claimed the same name), so a bucket never mixes
+	 * the two.
+	 *
+	 * Absent means observed. Present means the entry was inferred from a shell read
+	 * of a `SKILL.md`, which cannot distinguish an agent using a skill from a human
+	 * reading it and cannot count entries — see `CodexSkillScanner`.
+	 */
+	readonly detection?: "heuristic";
 }
 
 /**
@@ -1317,6 +1376,35 @@ export interface SkillInvocation {
 	readonly bodyChars?: number;
 	/** False for a failed invocation (the `is_error` tool results). */
 	readonly ok: boolean;
+	/**
+	 * Whether this invocation's result was actually present in the scanned window.
+	 *
+	 * `false` is the important value: Claude and Kimi both emit a real invocation
+	 * before its paired result arrives, with an optimistic `ok: true`. Optional for
+	 * histories written before this evidence existed; readers then fall back to the
+	 * source/entry-path capability table.
+	 */
+	readonly outcomeObserved?: boolean;
+	/**
+	 * Which mechanism entered the skill on THIS invocation.
+	 *
+	 * Distinct from {@link SkillUse.entryPaths}, which is the SET of mechanisms a
+	 * skill has ever been entered by and therefore cannot answer for one
+	 * invocation: a skill reached both ways carries `["command","tool"]`, and
+	 * nothing in that array says which of its invocations was which.
+	 *
+	 * Load-bearing for {@link ok}, not decoration. Whether a source can report an
+	 * outcome at all depends on the mechanism, not only on the host — Claude's
+	 * `Skill` tool has a `tool_result` to read a failure from while its slash
+	 * command has no result record at all, so both arrive as a hard-coded
+	 * `ok: true`. `skillOutcomeConfidence` needs this field to tell the two apart.
+	 *
+	 * Optional because a stored history predates it: `parseInvocationLine` reads
+	 * fields by name, so an older `skills/<source>/<skill>.md` deserializes with
+	 * this absent. Readers must treat absence as "unknown mechanism", never as a
+	 * default one.
+	 */
+	readonly entryPath?: SkillEntryPath;
 }
 
 /**

--- a/cli/src/core/GitFsLayout.test.ts
+++ b/cli/src/core/GitFsLayout.test.ts
@@ -2,7 +2,13 @@ import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSyn
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { type GitFsLayout, readBranchFromFs, readHeadHashFromFs, resolveGitFsLayout } from "./GitFsLayout.js";
+import {
+	type GitFsLayout,
+	readBranchFromFs,
+	readHeadHashFromFs,
+	readRepositoryKey,
+	resolveGitFsLayout,
+} from "./GitFsLayout.js";
 
 const HASH = "0123456789abcdef0123456789abcdef01234567";
 const OTHER_HASH = "89abcdef0123456789abcdef0123456789abcdef";
@@ -243,6 +249,117 @@ describe("resolveGitFsLayout", () => {
 	});
 });
 
+describe("readRepositoryKey", () => {
+	/**
+	 * A main repo plus one linked worktree of it, returning both worktree roots.
+	 *
+	 * Hand-built rather than driven through `git worktree add` so this stays in the
+	 * fast tier; `SessionDirMatch.realgit.test.ts` pins the same claims against real
+	 * git, which is what makes these fixtures evidence rather than a matching guess.
+	 */
+	function seedRepoWithWorktree(): { main: string; worktree: string } {
+		const main = join(root, "main");
+		const mainGitDir = seedPlainRepo(main, "ref: refs/heads/main\n");
+		const linkedGitDir = join(mainGitDir, "worktrees", "wt1");
+		mkdirSync(linkedGitDir, { recursive: true });
+		writeFileSync(join(linkedGitDir, "commondir"), "../..\n");
+		writeFileSync(join(linkedGitDir, "HEAD"), "ref: refs/heads/wt1\n");
+		const worktree = join(root, "wt1");
+		mkdirSync(worktree, { recursive: true });
+		writeFileSync(join(worktree, ".git"), `gitdir: ${linkedGitDir}\n`);
+		return { main, worktree };
+	}
+
+	it("gives every worktree of one repository the same key", () => {
+		const { main, worktree } = seedRepoWithWorktree();
+
+		const key = readRepositoryKey(main);
+		expect(key).not.toBeNull();
+		expect(readRepositoryKey(worktree)).toBe(key);
+	});
+
+	it("gives a subdirectory the same key as its worktree root", () => {
+		const { main, worktree } = seedRepoWithWorktree();
+		const sub = join(worktree, "packages", "foo");
+		mkdirSync(sub, { recursive: true });
+
+		expect(readRepositoryKey(sub)).toBe(readRepositoryKey(main));
+	});
+
+	it("gives two independent repositories different keys", () => {
+		const a = join(root, "a");
+		const b = join(root, "b");
+		seedPlainRepo(a, "ref: refs/heads/main\n");
+		seedPlainRepo(b, "ref: refs/heads/main\n");
+
+		expect(readRepositoryKey(a)).not.toBe(readRepositoryKey(b));
+	});
+
+	it("answers null outside any repository", () => {
+		const loose = join(root, "loose");
+		mkdirSync(loose, { recursive: true });
+
+		expect(readRepositoryKey(loose)).toBeNull();
+	});
+
+	it("answers null for a .git git itself would refuse", () => {
+		mkdirSync(join(root, ".git"), { recursive: true });
+
+		expect(readRepositoryKey(root)).toBeNull();
+	});
+
+	it.each(["", "relative/path", "./also-relative"])("answers null for the non-absolute path %o", (dir) => {
+		// `resolveGitFsLayout` would anchor these to the process cwd and walk up into
+		// whichever repository the test run itself lives in — answering about a
+		// directory nobody named. See the function's docstring.
+		expect(readRepositoryKey(dir)).toBeNull();
+	});
+
+	// POSIX only, because the claim is platform-specific rather than symmetric: a
+	// POSIX-style `/home/flyer/project` IS absolute on Windows (drive-relative), so
+	// there the guard never fires and the null comes from finding no repository —
+	// the same answer for a different reason, which would make the assertion lie.
+	it.skipIf(process.platform === "win32")("answers null for a Windows path on a POSIX host", () => {
+		// The case that made the guard necessary rather than tidy: a session recorded
+		// under WSL or synced from another machine carries `E:\project`, which POSIX
+		// does not read as absolute. Without the guard, `E:\project` and `e:\project`
+		// would BOTH resolve into the running repository and compare EQUAL — one
+		// directory claiming to be another repo's, with nothing to show it.
+		expect(readRepositoryKey("E:\\project")).toBeNull();
+	});
+
+	describe("immunity to the git location variables", () => {
+		// The behaviour that makes this usable from a git hook's detached children —
+		// the QueueWorker and the global daemon both inherit `GIT_DIR`. Honouring it
+		// (as `resolveGitFsLayout` does for its other callers) would answer null on
+		// exactly the paths that do the collecting. See the function's docstring.
+		let saved: string | undefined;
+
+		beforeEach(() => {
+			saved = process.env.GIT_DIR;
+		});
+
+		afterEach(() => {
+			if (saved === undefined) delete process.env.GIT_DIR;
+			else process.env.GIT_DIR = saved;
+		});
+
+		it("still answers when GIT_DIR points at another repository", () => {
+			const { main, worktree } = seedRepoWithWorktree();
+			const decoy = join(root, "decoy");
+			seedPlainRepo(decoy, "ref: refs/heads/main\n");
+			process.env.GIT_DIR = join(decoy, ".git");
+
+			const key = readRepositoryKey(main);
+			expect(key).not.toBeNull();
+			// The decoy named by GIT_DIR is ignored: both directories still resolve to
+			// the repository that CONTAINS them, and the decoy is a third one.
+			expect(readRepositoryKey(worktree)).toBe(key);
+			expect(readRepositoryKey(decoy)).not.toBe(key);
+		});
+	});
+});
+
 describe("readBranchFromFs", () => {
 	function layoutFor(head: string) {
 		seedPlainRepo(root, head);
@@ -302,6 +419,13 @@ describe("readHeadHashFromFs", () => {
 		);
 
 		expect(readHeadHashFromFs(layout)).toBe(HASH);
+	});
+
+	it("returns null when packed-refs exists but does not contain HEAD's branch", () => {
+		const layout = layoutFor("ref: refs/heads/missing\n");
+		writeFileSync(join(layout.gitDir, "packed-refs"), `${HASH} refs/heads/other\n`);
+
+		expect(readHeadHashFromFs(layout)).toBeNull();
 	});
 
 	it("prefers a loose ref over a stale packed one", () => {

--- a/cli/src/core/GitFsLayout.ts
+++ b/cli/src/core/GitFsLayout.ts
@@ -45,6 +45,7 @@
 
 import { readFileSync, realpathSync, statSync } from "node:fs";
 import { dirname, isAbsolute, join, resolve } from "node:path";
+import { normalizePathForCompare } from "./PathUtils.js";
 
 /** Resolved absolute paths for one worktree. */
 export interface GitFsLayout {
@@ -67,6 +68,14 @@ const GIT_LOCATION_ENV_VARS = ["GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR"] as 
 function gitLocationIsOverridden(env: NodeJS.ProcessEnv): boolean {
 	return GIT_LOCATION_ENV_VARS.some((name) => (env[name] ?? "") !== "");
 }
+
+/**
+ * An env carrying none of the location vars, for the one question that must be
+ * answered about `cwd` itself rather than about whatever git was pointed at. Used
+ * by {@link readRepositoryKey}; see its docstring for why that is correct there
+ * and nowhere else so far.
+ */
+const LOCATION_FREE_ENV: NodeJS.ProcessEnv = {};
 
 function readTextOrNull(path: string): string | null {
 	try {
@@ -215,6 +224,68 @@ export function resolveGitFsLayout(startDir: string, options: GitFsLayoutOptions
 		if (parent === dir) return null;
 		dir = parent;
 	}
+}
+
+/**
+ * A key identifying the REPOSITORY `dir` belongs to, or null when that cannot be
+ * read off the filesystem.
+ *
+ * The key is the shared git directory, which every worktree of one repository
+ * reports identically — so two directories belong to the same repository exactly
+ * when their keys are equal. That is the question a path comparison can only
+ * approximate, and it approximates it wrong in both directions: a linked worktree
+ * normally lives OUTSIDE the main worktree (so containment says no when the answer
+ * is yes), while a nested clone or submodule lives INSIDE it (so containment says
+ * yes when the answer is no).
+ *
+ * `realpath: true` is load-bearing, and it is the OPPOSITE of what
+ * {@link file://./RepoProfile.ts} passes. That module anchors `profile.json` and
+ * needs a path that never moves, so resolving symlinks there would relocate a
+ * user's opt-out. This function only ever compares two keys, so leaving symlinks
+ * unresolved is what would break it: on macOS `/tmp` and `/private/tmp` are one
+ * directory, and two spellings of one repository would compare as different —
+ * silently, since "different repositories" is also a valid answer.
+ *
+ * Null means "ask something else", NEVER "different repositories". The layout
+ * reader declines for a `.git` git itself would refuse and for a directory that
+ * no longer exists — so every caller keeps its own fallback. See the module
+ * docstring.
+ *
+ * ## Why this passes an EMPTY env, which the module otherwise refuses to do
+ *
+ * `resolveGitFsLayout` declines outright when `GIT_DIR` / `GIT_WORK_TREE` /
+ * `GIT_COMMON_DIR` are set, because its contract is to agree with the `git`
+ * command it replaces — and those vars make `git` answer for the repository they
+ * name instead of the one containing `cwd`. That contract is right for its other
+ * callers and WRONG for this question. Here the whole point is which repository
+ * CONTAINS `dir`, so the ambient vars are noise to be ignored, not honoured:
+ * `GitOps.resolveContainingRepoCommonDir` reaches the same conclusion from the
+ * subprocess side and deletes them before spawning, for the measured reason that
+ * a sibling repo otherwise resolves to the current repo's `.git`.
+ *
+ * Skipping the guard is what makes this work where it matters most. git exports
+ * those vars to every hook, and a detached child inherits them — so the
+ * QueueWorker and the global daemon both run with `GIT_DIR` set. Honouring the
+ * guard there would return null on exactly those paths and leave every caller on
+ * its fallback, i.e. fix nothing in the processes that do the collecting.
+ *
+ * A side effect worth having: the answer no longer depends on `process.env` at
+ * all, so it is the same in a hook, in a terminal and under test.
+ */
+export function readRepositoryKey(dir: string): string | null {
+	// A path THIS platform does not read as absolute is refused outright, and that is
+	// not defensive tidiness: `resolveGitFsLayout` starts with `resolve(dir)`, which
+	// anchors a relative-looking path to the process cwd and then walks UP from
+	// there — so it would answer confidently about whichever repository the current
+	// process happens to be running in, for a directory that was never named. The
+	// real input for this is a foreign-platform absolute path: `E:\project` recorded
+	// by a session under WSL or synced from another machine is not absolute on POSIX,
+	// and two such paths differing only in drive-letter case would both resolve into
+	// the running repository and compare EQUAL. Null hands them to the caller's
+	// fallback, where a plain path comparison gets them right.
+	if (!dir || !isAbsolute(dir)) return null;
+	const commonDir = resolveGitFsLayout(dir, { realpath: true, env: LOCATION_FREE_ENV })?.commonDir;
+	return commonDir ? normalizePathForCompare(commonDir) : null;
 }
 
 /**

--- a/cli/src/core/OpenCodeTranscriptReader.test.ts
+++ b/cli/src/core/OpenCodeTranscriptReader.test.ts
@@ -21,6 +21,7 @@ async function createTestDb(
 	messages: ReadonlyArray<{
 		id: string;
 		role: string;
+		data?: Record<string, unknown>;
 		parts: ReadonlyArray<{ type: string; text?: string; [key: string]: unknown }>;
 		time_created: number;
 	}>,
@@ -65,7 +66,7 @@ async function createTestDb(
 	);
 
 	for (const m of messages) {
-		const msgData = JSON.stringify({ role: m.role });
+		const msgData = JSON.stringify({ role: m.role, ...m.data });
 		insertMessage.run(m.id, sessionId, m.time_created, m.time_created, msgData);
 
 		for (let i = 0; i < m.parts.length; i++) {
@@ -464,7 +465,12 @@ describe("OpenCodeTranscriptReader toolUse", () => {
 			{
 				id: "m2",
 				role: "assistant",
-				parts: [{ type: "tool", tool: "bash", callID: "c3" }],
+				parts: [
+					{ type: "tool", tool: "bash", callID: "c3" },
+					// Older rows can omit callID. They still represent a call; only
+					// de-duplication is unavailable for that row.
+					{ type: "tool", tool: "write" },
+				],
 				time_created: now + 1,
 			},
 		]);
@@ -474,6 +480,7 @@ describe("OpenCodeTranscriptReader toolUse", () => {
 		expect(result.toolUse).toEqual([
 			{ name: "bash", kind: "builtin", calls: 2 },
 			{ name: "read", kind: "builtin", calls: 1 },
+			{ name: "write", kind: "builtin", calls: 1 },
 		]);
 	});
 
@@ -497,7 +504,62 @@ describe("OpenCodeTranscriptReader toolUse", () => {
 
 		const result = await readOpenCodeTranscript(transcriptPath);
 
-		expect(result.toolUse).toEqual([{ name: "brainstorming", kind: "skill", calls: 1 }]);
+		expect(result.toolUse).toEqual([
+			{
+				name: "brainstorming",
+				kind: "skill",
+				calls: 1,
+				lastCallAtMs: now,
+				invocations: [{ at: new Date(now).toISOString(), ok: true, entryPath: "tool" }],
+			},
+		]);
+	});
+
+	it("forwards OpenCode outcome, body size and interval-attributed usage", async () => {
+		const now = Date.now();
+		const output = '<skill_content name="brainstorming">body</skill_content>';
+		const transcriptPath = await createTestDb(tempDir, "sess-t2-detail", [
+			{
+				id: "m1",
+				role: "assistant",
+				parts: [
+					{
+						type: "tool",
+						tool: "skill",
+						callID: "c1",
+						state: {
+							status: "error",
+							metadata: { name: "brainstorming" },
+							time: { start: now + 2 },
+							output,
+						},
+					},
+				],
+				time_created: now,
+			},
+			{
+				id: "m2",
+				role: "assistant",
+				data: { tokens: { input: 7, output: 11, reasoning: 3, cache: { write: 5, read: 999 } } },
+				parts: [],
+				time_created: now + 10,
+			},
+		]);
+
+		const result = await readOpenCodeTranscript(transcriptPath);
+
+		expect(result.toolUse).toEqual([
+			{
+				name: "brainstorming",
+				kind: "skill",
+				calls: 1,
+				lastCallAtMs: now + 2,
+				usage: { input: 7, output: 14, cached: 5, confidence: "estimated" },
+				invocations: [
+					{ at: new Date(now + 2).toISOString(), bodyChars: output.length, ok: false, entryPath: "tool" },
+				],
+			},
+		]);
 	});
 
 	it("falls back to the requested skill name when metadata carries none", async () => {

--- a/cli/src/core/OpenCodeTranscriptReader.ts
+++ b/cli/src/core/OpenCodeTranscriptReader.ts
@@ -19,6 +19,9 @@
 import { createLogger } from "../Logger.js";
 import type { ToolCallCount, TranscriptCursor, TranscriptEntry, TranscriptReadResult } from "../Types.js";
 import { withSqliteDb } from "./SqliteHelpers.js";
+import { mergeToolCalls } from "./sessions/SessionSignalExtractor.js";
+import { type OpenCodeRow, scanOpenCodeSkillRows } from "./skills/OpenCodeSkillScanner.js";
+import { skillUseToToolCall } from "./skills/SkillToolCall.js";
 import { builtinTool, skillTool, ToolUseTally } from "./ToolNameClassify.js";
 import { mergeConsecutiveEntries, throwTranscriptReadError } from "./TranscriptReader.js";
 
@@ -56,68 +59,91 @@ export async function readOpenCodeTranscript(
 	const tally = new ToolUseTally();
 
 	try {
-		const { rawEntries, totalMessages, lastConsumedIndex } = await withSqliteDb(dbPath, (db) => {
-			// Query messages with their parts via JOIN
-			const rows = db
-				.prepare(
-					`SELECT m.id as msg_id, m.data as msg_data, m.time_created,
-					        p.data as part_data
+		const { rawEntries, totalMessages, lastConsumedIndex, partRows, messageRows } = await withSqliteDb(
+			dbPath,
+			(db) => {
+				// Query messages with their parts via JOIN
+				const rows = db
+					.prepare(
+						`SELECT m.id as msg_id, m.data as msg_data, m.time_created,
+					        p.id as part_id, p.time_created as part_time_created, p.data as part_data
 					 FROM message m
 					 LEFT JOIN part p ON p.message_id = m.id
 					 WHERE m.session_id = :sessionId
 					 ORDER BY m.time_created ASC, p.time_created ASC`,
-				)
-				.all({ sessionId }) as ReadonlyArray<{
-				msg_id: string;
-				msg_data: string;
-				time_created: number;
-				part_data: string | null;
-			}>;
+					)
+					.all({ sessionId }) as ReadonlyArray<{
+					msg_id: string;
+					msg_data: string;
+					time_created: number;
+					part_id: string | null;
+					part_time_created: number | null;
+					part_data: string | null;
+				}>;
 
-			// Group rows by message ID
-			const messageMap = new Map<string, { msgData: string; timeCreated: number; parts: string[] }>();
-			const messageOrder: string[] = [];
+				// Group rows by message ID
+				const messageMap = new Map<
+					string,
+					{ id: string; msgData: string; timeCreated: number; parts: OpenCodeRow[] }
+				>();
+				const messageOrder: string[] = [];
 
-			for (const row of rows) {
-				if (!messageMap.has(row.msg_id)) {
-					messageMap.set(row.msg_id, { msgData: row.msg_data, timeCreated: row.time_created, parts: [] });
-					messageOrder.push(row.msg_id);
+				for (const row of rows) {
+					if (!messageMap.has(row.msg_id)) {
+						messageMap.set(row.msg_id, {
+							id: row.msg_id,
+							msgData: row.msg_data,
+							timeCreated: row.time_created,
+							parts: [],
+						});
+						messageOrder.push(row.msg_id);
+					}
+
+					if (row.part_id !== null && row.part_time_created !== null && row.part_data !== null) {
+						messageMap.get(row.msg_id)?.parts.push({
+							id: row.part_id,
+							timeCreated: row.part_time_created,
+							data: row.part_data,
+						});
+					}
 				}
 
-				if (row.part_data) {
-					messageMap.get(row.msg_id)?.parts.push(row.part_data);
+				// Skip already-processed messages (cursor-based incremental read)
+				const newMessageIds = messageOrder.slice(startIndex);
+				const rawEntries: TranscriptEntry[] = [];
+				const partRows: OpenCodeRow[] = [];
+				const messageRows: OpenCodeRow[] = [];
+				let lastConsumedIndex = startIndex;
+
+				for (let i = 0; i < newMessageIds.length; i++) {
+					const msg = messageMap.get(newMessageIds[i]) as {
+						id: string;
+						msgData: string;
+						timeCreated: number;
+						parts: OpenCodeRow[];
+					};
+
+					// If a time cutoff is specified, stop consuming when we hit messages after it
+					if (cutoffTime && msg.timeCreated > cutoffTime) {
+						break;
+					}
+
+					const partData = msg.parts.map((part) => part.data);
+					const entry = parseOpenCodeMessage(msg.msgData, partData, msg.timeCreated);
+					if (entry) {
+						rawEntries.push(entry);
+					}
+					// Independent of `entry`: an assistant message whose only parts are
+					// tool calls yields no text entry but is real agent activity.
+					tallyOpenCodeToolParts(tally, partData);
+					partRows.push(...msg.parts);
+					messageRows.push({ id: msg.id, timeCreated: msg.timeCreated, data: msg.msgData });
+					lastConsumedIndex = startIndex + i + 1;
 				}
-			}
 
-			// Skip already-processed messages (cursor-based incremental read)
-			const newMessageIds = messageOrder.slice(startIndex);
-			const rawEntries: TranscriptEntry[] = [];
-			let lastConsumedIndex = startIndex;
-
-			for (let i = 0; i < newMessageIds.length; i++) {
-				const msg = messageMap.get(newMessageIds[i]) as {
-					msgData: string;
-					timeCreated: number;
-					parts: string[];
-				};
-
-				// If a time cutoff is specified, stop consuming when we hit messages after it
-				if (cutoffTime && msg.timeCreated > cutoffTime) {
-					break;
-				}
-
-				const entry = parseOpenCodeMessage(msg.msgData, msg.parts, msg.timeCreated);
-				if (entry) {
-					rawEntries.push(entry);
-				}
-				// Independent of `entry`: an assistant message whose only parts are
-				// tool calls yields no text entry but is real agent activity.
-				tallyOpenCodeToolParts(tally, msg.parts);
-				lastConsumedIndex = startIndex + i + 1;
-			}
-
-			return { rawEntries, totalMessages: messageOrder.length, lastConsumedIndex };
-		});
+				return { rawEntries, totalMessages: messageOrder.length, lastConsumedIndex, partRows, messageRows };
+			},
+		);
 
 		const entries = mergeConsecutiveEntries(rawEntries);
 
@@ -139,9 +165,18 @@ export async function readOpenCodeTranscript(
 			newCursor.lineNumber,
 		);
 
+		// The ordinary tally supplies every builtin plus the aggregate skill count.
+		// The row scanner enriches those same skill buckets with per-entry outcomes,
+		// body size and interval-attributed spend. `mergeToolCalls` takes the maximum
+		// count, so the two views of one set are never added together.
+		const skillTools = scanOpenCodeSkillRows(partRows, messageRows).uses.map((use) =>
+			skillUseToToolCall(use, use.usage),
+		);
+		const toolUse = mergeToolCalls([tally.values(), skillTools]);
+
 		// Always present, even when empty — see TOOL_RECORDING_SOURCES for why an
 		// empty array and an absent field mean opposite things.
-		return { entries, newCursor, totalLinesRead, toolUse: tally.values() };
+		return { entries, newCursor, totalLinesRead, toolUse };
 	} catch (error: unknown) {
 		throwTranscriptReadError(log, `Cannot read OpenCode session: ${sessionId}`, error);
 	}

--- a/cli/src/core/SessionDirMatch.realgit.test.ts
+++ b/cli/src/core/SessionDirMatch.realgit.test.ts
@@ -1,0 +1,198 @@
+/**
+ * The fixtures in `SessionDirMatch.test.ts` build `.git` entries by hand, and git
+ * itself rejects every one of them — so they exercise the path-shaped FALLBACK.
+ * These drive real `git init` / `git worktree add` / `git submodule add`, which is
+ * the only way to pin what the module is actually for: a session run in any
+ * worktree of a repository belongs to that repository, and a session run in a
+ * repository nested inside it does not.
+ *
+ * Split out from the unit file (and listed in `SLOW_TEST_FILES`) because these
+ * cases spawn git — the same load profile as the other real-git files.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sessionDirBelongsToRepo } from "./SessionDirMatch.js";
+
+let root: string;
+
+beforeEach(() => {
+	// `realpathSync`, because on macOS `mkdtemp` hands back `/var/...` while git
+	// reports `/private/var/...`. The predicate resolves symlinks on both sides, so
+	// it copes either way — but a test that then compares paths itself would not.
+	root = realpathSync(mkdtempSync(join(tmpdir(), "sessiondir-real-")));
+});
+
+afterEach(() => {
+	rmSync(root, { recursive: true, force: true });
+});
+
+function git(cwd: string, ...args: string[]): string {
+	return execFileSync("git", args, { cwd, encoding: "utf-8" }).trim();
+}
+
+/** A repository with one commit — `git worktree add` refuses an unborn HEAD. */
+function seedRealRepo(dir: string): void {
+	mkdirSync(dir, { recursive: true });
+	git(dir, "init", "-q", "-b", "main");
+	writeFileSync(join(dir, "f.txt"), "hello\n");
+	git(dir, "add", "f.txt");
+	// The identity is passed per-invocation: the monorepo's shared git env
+	// (`test/gitEnv.ts`) deliberately injects none.
+	git(dir, "-c", "user.email=t@example.com", "-c", "user.name=T", "commit", "-qm", "first");
+}
+
+describe("sessionDirBelongsToRepo against real git", () => {
+	it("attributes a worktree added OUTSIDE the main one to the repository", () => {
+		// The standard shape, and the one the whole fix is about: a sibling directory
+		// shares no path prefix with the main worktree, so containment says no while
+		// git says the two are one repository.
+		const main = join(root, "repo");
+		seedRealRepo(main);
+		const worktree = join(root, "repo-feature");
+		git(main, "worktree", "add", "-q", "-b", "feature", worktree);
+
+		expect(sessionDirBelongsToRepo(worktree, main)).toBe(true);
+	});
+
+	it("attributes a worktree added INSIDE the main one to the repository", () => {
+		// Passes containment but used to be rejected by the intervening-`.git` walk:
+		// a linked worktree's root carries a `.git` FILE, which that walk read as a
+		// nested repository.
+		const main = join(root, "repo");
+		seedRealRepo(main);
+		const worktree = join(main, ".worktrees", "foo");
+		git(main, "worktree", "add", "-q", "-b", "foo", worktree);
+
+		expect(sessionDirBelongsToRepo(worktree, main)).toBe(true);
+	});
+
+	it("attributes a SUBDIRECTORY of a linked worktree to the repository", () => {
+		// A session started with `cd packages/foo` inside a worktree — the JOLLI-2015
+		// shape, one worktree further out.
+		const main = join(root, "repo");
+		seedRealRepo(main);
+		const worktree = join(root, "repo-feature");
+		git(main, "worktree", "add", "-q", "-b", "feature", worktree);
+		const sub = join(worktree, "packages", "foo");
+		mkdirSync(sub, { recursive: true });
+
+		expect(sessionDirBelongsToRepo(sub, main)).toBe(true);
+	});
+
+	it("is symmetric: the main worktree belongs to the repository asked from a worktree", () => {
+		// Membership is a property of the repository, not of which checkout was
+		// registered first — so neither side may be privileged.
+		const main = join(root, "repo");
+		seedRealRepo(main);
+		const worktree = join(root, "repo-feature");
+		git(main, "worktree", "add", "-q", "-b", "feature", worktree);
+
+		expect(sessionDirBelongsToRepo(main, worktree)).toBe(true);
+	});
+
+	it("attributes one worktree's session when asked about a SIBLING worktree", () => {
+		// Both are linked worktrees of one repository, neither is the main one. They
+		// share a shared-git directory, so they share a repository.
+		const main = join(root, "repo");
+		seedRealRepo(main);
+		const a = join(root, "repo-a");
+		const b = join(root, "repo-b");
+		git(main, "worktree", "add", "-q", "-b", "branch-a", a);
+		git(main, "worktree", "add", "-q", "-b", "branch-b", b);
+
+		expect(sessionDirBelongsToRepo(a, b)).toBe(true);
+	});
+
+	it("excludes a session in a nested but INDEPENDENT clone", () => {
+		// The case the intervening-`.git` walk existed for. It must keep working: the
+		// inner repository has its own shared git directory, so the keys differ.
+		const main = join(root, "repo");
+		seedRealRepo(main);
+		const nested = join(main, "vendor", "lib");
+		seedRealRepo(nested);
+
+		expect(sessionDirBelongsToRepo(nested, main)).toBe(false);
+	});
+
+	it("excludes a session deeper inside a nested independent clone", () => {
+		const main = join(root, "repo");
+		seedRealRepo(main);
+		const nested = join(main, "vendor", "lib");
+		seedRealRepo(nested);
+		const deep = join(nested, "src", "core");
+		mkdirSync(deep, { recursive: true });
+
+		expect(sessionDirBelongsToRepo(deep, main)).toBe(false);
+	});
+
+	it("excludes a session inside a real submodule", () => {
+		// A submodule's shared git directory is `<super>/.git/modules/<name>`, which is
+		// not the super-project's — so it is excluded for the same reason a nested
+		// clone is, rather than by a special case.
+		const superRepo = join(root, "super");
+		seedRealRepo(superRepo);
+		const donor = join(root, "donor");
+		seedRealRepo(donor);
+		const sub = join(superRepo, "modules", "sdk");
+		git(
+			superRepo,
+			"-c",
+			"protocol.file.allow=always",
+			"submodule",
+			"--quiet",
+			"add",
+			donor,
+			join("modules", "sdk"),
+		);
+
+		expect(sessionDirBelongsToRepo(sub, superRepo)).toBe(false);
+	});
+
+	it("keeps a subdirectory session of a plain repository", () => {
+		// JOLLI-2015, re-pinned against real git rather than a hand-built `.git`.
+		const main = join(root, "repo");
+		seedRealRepo(main);
+		const sub = join(main, "packages", "foo");
+		mkdirSync(sub, { recursive: true });
+
+		expect(sessionDirBelongsToRepo(sub, main)).toBe(true);
+	});
+
+	it("excludes an unrelated repository whose path only shares a prefix string", () => {
+		// `repo2` starts with the string `repo` — the boundary check in `isPathInside`
+		// used to be the only thing standing between them, and now the differing keys
+		// are. Both must agree.
+		const main = join(root, "repo");
+		seedRealRepo(main);
+		const other = join(root, "repo2");
+		seedRealRepo(other);
+
+		expect(sessionDirBelongsToRepo(other, main)).toBe(false);
+	});
+
+	it("excludes a directory that is in no repository at all", () => {
+		// No key on the session side, so this one reaches the path-shaped fallback and
+		// is refused by containment. Pinned here because the fallback is where such a
+		// directory always lands, whichever way the primary path is written.
+		const main = join(root, "repo");
+		seedRealRepo(main);
+		const loose = join(root, "not-a-repo");
+		mkdirSync(loose, { recursive: true });
+
+		expect(sessionDirBelongsToRepo(loose, main)).toBe(false);
+	});
+
+	it("falls back when the target root is readable but is not a repository", () => {
+		// The session side has a definite repository key while the target side has
+		// none. That is not evidence of equality, so the legacy containment walk gets
+		// the final say and rejects the nested repository boundary.
+		const nested = join(root, "nested");
+		seedRealRepo(nested);
+
+		expect(sessionDirBelongsToRepo(nested, root)).toBe(false);
+	});
+});

--- a/cli/src/core/SessionDirMatch.test.ts
+++ b/cli/src/core/SessionDirMatch.test.ts
@@ -39,7 +39,13 @@ describe("sessionDirBelongsToRepo", () => {
 		expect(sessionDirBelongsToRepo("/nonexistent/repo/sub/dir", "/nonexistent/repo")).toBe(true);
 	});
 
-	describe("nested git repo / submodule exclusion (real filesystem)", () => {
+	// Every `.git` in this block is hand-built and git itself would refuse all of
+	// them (no HEAD, or a pointer to a directory that does not exist), so
+	// `readRepositoryKey` declines and these cases exercise the path-shaped
+	// FALLBACK. That is deliberate — the fallback is what an unreadable repository
+	// gets, and it must keep behaving as it always did. The primary path, where git
+	// answers, is pinned in `SessionDirMatch.realgit.test.ts`.
+	describe("nested git repo / submodule exclusion (unreadable-.git fallback)", () => {
 		let root: string;
 
 		beforeEach(async () => {
@@ -79,22 +85,32 @@ describe("sessionDirBelongsToRepo", () => {
 			expect(sessionDirBelongsToRepo(sub, root)).toBe(true);
 		});
 
-		// A linked worktree (`git worktree add .worktrees/foo`) has a `.git` FILE at
-		// its root. Excluding its sessions from a PARENT/sibling worktree's scan is
-		// intentional, not a gap (P2): the worktree is its own working context on its
-		// own branch and captures its sessions via its OWN post-commit (next test).
-		it("excludes a linked-worktree session from a parent worktree's scan (.git file at worktree root)", async () => {
+		// The next two cases pin the FALLBACK, not the product rule.
+		//
+		// Every fixture in this describe block builds a `.git` that git itself would
+		// reject — an empty directory, or a pointer file naming a directory that does
+		// not exist — so `readRepositoryKey` declines for both sides and
+		// `sessionDirBelongsToRepo` runs its path-shaped fallback. That is worth
+		// pinning (an unreadable repository must behave as it always did), but it is
+		// NOT what a real linked worktree does: see `SessionDirMatch.realgit.test.ts`,
+		// where a genuine `git worktree add` is attributed to its repository.
+		//
+		// The previous version of these two cases claimed the exclusion was deliberate,
+		// because such a worktree would "capture its sessions via its OWN post-commit"
+		// with its own root as `repoRoot`. That premise was false: `registerRepo`
+		// resolves every cwd through `getProjectRootDir`, so a linked worktree's path is
+		// never recorded and never becomes a `repoRoot`.
+		it("falls back to excluding an unreadable nested worktree from a parent's scan", async () => {
 			await mkdir(join(root, ".git"), { recursive: true });
 			const worktree = join(root, ".worktrees", "foo");
 			const worktreeSub = join(worktree, "packages", "bar");
 			await mkdir(worktreeSub, { recursive: true });
-			// The linked worktree's root carries a `.git` FILE pointing into the main repo.
+			// A `.git` FILE whose target does not exist — the layout reader declines.
 			await writeFile(join(worktree, ".git"), "gitdir: ../../.git/worktrees/foo\n");
-			// Scanned against the PARENT repo root: the intervening `.git` file excludes it.
 			expect(sessionDirBelongsToRepo(worktreeSub, root)).toBe(false);
 		});
 
-		it("keeps that same linked-worktree session when scanned against the worktree's own root", async () => {
+		it("falls back to keeping that session when scanned against the worktree's own root", async () => {
 			const worktree = join(root, ".worktrees", "foo");
 			const worktreeSub = join(worktree, "packages", "bar");
 			await mkdir(worktreeSub, { recursive: true });

--- a/cli/src/core/SessionDirMatch.ts
+++ b/cli/src/core/SessionDirMatch.ts
@@ -1,46 +1,73 @@
 /**
- * Directory-based session attribution for hookless sources.
+ * Directory-based session attribution: does a recorded working directory belong
+ * to a given repository?
  *
- * Devin, OpenCode, and Copilot have no agent hook: at post-commit time the
- * discoverer reads a global session DB and must map each session's recorded
- * working directory back to the committing repo itself. Hook-backed sources
- * (Claude/Gemini) don't need this — their hook resolves the git root when the
- * session ends and records against it directly.
+ * Every hookless source needs this. Codex, Kimi, OpenCode, Copilot (CLI and
+ * Chat), Cline, Devin and Antigravity read a machine-wide store at post-commit
+ * time and must map each session's recorded working directory back to a repo.
+ * Claude's DISK scan uses it too — its hook records against the resolved git
+ * root directly, but the transcript sweep that back-fills history has only a
+ * directory to go on.
+ *
+ * The question is about REPOSITORY MEMBERSHIP, and the repository is what the
+ * dashboard counts: `repoIdentity` is one row per project, and a linked worktree
+ * is deliberately folded into it (`registerRepo` anchors on the main worktree
+ * root). So "which repo does this session belong to" has exactly one correct
+ * answer per session, and every worktree of a project shares it.
  */
 
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { readRepositoryKey } from "./GitFsLayout.js";
 import { isPathInside, normalizePathForCompare } from "./PathUtils.js";
 
 /**
  * Decides whether an agent session whose working directory is `sessionDir`
- * should be attributed to the git worktree rooted at `repoRoot`.
+ * should be attributed to the repository whose main worktree is `repoRoot`.
  *
- * The match is prefix/containment (see {@link isPathInside}): a session run
- * from a subdirectory of the worktree — common in a monorepo, e.g.
- * `cd packages/foo && devin …` — still belongs to the repo. This replaced the
- * previous exact-equality match, which silently dropped every subdirectory
- * session (JOLLI-2015).
+ * ## The rule: same repository, whichever worktree
  *
- * Containment alone would double-capture a session that actually lives in a
- * NESTED git repo or submodule inside the worktree: it would be attributed to
- * BOTH the inner repo (its own post-commit) and this outer one. To prevent
- * that, a strict-subdirectory match is rejected when any directory between
- * `sessionDir` and `repoRoot` (including `sessionDir`, excluding `repoRoot`)
- * carries its own `.git` — a directory for a nested clone, a file for a
- * submodule/linked worktree. This deliberately also excludes a linked worktree
- * created inside the tree (e.g. `git worktree add .worktrees/foo`, whose root
- * carries a `.git` file): that worktree is its own working context on its own
- * branch, so its sessions are attributed by *its* post-commit — where its root
- * is `repoRoot` and the intervening-`.git` walk never fires — not swept up by a
- * sibling/parent worktree's commit, which would be cross-context bleed. The
- * check is filesystem `existsSync` only (no `git` subprocess) and runs solely
- * for the strict-subdirectory case; an exact `sessionDir === repoRoot` match
- * skips it. `repoRoot`'s own `.git` is never inspected, so a normal repo's
- * subdirectory sessions are always kept. If an
- * intermediate directory no longer exists, no `.git` is found and the session
- * is kept (best-effort: the recorded dir is gone, so attribute it to the repo
- * that matched by path).
+ * Asked of git via {@link readRepositoryKey}, which reads each side's shared git
+ * directory off the filesystem (~0.1 ms, no subprocess). Every worktree of one
+ * repository reports the same shared directory, so a session run in ANY of them
+ * is attributed to that repository — and a session in a nested clone or a
+ * submodule reports a different one and is excluded. Both answers fall out of one
+ * comparison.
+ *
+ * That is the only rule consistent with what the dashboard stores. `repoIdentity`
+ * is one row per project and `registerRepo` folds every linked worktree into it,
+ * so a worktree is never a statistics unit of its own — there is no second row
+ * for a session to belong to instead.
+ *
+ * ## Why the previous rule could not express it
+ *
+ * It was two path-shaped steps: containment (`isPathInside`), then a walk up from
+ * `sessionDir` rejecting any intervening `.git`. Both steps mis-handle a worktree,
+ * in opposite directions:
+ *
+ *   - A worktree added OUTSIDE the main one (`git worktree add ../feat-x`, the
+ *     usual shape) fails containment outright.
+ *   - A worktree added INSIDE it (`git worktree add .worktrees/foo`) passes
+ *     containment and is then rejected by the `.git` walk — because a linked
+ *     worktree's root carries a `.git` FILE, which that step reads as "a nested
+ *     repository" when it in fact says "a worktree of THIS repository".
+ *
+ * The exclusion used to be documented as deliberate, on the grounds that such a
+ * worktree "captures its sessions via its OWN post-commit — where its root is
+ * `repoRoot`". That premise does not hold: `registerRepo` resolves every cwd
+ * through `getProjectRootDir` (i.e. `dirname(--git-common-dir)`), so a linked
+ * worktree's path is never recorded and never becomes a `repoRoot`. The sessions
+ * were therefore attributed to nothing at all. Measured on one developer machine
+ * with 18 worktrees: 24 of 107 sessions in a week reached no repository.
+ *
+ * ## The fallback, and what it is for
+ *
+ * `readRepositoryKey` answers null rather than guessing — for a `.git` git itself
+ * would refuse, when the git location env vars redirect git away from `cwd`, and
+ * for a directory that no longer exists. Those cases keep the two path-shaped
+ * steps below, unchanged, so behaviour outside a readable repository is exactly
+ * what it was: containment plus the nested-`.git` walk, and a recorded directory
+ * that has since been deleted stays attributed to the repo it matches by path.
  *
  * Both paths are absolute; comparison folds separators and (on Windows/macOS)
  * case via {@link normalizePathForCompare}.
@@ -56,6 +83,19 @@ export function sessionDirBelongsToRepo(sessionDir: string, repoRoot: string): b
 	if (!sessionDir) {
 		return false;
 	}
+	// The session side first: it is the one that can be gone (a recorded directory
+	// outlives the checkout), so failing here saves reading `repoRoot` at all. A
+	// null on EITHER side means "unreadable", never "different" — fall through.
+	const sessionRepo = readRepositoryKey(sessionDir);
+	if (sessionRepo !== null) {
+		const targetRepo = readRepositoryKey(repoRoot);
+		if (targetRepo !== null) {
+			return sessionRepo === targetRepo;
+		}
+	}
+	// ── Fallback only, from here down: reached when at least one side's git layout
+	// was unreadable. Kept verbatim so an unreadable repository behaves exactly as
+	// it did before the key comparison above existed.
 	if (!isPathInside(sessionDir, repoRoot)) {
 		return false;
 	}
@@ -65,6 +105,8 @@ export function sessionDirBelongsToRepo(sessionDir: string, repoRoot: string): b
 		return true;
 	}
 	// Strict subdirectory: reject if an intervening `.git` marks a nested repo.
+	// Cannot tell a nested clone from a linked worktree (both leave a `.git` at
+	// that level) — which is why the key comparison above is the primary path.
 	let current = sessionDir;
 	while (normalizePathForCompare(current) !== repoNorm) {
 		if (existsSync(join(current, ".git"))) {

--- a/cli/src/core/sessions/SessionSignalExtractor.test.ts
+++ b/cli/src/core/sessions/SessionSignalExtractor.test.ts
@@ -91,6 +91,34 @@ describe("mergeToolCalls", () => {
 		expect(merged[0]).not.toHaveProperty("server");
 	});
 
+	it("adopts usage from whichever side attributed it", () => {
+		// Only the skill extractor attributes tokens, so in practice exactly one side
+		// carries a value — and which side depends on extractor registration order,
+		// which is not something a bucket should depend on.
+		const usage = { input: 1, cached: 4162, output: 797, confidence: "attributed" } as const;
+		const fromSecond = mergeToolCalls([
+			[bucket({ name: "code-review", kind: "skill", calls: 2 })],
+			[bucket({ name: "code-review", kind: "skill", calls: 1, usage })],
+		]);
+		const fromFirst = mergeToolCalls([
+			[bucket({ name: "code-review", kind: "skill", calls: 1, usage })],
+			[bucket({ name: "code-review", kind: "skill", calls: 2 })],
+		]);
+		expect(fromSecond).toEqual([{ name: "code-review", kind: "skill", calls: 2, usage }]);
+		expect(fromFirst).toEqual(fromSecond);
+	});
+
+	it("omits `usage` entirely when neither side attributed anything", () => {
+		// A merged bucket with a zeroed usage would claim the skill was measured and
+		// free. Most skill buckets on a real machine come from sources that attribute
+		// nothing, so this is the common path, not the edge.
+		const merged = mergeToolCalls([
+			[bucket({ name: "jolli-search", kind: "skill" })],
+			[bucket({ name: "jolli-search", kind: "skill", calls: 3 })],
+		]);
+		expect(merged[0]).not.toHaveProperty("usage");
+	});
+
 	it("takes the LATER instant when both sides have one", () => {
 		const merged = mergeToolCalls([
 			[bucket({ name: "Bash", lastCallAtMs: 1_000 })],
@@ -131,5 +159,70 @@ describe("mergeToolCalls", () => {
 			[bucket({ name: `a${NUL}b`, kind: "skill" }), bucket({ name: "a", kind: "skill" })],
 		]);
 		expect(merged).toHaveLength(2);
+	});
+
+	/**
+	 * The per-entry list, and the ORDER these arrive in is the whole point.
+	 *
+	 * `SESSION_SIGNAL_EXTRACTORS` runs the tool extractor first, so its bucket is the
+	 * one the merge starts from — and `parseToolUse` re-attributes a `Skill` call to
+	 * `input.skill`, which means both extractors produce a bucket for any skill entered
+	 * by that tool. Taking the first side's list therefore dropped every per-entry
+	 * record of the one path that can report an outcome. Measured before the fix: 72
+	 * detail rows in a real database and not one marked observed.
+	 */
+	it("keeps the LONGER invocation list, whichever side it arrived on", () => {
+		const entry = (at: string) => ({ at, ok: true, entryPath: "tool" as const });
+		// Tool side first and shorter, mirroring production: it cannot see the
+		// slash-command path, so its list is a subset rather than a second opinion.
+		const merged = mergeToolCalls([
+			[bucket({ name: "review", kind: "skill", calls: 2, invocations: [entry("2026-08-01T10:00:00.000Z")] })],
+			[
+				bucket({
+					name: "review",
+					kind: "skill",
+					calls: 3,
+					invocations: [entry("2026-08-01T10:00:00.000Z"), entry("2026-08-01T11:00:00.000Z")],
+				}),
+			],
+		]);
+		expect(merged[0].invocations).toHaveLength(2);
+	});
+
+	it("keeps a first-side invocation list when the second carries none", () => {
+		const merged = mergeToolCalls([
+			[
+				bucket({
+					name: "review",
+					kind: "skill",
+					calls: 1,
+					invocations: [{ at: "2026-08-01T10:00:00.000Z", ok: true }],
+				}),
+			],
+			[bucket({ name: "review", kind: "skill", calls: 1 })],
+		]);
+		expect(merged[0].invocations).toHaveLength(1);
+	});
+
+	it("carries the heuristic mark and the plugin from whichever side resolved one", () => {
+		// Only the skill extractor resolves either, so at most one side has a value —
+		// but the side it lands on is not the one the merge starts from.
+		const merged = mergeToolCalls([
+			[bucket({ name: "jolli-search", kind: "skill" })],
+			[bucket({ name: "jolli-search", kind: "skill", detection: "heuristic", plugin: "jolli" })],
+		]);
+		expect(merged[0]).toMatchObject({ detection: "heuristic", plugin: "jolli" });
+	});
+
+	it("leaves all three absent when neither side has them", () => {
+		// Absent must stay absent: an empty invocation list would read as "it ran zero
+		// times", and a null plugin as "namespace unknown" rather than "no namespace".
+		const merged = mergeToolCalls([
+			[bucket({ name: "Bash" })],
+			[bucket({ name: "Bash", calls: 2, lastCallAtMs: 5 })],
+		]);
+		expect(merged[0]).not.toHaveProperty("invocations");
+		expect(merged[0]).not.toHaveProperty("detection");
+		expect(merged[0]).not.toHaveProperty("plugin");
 	});
 });

--- a/cli/src/core/sessions/SessionSignalExtractor.ts
+++ b/cli/src/core/sessions/SessionSignalExtractor.ts
@@ -164,6 +164,28 @@ export function mergeToolCalls(groups: ReadonlyArray<ReadonlyArray<ToolCallCount
 				continue;
 			}
 			const lastCallAtMs = Math.max(seen.lastCallAtMs ?? 0, call.lastCallAtMs ?? 0);
+			const usage = seen.usage ?? call.usage;
+			/**
+			 * The LONGER list wins, which is not the `usage` rule and deliberately so.
+			 *
+			 * Only the skill extractor produces invocations today, but it is also the only
+			 * one that can see the slash-command path — there is no `SlashCommand` tool for a
+			 * tool-call reader to find. So a tool-side list would be a SUBSET of this one
+			 * rather than a second opinion, and `seen ?? call` would silently prefer it:
+			 * `SESSION_SIGNAL_EXTRACTORS` runs the tool extractor FIRST, so `seen` is its
+			 * bucket for every skill entered by the `Skill` tool.
+			 *
+			 * That is not hypothetical — it shipped. `parseToolUse` re-attributes a `Skill`
+			 * call to `input.skill`, so both extractors produce a bucket for such a skill, the
+			 * spread below took the tool side's, and every entry of the one path that CAN
+			 * report an outcome lost its per-entry record on the way to the database.
+			 */
+			const invocations =
+				(call.invocations?.length ?? 0) > (seen.invocations?.length ?? 0) ? call.invocations : seen.invocations;
+			/* Same "either side carries it" rule as `usage`: only the skill extractor
+			   resolves a namespace or marks an inference, so at most one side has a value. */
+			const detection = seen.detection ?? call.detection;
+			const plugin = seen.plugin ?? call.plugin;
 			merged.set(key, {
 				...seen,
 				// `server` rides along from whichever side has it: only MCP buckets carry
@@ -171,6 +193,16 @@ export function mergeToolCalls(groups: ReadonlyArray<ReadonlyArray<ToolCallCount
 				...((seen.server ?? call.server) ? { server: seen.server ?? call.server } : {}),
 				calls: Math.max(seen.calls, call.calls),
 				...(lastCallAtMs > 0 ? { lastCallAtMs } : {}),
+				// Same rule as `server`, and for the same reason rather than by analogy:
+				// only the skill extractor attributes tokens, so at most one side carries
+				// a value. Were both to carry one they would be the same attribution over
+				// the same records — these are two VIEWS of one set, per the note on
+				// `calls` — so taking either is taking the one answer, never picking a
+				// winner between two measurements.
+				...(usage !== undefined ? { usage } : {}),
+				...(invocations !== undefined ? { invocations } : {}),
+				...(detection !== undefined ? { detection } : {}),
+				...(plugin !== undefined ? { plugin } : {}),
 			});
 		}
 	}

--- a/cli/src/core/sessions/SkillExtractor.test.ts
+++ b/cli/src/core/sessions/SkillExtractor.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../skills/SkillTranscriptScanner.js", () => ({ getSkillScanner: vi.fn() }));
 
 import type { SkillInvocation, SkillUse, TranscriptSource } from "../../Types.js";
+import { USAGE_SPLIT_LINE_1 } from "../skills/__fixtures__/claudeTranscript.js";
 import { getSkillScanner } from "../skills/SkillTranscriptScanner.js";
 import type { SessionSignalInput } from "./SessionSignalExtractor.js";
 import { skillExtractor } from "./SkillExtractor.js";
@@ -99,8 +100,43 @@ describe("skillExtractor.extract", () => {
 		const signals = await skillExtractor.extract(input(async () => ["{}"]));
 
 		expect(signals.tools).toEqual([
-			{ name: "code-review", kind: "skill", calls: 1, lastCallAtMs: Date.parse("2026-08-01T10:00:00.000Z") },
+			{
+				name: "code-review",
+				kind: "skill",
+				calls: 1,
+				lastCallAtMs: Date.parse("2026-08-01T10:00:00.000Z"),
+				// Forwarded, not reduced to the count: the dashboard writes one row per entry.
+				invocations: [{ at: "2026-08-01T10:00:00.000Z", ok: true }],
+			},
 		]);
+	});
+
+	it("carries the attributed token spend onto the bucket", async () => {
+		// The very figures `SkillAttribution.test.ts` pins for this fixture, reached
+		// through the extractor — which is the point: the dashboard's per-skill numbers
+		// and the ones the IDE panel reads out of `plans.json` are one measurement run
+		// twice, not two implementations that agree until they don't.
+		vi.mocked(getSkillScanner).mockReturnValue(
+			scannerFor([use("superpowers:brainstorming", [{ at: "2026-07-12T11:08:35.523Z", ok: true }])]),
+		);
+
+		const signals = await skillExtractor.extract(input(async () => [USAGE_SPLIT_LINE_1]));
+
+		expect(signals.tools?.[0]?.usage).toEqual({ input: 1, cached: 4162, output: 797, confidence: "attributed" });
+	});
+
+	it("leaves usage ABSENT — never zeroed — when nothing could be attributed", async () => {
+		// Codex, Kimi and Cursor attribute nothing at all, and on a real machine they
+		// are the majority of skill calls. A zeroed bucket would price their skills at
+		// free rather than reporting them unmeasured, which is the distinction the whole
+		// column exists to keep.
+		vi.mocked(getSkillScanner).mockReturnValue(
+			scannerFor([use("code-review", [{ at: "2026-08-01T10:00:00.000Z", ok: true }])]),
+		);
+
+		const signals = await skillExtractor.extract(input(async () => ["{}"]));
+
+		expect(signals.tools?.[0]).not.toHaveProperty("usage");
 	});
 
 	it("counts calls as the number of invocations", async () => {

--- a/cli/src/core/sessions/SkillExtractor.ts
+++ b/cli/src/core/sessions/SkillExtractor.ts
@@ -40,52 +40,12 @@
  */
 
 import { errMsg } from "../../Logger.js";
-import type { SkillUse, ToolCallCount, TranscriptSource } from "../../Types.js";
+import type { TranscriptSource } from "../../Types.js";
+import { attributeSkillUsage } from "../skills/SkillAttribution.js";
+import { skillUseToToolCall } from "../skills/SkillToolCall.js";
 import { getSkillScanner } from "../skills/SkillTranscriptScanner.js";
+import { readSubagentLineGroups } from "../skills/TranscriptSkillDiscovery.js";
 import type { SessionSignalExtractor, SessionSignalInput, SessionSignals } from "./SessionSignalExtractor.js";
-
-/**
- * Folds one scanned skill into a tool bucket.
- *
- * `calls` is the invocation count the scanner measured, and `lastCallAtMs` comes
- * from the invocation list — NOT from the session's own clock. A session's
- * `updatedAt` moves every time the conversation is touched afterwards, so using it
- * would date a skill run from three weeks ago as today's and quietly shift it into
- * whatever window the dashboard is showing.
- *
- * Taken as the MAXIMUM over the list rather than as `invocations[0]`. Claude, Kimi
- * and OpenCode all sort newest-first, so for them the two are the same number —
- * this only stops the value depending on an ordering convention that lives in three
- * separate scanners and is not enforced anywhere.
- *
- * **The heuristic Codex path is a documented floor, not a last-call instant.**
- * `scanCodexSkillLines` records one invocation per skill at the FIRST `SKILL.md`
- * read it saw, deliberately: 49% of real (session, skill) pairs are several paged
- * reads of one use, so counting each read would claim a skill was entered ten times
- * when it was entered once. That leaves no last-use instant in the data to recover,
- * so a Codex bucket dates from when the skill entered the picture. Reporting the
- * first read is a lower bound on a real use; the alternative — no timestamp — would
- * drop the skill out of every windowed view instead of placing it early in one.
- *
- * Invocations with an unparseable instant contribute no timestamp rather than a
- * zero: absence means "no timestamp recorded", which readers fall back on, while
- * a zero is a real instant in 1970 and would sort as the oldest call ever made.
- */
-function toToolCall(use: SkillUse): ToolCallCount {
-	let lastCallAtMs = Number.NaN;
-	for (const invocation of use.invocations) {
-		const at = Date.parse(invocation.at);
-		if (Number.isFinite(at) && (!Number.isFinite(lastCallAtMs) || at > lastCallAtMs)) lastCallAtMs = at;
-	}
-	return {
-		// The skill's own name, matching what the `Skill` tool path reports, so the two
-		// halves of one skill's usage fold together instead of appearing as two rows.
-		name: use.skill,
-		kind: "skill",
-		calls: use.invocations.length,
-		...(Number.isFinite(lastCallAtMs) ? { lastCallAtMs } : {}),
-	};
-}
 
 export const skillExtractor: SessionSignalExtractor = {
 	id: "skills",
@@ -105,7 +65,22 @@ export const skillExtractor: SessionSignalExtractor = {
 			// so advancing one from here would permanently strand the lines between the
 			// old mark and the new one for the StopHook that was going to read them.
 			const result = scanner.scan(lines, 0);
-			return result.uses.length > 0 ? { tools: result.uses.map(toToolCall) } : {};
+			if (result.uses.length === 0) return {};
+
+			// Attribution reads the subagent files too, matching `scanSkillsFrom` exactly.
+			// It is the same function over the same input on purpose: the dashboard's
+			// per-skill figures and the ones the IDE panel reads out of `plans.json` have
+			// to be one measurement, not two implementations that agree until they don't.
+			//
+			// A subagent's `attributionSkill` is inherited from its parent and never
+			// updated, so a subagent's spend is invisible to attribution run over the
+			// session file alone — which is why the groups are read here rather than left
+			// to the caller's `content.lines()`.
+			//
+			// Read only once a skill was actually found: a session with no skills owes no
+			// `readdir`, and most sessions have none.
+			const usageBySkill = attributeSkillUsage(lines, await readSubagentLineGroups(input.transcriptPath));
+			return { tools: result.uses.map((use) => skillUseToToolCall(use, usageBySkill.get(use.skill))) };
 		} catch (err) {
 			throw new Error(`skill extraction failed for ${input.source}/${input.sessionId}: ${errMsg(err)}`);
 		}

--- a/cli/src/core/skills/ClaudeSkillScanner.test.ts
+++ b/cli/src/core/skills/ClaudeSkillScanner.test.ts
@@ -55,6 +55,7 @@ describe("scanClaudeSkillLines — Skill tool entry path", () => {
 		expect(uses).toHaveLength(1);
 		expect(uses[0].skill).toBe("superpowers:brainstorming");
 		expect(uses[0].invocations[0].bodyChars).toBeUndefined();
+		expect(uses[0].invocations[0].outcomeObserved).toBe(false);
 	});
 
 	it("rewinds the cursor to before a tool_use whose result has not arrived", () => {
@@ -111,6 +112,7 @@ describe("scanClaudeSkillLines — Skill tool entry path", () => {
 		);
 		const { uses } = scanClaudeSkillLines([TOOL_CALL, failed], 0);
 		expect(uses[0].invocations[0].ok).toBe(false);
+		expect(uses[0].invocations[0].outcomeObserved).toBe(true);
 	});
 
 	it("treats an is_error tool_result block as a failed invocation", () => {

--- a/cli/src/core/skills/ClaudeSkillScanner.ts
+++ b/cli/src/core/skills/ClaudeSkillScanner.ts
@@ -339,6 +339,12 @@ function assemble(
 			...(entry.args !== undefined ? { args: entry.args } : {}),
 			...(entry.bodyChars !== undefined ? { bodyChars: entry.bodyChars } : {}),
 			ok: entry.ok,
+			outcomeObserved: entry.sawResult,
+			// Stamped per invocation, not left to the bucket's `entryPaths` set: a skill
+			// reached both ways carries both paths there, so only this field can say which
+			// mechanism produced THIS entry — and that is what decides whether its `ok` was
+			// read from a `tool_result` or defaulted (see `skillOutcomeConfidence`).
+			entryPath: "tool",
 		});
 	}
 
@@ -347,7 +353,10 @@ function assemble(
 			at: entry.at,
 			...(entry.args !== undefined ? { args: entry.args } : {}),
 			bodyChars: entry.bodyChars,
+			// Hard-coded, and the reason is what `entryPath` below exists to record: this
+			// path has no result record at all, so failure is not knowable here.
 			ok: true,
+			entryPath: "command",
 		});
 	}
 

--- a/cli/src/core/skills/CodexSkillScanner.test.ts
+++ b/cli/src/core/skills/CodexSkillScanner.test.ts
@@ -327,6 +327,17 @@ describe("scanCodexSkillLines — the injected block (Codex Desktop)", () => {
 		expect(uses[0].plugin).toBe("documents");
 	});
 
+	it("learns a plugin when a bare id is followed by a namespaced id", () => {
+		// A bare id has no opinion about ownership. A later definite namespace may
+		// therefore fill the label without creating a second skill row.
+		const bare = CODEX_INJECTED_SKILL_BLOCK.split("documents:documents").join("documents");
+		const { uses } = scanCodexSkillLines([codexRecord(bare, T1), codexRecord(CODEX_INJECTED_SKILL_BLOCK, T2)], 0);
+
+		expect(uses).toHaveLength(1);
+		expect(uses[0].plugin).toBe("documents");
+		expect(uses[0].invocations.map((i) => i.at)).toEqual([T2, T1]);
+	});
+
 	it("ignores a user message that names a SKILL.md but carries no block", () => {
 		// The block requirement, isolated. Every other non-entry fixture is rejected by the
 		// role check first, so this is the only one that can fail when the block test alone
@@ -456,6 +467,44 @@ describe("scanCodexSkillLines — the injected block (Codex Desktop)", () => {
 		const plain = '{"type":"message","role":"user","content":[{"type":"input_text","text":"read the SKILL.md"}]}';
 
 		expect(scanCodexSkillLines([codexRecord(plain, T1)], 0).uses).toEqual([]);
+	});
+
+	it("ignores an injected block with no timestamp rather than inventing one", () => {
+		// Flat records exist, but an invocation without an observed instant cannot be
+		// keyed or ordered downstream.
+		expect(scanCodexSkillLines([CODEX_INJECTED_LOCAL_SKILL_BLOCK], 0).uses).toEqual([]);
+	});
+
+	it("ignores malformed message content parts independently", () => {
+		const block = "SKILL.md <skill><name>documents:documents</name></skill>";
+		const nonArray = JSON.stringify({ type: "message", role: "user", timestamp: T1, content: block });
+		const malformedParts = JSON.stringify({
+			type: "message",
+			role: "user",
+			timestamp: T1,
+			content: [null, { text: 42 }],
+		});
+
+		expect(scanCodexSkillLines([nonArray, malformedParts], 0).uses).toEqual([]);
+	});
+
+	it("ignores a non-message, non-call record that quotes a skill path", () => {
+		const output = JSON.stringify({
+			type: "custom_tool_call_output",
+			output: "cat /x/skills/documents/SKILL.md",
+			timestamp: T1,
+		});
+
+		expect(scanCodexSkillLines([output], 0).uses).toEqual([]);
+	});
+
+	it("advances across a sparse transcript line without reading it", () => {
+		const lines = Array<string>(2);
+		lines[1] = codexRecord(CODEX_INJECTED_LOCAL_SKILL_BLOCK, T1);
+
+		const result = scanCodexSkillLines(lines, 0);
+		expect(result.uses).toHaveLength(1);
+		expect(result.lastLine).toBe(2);
 	});
 
 	it("ignores a block whose name tag is empty", () => {

--- a/cli/src/core/skills/CodexSkillScanner.ts
+++ b/cli/src/core/skills/CodexSkillScanner.ts
@@ -344,7 +344,12 @@ export function scanCodexSkillLines(lines: ReadonlyArray<string>, fromLine: numb
 			// Kimi and OpenCode all produce. `toToolCall` takes the MAX rather than the head,
 			// so nothing depends on the order — but an ordering the type declares should not
 			// be left to whatever `Set` iteration happened to give.
-			invocations: [...entry.ats].sort((a, b) => (a < b ? 1 : a > b ? -1 : 0)).map((at) => ({ at, ok: true })),
+			// `ok: true` is a DEFAULT, not a reading: an injected block is a definite entry
+			// but has no result record, so failure is unknowable on this path too. The
+			// `entryPath` stamp is what lets `skillOutcomeConfidence` say so downstream.
+			invocations: [...entry.ats]
+				.sort((a, b) => (a < b ? 1 : a > b ? -1 : 0))
+				.map((at) => ({ at, ok: true, entryPath: "command" as const })),
 			// No `detection` marker — the block is a definite entry, not an inference. Note
 			// the store's cross-window rule is "sticky once heuristic", so this does not
 			// un-label a name a shell read already marked; see this file's header.
@@ -369,7 +374,7 @@ export function scanCodexSkillLines(lines: ReadonlyArray<string>, fromLine: numb
 			// there is no namespace to recover. No usage: see the header. No bodyChars: a
 			// paged read tells us nothing about what reached the model.
 			entryPaths: ["tool"],
-			invocations: [{ at, ok: true }],
+			invocations: [{ at, ok: true, entryPath: "tool" }],
 			detection: "heuristic",
 		});
 	}

--- a/cli/src/core/skills/KimiSkillScanner.test.ts
+++ b/cli/src/core/skills/KimiSkillScanner.test.ts
@@ -38,7 +38,7 @@ describe("scanKimiSkillLines", () => {
 			source: "kimi",
 			skill: "hello-capture",
 			entryPaths: ["tool"],
-			invocations: [{ at: iso(1_700_000_000_000), ok: true }],
+			invocations: [{ at: iso(1_700_000_000_000), ok: true, entryPath: "tool", outcomeObserved: true }],
 		});
 		// No heuristic marker — Kimi's skill tool is observed.
 		expect(uses[0]).not.toHaveProperty("detection");
@@ -61,7 +61,9 @@ describe("scanKimiSkillLines", () => {
 		];
 		const { uses } = scanKimiSkillLines(lines, 0);
 		expect(uses).toHaveLength(1);
-		expect(uses[0].invocations).toEqual([{ at: iso(1_700_000_000_000), ok: false }]);
+		expect(uses[0].invocations).toEqual([
+			{ at: iso(1_700_000_000_000), ok: false, entryPath: "tool", outcomeObserved: true },
+		]);
 	});
 
 	it("groups repeat invocations of one skill, newest-first", () => {
@@ -74,8 +76,8 @@ describe("scanKimiSkillLines", () => {
 		const { uses } = scanKimiSkillLines(lines, 0);
 		expect(uses).toHaveLength(1);
 		expect(uses[0].invocations).toEqual([
-			{ at: iso(1_700_000_009_000), ok: true }, // newest first
-			{ at: iso(1_700_000_000_000), ok: true },
+			{ at: iso(1_700_000_009_000), ok: true, entryPath: "tool", outcomeObserved: true }, // newest first
+			{ at: iso(1_700_000_000_000), ok: true, entryPath: "tool", outcomeObserved: true },
 		]);
 	});
 
@@ -138,7 +140,9 @@ describe("scanKimiSkillLines", () => {
 		});
 		const { uses } = scanKimiSkillLines([call], 0);
 		expect(uses).toHaveLength(1);
-		expect(uses[0].invocations).toEqual([{ at: iso(1_700_000_000_000), ok: true }]);
+		expect(uses[0].invocations).toEqual([
+			{ at: iso(1_700_000_000_000), ok: true, entryPath: "tool", outcomeObserved: false },
+		]);
 	});
 
 	it("holds the cursor before an in-flight Skill call (toolCallId, result not yet landed)", () => {
@@ -149,6 +153,7 @@ describe("scanKimiSkillLines", () => {
 		const { uses, lastLine } = scanKimiSkillLines(lines, 0);
 		expect(uses).toHaveLength(1);
 		expect(uses[0].invocations[0].ok).toBe(true);
+		expect(uses[0].invocations[0].outcomeObserved).toBe(false);
 		expect(lastLine).toBe(0); // held before the call (0-based line 0), not advanced to EOF (1)
 	});
 
@@ -219,5 +224,6 @@ describe("scanKimiSkillLines", () => {
 		const { uses } = scanKimiSkillLines(lines, 0);
 		expect(uses).toHaveLength(1);
 		expect(uses[0].invocations[0].ok).toBe(true);
+		expect(uses[0].invocations[0].outcomeObserved).toBe(true);
 	});
 });

--- a/cli/src/core/skills/KimiSkillScanner.ts
+++ b/cli/src/core/skills/KimiSkillScanner.ts
@@ -152,7 +152,14 @@ function assemble(entries: ReadonlyArray<PendingSkill>): ReadonlyArray<SkillUse>
 			invocations = [];
 			bySkill.set(entry.skill, invocations);
 		}
-		invocations.push({ at: entry.at, ok: entry.ok });
+		invocations.push({
+			at: entry.at,
+			ok: entry.ok,
+			entryPath: "tool",
+			// A call without its paired result is still a run, but its optimistic `ok`
+			// is not an observed outcome.
+			outcomeObserved: entry.sawResult,
+		});
 	}
 
 	const uses: SkillUse[] = [];

--- a/cli/src/core/skills/OpenCodeSkillScanner.test.ts
+++ b/cli/src/core/skills/OpenCodeSkillScanner.test.ts
@@ -126,7 +126,11 @@ describe("scanOpenCodeSkillRows", () => {
 		// dropping it, and an absent output means no body size rather than a zero one.
 		const sparse = '{"type":"tool","tool":"skill","state":{"status":"completed","metadata":{"name":"jolli"}}}';
 		const { uses } = scanOpenCodeSkillRows([part(sparse, 1785216878468)], []);
-		expect(uses[0].invocations[0]).toEqual({ at: new Date(1785216878468).toISOString(), ok: true });
+		expect(uses[0].invocations[0]).toEqual({
+			at: new Date(1785216878468).toISOString(),
+			ok: true,
+			entryPath: "tool",
+		});
 	});
 
 	it("orders invocations newest-first however the rows arrive", () => {

--- a/cli/src/core/skills/OpenCodeSkillScanner.ts
+++ b/cli/src/core/skills/OpenCodeSkillScanner.ts
@@ -150,7 +150,10 @@ export function scanOpenCodeSkillRows(
 			invocation: {
 				at: new Date(at).toISOString(),
 				...(output !== undefined ? { bodyChars: output.length } : {}),
+				// A reading, not a default: `state.status` distinguishes `completed` from
+				// `error`, which is why the `tool` stamp below resolves to observed.
 				ok: status === "completed",
+				entryPath: "tool",
 			},
 		});
 	}

--- a/cli/src/core/skills/SkillOutcomeConfidence.test.ts
+++ b/cli/src/core/skills/SkillOutcomeConfidence.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { skillOutcomeConfidence } from "./SkillOutcomeConfidence.js";
+
+describe("skillOutcomeConfidence", () => {
+	it("reports observed for the three mechanisms with a result record", () => {
+		// Each of these was read off a real transcript: Claude's `tool_result`, Kimi's
+		// paired `tool.result`, OpenCode's `state.status`. See the module docblock.
+		expect(skillOutcomeConfidence("claude", "tool")).toBe("observed");
+		expect(skillOutcomeConfidence("kimi", "tool")).toBe("observed");
+		expect(skillOutcomeConfidence("opencode", "tool")).toBe("observed");
+	});
+
+	it("reports assumed when a result-capable mechanism has not produced its result yet", () => {
+		expect(skillOutcomeConfidence("claude", "tool", false)).toBe("assumed");
+		expect(skillOutcomeConfidence("kimi", "tool", false)).toBe("assumed");
+	});
+
+	it("does not let an explicit observation promote a mechanism outside the allowlist", () => {
+		expect(skillOutcomeConfidence("codex", "tool", true)).toBe("assumed");
+	});
+
+	it("reports assumed for a Claude slash command, which has no result record", () => {
+		// The path that matters most in practice: measured on one machine, five of seven
+		// Claude skills were entered this way and none of them can report a failure.
+		expect(skillOutcomeConfidence("claude", "command")).toBe("assumed");
+	});
+
+	it("reports assumed for both Codex paths", () => {
+		// The injected block is a definite ENTRY but carries no outcome, and the shell
+		// read is not an entry event at all — so neither can be believed about success.
+		expect(skillOutcomeConfidence("codex", "command")).toBe("assumed");
+		expect(skillOutcomeConfidence("codex", "tool")).toBe("assumed");
+	});
+
+	it("reports assumed when the mechanism is unknown", () => {
+		// A stored history predating `entryPath` deserializes without it. An unknown
+		// mechanism cannot have been verified to report outcomes, so it takes the weaker
+		// answer rather than the likelier-looking one.
+		expect(skillOutcomeConfidence("claude", undefined)).toBe("assumed");
+		expect(skillOutcomeConfidence("kimi", undefined)).toBe("assumed");
+	});
+
+	it("reports assumed for a source the table does not name", () => {
+		// The allowlist's whole point: a source added without a verified reading of its
+		// outcome field degrades to "we cannot say" instead of claiming it reports one.
+		// `cursor` is the live case — it has skills but no invocation record at all.
+		expect(skillOutcomeConfidence("cursor", "tool")).toBe("assumed");
+		expect(skillOutcomeConfidence("gemini", "tool")).toBe("assumed");
+		expect(skillOutcomeConfidence("some-future-agent", "command")).toBe("assumed");
+	});
+
+	it("keys on the pair, not on either half alone", () => {
+		// `claude` reports outcomes and `command` does not report them anywhere, so a
+		// lookup that considered only the source (or only the mechanism) would answer
+		// differently for at least one of these two.
+		expect(skillOutcomeConfidence("claude", "tool")).toBe("observed");
+		expect(skillOutcomeConfidence("claude", "command")).toBe("assumed");
+		expect(skillOutcomeConfidence("codex", "tool")).toBe("assumed");
+	});
+});

--- a/cli/src/core/skills/SkillOutcomeConfidence.ts
+++ b/cli/src/core/skills/SkillOutcomeConfidence.ts
@@ -1,0 +1,131 @@
+/**
+ * SkillOutcomeConfidence — whether a recorded skill outcome was READ or DEFAULTED.
+ *
+ * ## Why the mechanism alone is not enough
+ *
+ * `SkillInvocation.ok` is a required boolean, and two entirely different facts
+ * arrive as `true`:
+ *
+ *   - **A reading.** Claude's `Skill` tool path has a `tool_result` record whose
+ *     `toolUseResult.success` / `is_error` say what happened; Kimi pairs a
+ *     `tool.result` carrying `isError`; OpenCode has `state.status`.
+ *   - **A default.** Claude's slash-command path and both Codex paths have NO
+ *     result record at all, so their scanners hard-code `ok: true` because failure
+ *     is not knowable — not because nothing failed.
+ *
+ * New scanner output stamps `SkillInvocation.outcomeObserved` when it can distinguish
+ * those cases, including `false` for a live window that ended before the result. Older
+ * stored histories predate that field, and mechanisms with no result record never set
+ * it, so the invocation still needs the capability table below. A surface reading
+ * `ok` alone would otherwise show one flat wall of green and call three sources
+ * reliable. That is the same class of lie a zeroed `SkillUsage` would tell about an
+ * unattributed skill, which the codebase already refuses (see `SkillUsage`'s "an
+ * absent field is honest, a zero is a lie").
+ *
+ * ## Why a table, and why an allowlist
+ *
+ * Which mechanisms can report an outcome is a property of the HOST's transcript
+ * format, exactly like `TOOL_RECORDING_SOURCES` in `core/TranscriptParser.ts` — so
+ * it is declared in one place rather than restated by each scanner. Each scanner stamps
+ * `SkillInvocation.entryPath`; this maps `(source, entryPath)` onto the answer unless
+ * that invocation explicitly says its result was not observed.
+ *
+ * The set below is an ALLOWLIST and the default is `assumed`. A source added to
+ * `SkillSource` without a verified reading of its outcome field therefore degrades
+ * to "we cannot say", which is merely incomplete. An inverted table (listing the
+ * ones that cannot report) would make the same omission claim a NEW host reports
+ * real outcomes — the failure that must not be possible here.
+ *
+ * ## What `assumed` entitles a surface to show
+ *
+ * `assumed` bars a verdict, NOT the run. The run itself is a fact — the entry is on
+ * record with its timestamp, arguments and body size — so a surface shows it and says
+ * the result is unknown; the dashboard draws it as a neutral tick beside the measured
+ * ones and counts it separately (`SkillDetailOutcomes.assumed`). Hiding it was the
+ * first shape of this and read as "nothing was recorded" about runs that were fully
+ * recorded, which on a Claude machine is nearly every one of them.
+ *
+ * The one thing that stays forbidden is arithmetic: an `assumed` entry may never join
+ * a `measured` denominator. `failed / measured` is the only rate, because a defaulted
+ * `ok: true` is the absence of a failure report and folding it in would publish a 0%
+ * failure rate for a mechanism that cannot report failure at all.
+ *
+ * ## What deliberately is NOT here
+ *
+ * `detection` — whether the invocation was observed or inferred — is a different
+ * question with a different answer, and it must NOT be derived from this table.
+ * It arrives on `SkillUse.detection` from the scanner that made the call, and
+ * although "codex + tool" happens to be the only inferred combination today, a
+ * re-derivation would silently disagree the moment a host grows a second inferred
+ * path. See `ToolCallCount.detection`.
+ */
+
+import type { SkillEntryPath } from "../../Types.js";
+
+/**
+ * Whether a stored `ok` was read from the transcript or filled in.
+ *
+ * Named to match `SkillUsage.confidence`, which qualifies a token figure the same
+ * way for the same reason.
+ */
+export type SkillOutcomeConfidence = "observed" | "assumed";
+
+/**
+ * `<source>:<entryPath>` pairs whose transcripts carry a real outcome record.
+ *
+ * One line per verified mechanism, with what supplies the outcome:
+ *
+ *   - `claude:tool`    — the `tool_result` record's `toolUseResult.success` + `is_error`
+ *   - `kimi:tool`      — the paired `tool.result` event's `result.isError`
+ *   - `opencode:tool`  — the `part` row's `state.status` (`completed` vs `error`)
+ *
+ * Absent, and each for a measured reason rather than an omission:
+ *
+ *   - `claude:command` — the slash-command path is a `<command-name>` tag plus a body
+ *     record. There is no result record and no `SlashCommand` tool anywhere in the
+ *     corpus, so nothing can report failure.
+ *   - `codex:command`  — Codex Desktop injects the skill AS the user's turn. A definite
+ *     entry, but a `role: "user"` message has no outcome.
+ *   - `codex:tool`     — a shell call that read a `SKILL.md`. Not an entry event at all,
+ *     let alone one with a result.
+ *   - `cursor:*`       — its only record is a `readToolCall` bubble naming a
+ *     `SKILL.md` path (see `SkillTranscriptScanner` for the store and its shape), so
+ *     like `codex:tool` it is a file read rather than an entry, and a read has no
+ *     outcome. The earlier reason given here — that no record exists on disk at all —
+ *     was measured before that store was found and is not why this stays absent.
+ */
+const OUTCOME_REPORTING_MECHANISMS: ReadonlySet<string> = new Set<string>([
+	"claude:tool",
+	"kimi:tool",
+	"opencode:tool",
+]);
+
+/**
+ * Whether this invocation's `ok` means anything.
+ *
+ * `source` is the session's own `TranscriptSource` rather than a `SkillSource`,
+ * because that is what every call site holds (`SessionUpsertedEvent.source`) and a
+ * narrowing cast at each of them would be a cast that can be wrong. A source with
+ * no skill concept simply matches nothing and answers `assumed`.
+ *
+ * An absent `entryPath` is `assumed`, not a guess at the likely mechanism. It means
+ * the record predates the field (an older `skills/<source>/<skill>.md`, whose
+ * fields are read by name) or carried a value no scanner produces — in both cases
+ * the mechanism is unknown, and an unknown mechanism cannot have been verified to
+ * report outcomes.
+ *
+ * `outcomeObserved: false` also forces `assumed`: a host may support result records
+ * without the current scan window containing this invocation's result yet. `true`
+ * never bypasses the allowlist, so a malformed or future source cannot promote itself.
+ */
+export function skillOutcomeConfidence(
+	source: string,
+	entryPath: SkillEntryPath | undefined,
+	outcomeObserved?: boolean,
+): SkillOutcomeConfidence {
+	// A result-capable mechanism is not evidence that THIS invocation's result was
+	// present. Live transcript windows routinely end between the call and result.
+	if (outcomeObserved === false) return "assumed";
+	if (entryPath === undefined) return "assumed";
+	return OUTCOME_REPORTING_MECHANISMS.has(`${source}:${entryPath}`) ? "observed" : "assumed";
+}

--- a/cli/src/core/skills/SkillStore.test.ts
+++ b/cli/src/core/skills/SkillStore.test.ts
@@ -125,12 +125,20 @@ describe("foldSkillUse", () => {
 		// discarded that second reading entirely, so the fragment's gaps — no bodyChars,
 		// the default ok:true — were frozen on the row forever.
 		const at = "2026-07-30T06:01:00.000Z";
-		const fragment = foldSkillUse(use({ invocations: [inv(at)] }), undefined);
+		const fragment = foldSkillUse(
+			use({ invocations: [inv(at, { entryPath: "tool", outcomeObserved: false })] }),
+			undefined,
+		);
 		expect(fragment.invocations[0].bodyChars).toBeUndefined();
 
-		const completed = foldSkillUse(use({ invocations: [inv(at, { bodyChars: 10280, ok: false })] }), fragment);
+		const completed = foldSkillUse(
+			use({ invocations: [inv(at, { bodyChars: 10280, ok: false, entryPath: "tool", outcomeObserved: true })] }),
+			fragment,
+		);
 		expect(completed.invocations[0].bodyChars).toBe(10280);
 		expect(completed.invocations[0].ok).toBe(false);
+		expect(completed.invocations[0].entryPath).toBe("tool");
+		expect(completed.invocations[0].outcomeObserved).toBe(true);
 		// An upgrade is not a new entry.
 		expect(completed.invocationCount).toBe(1);
 		expect(completed.invocations).toHaveLength(1);
@@ -140,9 +148,10 @@ describe("foldSkillUse", () => {
 		// `ok: true` is what an unresolved entry defaults to, so it must never overwrite
 		// a false that was actually read off a tool_result.
 		const at = "2026-07-30T06:01:00.000Z";
-		const failed = foldSkillUse(use({ invocations: [inv(at, { ok: false })] }), undefined);
-		const reread = foldSkillUse(use({ invocations: [inv(at)] }), failed);
+		const failed = foldSkillUse(use({ invocations: [inv(at, { ok: false, outcomeObserved: true })] }), undefined);
+		const reread = foldSkillUse(use({ invocations: [inv(at, { outcomeObserved: false })] }), failed);
 		expect(reread.invocations[0].ok).toBe(false);
+		expect(reread.invocations[0].outcomeObserved).toBe(true);
 	});
 
 	it("does not lose a field the re-read pass no longer reports", () => {
@@ -368,6 +377,32 @@ describe("renderSkillMarkdown / parseSkillMarkdownFromString", () => {
 		expect(parsed?.invocations).toEqual([{ at: "2026-07-30T06:35:21.000Z", ok: true }]);
 	});
 
+	it("treats an unknown invocation mechanism as absent", () => {
+		// Skill files are user-editable and may outlive the reader that wrote them. An
+		// unfamiliar value must not be cast into the closed entry-path union.
+		const parsed = parseSkillMarkdownFromString(
+			["---", 'source: "claude"', 'skill: "a:b"', "---", "", "- 2026-07-30T06:35:21.000Z · via: future"].join(
+				"\n",
+			),
+		);
+		expect(parsed?.invocations).toEqual([{ at: "2026-07-30T06:35:21.000Z", ok: true }]);
+	});
+
+	it("parses both known invocation mechanisms", () => {
+		const parsed = parseSkillMarkdownFromString(
+			[
+				"---",
+				'source: "claude"',
+				'skill: "a:b"',
+				"---",
+				"",
+				"- 2026-07-30T06:35:21.000Z · via: tool",
+				"- 2026-07-30T06:36:21.000Z · via: command",
+			].join("\n"),
+		);
+		expect(parsed?.invocations.map((invocation) => invocation.entryPath)).toEqual(["tool", "command"]);
+	});
+
 	it("round-trips a fully populated skill file", () => {
 		const content = foldSkillUse(
 			use({
@@ -428,6 +463,20 @@ describe("renderSkillMarkdown / parseSkillMarkdownFromString", () => {
 		const content = foldSkillUse(use({ invocations: [inv("2026-07-30T06:35:21.000Z", { ok: false })] }), undefined);
 		const parsed = parseSkillMarkdownFromString(renderSkillMarkdown(content));
 		expect(parsed?.invocations[0]?.ok).toBe(false);
+	});
+
+	it("round-trips whether each invocation had an observed outcome", () => {
+		const content = foldSkillUse(
+			use({
+				invocations: [
+					inv("2026-07-30T06:35:21.000Z", { entryPath: "tool", outcomeObserved: false }),
+					inv("2026-07-30T06:36:21.000Z", { entryPath: "tool", outcomeObserved: true }),
+				],
+			}),
+			undefined,
+		);
+		const parsed = parseSkillMarkdownFromString(renderSkillMarkdown(content));
+		expect(parsed?.invocations.map((invocation) => invocation.outcomeObserved)).toEqual([true, false]);
 	});
 
 	it("omits an absent plugin rather than writing a null", () => {

--- a/cli/src/core/skills/SkillStore.ts
+++ b/cli/src/core/skills/SkillStore.ts
@@ -362,11 +362,24 @@ export function foldSkillUse(use: SkillUse, prior: SkillFileContent | undefined)
 function moreCompleteInvocation(prior: SkillInvocation, incoming: SkillInvocation): SkillInvocation {
 	const bodyChars = incoming.bodyChars ?? prior.bodyChars;
 	const args = incoming.args ?? prior.args;
+	const entryPath = incoming.entryPath ?? prior.entryPath;
+	const outcomeObserved =
+		prior.outcomeObserved === true || incoming.outcomeObserved === true
+			? true
+			: (prior.outcomeObserved ?? incoming.outcomeObserved);
+	const ok =
+		incoming.outcomeObserved === true
+			? incoming.ok
+			: prior.outcomeObserved === true
+				? prior.ok
+				: prior.ok && incoming.ok;
 	return {
 		at: prior.at,
 		...(args !== undefined ? { args } : {}),
 		...(bodyChars !== undefined ? { bodyChars } : {}),
-		ok: prior.ok && incoming.ok,
+		ok,
+		...(outcomeObserved !== undefined ? { outcomeObserved } : {}),
+		...(entryPath !== undefined ? { entryPath } : {}),
 	};
 }
 
@@ -406,6 +419,11 @@ function formatInvocation(inv: SkillInvocation): string {
 	// newline, and a JSON string literal has an unambiguous end quote to scan to.
 	if (inv.args !== undefined && inv.args !== "") parts.push(`args: ${JSON.stringify(inv.args)}`);
 	if (inv.bodyChars !== undefined) parts.push(`body: ${inv.bodyChars}`);
+	// Ahead of `failed` so that marker keeps the end of the line, where it is easiest to
+	// spot when scanning a file by eye. Field order carries no meaning to the parser,
+	// which reads by name.
+	if (inv.entryPath !== undefined) parts.push(`via: ${inv.entryPath}`);
+	if (inv.outcomeObserved !== undefined) parts.push(`outcome: ${inv.outcomeObserved ? "observed" : "assumed"}`);
 	if (!inv.ok) parts.push("failed");
 	return `- ${parts.join(FIELD_SEPARATOR)}`;
 }
@@ -505,16 +523,36 @@ function parseInvocationLine(line: string): SkillInvocation | null {
 	}
 
 	let bodyChars: number | undefined;
+	let entryPath: SkillEntryPath | undefined;
+	let outcomeObserved: boolean | undefined;
 	let ok = true;
 	for (const field of tail.split(FIELD_SEPARATOR)) {
 		if (field.startsWith("body: ")) {
 			const n = Number.parseInt(field.slice("body: ".length), 10);
 			if (Number.isFinite(n)) bodyChars = n;
+		} else if (field.startsWith("via: ")) {
+			// Validated against the union rather than cast: this file is user-editable text,
+			// and an unrecognised value must degrade to "unknown mechanism" — which
+			// `skillOutcomeConfidence` then treats as unmeasurable — instead of entering the
+			// type system as a mechanism no scanner produces.
+			const via = field.slice("via: ".length);
+			if (via === "tool" || via === "command") entryPath = via;
+		} else if (field === "outcome: observed") {
+			outcomeObserved = true;
+		} else if (field === "outcome: assumed") {
+			outcomeObserved = false;
 		} else if (field === "failed") {
 			ok = false;
 		}
 	}
-	return { at, ...(args !== undefined ? { args } : {}), ...(bodyChars !== undefined ? { bodyChars } : {}), ok };
+	return {
+		at,
+		...(args !== undefined ? { args } : {}),
+		...(bodyChars !== undefined ? { bodyChars } : {}),
+		...(entryPath !== undefined ? { entryPath } : {}),
+		...(outcomeObserved !== undefined ? { outcomeObserved } : {}),
+		ok,
+	};
 }
 
 function isUsageBySession(value: unknown): value is Readonly<Record<string, SkillUsage>> {

--- a/cli/src/core/skills/SkillToolCall.test.ts
+++ b/cli/src/core/skills/SkillToolCall.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import type { SkillUse } from "../../Types.js";
+import { skillUseToToolCall } from "./SkillToolCall.js";
+
+describe("skillUseToToolCall", () => {
+	it("keeps namespace, detection, usage and the newest valid invocation instant", () => {
+		const use: SkillUse = {
+			source: "codex",
+			skill: "code-review",
+			plugin: "superpowers",
+			entryPaths: ["tool"],
+			detection: "heuristic",
+			invocations: [
+				{ at: "not-a-date", ok: true, entryPath: "tool" },
+				{ at: "2026-08-01T10:00:00.000Z", ok: true, entryPath: "tool" },
+				{ at: "2026-08-01T11:00:00.000Z", ok: false, entryPath: "tool" },
+			],
+		};
+		const usage = { input: 10, output: 5, cached: 2, confidence: "estimated" as const };
+
+		expect(skillUseToToolCall(use, usage)).toEqual({
+			name: "code-review",
+			kind: "skill",
+			calls: 3,
+			plugin: "superpowers",
+			lastCallAtMs: Date.parse("2026-08-01T11:00:00.000Z"),
+			usage,
+			invocations: use.invocations,
+			detection: "heuristic",
+		});
+	});
+
+	it("does not invent optional enrichment for an empty scan", () => {
+		const use: SkillUse = {
+			source: "opencode",
+			skill: "plain",
+			entryPaths: [],
+			invocations: [],
+		};
+		expect(skillUseToToolCall(use, undefined)).toEqual({ name: "plain", kind: "skill", calls: 0 });
+	});
+});

--- a/cli/src/core/skills/SkillToolCall.ts
+++ b/cli/src/core/skills/SkillToolCall.ts
@@ -1,0 +1,46 @@
+import type { SkillUsage, SkillUse, ToolCallCount } from "../../Types.js";
+
+/**
+ * Folds one scanned skill into the tool bucket consumed by session projection.
+ *
+ * `calls` is the invocation count the scanner measured, and `lastCallAtMs` comes
+ * from the invocation list — NOT from the session's own clock. A session's
+ * `updatedAt` moves every time the conversation is touched afterwards, so using it
+ * would date a skill run from three weeks ago as today's and quietly shift it into
+ * whatever window the dashboard is showing.
+ *
+ * Taken as the MAXIMUM over the list rather than as `invocations[0]`. Claude, Kimi
+ * and OpenCode all sort newest-first, so for them the two are the same number —
+ * this only stops the value depending on an ordering convention that lives in
+ * three separate scanners and is not enforced anywhere.
+ *
+ * **The heuristic Codex path is a documented floor, not a last-call instant.**
+ * `scanCodexSkillLines` records one invocation per skill at the FIRST `SKILL.md`
+ * read it saw, deliberately: repeated paged reads of one use are common, so
+ * counting each read would claim a skill was entered many times when it was
+ * entered once. Reporting that first read is a lower bound; omitting it would
+ * drop the skill out of every windowed view instead of placing it early in one.
+ */
+export function skillUseToToolCall(use: SkillUse, usage: SkillUsage | undefined): ToolCallCount {
+	let lastCallAtMs = Number.NaN;
+	for (const invocation of use.invocations) {
+		const at = Date.parse(invocation.at);
+		if (Number.isFinite(at) && (!Number.isFinite(lastCallAtMs) || at > lastCallAtMs)) lastCallAtMs = at;
+	}
+	return {
+		// The skill's own name, matching what the `Skill` tool path reports, so the two
+		// halves of one skill's usage fold together instead of appearing as two rows.
+		name: use.skill,
+		kind: "skill",
+		calls: use.invocations.length,
+		...(use.plugin !== undefined ? { plugin: use.plugin } : {}),
+		...(Number.isFinite(lastCallAtMs) ? { lastCallAtMs } : {}),
+		// Absent stays absent — see `ToolCallCount.usage`. A zeroed bucket would price
+		// an unmeasured skill at nothing rather than reporting it as unmeasured.
+		...(usage !== undefined ? { usage } : {}),
+		// Forwarded rather than reduced to the count: the dashboard writes one row per
+		// entry, including the mechanism and observed outcome.
+		...(use.invocations.length > 0 ? { invocations: use.invocations } : {}),
+		...(use.detection !== undefined ? { detection: use.detection } : {}),
+	};
+}

--- a/cli/src/core/skills/SkillTranscriptScanner.ts
+++ b/cli/src/core/skills/SkillTranscriptScanner.ts
@@ -10,14 +10,38 @@
  *     invocation is an `exec_command` reading a `SKILL.md`. Covered here, with
  *     `detection: "heuristic"` on every entry, after 976 real calls across 1,503
  *     session files were measured.
- *   - **A skill concept with no on-disk invocation record at all** — Cursor and
- *     Copilot CLI. Cursor DOES ship skills (`~/.cursor/skills-cursor/`), but a scan
- *     of 139 real chat files and the IDE composer store found ZERO references to
- *     any of them, so there is no envelope to pin a matcher against. Copilot CLI's
- *     `forge_skill_proposals` is an authoring table, not an invocation log. No
- *     matcher may be written for either until a real invocation is captured from a
- *     live run — this repo has shipped a parser whose fixtures and code were both
- *     imagined, which agreed with each other and with nothing real.
+ *   - **A skill concept whose only record is an inference, in a store this table
+ *     cannot read** — Cursor. An earlier note here said a scan of 139 chat files and
+ *     the IDE composer store found ZERO references, and concluded that no envelope
+ *     existed to pin a matcher against; that is OUT OF DATE. Measured on Cursor
+ *     3.15.x: `state.vscdb` under the app's `globalStorage` holds one `cursorDiskKV`
+ *     row per conversation, keyed `composerData:<composerId>`, whose
+ *     `fullConversationHeadersOnly` array carries one entry per bubble with `type`
+ *     (1 = user, 2 = assistant), a millisecond `createdAt`, and — on a tool bubble —
+ *     `grouping.toolCallCase` plus `grouping.toolDisplayPath`. A skill appears as
+ *     `toolCallCase: "readToolCall"` whose path ends `skills/<name>/SKILL.md`, and it
+ *     was captured live: a natural-language request naming the skill, then 44 s later
+ *     a read of `.claude/skills/jolli-recall/SKILL.md`.
+ *
+ *     An envelope therefore EXISTS, and it is the same KIND as Codex CLI's — a file
+ *     read, not an entry event — so it would carry `detection: "heuristic"`. Two
+ *     things still block a scanner, and neither of them is "no data". It is not
+ *     line-oriented JSONL, so it needs a reader of its own the way OpenCode does
+ *     rather than an entry in this table. And its coverage is UNMEASURED: in that
+ *     same capture the agent read the `SKILL.md` and then went straight to
+ *     `getMcpToolsToolCall`, so a skill whose body routes to MCP may well be entered
+ *     with no file read to infer from at all. One conversation is not a corpus, which
+ *     is what the warning below is about.
+ *
+ *     `ItemTable`'s `cursor.skills.recentlyUsed` is NOT a second source: a
+ *     machine-global LRU of `<name>/SKILL.md` strings carrying no time, no
+ *     conversation and no entry path, so it can prove a skill was used and no more.
+ *
+ *   - **A skill concept with no on-disk invocation record at all** — Copilot CLI,
+ *     whose `forge_skill_proposals` is an authoring table, not an invocation log. No
+ *     matcher may be written until a real invocation is captured from a live run —
+ *     this repo has shipped a parser whose fixtures and code were both imagined,
+ *     which agreed with each other and with nothing real.
  *
  * OpenCode IS covered, but not through this table: its transcripts are SQLite rows
  * rather than JSONL lines, so it has its own reader

--- a/cli/src/core/skills/TranscriptSkillDiscovery.test.ts
+++ b/cli/src/core/skills/TranscriptSkillDiscovery.test.ts
@@ -180,6 +180,24 @@ describe("scanSkillsFrom", () => {
 		expect((await loadPlansRegistry(tempDir)).skills).toBeUndefined();
 	});
 
+	it("derives a Kimi session id from the directory above agents/main", async () => {
+		// Kimi names every transcript wire.jsonl, so using the basename would collapse
+		// every session onto kimi:wire. The session directory is the stable id source.
+		const sessionDir = join(tempDir, "sessions", "work-key", "kimi-session-1");
+		const transcriptDir = join(sessionDir, "agents", "main");
+		await mkdir(transcriptDir, { recursive: true });
+		const path = join(transcriptDir, "wire.jsonl");
+		const call = JSON.stringify({
+			type: "context.append_loop_event",
+			event: { type: "tool.call", name: "Skill", args: { skill: "hello-capture" } },
+			time: 1_700_000_000_000,
+		});
+		await writeFile(path, `${call}\n`, "utf-8");
+
+		await scanSkillsFrom(path, 0, tempDir, "kimi");
+		expect((await loadPlansRegistry(tempDir)).skills?.["kimi:hello-capture"]).toBeDefined();
+	});
+
 	it("attaches attributed token usage to the persisted row", async () => {
 		const path = await writeTranscript([TOOL_CALL, TOOL_RESULT, TOOL_BODY, USAGE_SPLIT_LINE_1, USAGE_SPLIT_LINE_2]);
 		await scanSkillsFrom(path, 0, tempDir, "claude");

--- a/cli/src/core/skills/TranscriptSkillDiscovery.ts
+++ b/cli/src/core/skills/TranscriptSkillDiscovery.ts
@@ -125,13 +125,8 @@ export async function scanSkillsFrom(
 	const { uses, lastLine } = scanner.scan(lines, fromLine);
 	const all = [...uses];
 
-	const subagentGroups: string[][] = [];
-	for (const subagentPath of await subagentTranscripts(transcriptPath)) {
-		const subagentLines = await readLines(subagentPath);
-		if (subagentLines === undefined) continue;
-		subagentGroups.push(subagentLines);
-		all.push(...scanner.scan(subagentLines, 0).uses);
-	}
+	const subagentGroups = await readSubagentLineGroups(transcriptPath);
+	for (const subagentLines of subagentGroups) all.push(...scanner.scan(subagentLines, 0).uses);
 
 	// Attribution reads from line 0 regardless of the scan cursor: a skill's spend is
 	// a property of the whole session, not of the slice discovered in this pass. Its
@@ -179,6 +174,29 @@ export async function scanSkillsFrom(
 function sessionStemFor(source: SkillSource, transcriptPath: string): string {
 	if (source === "kimi") return basename(dirname(dirname(dirname(transcriptPath))));
 	return basename(transcriptPath).replace(/\.jsonl$/, "");
+}
+
+/**
+ * Every subagent transcript's lines for one session file, unreadable files skipped.
+ *
+ * Exported because attribution needs the SAME groups the scan above walks, and a
+ * second caller deriving them another way is how the two would drift: a subagent's
+ * `attributionSkill` is inherited from its parent and never updated (see the module
+ * header), so a caller that attributes over the session file alone silently loses
+ * whatever a subagent spent. The dashboard's `skillExtractor` is that second caller.
+ *
+ * Returns `[]` for a session with no subagents, which is the common case — distinct
+ * from a file that could not be read, which is dropped from the groups rather than
+ * represented, since attribution over a partial group is still correct for the lines
+ * it did get.
+ */
+export async function readSubagentLineGroups(transcriptPath: string): Promise<string[][]> {
+	const groups: string[][] = [];
+	for (const subagentPath of await subagentTranscripts(transcriptPath)) {
+		const subagentLines = await readLines(subagentPath);
+		if (subagentLines !== undefined) groups.push(subagentLines);
+	}
+	return groups;
 }
 
 /** Read a transcript's lines, or undefined when it cannot be read. */

--- a/cli/src/dashboard/DashboardDb.ts
+++ b/cli/src/dashboard/DashboardDb.ts
@@ -40,6 +40,9 @@ import {
 	SESSION_ACTIVITY_DDL,
 	SESSION_USAGE_EVENTS_DDL,
 	SKILL_CONTEXT_KIND_DDL,
+	SKILL_INVOCATIONS_DDL,
+	SKILL_PLUGIN_DDL,
+	SKILL_TOKEN_USAGE_DDL,
 	STATS_DAILY_DAY_INDEX_DDL,
 	STATS_DAILY_DDL,
 	SYNC_KEYSET_INDEX_DDL,
@@ -126,7 +129,7 @@ const log = createLogger("DashboardDb");
  * user's database (other processes may hold the file open, and the memory half
  * is the only copy there is).
  */
-export const DASHBOARD_SCHEMA_VERSION = 9;
+export const DASHBOARD_SCHEMA_VERSION = 12;
 
 /**
  * NOTE ON COMPATIBILITY, because its absence here is a decision.
@@ -420,6 +423,9 @@ BEGIN SELECT RAISE(ABORT, 'repos are never deleted: set disabled_at instead'); E
 			SYNC_STAMP_NULL_BACKFILL_DDL,
 	},
 	{ name: "SESSION_ACTIVITY_DDL", ddl: SESSION_ACTIVITY_DDL },
+	{ name: "SKILL_TOKEN_USAGE_DDL", ddl: SKILL_TOKEN_USAGE_DDL },
+	{ name: "SKILL_INVOCATIONS_DDL", ddl: SKILL_INVOCATIONS_DDL },
+	{ name: "SKILL_PLUGIN_DDL", ddl: SKILL_PLUGIN_DDL },
 ];
 
 /** Reads the stored schema version, treating a fresh DB as 0. */

--- a/cli/src/dashboard/DashboardModel.ts
+++ b/cli/src/dashboard/DashboardModel.ts
@@ -20,6 +20,7 @@ import type {
 	LocalAgentToolId,
 	RecallOutcome,
 	SessionUsageEvent,
+	SkillEntryPath,
 	ToolCallCount,
 	ToolCallKind,
 	TranscriptSource,
@@ -401,7 +402,7 @@ export type AdoptionTier = "installed" | "memory" | "space";
  * (`jolli disable` still pauses a repository — the dashboard just no longer
  * offers a control for it).
  */
-export type DashboardView = "stats" | "standup" | "memories" | "knowledge" | "graph" | "settings";
+export type DashboardView = "stats" | "standup" | "skills" | "memories" | "knowledge" | "graph" | "settings";
 
 /** One browsable `_wiki` markdown file (a topic page or the `_index.md`). */
 export interface KnowledgeFile {
@@ -1549,6 +1550,62 @@ export interface ToolUsageAgentTotal extends ToolUsageAgentShare {
 	readonly sessions: number;
 }
 
+/**
+ * One skill's token spend over the window, summed across the sessions that could
+ * be attributed.
+ *
+ * `sessions` is the load-bearing field and the reason this is not just a
+ * {@link SkillUsage}: the sum covers only the rows that carry figures, which on a
+ * real machine is a MINORITY (measured: 12 of 112 skill calls came from a source
+ * that attributes anything). Without it a reader cannot tell a skill that genuinely
+ * cost this much from one where nine sessions in ten went unmeasured — and the
+ * second reading is the common one. Compare it against {@link ToolUsageRow.sessions}
+ * to state the coverage.
+ *
+ * Absent on the row entirely when NO session could be attributed, never a zeroed
+ * object: the same rule the markdown table states by printing an em dash.
+ */
+export interface ToolUsageTokens {
+	readonly input: number;
+	readonly output: number;
+	readonly cached: number;
+	/**
+	 * `estimated` when ANY contributing session was, matching
+	 * `buildSkillsSummaryLabel`: a sum containing one estimate is an estimate, so
+	 * the whole figure carries the weaker claim rather than averaging the two.
+	 */
+	readonly confidence: "attributed" | "estimated";
+	/** Sessions whose figures are in the sum, out of {@link ToolUsageRow.sessions}. */
+	readonly sessions: number;
+}
+
+/**
+ * One local calendar day of skill adoption — the shape `JD.stackedBars` consumes.
+ *
+ * Buckets are LOCAL days, through this file's one time-zone engine, and the whole
+ * window is emitted whether or not a day has rows — the same treatment the token
+ * and spend series get.
+ *
+ * This replaced epoch-week buckets (`at / 604800000`), whose divisor was chosen to
+ * keep the series identical for two readers in different zones. That symmetry cost
+ * more than it bought. The boundary landed on Thursday, so a bar labelled `Aug 6`
+ * covered Aug 6-12 while the heatmap cell labelled `Aug 6` on the same page covered
+ * one local day — two meanings of "day" in one product, and the axis prints a bare
+ * day key either way. It also made the bar WIDTH mislead: `JD.stackedBars` divides
+ * the plot by the number of points, so a fortnight of data drew two bars each 29% of
+ * the chart wide, which reads as a range rather than as a bucket.
+ *
+ * The cost of the switch is stated on {@link ToolUsage.skillDays}: a bucket is
+ * resolved from ONE timestamp per (session, skill), so a session that ran past local
+ * midnight lands wholly in the later day.
+ */
+export interface SkillDayPoint {
+	/** The local calendar day, `YYYY-MM-DD`. */
+	readonly date: string;
+	/** Skill name → sessions that reached for it inside the day. Absent keys are zero. */
+	readonly bySeries: Readonly<Record<string, number>>;
+}
+
 /** One tool, skill or MCP server, aggregated over the window. */
 export interface ToolUsageRow {
 	/** `Bash`, `linear.list_issues`, `code-review`. */
@@ -1559,6 +1616,40 @@ export interface ToolUsageRow {
 	readonly calls: number;
 	/** Which agents made those calls, most calls first — see {@link ToolUsageAgentShare}. */
 	readonly agents: ReadonlyArray<ToolUsageAgentShare>;
+	/**
+	 * Tokens spent under it. Only ever present on `kind: "skill"` rows, and only
+	 * when at least one session could be attributed — see {@link ToolUsageTokens}.
+	 */
+	readonly usage?: ToolUsageTokens;
+	/**
+	 * Providing plugin, on `kind: "skill"` rows alone.
+	 *
+	 * Absent for an unprefixed skill, which is the common case — never "unknown".
+	 * Carried on the list row and not only on {@link SkillDetail} so a reader can
+	 * see which entries came from a plugin without opening each one.
+	 */
+	readonly plugin?: string;
+	/**
+	 * `"heuristic"` when ANY entry behind this row was INFERRED from a file read
+	 * rather than observed; absent otherwise. `kind: "skill"` rows alone.
+	 *
+	 * Any-one-taints, the same rule {@link ToolUsageTokens.confidence} takes for
+	 * `estimated` and `SkillStore.mergeSkillRef` takes across scan windows — a row
+	 * that mixes an observed entry with an inferred one cannot be presented as
+	 * measured. The three had better agree: the same skill is rendered from this
+	 * field here, from `SkillCommitRef.detection` on a committed memory, and from
+	 * `SkillEntry.detection` in the Memory Bank markdown.
+	 *
+	 * ABSENT IS NOT A CLAIM THAT THE ENTRIES WERE OBSERVED. A row's `calls` can
+	 * outlive every entry row behind it — a count merged in from an archived commit,
+	 * or a transcript the agent pruned (see {@link SkillDetail.invocations}) — and
+	 * such a row has nothing left to read a detection off. Absent therefore means
+	 * "no entry on record says inferred", which covers both the genuinely observed
+	 * row and the unreadable one. Spelling that third state out here was considered
+	 * and dropped: the detail view already says "no per-entry record survives" where
+	 * it applies, and a list row has no room to say it a second way.
+	 */
+	readonly detection?: "heuristic";
 }
 
 /** One MCP server, rolled up across all of its tools. */
@@ -1571,6 +1662,224 @@ export interface McpServerRow {
 	readonly tools: number;
 	/** Which agents called it, most calls first — see {@link ToolUsageAgentShare}. */
 	readonly agents: ReadonlyArray<ToolUsageAgentShare>;
+}
+
+/** One agent's share of a single skill, for the detail view's per-agent table. */
+export interface SkillDetailAgent {
+	/** `sessions.source` — the raw `claude` / `codex` tag every other axis shows. */
+	readonly source: string;
+	readonly sessions: number;
+	readonly calls: number;
+	/** Absent for an agent that attributes nothing — see {@link ToolUsageTokens}. */
+	readonly usage?: ToolUsageTokens;
+}
+
+/**
+ * One commit a skill's work reached, with what that commit changed.
+ *
+ * This is the half no other tool can show: not "the skill ran N times" but "this
+ * is what came out of it". The diff figures and categories are the COMMIT's, not
+ * the skill's — a commit usually carries other work too — so a caller must not
+ * present them as the skill's own output.
+ */
+export interface SkillDetailCommit {
+	readonly hash: string;
+	readonly repoName: string;
+	readonly branch?: string;
+	readonly message?: string;
+	readonly committedAtMs: number;
+	readonly filesChanged?: number;
+	readonly insertions?: number;
+	readonly deletions?: number;
+	/** Topic categories of that memory, deduped — `bugfix`, `feature`, … */
+	readonly categories: ReadonlyArray<string>;
+}
+
+/** One session that ran the skill, plus how much of it was this skill's. */
+export interface SkillDetailSession {
+	readonly sessionId: string;
+	readonly source: string;
+	readonly title?: string;
+	readonly startedAtMs?: number;
+	readonly updatedAtMs: number;
+	readonly durationMs?: number;
+	readonly messageCount?: number;
+	readonly model?: string;
+	/** Calls of THIS skill in this session. */
+	readonly calls: number;
+	/**
+	 * The WHOLE session's spend, which is not this skill's — a session normally
+	 * runs several skills and plenty of unattributed work besides. Carried as the
+	 * denominator a reader needs to judge {@link usage} against, and a surface
+	 * showing it must say which of the two it is printing.
+	 *
+	 * Absent when the source reports no session usage either (today: every agent
+	 * except Claude, whose parser is the only one implementing `parseUsageTokens`).
+	 */
+	readonly sessionTokens?: number;
+	/** This skill's own spend inside this session. Absent when unattributable. */
+	readonly usage?: ToolUsageTokens;
+}
+
+/**
+ * Run outcomes over this skill's recorded entries, SPLIT by whether the result was
+ * actually read.
+ *
+ * Three of the six entry mechanisms have no result record at all, so their `ok` was
+ * defaulted rather than observed (see `skillOutcomeConfidence`): nothing said the run
+ * failed, which is not the same as something saying it succeeded. The two classes are
+ * therefore counted separately and must stay separate:
+ *
+ *   - {@link measured} / {@link failed} — entries whose `ok` came from a result
+ *     record. `measured` is the only honest denominator for a failure rate; averaging
+ *     over every entry would price an unknowable run as a success.
+ *   - {@link assumed} — entries that definitely RAN but whose result the transcript
+ *     never stated. Reported as its own number, in words that say what is missing.
+ *
+ * Either count may be 0 on its own. The object is absent only when the skill has no
+ * entry row at all — a count merged in from an archived commit, or a transcript the
+ * agent has since pruned — which is the same distinction {@link SkillDetail.invocations}
+ * draws, and it is the surface's cue to say "no per-entry record", never "it never ran".
+ *
+ * It used to be absent whenever `measured` was 0, so on the common machine — where
+ * nearly every Claude skill is entered by slash command — the whole section vanished
+ * and the reader was told nothing about runs that were fully on record. Surfacing
+ * them as "ran, outcome not recorded" says exactly as much as the record supports,
+ * and no more.
+ */
+export interface SkillDetailOutcomes {
+	/** Entries whose `ok` came from a result record. 0 when no mechanism could report one. */
+	readonly measured: number;
+	/** Failures among {@link measured} alone — never among {@link assumed}. */
+	readonly failed: number;
+	/**
+	 * Entries whose `ok` was defaulted, so the run is known to have happened and its
+	 * result is not knowable. Never added to {@link measured}.
+	 */
+	readonly assumed: number;
+}
+
+/**
+ * One recorded entry into the skill, for the outcome strip and its tooltips.
+ *
+ * Ordered oldest-first by the query, which is what makes "it started failing on
+ * Tuesday" readable left to right.
+ */
+export interface SkillDetailInvocation {
+	readonly atMs: number;
+	readonly ok: boolean;
+	/**
+	 * Whether {@link ok} was read from the transcript or defaulted.
+	 *
+	 * Carried so a surface can decide what it is entitled to SAY: a defaulted outcome
+	 * has no failure to report, so the dashboard draws it as an ordinary tick (the run
+	 * happened, and skipping it reported less than the record holds) and qualifies it
+	 * in words — per-tick hover text, plus the {@link SkillDetailOutcomes.assumed}
+	 * sentence under the strip. What the flag must keep preventing is the other
+	 * reading: {@link ok} being `true` here is the absence of a failure report, so such
+	 * an entry may be counted beside a measured one but never averaged in with it.
+	 */
+	readonly outcomeKnown: boolean;
+	readonly args?: string;
+	readonly bodyChars?: number;
+}
+
+/**
+ * Everything the skill detail view shows — the answer to `/api/skill-detail`.
+ *
+ * Scoped to the same window and repo selection as the card it was opened from, so
+ * the totals here agree with the row that was clicked. That is also why it is a
+ * fetch rather than a slice of the page model: the model carries ONE PAGE of
+ * skills and none of this per-skill breakdown.
+ */
+export interface SkillDetail {
+	readonly name: string;
+	/** Distinct sessions that ran it, over the window. */
+	readonly sessions: number;
+	readonly calls: number;
+	readonly lastCallAtMs?: number;
+	/** Summed over every attributable session — see {@link ToolUsageTokens.sessions}. */
+	readonly usage?: ToolUsageTokens;
+	readonly agents: ReadonlyArray<SkillDetailAgent>;
+	/**
+	 * Commits this skill's usage was archived onto, newest first.
+	 *
+	 * Routinely EMPTY, and that is the normal state rather than a failure: measured
+	 * on one machine, 27 of 111 skill rows linked to a commit at all — the rest is
+	 * work still in the tree. A surface must render the empty case as "not committed
+	 * yet", never as "no data".
+	 */
+	readonly commits: ReadonlyArray<SkillDetailCommit>;
+	readonly linkedSessions: ReadonlyArray<SkillDetailSession>;
+	/** Category mix across {@link commits}, most commits first. */
+	readonly categories: ReadonlyArray<{ readonly category: string; readonly commits: number }>;
+	/** Providing plugin, absent for an unprefixed skill (the common case). */
+	readonly plugin?: string;
+	/**
+	 * Repositories the skill ran in, by name, alphabetically.
+	 *
+	 * From the SESSIONS rather than from {@link commits}: most skill usage is never
+	 * archived onto a commit (measured: 27 of 111 rows), so deriving this from the
+	 * commit list would report "ran in nothing" for the majority.
+	 */
+	readonly repos: ReadonlyArray<string>;
+	/**
+	 * First entry in the window, from the per-entry record rather than the session's
+	 * clock. Absent when no entry row survives — see {@link invocations}.
+	 */
+	readonly firstCallAtMs?: number;
+	/**
+	 * Mechanisms this skill was entered by, deduped. `tool` is the agent choosing to
+	 * invoke it, `command` is a person asking for it by name; both together is normal.
+	 *
+	 * Empty when no entry row carries one, which is not the same as "entered by
+	 * neither" — a stored history predating the field reads as empty.
+	 */
+	readonly entryPaths: ReadonlyArray<SkillEntryPath>;
+	/**
+	 * `"heuristic"` when any entry in the window was inferred from a file read rather
+	 * than observed — see {@link ToolUsageRow.detection}, which carries the identical
+	 * field for the list row so a reader sees the same mark before and after opening.
+	 *
+	 * Sits beside {@link entryPaths} and {@link outcomes} because all three are
+	 * qualifiers read off the per-entry table, and all three go quiet together when
+	 * no entry row survives.
+	 */
+	readonly detection?: "heuristic";
+	/** Absent only when no entry row survives — see {@link SkillDetailOutcomes}. */
+	readonly outcomes?: SkillDetailOutcomes;
+	/**
+	 * The entry rows themselves, oldest first.
+	 *
+	 * Routinely EMPTY while {@link calls} is not, and that is a normal state rather
+	 * than a gap: a count merged in from an already-archived commit has no per-entry
+	 * record, and an agent that pruned its own transcript can never have one again.
+	 * A surface must render the empty case as "no per-entry record", never as "it
+	 * never ran".
+	 */
+	readonly invocations: ReadonlyArray<SkillDetailInvocation>;
+	/**
+	 * One point per session that ran the skill, oldest first — the grain both of the
+	 * detail view's time charts read at.
+	 *
+	 * Separate from {@link linkedSessions}, which is capped for a table a reader
+	 * scrolls: a chart drawn from 20 of 51 sessions is a chart of the wrong shape, so
+	 * this carries the whole window at two numbers per point.
+	 *
+	 * `tokens` is absent where the source attributed none — the charts skip those
+	 * points rather than plotting them at zero.
+	 */
+	readonly sessionSeries: ReadonlyArray<{ readonly atMs: number; readonly tokens?: number }>;
+	/**
+	 * Characters this skill injects on a full entry — the LARGEST body recorded, not
+	 * an average.
+	 *
+	 * A repeat entry within one conversation injects an "already loaded above" stub
+	 * instead of the body (measured: 3,619 characters then 69 for the same skill), so
+	 * an average answers "what did entries cost on average here" while the question
+	 * this figure is read for is "what does this skill cost to load".
+	 */
+	readonly bodyChars?: number;
 }
 
 /**
@@ -1720,6 +2029,35 @@ export interface ToolUsage {
 	readonly skillsTotal: number;
 	/** Every skill run in the window, including rows past the first page. */
 	readonly skillCallsTotal: number;
+	/**
+	 * Day-by-day adoption for the Skills page's stacked band, oldest first.
+	 *
+	 * ONE POINT PER LOCAL DAY IN THE WINDOW, including days with no skill use. The
+	 * chart lays bars out by index, so a dropped day would silently compress the axis
+	 * and make a week-long gap look like a busy stretch. No cap is needed on top of
+	 * that: the window itself is bounded (a custom range is clamped to `MAX_CUSTOM_DAYS`),
+	 * which is what the retired week-bucket cap existed to do.
+	 *
+	 * Covers EVERY skill in the window, not only {@link skills}' first page — the band
+	 * is a whole-window view and a chart drawn from one page would change shape as the
+	 * list below it grew.
+	 *
+	 * **The unit is a skill-session, and it does not sum to sessions.** A session that
+	 * reached for three skills counts once in each of their series, so a bar's total is
+	 * skill-sessions rather than distinct sessions. Adoption is the honest question here
+	 * because usage is recorded per session; a per-RUN daily count does not exist to
+	 * draw, since only the capped entry list carries run timestamps.
+	 *
+	 * **A session is filed under ONE day — the day of its last recorded call for that
+	 * skill.** `session_tool_use` keeps a single timestamp per (session, skill), so a
+	 * session that ran past local midnight contributes entirely to the later day rather
+	 * than to both. Measured on a real database: 5 of 68 (session, skill) pairs spanned
+	 * more than one local day. `skill_invocations` does carry per-call timestamps and
+	 * would resolve those exactly, but it is deliberately NOT the source — it had detail
+	 * for 68 pairs against the aggregate's 116, so 41% of the rows the list below shows
+	 * would be missing from the chart above it.
+	 */
+	readonly skillDays: ReadonlyArray<SkillDayPoint>;
 	/**
 	 * MCP servers, busiest first — ranked by {@link McpServerRow.calls}, with
 	 * sessions as the tiebreak.

--- a/cli/src/dashboard/DashboardQuery.test.ts
+++ b/cli/src/dashboard/DashboardQuery.test.ts
@@ -26,7 +26,7 @@ import { MEMORY_CARDS_LIMIT, TOOL_ROWS_LIMIT } from "./DashboardModel.js";
 /** UTC+8, no DST — the zone the day-boundary cases below contrast with UTC. */
 const SH = "Asia/Shanghai";
 
-import { buildDashboardModel, buildToolUsagePage, type QueryOptions } from "./DashboardQuery.js";
+import { buildDashboardModel, buildSkillDetail, buildToolUsagePage, type QueryOptions } from "./DashboardQuery.js";
 import { volumeReachable } from "./RepoForget.js";
 import { applyStatsEvents } from "./StatsWriter.js";
 
@@ -1176,7 +1176,26 @@ describe("buildDashboardModel — tool usage", () => {
 
 	const sessionWith = (
 		sessionId: string,
-		tools?: ReadonlyArray<{ name: string; kind: "builtin" | "mcp" | "skill"; server?: string; calls: number }>,
+		tools?: ReadonlyArray<{
+			name: string;
+			kind: "builtin" | "mcp" | "skill";
+			server?: string;
+			calls: number;
+			/** Marks the bucket inferred; the writer copies it onto each of its entries. */
+			detection?: "heuristic";
+			plugin?: string;
+			lastCallAtMs?: number;
+			usage?: { input: number; output: number; cached: number; confidence: "attributed" | "estimated" };
+			/** Per-entry rows. Required to reach `skill_invocations` at all — see the detection tests. */
+			invocations?: ReadonlyArray<{
+				at: string;
+				ok: boolean;
+				entryPath?: "tool" | "command";
+				outcomeObserved?: boolean;
+				args?: string;
+				bodyChars?: number;
+			}>;
+		}>,
 		source: "claude" | "codex" | "cline" = "claude",
 	): StatsEventEnvelope => ({
 		producerKind: "cli",
@@ -1933,6 +1952,643 @@ describe("buildDashboardModel — tool usage", () => {
 		// know nothing about.
 		expect(page.rows.map(rowKey)).toEqual(["code-review"]);
 		expect(page.totalCount).toBe(1);
+	});
+
+	it("surfaces a skill namespace and degrades partial legacy usage to zero", async () => {
+		await applySummaryEvents(
+			[
+				repoEvent,
+				sessionWith("legacy-usage", [
+					{
+						name: "code-review",
+						kind: "skill",
+						calls: 1,
+						plugin: "superpowers",
+						usage: { input: 9, output: 4, cached: 2, confidence: "estimated" },
+					},
+				]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		// These columns normally move together. A partially populated pre-migration
+		// row must still render instead of crashing or losing the attributed input.
+		await withDashboardDb(
+			(db) => db.exec("UPDATE session_tool_use SET output_tokens = NULL, cached_tokens = NULL"),
+			{ dbPath },
+		);
+
+		expect((await usage())?.skills[0]).toMatchObject({
+			name: "code-review",
+			plugin: "superpowers",
+			usage: { input: 9, output: 0, cached: 0, confidence: "estimated", sessions: 1 },
+		});
+	});
+
+	it("omits a plugin label when different plugins used the same bare skill name", async () => {
+		await applySummaryEvents(
+			[
+				repoEvent,
+				sessionWith("team-a", [{ name: "review", kind: "skill", calls: 1, plugin: "team-a" }]),
+				sessionWith("team-b", [{ name: "review", kind: "skill", calls: 1, plugin: "team-b" }]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+
+		const row = (await usage())?.skills.find((skill) => skill.name === "review");
+		expect(row).toMatchObject({ name: "review", sessions: 2, calls: 2 });
+		expect(row).not.toHaveProperty("plugin");
+		const detailRow = await withDashboardDb(
+			(db) => buildSkillDetail(db, { scope: { kind: "all" }, name: "review", timeZone: "UTC", nowMs }),
+			{ dbPath },
+		);
+		expect(detailRow).not.toHaveProperty("plugin");
+	});
+
+	/**
+	 * `ToolUsageRow.detection` — the list row's inferred mark.
+	 *
+	 * The mark is read from `skill_invocations`, which is a DIFFERENT GRAIN from the
+	 * aggregate the rest of the row comes from (one row per entry, against one per
+	 * session+skill). Every case here is about that mismatch rather than about the
+	 * mark itself.
+	 */
+	describe("inferred marking", () => {
+		const entry = (at: string) => ({ at, ok: true, entryPath: "tool" as const });
+
+		it("marks a row when any entry behind it was inferred, and leaves an observed row clean", async () => {
+			await applySummaryEvents(
+				[
+					repoEvent,
+					sessionWith(
+						"s1",
+						[
+							{
+								name: "inferred-skill",
+								kind: "skill",
+								calls: 1,
+								detection: "heuristic",
+								invocations: [entry("2026-07-30T10:00:00.000Z")],
+							},
+							{
+								name: "observed-skill",
+								kind: "skill",
+								calls: 1,
+								invocations: [entry("2026-07-30T10:00:00.000Z")],
+							},
+						],
+						"codex",
+					),
+				],
+				{ producerKind: "cli", dbPath },
+			);
+			const byName = new Map((await usage())?.skills.map((row) => [row.name, row]));
+			expect(byName.get("inferred-skill")?.detection).toBe("heuristic");
+			// Absent, not a second value — see `ToolUsageRow.detection` on why "observed"
+			// and "nothing on record" deliberately share the quiet case.
+			expect(byName.get("observed-skill")?.detection).toBeUndefined();
+		});
+
+		it("does not multiply the row's own figures by the number of entries behind it", async () => {
+			// THE REGRESSION THIS SUITE EXISTS FOR, and the assertions are deliberately on
+			// the numbers that have NOTHING to do with the mark. `skill_invocations` holds
+			// one row per entry, so reaching it with a JOIN instead of the correlated
+			// subquery fans the aggregate out: these four entries turn 3 calls into 12 and
+			// each token sum into four times itself. Nothing throws.
+			//
+			// FOUR ENTRIES AGAINST THREE CALLS, not a matching count, and the mismatch is
+			// the realistic shape rather than a contrivance — an inferred skill is entered
+			// once per session however many paged reads produced it, so the two numbers are
+			// independent by design. It also means a JOIN cannot be caught by comparing them.
+			//
+			// `sessions` is asserted for the opposite reason: it is a COUNT(DISTINCT) and so
+			// survives the fan-out unharmed. That is what makes the bug quiet on a real
+			// database — half the row keeps agreeing with itself.
+			await applySummaryEvents(
+				[
+					repoEvent,
+					sessionWith(
+						"s1",
+						[
+							{
+								name: "paged-reads",
+								kind: "skill",
+								calls: 3,
+								detection: "heuristic",
+								usage: { input: 500, output: 300, cached: 100, confidence: "attributed" },
+								invocations: [
+									entry("2026-07-30T10:00:00.000Z"),
+									entry("2026-07-30T10:01:00.000Z"),
+									entry("2026-07-30T10:02:00.000Z"),
+									entry("2026-07-30T10:03:00.000Z"),
+								],
+							},
+						],
+						"codex",
+					),
+				],
+				{ producerKind: "cli", dbPath },
+			);
+			const row = (await usage())?.skills[0];
+			expect(row?.detection).toBe("heuristic");
+			expect(row?.calls).toBe(3);
+			expect(row?.sessions).toBe(1);
+			expect(row?.usage).toMatchObject({ input: 500, output: 300, cached: 100 });
+			// The per-agent split rides on its own query and must survive the same way.
+			expect(row?.agents).toEqual([{ source: "codex", calls: 3 }]);
+		});
+
+		it("leaves an MCP tool unmarked even when a heuristic skill shares its name", async () => {
+			// `skill_invocations` has no `kind` column, so the subquery matches on name
+			// alone and the two lists are separated only by `t.kind` — which the subquery
+			// cannot see. Without the `list` gate this MCP row inherits the skill's mark.
+			await applySummaryEvents(
+				[
+					repoEvent,
+					sessionWith(
+						"s1",
+						[
+							{
+								name: "exec",
+								kind: "skill",
+								calls: 1,
+								detection: "heuristic",
+								invocations: [entry("2026-07-30T10:00:00.000Z")],
+							},
+							{ name: "exec", kind: "mcp", server: "shell", calls: 1 },
+						],
+						"codex",
+					),
+				],
+				{ producerKind: "cli", dbPath },
+			);
+			const result = await usage();
+			expect(result?.skills.find((row) => row.name === "exec")?.detection).toBe("heuristic");
+			expect(result?.mcpTools.find((row) => row.name === "exec")?.detection).toBeUndefined();
+		});
+
+		it("leaves a row unmarked when no entry row survives to read a detection off", async () => {
+			// A count with no per-entry record — an archived commit's merged total, or a
+			// transcript the agent pruned. There is nothing to read, so the row falls quiet
+			// rather than claiming either nature.
+			await applySummaryEvents(
+				[repoEvent, sessionWith("s1", [{ name: "no-entries", kind: "skill", calls: 5 }], "codex")],
+				{ producerKind: "cli", dbPath },
+			);
+			const row = (await usage())?.skills[0];
+			expect(row?.calls).toBe(5);
+			expect(row?.detection).toBeUndefined();
+		});
+	});
+
+	describe("skill detail", () => {
+		const detail = async (name: string) =>
+			await withDashboardDb(
+				(db) => buildSkillDetail(db, { scope: { kind: "all" }, name, timeZone: "UTC", nowMs }),
+				{ dbPath },
+			);
+
+		it("returns undefined when the window contains no call of that skill", async () => {
+			await applySummaryEvents([repoEvent], { producerKind: "cli", dbPath });
+			expect(await detail("missing")).toBeUndefined();
+		});
+
+		it("projects usage, agents, sessions, commits and every per-entry detail without join fan-out", async () => {
+			const firstAt = nowMs - 2 * 3_600_000;
+			const lastAt = nowMs - 3_600_000;
+			const hash = "d".repeat(40);
+			await applySummaryEvents(
+				[
+					repoEvent,
+					{
+						producerKind: "cli",
+						event: {
+							type: "session.upserted",
+							repoIdentity: "repo-1",
+							source: "claude",
+							sessionId: "rich",
+							title: "Review the release",
+							startedAtMs: firstAt - 60_000,
+							updatedAtMs: nowMs,
+							durationMs: 7_200_000,
+							messageCount: 9,
+							models: [
+								{
+									model: "claude-opus-4-8",
+									provider: "anthropic",
+									inputTokens: 100,
+									outputTokens: 50,
+									cachedTokens: 25,
+								},
+							],
+							tokenCoverage: "full",
+							tools: [
+								{
+									name: "code-review",
+									kind: "skill",
+									calls: 2,
+									plugin: "superpowers",
+									lastCallAtMs: lastAt,
+									usage: { input: 40, output: 20, cached: 10, confidence: "attributed" },
+									invocations: [
+										{
+											at: new Date(firstAt).toISOString(),
+											ok: true,
+											entryPath: "tool",
+											args: "--base main",
+											bodyChars: 3200,
+										},
+										{
+											at: new Date(lastAt).toISOString(),
+											ok: false,
+											entryPath: "tool",
+											bodyChars: 120,
+										},
+									],
+								},
+							],
+						},
+					},
+					sessionWith(
+						"inferred",
+						[
+							{
+								name: "code-review",
+								kind: "skill",
+								calls: 1,
+								lastCallAtMs: lastAt - 1,
+								detection: "heuristic",
+								usage: { input: 7, output: 3, cached: 2, confidence: "estimated" },
+								invocations: [
+									{ at: new Date(lastAt - 1).toISOString(), ok: true, entryPath: "command" },
+								],
+							},
+						],
+						"codex",
+					),
+					{
+						producerKind: "cli",
+						event: {
+							type: "commit.created",
+							repoIdentity: "repo-1",
+							hash,
+							branch: "main",
+							branches: ["main"],
+							message: "fix: review finding",
+							committedAtMs: lastAt,
+							filesChanged: 2,
+							insertions: 12,
+							deletions: 3,
+						},
+					},
+				],
+				{ producerKind: "cli", dbPath },
+			);
+			await seedTopicRows(dbPath, hash, ["bugfix", "bugfix", "architecture"], { commitDateMs: lastAt });
+			await withDashboardDb(
+				(db) => {
+					const { id: repoId } = db.prepare("SELECT id FROM repos WHERE repo_identity = 'repo-1'").get() as {
+						id: number;
+					};
+					db.prepare(
+						`UPDATE memories
+						    SET summary_json = json_set(summary_json,
+						        '$.branch', 'main',
+						        '$.commitMessage', 'fix: review finding',
+						        '$.diffStats.filesChanged', 2,
+						        '$.diffStats.insertions', 12,
+						        '$.diffStats.deletions', 3)
+						  WHERE repo_id = ? AND commit_hash = ?`,
+					).run(repoId, hash);
+					for (const transcriptId of ["t-rich-1", "t-rich-2"]) {
+						db.prepare(
+							"INSERT INTO transcripts (repo_id, transcript_id, sessions_blob, written_at_ms) VALUES (?, ?, ?, 1)",
+						).run(repoId, transcriptId, Buffer.from("fixture"));
+						db.prepare(
+							"INSERT INTO memory_transcripts (repo_id, commit_hash, transcript_id) VALUES (?, ?, ?)",
+						).run(repoId, hash, transcriptId);
+						db.prepare(
+							"INSERT INTO transcript_sessions (repo_id, transcript_id, session_id, source) VALUES (?, ?, 'rich', 'claude')",
+						).run(repoId, transcriptId);
+					}
+				},
+				{ dbPath },
+			);
+
+			const result = await detail("code-review");
+			expect(result).toMatchObject({
+				name: "code-review",
+				sessions: 2,
+				calls: 3,
+				lastCallAtMs: lastAt,
+				plugin: "superpowers",
+				usage: { input: 47, output: 23, cached: 12, confidence: "estimated", sessions: 2 },
+				agents: [
+					{
+						source: "claude",
+						sessions: 1,
+						calls: 2,
+						usage: { input: 40, output: 20, cached: 10, confidence: "attributed", sessions: 1 },
+					},
+					{
+						source: "codex",
+						sessions: 1,
+						calls: 1,
+						usage: { input: 7, output: 3, cached: 2, confidence: "estimated", sessions: 1 },
+					},
+				],
+				outcomes: { measured: 2, failed: 1, assumed: 1 },
+				entryPaths: ["tool", "command"],
+				detection: "heuristic",
+				firstCallAtMs: firstAt,
+				bodyChars: 3200,
+				repos: ["jolli"],
+				categories: [
+					{ category: "architecture", commits: 1 },
+					{ category: "bugfix", commits: 1 },
+				],
+			});
+			expect(result?.commits).toEqual([
+				{
+					hash,
+					repoName: "jolli",
+					branch: "main",
+					message: "fix: review finding",
+					committedAtMs: lastAt,
+					filesChanged: 2,
+					insertions: 12,
+					deletions: 3,
+					categories: ["architecture", "bugfix"],
+				},
+			]);
+			expect(result?.linkedSessions[0]).toMatchObject({
+				sessionId: "rich",
+				title: "Review the release",
+				startedAtMs: firstAt - 60_000,
+				durationMs: 7_200_000,
+				messageCount: 9,
+				model: "claude-opus-4-8",
+				sessionTokens: 175,
+			});
+			expect(result?.invocations).toEqual([
+				{ atMs: firstAt, ok: true, outcomeKnown: true, args: "--base main", bodyChars: 3200 },
+				{ atMs: lastAt - 1, ok: true, outcomeKnown: false },
+				{ atMs: lastAt, ok: false, outcomeKnown: true, bodyChars: 120 },
+			]);
+			expect(result?.sessionSeries).toEqual([
+				{ atMs: lastAt - 1, tokens: 12 },
+				{ atMs: lastAt, tokens: 70 },
+			]);
+		});
+
+		it("keeps sparse calls visible without inventing usage, outcomes or optional session facts", async () => {
+			await applySummaryEvents([repoEvent, sessionWith("sparse", [{ name: "plain", kind: "skill", calls: 5 }])], {
+				producerKind: "cli",
+				dbPath,
+			});
+			const result = await detail("plain");
+			expect(result).toMatchObject({
+				name: "plain",
+				sessions: 1,
+				calls: 5,
+				agents: [{ source: "claude", sessions: 1, calls: 5 }],
+				commits: [],
+				categories: [],
+				entryPaths: [],
+				invocations: [],
+				sessionSeries: [{ atMs: nowMs - 3_600_000 }],
+			});
+			expect(result).not.toHaveProperty("usage");
+			expect(result).not.toHaveProperty("outcomes");
+			expect(result).not.toHaveProperty("plugin");
+			expect(result?.linkedSessions[0]).not.toHaveProperty("sessionTokens");
+			expect(result?.linkedSessions[0]).not.toHaveProperty("usage");
+		});
+
+		it("keeps the newest 400 session-series points in ascending order", async () => {
+			const points = Array.from({ length: 401 }, (_, i) => nowMs - (401 - i) * 60_000);
+			await applySummaryEvents(
+				[
+					repoEvent,
+					...points.map((atMs, i) =>
+						sessionWith(`series-${i}`, [
+							{ name: "long-running", kind: "skill", calls: 1, lastCallAtMs: atMs },
+						]),
+					),
+				],
+				{ producerKind: "cli", dbPath },
+			);
+
+			const series = (await detail("long-running"))?.sessionSeries ?? [];
+			expect(series).toHaveLength(400);
+			expect(series[0]?.atMs).toBe(points[1]);
+			expect(series.at(-1)?.atMs).toBe(points.at(-1));
+			expect(series.map((point) => point.atMs)).toEqual(
+				[...series.map((point) => point.atMs)].sort((a, b) => a - b),
+			);
+			expect(series.some((point) => point.atMs === points[0])).toBe(false);
+		});
+
+		it("keeps a sparse linked commit and partially populated legacy token row readable", async () => {
+			const hash = "e".repeat(40);
+			await applySummaryEvents(
+				[
+					repoEvent,
+					sessionWith("legacy", [
+						{
+							name: "legacy-skill",
+							kind: "skill",
+							calls: 1,
+							usage: { input: 5, output: 2, cached: 1, confidence: "attributed" },
+						},
+					]),
+				],
+				{ producerKind: "cli", dbPath },
+			);
+			await seedTopicRows(dbPath, hash, [], { commitDateMs: nowMs - 1_000 });
+			await withDashboardDb(
+				(db) => {
+					const { id: repoId } = db.prepare("SELECT id FROM repos WHERE repo_identity = 'repo-1'").get() as {
+						id: number;
+					};
+					db.prepare(
+						"INSERT INTO transcripts (repo_id, transcript_id, sessions_blob, written_at_ms) VALUES (?, 't-legacy', ?, 1)",
+					).run(repoId, Buffer.from("fixture"));
+					db.prepare(
+						"INSERT INTO memory_transcripts (repo_id, commit_hash, transcript_id) VALUES (?, ?, 't-legacy')",
+					).run(repoId, hash);
+					db.prepare(
+						"INSERT INTO transcript_sessions (repo_id, transcript_id, session_id, source) VALUES (?, 't-legacy', 'legacy', 'claude')",
+					).run(repoId);
+					// `full` with zero session tokens exercises the honest "known zero" path;
+					// the skill row itself simulates a partially populated legacy record.
+					db.prepare("UPDATE sessions SET token_coverage = 'full' WHERE session_id = 'legacy'").run();
+					db.prepare(
+						"UPDATE session_tool_use SET output_tokens = NULL, cached_tokens = NULL WHERE tool_name = 'legacy-skill'",
+					).run();
+				},
+				{ dbPath },
+			);
+
+			const result = await detail("legacy-skill");
+			expect(result?.commits).toEqual([
+				{
+					hash,
+					repoName: "jolli",
+					committedAtMs: nowMs - 1_000,
+					categories: [],
+				},
+			]);
+			expect(result?.usage).toMatchObject({ input: 5, output: 0, cached: 0 });
+			expect(result?.linkedSessions[0]).toMatchObject({
+				sessionId: "legacy",
+				usage: { input: 5, output: 0, cached: 0 },
+			});
+			expect(result?.linkedSessions[0]).not.toHaveProperty("sessionTokens");
+			expect(result?.sessionSeries).toEqual([{ atMs: nowMs - 3_600_000, tokens: 5 }]);
+		});
+	});
+});
+
+describe("buildDashboardModel — skill adoption band (skillDays)", () => {
+	let dir: string;
+	let dbPath: string;
+	// 20:00 local in Asia/Shanghai, so `custom` can name today without being clamped.
+	const nowMs = Date.parse("2026-07-30T12:00:00Z");
+	const ZONE = "Asia/Shanghai";
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "jolli-band-"));
+		dbPath = join(dir, "dashboard.db");
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	const repoEvent: StatsEventEnvelope = {
+		producerKind: "cli",
+		event: {
+			type: "repo.enabled",
+			repoIdentity: "repo-1",
+			repoName: "jolli",
+			worktreeRoot: "/w",
+			enabledAt: "t",
+		},
+	};
+
+	/**
+	 * A session whose skill rows carry their own call time.
+	 *
+	 * `lastCallAtMs` is what the band buckets on, and it is set per tool rather than
+	 * per session: the session's own `updatedAtMs` is the COALESCE fallback, so a
+	 * fixture that set only the session clock would still pass if the query read the
+	 * wrong one.
+	 */
+	const sessionAt = (sessionId: string, callAtMs: number, skills: ReadonlyArray<string>): StatsEventEnvelope => ({
+		producerKind: "cli",
+		event: {
+			type: "session.upserted",
+			repoIdentity: "repo-1",
+			source: "claude",
+			sessionId,
+			updatedAtMs: nowMs - 3_600_000,
+			tools: skills.map((name) => ({ name, kind: "skill" as const, calls: 1, lastCallAtMs: callAtMs })),
+		},
+	});
+
+	const band = async (customFrom: string, customTo: string) =>
+		(
+			await withDashboardDb(
+				(db) =>
+					buildDashboardModel(db, {
+						view: "stats",
+						scope: { kind: "all" },
+						timeZone: ZONE,
+						nowMs,
+						range: "custom",
+						customFrom,
+						customTo,
+					}),
+				{ dbPath },
+			)
+		).stats?.toolUsage?.skillDays;
+
+	it("buckets by LOCAL day, not by the UTC day the epoch division would give", async () => {
+		await applySummaryEvents(
+			[
+				repoEvent,
+				// 23:00 UTC on the 28th is 07:00 local on the 29th. A UTC bucket files
+				// this under the 28th — the divergence the whole switch is about.
+				sessionAt("s-late", Date.parse("2026-07-28T23:00:00Z"), ["deep-work"]),
+				// 20:00 UTC on the 27th is 04:00 local on the 28th, i.e. inside the
+				// window even though its UTC day sits before the window's first key.
+				sessionAt("s-early", Date.parse("2026-07-27T20:00:00Z"), ["deep-work"]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		expect(await band("2026-07-28", "2026-07-29")).toEqual([
+			{ date: "2026-07-28", bySeries: { "deep-work": 1 } },
+			{ date: "2026-07-29", bySeries: { "deep-work": 1 } },
+		]);
+	});
+
+	it("emits every day of the window, including days nothing ran", async () => {
+		await applySummaryEvents([repoEvent, sessionAt("s1", Date.parse("2026-07-28T04:00:00Z"), ["deep-work"])], {
+			producerKind: "cli",
+			dbPath,
+		});
+		// The chart lays bars out by index, so the two silent days have to be present
+		// as empty points rather than dropped — otherwise a three-day window with one
+		// active day draws one full-width bar and reads as three busy days.
+		expect(await band("2026-07-28", "2026-07-30")).toEqual([
+			{ date: "2026-07-28", bySeries: { "deep-work": 1 } },
+			{ date: "2026-07-29", bySeries: {} },
+			{ date: "2026-07-30", bySeries: {} },
+		]);
+	});
+
+	it("counts a session once per skill, so one day's bar totals skill-sessions", async () => {
+		const at = Date.parse("2026-07-29T04:00:00Z");
+		await applySummaryEvents(
+			[
+				repoEvent,
+				sessionAt("s1", at, ["deep-work", "code-review"]),
+				// A second session reaching for one of the same skills is a second
+				// session for THAT series only.
+				sessionAt("s2", at, ["deep-work"]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		expect(await band("2026-07-29", "2026-07-29")).toEqual([
+			{ date: "2026-07-29", bySeries: { "deep-work": 2, "code-review": 1 } },
+		]);
+	});
+
+	it("files a session under one day even when its calls straddled local midnight", async () => {
+		await applySummaryEvents([repoEvent, sessionAt("s1", Date.parse("2026-07-29T01:00:00Z"), ["deep-work"])], {
+			producerKind: "cli",
+			dbPath,
+		});
+		// 01:00 UTC is 09:00 local on the 29th. The session may well have started on
+		// the 28th, but `session_tool_use` keeps only this one timestamp, so the whole
+		// contribution lands on the 29th — the documented cost of using the aggregate
+		// table rather than `skill_invocations`.
+		expect(await band("2026-07-28", "2026-07-29")).toEqual([
+			{ date: "2026-07-28", bySeries: {} },
+			{ date: "2026-07-29", bySeries: { "deep-work": 1 } },
+		]);
+	});
+
+	it("returns a point per day even with no skill rows at all", async () => {
+		await applySummaryEvents([repoEvent], { producerKind: "cli", dbPath });
+		// Not an empty array — the window is what decides the point count, not the data.
+		// This is why `bandHtml` tests for "no SERIES" rather than "no points": a
+		// `series.length` test would never fire here and would draw an empty axis
+		// instead of the "no skill invocations" note.
+		expect(await band("2026-07-29", "2026-07-30")).toEqual([
+			{ date: "2026-07-29", bySeries: {} },
+			{ date: "2026-07-30", bySeries: {} },
+		]);
 	});
 });
 

--- a/cli/src/dashboard/DashboardQuery.ts
+++ b/cli/src/dashboard/DashboardQuery.ts
@@ -22,7 +22,7 @@ import { collectDisplayTopics } from "../core/SummaryTree.js";
 import { TOOL_RECORDING_SOURCES } from "../core/TranscriptParser.js";
 import type { TranscriptRepairState } from "../core/TranscriptRepair.js";
 import { createLogger, errMsg } from "../Logger.js";
-import type { CommitSummary } from "../Types.js";
+import type { CommitSummary, SkillEntryPath } from "../Types.js";
 import { ACTIVITY_BUCKET_MS } from "./ActivityBuckets.js";
 import type { DashboardDbHandle } from "./DashboardDb.js";
 import type {
@@ -49,6 +49,8 @@ import type {
 	RepoOption,
 	SeriesDimension,
 	SettingsPageModel,
+	SkillDayPoint,
+	SkillDetail,
 	StandupCommit,
 	StandupInsight,
 	StandupModel,
@@ -61,6 +63,7 @@ import type {
 	ToolUsageList,
 	ToolUsagePage,
 	ToolUsageRow,
+	ToolUsageTokens,
 } from "./DashboardModel.js";
 import {
 	commitCategoryLabels,
@@ -988,7 +991,7 @@ function buildStats(
 		range: window.range,
 		rangeFrom: window.from,
 		rangeTo: window.to,
-		toolUsage: buildToolUsage(db, scope, window),
+		toolUsage: buildToolUsage(db, scope, window, timeZone),
 		...(concurrency !== undefined ? { concurrency } : {}),
 		...(pricesAsOf ? { pricesAsOf } : {}),
 		...(memoriesCreated !== undefined ? { memoriesCreated } : {}),
@@ -1702,6 +1705,39 @@ function toolNameRowsPage(
 	limit: number,
 ): ToolUsageRow[] {
 	const kind = TOOL_LIST_KIND[list];
+	// Whether ANY entry behind a row was inferred from a file read — the list-row half
+	// of `ToolUsageRow.detection`, in the shape `any_estimated` below already uses.
+	//
+	// A CORRELATED SUBQUERY, never a join to `skill_invocations`. That table holds one
+	// row per invocation while this one holds one per (session, skill), so joining it
+	// fans every SUM out by the number of entries behind each row. Measured against a
+	// real database by running both forms side by side: `align-command-behavior` came
+	// back as 7 calls instead of 5, `clear-worktree` and `frontend-design` as 5 instead
+	// of 3. The three token sums inflate the same way.
+	//
+	// WHAT MAKES IT HIDE is that only half the row moves. `sessions` is a
+	// COUNT(DISTINCT), so it is immune and stays correct — the row reads as a plausible
+	// "3 sessions, 5 runs" rather than as anything obviously broken, and nothing errors.
+	// It also will not reproduce on every machine: Codex CLI writes one entry per session
+	// by design, so a Codex-dominated database has 1:1 rows and shows no inflation at all
+	// (both forms agreed on `jolli-search` and `jolli-recall` there). The pairs above had
+	// two entries each, which is the ordinary case for a host with a real skill tool.
+	//
+	// GATED ON `list`, and the gate is load-bearing rather than an optimisation:
+	// `skill_invocations` has no `kind` column (it only ever holds skills), so for the
+	// MCP list an `exec` tool that happens to share a name with an `exec` skill would
+	// match and be marked inferred. The two lists are separated by `t.kind`, which the
+	// subquery cannot see. `plugin` above gets away with no such guard because nothing
+	// WRITES it for an MCP row; an EXISTS has no equivalent protection.
+	const inferredExpr =
+		list === "skill"
+			? `MAX(CASE WHEN EXISTS (
+			                SELECT 1 FROM skill_invocations i
+			                 WHERE i.session_event_id = t.session_event_id
+			                   AND i.skill_name = t.tool_name
+			                   AND i.detection = 'heuristic'
+			              ) THEN 1 ELSE 0 END)`
+			: "0";
 	const rows = db
 		.prepare(
 			// Grouped by name alone: the kind is already pinned by the WHERE, so this
@@ -1710,7 +1746,27 @@ function toolNameRowsPage(
 			// its per-source counts (a session has exactly one source).
 			`SELECT ${TOOL_LIST_KEY[list]} AS tool_name,
 			        COUNT(DISTINCT t.session_event_id) AS session_count,
-			        COALESCE(SUM(t.calls), 0) AS call_count
+			        COALESCE(SUM(t.calls), 0) AS call_count,
+			        SUM(t.input_tokens) AS input_tokens,
+			        SUM(t.output_tokens) AS output_tokens,
+			        SUM(t.cached_tokens) AS cached_tokens,
+			        -- The coverage denominator's numerator: how many of this row's
+			        -- sessions carry figures at all. Counted rather than derived from a
+			        -- NULL sum, because SUM() over a mix of NULLs and numbers answers
+			        -- with the numbers and says nothing about how many were missing.
+			        COUNT(DISTINCT CASE WHEN t.input_tokens IS NOT NULL
+			                            THEN t.session_event_id END) AS usage_sessions,
+			        -- One estimated contributor makes the whole sum an estimate, the
+			        -- same rule buildSkillsSummaryLabel applies. MAX over a 0/1 CASE
+			        -- rather than MAX(usage_confidence): the string form happens to work
+			        -- by dictionary order ('estimated' > 'attributed') and would break
+			        -- silently the day a third confidence is added.
+			        MAX(CASE WHEN t.usage_confidence = 'estimated' THEN 1 ELSE 0 END) AS any_estimated,
+			        -- A bare name can be claimed by different plugins across sessions. Show
+			        -- the namespace only when the group has exactly one named claimant;
+			        -- NULL rows say nothing and therefore do not conflict with that claimant.
+			        CASE WHEN COUNT(DISTINCT t.plugin) = 1 THEN MAX(t.plugin) END AS plugin,
+			        ${inferredExpr} AS any_inferred
 			   FROM session_tool_use t
 			   JOIN sessions s ON s.event_id = t.session_event_id
 			  WHERE ${where.sql} AND t.kind = ?
@@ -1722,6 +1778,13 @@ function toolNameRowsPage(
 		tool_name: string;
 		session_count: number;
 		call_count: number;
+		input_tokens: number | null;
+		output_tokens: number | null;
+		cached_tokens: number | null;
+		usage_sessions: number;
+		any_estimated: number;
+		plugin: string | null;
+		any_inferred: number;
 	}>;
 	const agents = toolRowAgents(
 		db,
@@ -1729,13 +1792,53 @@ function toolNameRowsPage(
 		list,
 		rows.map((row) => row.tool_name),
 	);
-	return rows.map((row) => ({
-		name: row.tool_name,
-		kind: list === "skill" ? ("skill" as const) : ("mcp" as const),
-		sessions: row.session_count,
-		calls: row.call_count,
-		agents: agents.get(row.tool_name) ?? [],
-	}));
+	return rows.map((row) => {
+		const usage = toolRowUsage(row);
+		return {
+			name: row.tool_name,
+			kind: list === "skill" ? ("skill" as const) : ("mcp" as const),
+			sessions: row.session_count,
+			calls: row.call_count,
+			agents: agents.get(row.tool_name) ?? [],
+			...(usage !== undefined ? { usage } : {}),
+			...(row.plugin !== null ? { plugin: row.plugin } : {}),
+			// Omitted rather than set to a second value: absent already means "no entry
+			// says inferred", which is where a row with no entry rows at all has to fall.
+			// See `ToolUsageRow.detection` on why that is not a claim of observation.
+			...(row.any_inferred === 1 ? { detection: "heuristic" as const } : {}),
+		};
+	});
+}
+
+/**
+ * One row's token sum, or undefined when nothing in it could be attributed.
+ *
+ * Gated on `usage_sessions`, never on the sums being non-null: a skill whose only
+ * attributed session genuinely spent nothing is a measurement of zero and must
+ * survive as one, while a skill nobody could measure has to stay absent. Those two
+ * are the same three numbers and only the count tells them apart.
+ *
+ * MCP and builtin rows fall out here on their own — nothing writes their token
+ * columns — so this needs no test on `kind`.
+ */
+function toolRowUsage(row: {
+	input_tokens: number | null;
+	output_tokens: number | null;
+	cached_tokens: number | null;
+	usage_sessions: number;
+	any_estimated: number;
+}): ToolUsageTokens | undefined {
+	if (row.usage_sessions === 0) return undefined;
+	return {
+		// The columns move together, so a null here means the sum ran over rows that
+		// all had one — impossible once usage_sessions is positive. Defaulted rather
+		// than asserted: a stray legacy row must not crash a page render.
+		input: row.input_tokens ?? 0,
+		output: row.output_tokens ?? 0,
+		cached: row.cached_tokens ?? 0,
+		confidence: row.any_estimated === 1 ? "estimated" : "attributed",
+		sessions: row.usage_sessions,
+	};
 }
 
 /**
@@ -1923,6 +2026,489 @@ export function buildToolUsagePage(db: DashboardDbHandle, opts: ToolUsagePageOpt
 }
 
 /**
+ * Rows per list in a skill's detail view.
+ *
+ * One number for both the session list and the commit list, because they answer
+ * the same question at two granularities and a reader comparing them should not
+ * have to hold two caps in mind. 20 rather than the card's 8: this view is opened
+ * deliberately, so it can be longer than a summary card that has to share a band
+ * with two others.
+ */
+const SKILL_DETAIL_ROW_LIMIT = 20;
+
+/**
+ * Entry rows returned for the outcome strip.
+ *
+ * Higher than {@link SKILL_DETAIL_ROW_LIMIT} because the two are read at different
+ * densities: a tick is a few pixels wide while a table row is a line, so 50 ticks
+ * occupy less space than 20 rows. The failure counts beside the strip are computed
+ * over the WHOLE window rather than over these rows, so this bound decides how far
+ * back the strip reads and nothing about the figures.
+ */
+const SKILL_INVOCATION_ROWS_LIMIT = 50;
+
+/**
+ * Session points returned for the detail view's time charts.
+ *
+ * Two numbers per point, so this can be far higher than the table's cap without
+ * mattering to the payload — and it has to be, because a chart drawn from 20 of a
+ * skill's 51 sessions has the wrong shape rather than a shorter one. The bound
+ * exists only so an unbounded custom range cannot return an unbounded array.
+ */
+const SKILL_SESSION_SERIES_LIMIT = 400;
+
+/**
+ * Folds `(skill, session, call time)` rows into the stacked-bar series, one point
+ * per LOCAL day of the window.
+ *
+ * The window is walked rather than the data: every day between its bounds is emitted,
+ * whether or not a skill ran. The chart lays bars out by index, so a dropped day would
+ * silently compress the axis and make a week-long gap look like a busy stretch. Walking
+ * the window is also what bounds the result — `resolveWindow` already clamps a custom
+ * range to {@link MAX_CUSTOM_DAYS}, so the retired week-bucket cap has no work left.
+ *
+ * Bucketing happens HERE and not in SQL, per this file's time-zone rule: SQLite's
+ * `localtime` answers with the process's zone and cannot agree with the boundaries the
+ * heatmap and the token series draw. A day key from `localDayKey` is the same key those
+ * use, so `Aug 6` means one thing across the whole page.
+ *
+ * Sessions are counted through a Set rather than by counting rows. `session_tool_use`
+ * is keyed `(session, tool, kind)`, so one row per (session, skill) is what the table
+ * guarantees today and counting rows would agree — but the figure this feeds is defined
+ * as "sessions that reached for the skill", and spelling that as a de-duplication keeps
+ * it right if a row ever splits.
+ *
+ * `addLocalDays` steps the cursor, never a fixed 86_400_000: a 23- or 25-hour DST day
+ * would otherwise skip or repeat a bucket.
+ */
+function buildSkillDays(
+	rows: ReadonlyArray<{ tool_name: string; session_event_id: string; at_ms: number }>,
+	window: ResolvedWindow,
+	timeZone: string,
+): SkillDayPoint[] {
+	const byDay = new Map<string, Map<string, Set<string>>>();
+	for (let dayStart = window.startMs; dayStart < window.endMs; dayStart = addLocalDays(dayStart, 1, timeZone)) {
+		byDay.set(localDayKey(dayStart, timeZone), new Map());
+	}
+	for (const row of rows) {
+		// A row whose call time falls outside the window is dropped rather than
+		// clamped into an edge bucket. The SQL filters by the same bounds, so this
+		// only fires on the boundary rounding between an epoch-ms filter and a local
+		// day key — and attributing such a row to a day it did not happen on would be
+		// worse than omitting it.
+		const bucket = byDay.get(localDayKey(row.at_ms, timeZone));
+		if (!bucket) continue;
+		const sessions = bucket.get(row.tool_name) ?? new Set<string>();
+		sessions.add(row.session_event_id);
+		bucket.set(row.tool_name, sessions);
+	}
+	return [...byDay.entries()].map(([date, skills]) => ({
+		date,
+		bySeries: Object.fromEntries([...skills.entries()].map(([skill, sessions]) => [skill, sessions.size])),
+	}));
+}
+
+/** The four token columns plus the coverage counters, shared by both roll-ups. */
+const SKILL_USAGE_COLUMNS = `SUM(t.input_tokens) AS input_tokens,
+	        SUM(t.output_tokens) AS output_tokens,
+	        SUM(t.cached_tokens) AS cached_tokens,
+	        COUNT(DISTINCT CASE WHEN t.input_tokens IS NOT NULL THEN t.session_event_id END) AS usage_sessions,
+	        MAX(CASE WHEN t.usage_confidence = 'estimated' THEN 1 ELSE 0 END) AS any_estimated`;
+
+/** What one `/api/skill-detail` request names: a skill, and the window to read it over. */
+export interface SkillDetailOptions {
+	readonly scope: DashboardScope;
+	/** `session_tool_use.tool_name` — the exact row the card was showing. */
+	readonly name: string;
+	readonly range?: DashboardRange;
+	readonly customFrom?: string;
+	readonly customTo?: string;
+	readonly timeZone?: string;
+	readonly nowMs?: number;
+}
+
+/**
+ * One skill's whole story over the window — per agent, per session, per commit.
+ *
+ * Five queries rather than one join: the commit chain fans out (a session links to
+ * several transcript files, and a memory tree carries one row per amended commit),
+ * so folding it into the token roll-up would multiply the sums by the fan-out. They
+ * are separated for correctness, not for tidiness.
+ *
+ * Returns undefined when the window holds no call of that skill at all, which the
+ * route turns into a 404 — distinct from a skill that ran but attributed nothing,
+ * which is a real answer with `usage` absent.
+ */
+export function buildSkillDetail(db: DashboardDbHandle, opts: SkillDetailOptions): SkillDetail | undefined {
+	const timeZone = opts.timeZone ?? machineTimeZone();
+	const window = resolveWindow(opts.range, opts.customFrom, opts.customTo, opts.nowMs ?? Date.now(), timeZone);
+	const where = toolUsageWhere(db, opts.scope, window);
+	const scoped = [...where.params, opts.name];
+
+	const total = db
+		.prepare(
+			`SELECT COUNT(DISTINCT t.session_event_id) AS session_count,
+			        COALESCE(SUM(t.calls), 0) AS call_count,
+			        MAX(${TOOL_CALL_TIME_SQL}) AS last_call_at_ms,
+			        -- Conflicts can span scan windows even though one scan suppresses a
+			        -- contested namespace. Never label the combined bare-name bucket as one
+			        -- plugin when more than one named claimant survives behind it.
+			        CASE WHEN COUNT(DISTINCT t.plugin) = 1 THEN MAX(t.plugin) END AS plugin,
+			        ${SKILL_USAGE_COLUMNS}
+			   FROM session_tool_use t
+			   JOIN sessions s ON s.event_id = t.session_event_id
+			  WHERE ${where.sql} AND t.kind = 'skill' AND t.tool_name = ?`,
+		)
+		.get(...scoped) as
+		| {
+				session_count: number;
+				call_count: number;
+				last_call_at_ms: number | null;
+				plugin: string | null;
+				input_tokens: number | null;
+				output_tokens: number | null;
+				cached_tokens: number | null;
+				usage_sessions: number;
+				any_estimated: number;
+		  }
+		| undefined;
+	// An aggregate always returns a row, so `session_count` is what says "not here"
+	// — never the row's absence.
+	if (!total || total.session_count === 0) return undefined;
+
+	const agentRows = db
+		.prepare(
+			`SELECT s.source,
+			        COUNT(DISTINCT t.session_event_id) AS session_count,
+			        COALESCE(SUM(t.calls), 0) AS call_count,
+			        ${SKILL_USAGE_COLUMNS}
+			   FROM session_tool_use t
+			   JOIN sessions s ON s.event_id = t.session_event_id
+			  WHERE ${where.sql} AND t.kind = 'skill' AND t.tool_name = ?
+			  GROUP BY s.source
+			  ORDER BY call_count DESC, s.source ASC`,
+		)
+		.all(...scoped) as ReadonlyArray<{
+		source: string;
+		session_count: number;
+		call_count: number;
+		input_tokens: number | null;
+		output_tokens: number | null;
+		cached_tokens: number | null;
+		usage_sessions: number;
+		any_estimated: number;
+	}>;
+
+	const sessionRows = db
+		.prepare(
+			`SELECT s.session_id, s.source, s.title, s.started_at_ms, s.updated_at_ms,
+			        s.duration_ms, s.message_count, s.model, s.token_coverage,
+			        s.input_tokens + s.output_tokens + s.cached_tokens AS session_tokens,
+			        t.calls, t.input_tokens, t.output_tokens, t.cached_tokens, t.usage_confidence
+			   FROM session_tool_use t
+			   JOIN sessions s ON s.event_id = t.session_event_id
+			  WHERE ${where.sql} AND t.kind = 'skill' AND t.tool_name = ?
+			  ORDER BY ${TOOL_CALL_TIME_SQL} DESC
+			  LIMIT ?`,
+		)
+		.all(...scoped, SKILL_DETAIL_ROW_LIMIT) as ReadonlyArray<{
+		session_id: string;
+		source: string;
+		title: string | null;
+		started_at_ms: number | null;
+		updated_at_ms: number;
+		duration_ms: number | null;
+		message_count: number | null;
+		model: string | null;
+		token_coverage: string;
+		session_tokens: number;
+		calls: number;
+		input_tokens: number | null;
+		output_tokens: number | null;
+		cached_tokens: number | null;
+		usage_confidence: string | null;
+	}>;
+
+	const repoRows = db
+		.prepare(
+			`SELECT DISTINCT r.repo_name
+			   FROM session_tool_use t
+			   JOIN sessions s ON s.event_id = t.session_event_id
+			   JOIN repos r    ON r.id = s.repo_id
+			  WHERE ${where.sql} AND t.kind = 'skill' AND t.tool_name = ?
+			  ORDER BY r.repo_name`,
+		)
+		.all(...scoped) as ReadonlyArray<{ repo_name: string }>;
+
+	// The two time charts' own grain, uncapped where `sessionRows` is capped — a chart
+	// drawn from 20 of 51 sessions has the wrong SHAPE, not just fewer points. Two
+	// columns, so the whole window costs less than the table above it.
+	const seriesRows = db
+		.prepare(
+			`SELECT at_ms, input_tokens, output_tokens, cached_tokens
+			   FROM (
+			        SELECT ${TOOL_CALL_TIME_SQL} AS at_ms,
+			               t.input_tokens, t.output_tokens, t.cached_tokens,
+			               t.session_event_id
+			          FROM session_tool_use t
+			          JOIN sessions s ON s.event_id = t.session_event_id
+			         WHERE ${where.sql} AND t.kind = 'skill' AND t.tool_name = ?
+			         ORDER BY at_ms DESC, t.session_event_id DESC
+			         LIMIT ?
+			   ) recent
+			  ORDER BY at_ms ASC, session_event_id ASC`,
+		)
+		.all(...scoped, SKILL_SESSION_SERIES_LIMIT) as ReadonlyArray<{
+		at_ms: number;
+		input_tokens: number | null;
+		output_tokens: number | null;
+		cached_tokens: number | null;
+	}>;
+
+	// DISTINCT is load-bearing twice over: one session legitimately links to several
+	// transcript FILES, and `parent_hash IS NULL` keeps an amend/rebase tree to its
+	// root — measured, one skill's ref appeared on 15 nodes of one 15-deep tree, so
+	// without the root filter a commit list would repeat it once per node.
+	const commitRows = db
+		.prepare(
+			`SELECT DISTINCT m.commit_hash, r.repo_name, m.branch, m.commit_message,
+			        COALESCE(cm.committed_at_ms, m.commit_date_ms) AS committed_at_ms,
+			        m.files_changed, m.insertions, m.deletions
+			   FROM session_tool_use t
+			   JOIN sessions s ON s.event_id = t.session_event_id
+			   JOIN transcript_sessions ts
+			     ON ts.repo_id = s.repo_id AND ts.session_id = s.session_id AND ts.source = s.source
+			   JOIN memory_transcripts mt ON mt.repo_id = ts.repo_id AND mt.transcript_id = ts.transcript_id
+			   JOIN memories m ON m.repo_id = mt.repo_id AND m.commit_hash = mt.commit_hash
+			   JOIN repos r ON r.id = m.repo_id
+			   LEFT JOIN commits cm ON cm.repo_id = m.repo_id AND cm.hash = m.commit_hash
+			  WHERE ${where.sql} AND t.kind = 'skill' AND t.tool_name = ? AND m.parent_hash IS NULL
+			  ORDER BY committed_at_ms DESC
+			  LIMIT ?`,
+		)
+		.all(...scoped, SKILL_DETAIL_ROW_LIMIT) as ReadonlyArray<{
+		commit_hash: string;
+		repo_name: string;
+		branch: string | null;
+		commit_message: string | null;
+		committed_at_ms: number;
+		files_changed: number | null;
+		insertions: number | null;
+		deletions: number | null;
+	}>;
+
+	// Fetched per hash rather than joined into the query above: `memory_topics` has a
+	// row per topic, so joining it would return one commit row per topic and the
+	// LIMIT would silently cover fewer commits than it says.
+	const categoriesByHash = new Map<string, string[]>();
+	if (commitRows.length > 0) {
+		const holes = commitRows.map(() => "?").join(",");
+		const topicRows = db
+			.prepare(
+				`SELECT DISTINCT commit_hash, category FROM memory_topics
+				  WHERE commit_hash IN (${holes}) AND category IS NOT NULL`,
+			)
+			.all(...commitRows.map((row) => row.commit_hash)) as ReadonlyArray<{
+			commit_hash: string;
+			category: string;
+		}>;
+		for (const row of topicRows) {
+			const bucket = categoriesByHash.get(row.commit_hash);
+			if (bucket) bucket.push(row.category);
+			else categoriesByHash.set(row.commit_hash, [row.category]);
+		}
+	}
+
+	const commits = commitRows.map((row) => ({
+		hash: row.commit_hash,
+		repoName: row.repo_name,
+		...(row.branch !== null ? { branch: row.branch } : {}),
+		...(row.commit_message !== null ? { message: row.commit_message } : {}),
+		committedAtMs: row.committed_at_ms,
+		...(row.files_changed !== null ? { filesChanged: row.files_changed } : {}),
+		...(row.insertions !== null ? { insertions: row.insertions } : {}),
+		...(row.deletions !== null ? { deletions: row.deletions } : {}),
+		categories: (categoriesByHash.get(row.commit_hash) ?? []).sort(),
+	}));
+
+	const categoryCounts = new Map<string, number>();
+	for (const commit of commits) {
+		// Deduped per commit by the DISTINCT above, so a commit with three `bugfix`
+		// topics counts once — this axis is "how many commits", not "how many topics".
+		for (const category of commit.categories) categoryCounts.set(category, (categoryCounts.get(category) ?? 0) + 1);
+	}
+
+	// The per-entry table, reached THROUGH the aggregate rather than joined only to
+	// `sessions`. Two reasons, and the first is not optional: `where.sql` windows on
+	// `TOOL_CALL_TIME_SQL`, which reads `t.last_call_at_ms`, so the aggregate has to be
+	// in scope for the shared filter to compile at all. It also confines this pass to
+	// exactly the rows the card was showing. The join cannot duplicate an entry — the
+	// aggregate holds one row per (session, skill) by primary key.
+	const invocationSource = `FROM skill_invocations i
+		   JOIN session_tool_use t
+		     ON t.session_event_id = i.session_event_id AND t.tool_name = i.skill_name AND t.kind = 'skill'
+		   JOIN sessions s ON s.event_id = i.session_event_id
+		  WHERE ${where.sql} AND i.skill_name = ?`;
+
+	const entryTotals = db
+		.prepare(
+			`SELECT COUNT(*) AS entry_count,
+			        MIN(i.at_ms) AS first_at_ms,
+			        -- The largest body, never an average — a repeat entry injects a stub. See
+			        -- SkillDetail.bodyChars.
+			        MAX(i.body_chars) AS body_chars,
+			        -- Counted over the ENTRIES WHOSE OUTCOME WAS READ, which is the whole point:
+			        -- a defaulted ok is not evidence of success, so including it would report a
+			        -- 0% failure rate for three of the six entry mechanisms.
+			        SUM(CASE WHEN i.ok_confidence = 'observed' THEN 1 ELSE 0 END) AS measured,
+			        SUM(CASE WHEN i.ok_confidence = 'observed' AND i.ok = 0 THEN 1 ELSE 0 END) AS failed,
+			        -- The complement, carried rather than dropped: those runs DID happen, and a
+			        -- surface handed only the measured count has to choose between hiding them
+			        -- and implying they succeeded. Spelled as "not observed" because the column
+			        -- is free-form TEXT — anything that is not the one verified value is
+			        -- unknowable, which is the direction a stray value must fall.
+			        SUM(CASE WHEN i.ok_confidence <> 'observed' THEN 1 ELSE 0 END) AS assumed,
+			        -- Entries inferred from a file read rather than observed. A plain SUM is
+			        -- safe here where the list query needs an EXISTS: this statement's FROM
+			        -- LEADS with the per-entry table, so there is nothing to fan out.
+			        -- Compared to the one verified value rather than tested for NOT NULL —
+			        -- the column is free-form TEXT, and an unrecognised value is not evidence
+			        -- of inference, so a stray one must fall on the quiet side.
+			        SUM(CASE WHEN i.detection = 'heuristic' THEN 1 ELSE 0 END) AS inferred,
+			        -- Comma-joined; NULLs are dropped by GROUP_CONCAT, so a history with no
+			        -- recorded mechanism comes back NULL rather than as an empty member.
+			        GROUP_CONCAT(DISTINCT i.entry_path) AS entry_paths
+			   ${invocationSource}`,
+		)
+		.get(...scoped) as
+		| {
+				entry_count: number;
+				first_at_ms: number | null;
+				body_chars: number | null;
+				measured: number;
+				failed: number;
+				assumed: number;
+				inferred: number;
+				entry_paths: string | null;
+		  }
+		| undefined;
+
+	// Newest-first in SQL so the LIMIT keeps the RECENT entries, then reversed for the
+	// caller: "it started failing on Tuesday" reads left to right. The counts above are
+	// unaffected by this cap and stay exact over the whole window.
+	const invocationRows = db
+		.prepare(
+			`SELECT i.at_ms, i.ok, i.ok_confidence, i.args, i.body_chars
+			   ${invocationSource}
+			  ORDER BY i.at_ms DESC
+			  LIMIT ?`,
+		)
+		.all(...scoped, SKILL_INVOCATION_ROWS_LIMIT) as ReadonlyArray<{
+		at_ms: number;
+		ok: number;
+		ok_confidence: string;
+		args: string | null;
+		body_chars: number | null;
+	}>;
+
+	// Validated against the union rather than cast: the column is free-form TEXT, and a
+	// value no scanner produces must be dropped rather than enter the model as a
+	// mechanism the renderer will not recognise.
+	const entryPaths = (entryTotals?.entry_paths ?? "")
+		.split(",")
+		.filter((path): path is SkillEntryPath => path === "tool" || path === "command");
+
+	// Absent only when there is NO entry row — not merely when none was measurable. The
+	// two are different answers: "no per-entry record survives" (an archived commit's
+	// merged count, a pruned transcript) versus "it ran N times and the mechanism records
+	// no result". Gating on `measured` collapsed the second into the first and hid every
+	// slash-command entry, which is nearly all of them on a Claude machine. The counts
+	// are handed over separately so the renderer cannot add them: `failed / measured`
+	// stays the only rate, and `assumed` is reported in words. See `SkillDetailOutcomes`.
+	const outcomes =
+		entryTotals !== undefined && entryTotals.entry_count > 0
+			? { measured: entryTotals.measured, failed: entryTotals.failed, assumed: entryTotals.assumed }
+			: undefined;
+	const usage = toolRowUsage(total);
+
+	return {
+		name: opts.name,
+		sessions: total.session_count,
+		calls: total.call_count,
+		...(total.last_call_at_ms !== null ? { lastCallAtMs: total.last_call_at_ms } : {}),
+		...(usage !== undefined ? { usage } : {}),
+		agents: agentRows.map((row) => {
+			const usage = toolRowUsage(row);
+			return {
+				source: row.source,
+				sessions: row.session_count,
+				calls: row.call_count,
+				...(usage !== undefined ? { usage } : {}),
+			};
+		}),
+		commits,
+		linkedSessions: sessionRows.map((row) => ({
+			sessionId: row.session_id,
+			source: row.source,
+			...(row.title !== null ? { title: row.title } : {}),
+			...(row.started_at_ms !== null ? { startedAtMs: row.started_at_ms } : {}),
+			updatedAtMs: row.updated_at_ms,
+			...(row.duration_ms !== null ? { durationMs: row.duration_ms } : {}),
+			...(row.message_count !== null ? { messageCount: row.message_count } : {}),
+			...(row.model !== null ? { model: row.model } : {}),
+			calls: row.calls,
+			// `sessions-only` means the parser read the session but could not read its
+			// tokens, so the three columns are structural zeros rather than a measured
+			// nothing. Omitted in that case for the same reason a skill's usage is.
+			...(row.token_coverage !== "sessions-only" && row.session_tokens > 0
+				? { sessionTokens: row.session_tokens }
+				: {}),
+			...(row.input_tokens !== null
+				? {
+						usage: {
+							input: row.input_tokens,
+							output: row.output_tokens ?? 0,
+							cached: row.cached_tokens ?? 0,
+							confidence:
+								row.usage_confidence === "estimated" ? ("estimated" as const) : ("attributed" as const),
+							// One session, so the coverage denominator is 1 by construction.
+							sessions: 1,
+						},
+					}
+				: {}),
+		})),
+		categories: [...categoryCounts]
+			.map(([category, count]) => ({ category, commits: count }))
+			.sort((a, b) => b.commits - a.commits || a.category.localeCompare(b.category)),
+		...(total.plugin !== null ? { plugin: total.plugin } : {}),
+		repos: repoRows.map((row) => row.repo_name),
+		...(entryTotals?.first_at_ms != null ? { firstCallAtMs: entryTotals.first_at_ms } : {}),
+		entryPaths,
+		// Any-one-taints, matching the list row and `SkillStore.mergeSkillRef`. Absent
+		// where nothing says inferred, which is also where a skill with no surviving
+		// entry row lands — the pane says "no per-entry record" there in its own words.
+		...((entryTotals?.inferred ?? 0) > 0 ? { detection: "heuristic" as const } : {}),
+		...(outcomes !== undefined ? { outcomes } : {}),
+		invocations: [...invocationRows].reverse().map((row) => ({
+			atMs: row.at_ms,
+			ok: row.ok !== 0,
+			outcomeKnown: row.ok_confidence === "observed",
+			...(row.args !== null ? { args: row.args } : {}),
+			...(row.body_chars !== null ? { bodyChars: row.body_chars } : {}),
+		})),
+		...(entryTotals?.body_chars != null ? { bodyChars: entryTotals.body_chars } : {}),
+		sessionSeries: seriesRows.map((row) => ({
+			atMs: row.at_ms,
+			// Absent, not zero, where the source attributed nothing — the cost chart skips
+			// the point rather than drawing a session that spent nothing.
+			...(row.input_tokens !== null
+				? { tokens: row.input_tokens + (row.output_tokens ?? 0) + (row.cached_tokens ?? 0) }
+				: {}),
+		})),
+	};
+}
+
+/**
  * Skills, MCP servers and the tool mix over the window, each row carrying the
  * agents that produced it — the FIRST page of each of the three lists, plus the
  * totals they page against.
@@ -1941,7 +2527,12 @@ export function buildToolUsagePage(db: DashboardDbHandle, opts: ToolUsagePageOpt
  * they answer "who ran this", where the count IS the point. See
  * {@link TOOL_LIST_ORDER}.
  */
-function buildToolUsage(db: DashboardDbHandle, scope: DashboardScope, window: ResolvedWindow): ToolUsage {
+function buildToolUsage(
+	db: DashboardDbHandle,
+	scope: DashboardScope,
+	window: ResolvedWindow,
+	timeZone: string,
+): ToolUsage {
 	const where = toolUsageWhere(db, scope, window);
 	const skillTotals = toolListTotals(db, where, "skill");
 	const serverTotals = toolListTotals(db, where, "server");
@@ -1978,6 +2569,21 @@ function buildToolUsage(db: DashboardDbHandle, scope: DashboardScope, window: Re
 				.filter((row) => row.kind === kind)
 				.map((row) => ({ source: row.source, sessions: row.session_count, calls: row.call_count })),
 		);
+
+	// Adoption per skill per local day, over EVERY skill in the window rather than the
+	// first page — see `ToolUsage.skillDays`. Unaggregated on purpose: the bucket is a
+	// LOCAL calendar day, which only `buildSkillDays` can compute (see this file's
+	// header on why SQLite's `localtime` is never used), so grouping here would have to
+	// group by a boundary the rest of the page does not share. The call-time expression
+	// is the one the rankings use, so a row's bar and its rank agree about when it ran.
+	const dayRows = db
+		.prepare(
+			`SELECT t.tool_name, t.session_event_id, ${TOOL_CALL_TIME_SQL} AS at_ms
+			   FROM session_tool_use t
+			   JOIN sessions s ON s.event_id = t.session_event_id
+			  WHERE ${where.sql} AND t.kind = 'skill'`,
+		)
+		.all(...where.params) as ReadonlyArray<{ tool_name: string; session_event_id: string; at_ms: number }>;
 
 	// Coverage from the FULL session population, never from the join above — and
 	// windowed by the SESSION's own time OR by any call it made, which is the
@@ -2035,6 +2641,7 @@ function buildToolUsage(db: DashboardDbHandle, scope: DashboardScope, window: Re
 		skills,
 		skillsTotal: skillTotals.totalCount,
 		skillCallsTotal: skillTotals.callsTotal,
+		skillDays: buildSkillDays(dayRows, window, timeZone),
 		mcpTools,
 		mcpToolsTotal: mcpToolTotals.totalCount,
 		recallCalls,
@@ -2306,7 +2913,19 @@ export function buildDashboardModel(db: DashboardDbHandle, opts: QueryOptions): 
 	// wasted queries, and the page only ever reads its own.
 	const payload = (): Pick<DashboardModel, "stats" | "standup" | "memories" | "knowledge" | "graph" | "settings"> => {
 		switch (options.view) {
+			// Skills reads `stats.toolUsage` and nothing else, so it shares this payload
+			// rather than declaring one of its own — which is also what lets its list and
+			// the Stats card's Skills card agree by construction instead of by two queries
+			// that have to be kept in step.
+			//
+			// It does pay for the whole of `buildStats` (the feed, the activity series, the
+			// token dimensions) to read one field of it. Accepted for now: the alternative
+			// is splitting `buildStats` along a seam that does not exist yet, and a reader
+			// arriving from the dashboard has just paid the same cost anyway. The seam to
+			// cut, if this page grows heavy, is a `toolUsage`-only payload — not a second
+			// query over `session_tool_use`.
 			case "stats":
+			case "skills":
 				return {
 					stats: buildStats(
 						db,

--- a/cli/src/dashboard/DashboardServer.test.ts
+++ b/cli/src/dashboard/DashboardServer.test.ts
@@ -117,6 +117,7 @@ function writeTestAssets(base: string): string {
 		"charts.js",
 		"shell.js",
 		"stats.js",
+		"skills.js",
 		"standup.js",
 		"graph.js",
 		"memories.js",
@@ -1909,6 +1910,9 @@ describe("defaultModelBuilder (no injected buildModel)", () => {
 			totalCount: 2,
 			rows: [{ server: "github", calls: 4 }],
 		});
+		// Window fields are forwarded independently. A non-custom range ignores the
+		// extra bounds in the query layer, but the route must not drop them silently.
+		expect((await get(port, "/api/tool-usage?list=server&range=3m&from=ignored&to=ignored")).status).toBe(200);
 
 		// An unknown list is a 400, never a fallback to the first one: the answer
 		// would be a page of the WRONG list, which the client appends to the one it
@@ -1984,6 +1988,82 @@ describe("defaultModelBuilder (no injected buildModel)", () => {
 		// Same rule as `offset`: a value this route cannot read is the caller's bug,
 		// and silently answering a different question is what hides it.
 		expect((await get(port, "/api/tool-usage?list=server&limit=abc")).status).toBe(400);
+	});
+
+	it("serves one skill detail and distinguishes a bad name from a missing skill", async () => {
+		const dbPath = join(dir, "skill-detail.db");
+		const configDir = join(dir, "config-skill-detail");
+		await applyStatsEvents(
+			[
+				{
+					producerKind: "cli",
+					event: {
+						type: "repo.enabled",
+						repoIdentity: "repo-1",
+						repoName: "jolli",
+						worktreeRoot: "/w/jolli",
+						enabledAt: "t",
+					},
+				},
+				{
+					producerKind: "cli",
+					event: {
+						type: "session.upserted",
+						repoIdentity: "repo-1",
+						source: "claude",
+						sessionId: "review-session",
+						updatedAtMs: Date.now() - 3_600_000,
+						tools: [{ name: "code-review", kind: "skill", calls: 2, plugin: "superpowers" }],
+					},
+				},
+			],
+			{ producerKind: "cli", dbPath },
+		);
+
+		const port = await listen(createDashboardServer({ port: 0, assetsDir, dbPath, configDir }));
+		const ok = await get(port, "/api/skill-detail?name=%20code-review%20&range=3m&from=ignored&to=ignored");
+		expect(ok.status).toBe(200);
+		expect(await ok.json()).toMatchObject({
+			name: "code-review",
+			sessions: 1,
+			calls: 2,
+			plugin: "superpowers",
+			agents: [{ source: "claude", sessions: 1, calls: 2 }],
+		});
+
+		expect((await get(port, "/api/skill-detail")).status).toBe(400);
+		expect((await get(port, "/api/skill-detail?name=%20%20")).status).toBe(400);
+		expect((await get(port, "/api/skill-detail?name=missing")).status).toBe(404);
+	});
+
+	it("500s dashboard detail reads when the dashboard database is invalid", async () => {
+		const dbPath = join(dir, "broken-tool-reads.db");
+		writeFileSync(dbPath, "this is not a database");
+		const port = await listen(
+			createDashboardServer({ port: 0, assetsDir, dbPath, configDir: join(dir, "config-broken-tools") }),
+		);
+
+		expect((await get(port, "/api/tool-usage?list=skill")).status).toBe(500);
+		expect((await get(port, "/api/skill-detail?name=code-review")).status).toBe(500);
+		expect((await get(port, "/api/context?repo=repo-1&kind=plan&key=p1")).status).toBe(500);
+		expect((await get(port, "/api/conversation?repo=repo-1&hash=abc&source=claude&session=s1")).status).toBe(500);
+	});
+
+	it("uses the isolated machine-global database for tool and skill detail when dbPath is omitted", async () => {
+		const home = join(dir, "skill-detail-home");
+		await withIsolatedHome(home, async () => {
+			await withDashboardDb(() => {});
+			const port = await listen(
+				createDashboardServer({
+					port: 0,
+					assetsDir,
+					configDir: join(dir, "config-global-skill-detail"),
+				}),
+			);
+
+			expect((await get(port, "/api/tool-usage?list=skill")).status).toBe(200);
+			expect((await get(port, "/api/skill-detail?name=missing")).status).toBe(404);
+		});
 	});
 
 	// The Context dialog's fetch. A read like every other GET here — no token —

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -124,6 +124,7 @@ import {
 } from "./DashboardModel.js";
 import {
 	buildDashboardModel,
+	buildSkillDetail,
 	buildToolUsagePage,
 	clearWorktreeExistenceCache,
 	type QueryOptions,
@@ -205,6 +206,10 @@ export const DASHBOARD_SCRIPT_FILES = [
 	"charts.js",
 	"shell.js",
 	"stats.js",
+	// Needs format/charts/shell above it for `JD.stackedBars`, `JD.seriesColor` and the
+	// fetch helpers; nothing in stats.js. Ordered here rather than earlier only to keep
+	// the list reading in nav order.
+	"skills.js",
 	"standup.js",
 	"memories.js",
 	"knowledge.js",
@@ -1093,6 +1098,7 @@ function parseWindow(url: URL): Omit<ModelRequest, "view" | "scope"> {
 const VIEW_PATHS: Readonly<Record<string, DashboardView>> = {
 	"/dashboard": "stats",
 	"/dashboard/standup": "standup",
+	"/skills": "skills",
 	"/memories": "memories",
 	"/knowledge": "knowledge",
 	"/graph": "graph",
@@ -1109,6 +1115,7 @@ const VIEW_PATHS: Readonly<Record<string, DashboardView>> = {
 const VIEW_TOKENS: ReadonlySet<string> = new Set<DashboardView>([
 	"stats",
 	"standup",
+	"skills",
 	"memories",
 	"knowledge",
 	"graph",
@@ -1653,6 +1660,47 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 			} catch (err) {
 				log.warn("tool usage page read failed: %s", errMsg(err));
 				sendJson(res, 500, { error: "could not read that page of tool usage" });
+			}
+			return;
+		}
+
+		// One skill's breakdown, for the Skills card's detail view. A fetch rather
+		// than a slice of the page model: that model carries ONE PAGE of skills and
+		// none of the per-agent / per-session / per-commit detail, so a skill past
+		// row 8 would have nothing to open.
+		if (url.pathname === "/api/skill-detail") {
+			// Trimmed, because the name rides in a query string and a stray space is a
+			// name that matches nothing — indistinguishable, to the reader, from a skill
+			// with no recorded calls. Empty after trimming is the caller's bug.
+			const name = (url.searchParams.get("name") ?? "").trim();
+			if (name === "") {
+				sendJson(res, 400, { error: "name is required" });
+				return;
+			}
+			const requestedWindow = parseWindow(url);
+			try {
+				const detail = await withReadonlyDashboardDb(
+					(db) =>
+						buildSkillDetail(db, {
+							scope: parseScope(url),
+							name,
+							...(requestedWindow.range ? { range: requestedWindow.range } : {}),
+							...(requestedWindow.customFrom ? { customFrom: requestedWindow.customFrom } : {}),
+							...(requestedWindow.customTo ? { customTo: requestedWindow.customTo } : {}),
+						}),
+					{ ...(options.dbPath ? { dbPath: options.dbPath } : {}) },
+				);
+				// 404 for "no call of that skill in this window" — a real answer, and one
+				// the client must not paint as an empty detail view. A skill that ran but
+				// attributed no tokens comes back 200 with `usage` absent instead.
+				if (!detail) {
+					sendJson(res, 404, { error: "no recorded calls for that skill in this window" });
+					return;
+				}
+				sendJson(res, 200, detail);
+			} catch (err) {
+				log.warn("skill detail read failed: %s", errMsg(err));
+				sendJson(res, 500, { error: "could not read that skill's detail" });
 			}
 			return;
 		}

--- a/cli/src/dashboard/DbBackfill.test.ts
+++ b/cli/src/dashboard/DbBackfill.test.ts
@@ -125,6 +125,7 @@ import { scanOpenCodeSessionsOnDisk } from "../core/OpenCodeSessionDiscoverer.js
 import { readCutoverFence, readManualDisableFlagSync } from "../core/RepoProfile.js";
 import { BACKFILL_SESSION_WINDOW_MS } from "../core/SessionWindow.js";
 import { getIndex, resolveReadStorage } from "../core/SummaryStore.js";
+import type { SkillUsage } from "../Types.js";
 import {
 	collectCommitEvents,
 	collectRepoGraph,
@@ -300,7 +301,7 @@ describe("dbBackfillRepo — bootstrap", () => {
 			// full transcript read produced the stored session rows, and it is the only
 			// thing that makes the per-session skip safe to trust. See
 			// `SESSION_READ_GENERATION`.
-			{ source: "sessions-read-generation", cursor: "5" },
+			{ source: "sessions-read-generation", cursor: "8" },
 			// The memory import's own signal: the orphan tip (a hash of everything it
 			// reads) plus the mode, since seed and catch-up do not write the same rows.
 			{ source: "sot-import", cursor: `${"ab".repeat(20)}#seed` },
@@ -1115,7 +1116,7 @@ describe("dbBackfillRepo — per-session skip", () => {
 		const cursors = await query<{ source: string; cursor: string }>(
 			"SELECT source, cursor FROM ingest_cursors WHERE source = 'sessions-read-generation'",
 		);
-		expect(cursors).toEqual([{ source: "sessions-read-generation", cursor: "5" }]);
+		expect(cursors).toEqual([{ source: "sessions-read-generation", cursor: "8" }]);
 		// And the second sweep is the one that gets a predicate.
 		await dbBackfillRepo({ repo, dbPath });
 		expect(vi.mocked(collectSessionEvents).mock.calls.at(-1)?.[0].isAlreadyCurrent).toBeDefined();
@@ -1150,7 +1151,7 @@ describe("dbBackfillRepo — per-session skip", () => {
 		const cursors = await query<{ cursor: string }>(
 			"SELECT cursor FROM ingest_cursors WHERE source = 'sessions-read-generation'",
 		);
-		expect(cursors).toEqual([{ cursor: "5" }]);
+		expect(cursors).toEqual([{ cursor: "8" }]);
 	});
 });
 
@@ -2249,21 +2250,380 @@ describe("dbBackfillRepo — sessions sweep", () => {
 		expect(row).toEqual([{ server: "jollimemory-remote" }]);
 	});
 
-	it("still projects a session whose tool lost its recorded instant", async () => {
-		// The MAX around `last_call_at_ms` cannot save the stored instant here: the
-		// projection DELETEs the tool rows before inserting, so there is no
-		// conflicting row for it to consult and the re-read's absent time lands as
-		// NULL. That erasure is a real write, which is exactly why this comparison
-		// may not treat "no instant" as equal to a stored one.
-		vi.mocked(collectSessionEvents).mockResolvedValue([toolSession]);
+	it("does not re-enqueue sparse tool evidence that the writer would preserve", async () => {
+		// A truncated transcript can lose attribution and see only an earlier call.
+		// StatsWriter carries the tokens forward and takes the later timestamp, so the
+		// unchanged filter must compare against that merged result or this session is
+		// re-projected forever while its stored row never moves.
+		const lastCallAtMs = 1_700_000_040_000;
+		const attributed = {
+			name: "code-review",
+			kind: "skill" as const,
+			calls: 1,
+			lastCallAtMs,
+			usage: { input: 1, output: 2, cached: 3, confidence: "attributed" as const },
+		};
+		vi.mocked(collectSessionEvents).mockResolvedValue([{ ...sessionEvent, tools: [attributed] }]);
+		await dbBackfillRepo({ repo, dbPath });
+		expect(await loggedSessions("s1")).toBe(1);
+
+		const { usage: _lost, ...withoutUsage } = attributed;
+		vi.mocked(collectSessionEvents).mockResolvedValue([
+			{ ...sessionEvent, tools: [{ ...withoutUsage, lastCallAtMs: lastCallAtMs - 1_000 }] },
+		]);
 		await dbBackfillRepo({ repo, dbPath });
 
-		const [bash, recall] = toolSession.tools ?? [];
-		const { lastCallAtMs: _gone, ...timeless } = bash;
-		vi.mocked(collectSessionEvents).mockResolvedValue([{ ...toolSession, tools: [timeless, recall] }]);
+		expect(await loggedSessions("s1")).toBe(1);
+		expect(
+			await query(
+				`SELECT last_call_at_ms, input_tokens, output_tokens, cached_tokens, usage_confidence
+				   FROM session_tool_use WHERE tool_name = 'code-review'`,
+			),
+		).toEqual([
+			{
+				last_call_at_ms: lastCallAtMs,
+				input_tokens: 1,
+				output_tokens: 2,
+				cached_tokens: 3,
+				usage_confidence: "attributed",
+			},
+		]);
+	});
+
+	it("projects each independently changed skill-usage field", async () => {
+		const skill = {
+			name: "code-review",
+			kind: "skill" as const,
+			calls: 1,
+			usage: { input: 1, output: 2, cached: 3, confidence: "attributed" as const },
+		};
+		const eventWithUsage = (usage: SkillUsage): SessionUpsertedEvent => ({
+			...sessionEvent,
+			tools: [{ ...skill, usage }],
+		});
+
+		const revisions = [
+			skill.usage,
+			{ ...skill.usage, input: 9 },
+			{ ...skill.usage, input: 9, output: 8 },
+			{ ...skill.usage, input: 9, output: 8, cached: 7 },
+			{ input: 9, output: 8, cached: 7, confidence: "estimated" as const },
+		];
+		for (const usage of revisions) {
+			vi.mocked(collectSessionEvents).mockResolvedValue([eventWithUsage(usage)]);
+			await dbBackfillRepo({ repo, dbPath });
+		}
+
+		expect(await loggedSessions("s1")).toBe(revisions.length);
+		expect(
+			await query<{
+				input_tokens: number;
+				output_tokens: number;
+				cached_tokens: number;
+				usage_confidence: string;
+			}>(
+				`SELECT input_tokens, output_tokens, cached_tokens, usage_confidence
+				   FROM session_tool_use WHERE kind = 'skill'`,
+			),
+		).toEqual([{ input_tokens: 9, output_tokens: 8, cached_tokens: 7, usage_confidence: "estimated" }]);
+	});
+
+	/**
+	 * The per-entry table is a THIRD child table this comparison has to mirror, and
+	 * omitting it left `skill_invocations` permanently empty when it shipped: the
+	 * generation bump re-read every transcript and this function threw the result away
+	 * because the call counts had not moved. Same trap as the token columns on
+	 * `StoredToolRow`, one table further along.
+	 */
+	const skillSession: SessionUpsertedEvent = {
+		...sessionEvent,
+		tools: [
+			{
+				name: "code-review",
+				kind: "skill",
+				calls: 1,
+				invocations: [{ at: "2026-08-01T10:00:00.000Z", ok: true, entryPath: "tool" }],
+			},
+		],
+	};
+
+	it("does not re-enqueue a session whose skill entries are unchanged", async () => {
+		vi.mocked(collectSessionEvents).mockResolvedValue([skillSession]);
+		await dbBackfillRepo({ repo, dbPath });
+		expect(await loggedSessions("s1")).toBe(1);
+
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(1);
+	});
+
+	it("still projects a session whose only change is a NEW skill entry", async () => {
+		// The call count moves with it here, but the point is the row that has to land:
+		// a second entry at its own instant, which only the per-entry comparison can ask
+		// about.
+		vi.mocked(collectSessionEvents).mockResolvedValue([skillSession]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		const [skill] = skillSession.tools ?? [];
+		vi.mocked(collectSessionEvents).mockResolvedValue([
+			{
+				...skillSession,
+				tools: [
+					{
+						...skill,
+						calls: 2,
+						invocations: [
+							{ at: "2026-08-01T11:00:00.000Z", ok: true, entryPath: "tool" },
+							{ at: "2026-08-01T10:00:00.000Z", ok: true, entryPath: "tool" },
+						],
+					},
+				],
+			},
+		]);
 		await dbBackfillRepo({ repo, dbPath });
 
 		expect(await loggedSessions("s1")).toBe(2);
+		expect(await query<{ n: number }>("SELECT COUNT(*) AS n FROM skill_invocations")).toEqual([{ n: 2 }]);
+	});
+
+	it("still projects a new skill entry when the aggregate call count is unchanged", async () => {
+		// A generation bump can discover invocation detail that the older reader never
+		// emitted. The aggregate row is already byte-identical in that case, so only
+		// the missing detail row can make the re-read observable.
+		const [skill] = skillSession.tools ?? [];
+		vi.mocked(collectSessionEvents).mockResolvedValue([
+			{ ...skillSession, tools: [{ ...skill, invocations: undefined }] },
+		]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		vi.mocked(collectSessionEvents).mockResolvedValue([skillSession]);
+		await dbBackfillRepo({ repo, dbPath });
+		// The reverse read is intentionally one-sided: detail learned on the second
+		// pass survives when a compacted transcript no longer emits it, and the third
+		// pass settles instead of re-projecting forever.
+		vi.mocked(collectSessionEvents).mockResolvedValue([
+			{ ...skillSession, tools: [{ ...skill, invocations: undefined }] },
+		]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		expect(await query<{ n: number }>("SELECT COUNT(*) AS n FROM skill_invocations")).toEqual([{ n: 1 }]);
+	});
+
+	it("still projects a session whose entry OUTCOME moved, with every other figure equal", async () => {
+		// The case the count cannot see: a window that closed mid-invocation stored an
+		// optimistic `ok: true`, and the re-read that learned it failed carries the same
+		// name, the same count and the same instant. Reporting it unchanged would freeze
+		// that optimism in the database forever.
+		vi.mocked(collectSessionEvents).mockResolvedValue([skillSession]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		const [skill] = skillSession.tools ?? [];
+		vi.mocked(collectSessionEvents).mockResolvedValue([
+			{
+				...skillSession,
+				tools: [
+					{
+						...skill,
+						invocations: [
+							{
+								at: "2026-08-01T10:00:00.000Z",
+								ok: false,
+								entryPath: "tool",
+								outcomeObserved: true,
+							},
+						],
+					},
+				],
+			},
+		]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		expect(await query<{ ok: number }>("SELECT ok FROM skill_invocations")).toEqual([{ ok: 0 }]);
+	});
+
+	it("still projects a session whose optimistic outcome became observed", async () => {
+		const [skill] = skillSession.tools ?? [];
+		vi.mocked(collectSessionEvents).mockResolvedValue([
+			{
+				...skillSession,
+				tools: [
+					{
+						...skill,
+						invocations: [
+							{
+								at: "2026-08-01T10:00:00.000Z",
+								ok: true,
+								entryPath: "tool",
+								outcomeObserved: false,
+							},
+						],
+					},
+				],
+			},
+		]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		vi.mocked(collectSessionEvents).mockResolvedValue([
+			{
+				...skillSession,
+				tools: [
+					{
+						...skill,
+						invocations: [
+							{
+								at: "2026-08-01T10:00:00.000Z",
+								ok: true,
+								entryPath: "tool",
+								outcomeObserved: true,
+							},
+						],
+					},
+				],
+			},
+		]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		expect(await query<{ ok_confidence: string }>("SELECT ok_confidence FROM skill_invocations")).toEqual([
+			{ ok_confidence: "observed" },
+		]);
+	});
+
+	it("projects each independently changed skill-entry field", async () => {
+		const at = "2026-08-01T10:00:00.000Z";
+		const eventWithEntry = (
+			invocation: {
+				at: string;
+				ok: boolean;
+				entryPath?: "tool" | "command";
+				outcomeObserved?: boolean;
+				args?: string;
+				bodyChars?: number;
+			},
+			detection?: "heuristic",
+		): SessionUpsertedEvent => ({
+			...sessionEvent,
+			tools: [
+				{
+					name: "code-review",
+					kind: "skill",
+					calls: 1,
+					...(detection ? { detection } : {}),
+					invocations: [invocation],
+				},
+			],
+		});
+
+		const revisions: SessionUpsertedEvent[] = [
+			eventWithEntry({ at, ok: true, entryPath: "tool", args: "--base main", bodyChars: 100 }),
+			// Identical, and deliberately still carrying args/body: exercises the
+			// COALESCE-aware equality path before the following mutations.
+			eventWithEntry({ at, ok: true, entryPath: "tool", args: "--base main", bodyChars: 100 }),
+			// The path changes, but weaker confidence cannot erase the observed result.
+			eventWithEntry({ at, ok: true, entryPath: "command", args: "--base main", bodyChars: 100 }),
+			// Unknown still changes entry_path independently.
+			eventWithEntry({ at, ok: true, args: "--base main", bodyChars: 100 }),
+			eventWithEntry({ at, ok: true, args: "--base main", bodyChars: 100 }, "heuristic"),
+			eventWithEntry({ at, ok: true, args: "--base release", bodyChars: 100 }, "heuristic"),
+			eventWithEntry({ at, ok: true, args: "--base release", bodyChars: 200 }, "heuristic"),
+		];
+		for (const event of revisions) {
+			vi.mocked(collectSessionEvents).mockResolvedValue([event]);
+			await dbBackfillRepo({ repo, dbPath });
+		}
+
+		// Seven reads, but the byte-identical second one is the only no-op.
+		expect(await loggedSessions("s1")).toBe(revisions.length - 1);
+		expect(
+			await query<{
+				ok_confidence: string;
+				detection: string;
+				entry_path: string | null;
+				args: string;
+				body_chars: number;
+			}>("SELECT ok_confidence, detection, entry_path, args, body_chars FROM skill_invocations"),
+		).toEqual([
+			{
+				ok_confidence: "observed",
+				detection: "heuristic",
+				entry_path: null,
+				args: "--base release",
+				body_chars: 200,
+			},
+		]);
+	});
+
+	it("ignores an unparseable skill-entry instant just like the writer", async () => {
+		const event: SessionUpsertedEvent = {
+			...sessionEvent,
+			tools: [
+				{
+					name: "code-review",
+					kind: "skill",
+					calls: 1,
+					invocations: [{ at: "not-a-date", ok: true, entryPath: "tool" }],
+				},
+			],
+		};
+		vi.mocked(collectSessionEvents).mockResolvedValue([event]);
+		await dbBackfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(1);
+		expect(await query<{ n: number }>("SELECT COUNT(*) AS n FROM skill_invocations")).toEqual([{ n: 0 }]);
+	});
+
+	it("still projects a session whose skill gained a plugin label", async () => {
+		vi.mocked(collectSessionEvents).mockResolvedValue([skillSession]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		const [skill] = skillSession.tools ?? [];
+		vi.mocked(collectSessionEvents).mockResolvedValue([
+			{ ...skillSession, tools: [{ ...skill, plugin: "superpowers" }] },
+		]);
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		expect(await query<{ plugin: string }>("SELECT plugin FROM session_tool_use WHERE kind = 'skill'")).toEqual([
+			{ plugin: "superpowers" },
+		]);
+	});
+
+	it("does not re-enqueue over a stored entry the newer read no longer mentions", async () => {
+		// One-sided on purpose: the detail table is add-or-update with no DELETE, so a
+		// row the event dropped is not a difference this projection would resolve.
+		// Comparing sizes would re-project the session on every pass, forever, without
+		// ever removing the row.
+		const [skill] = skillSession.tools ?? [];
+		vi.mocked(collectSessionEvents).mockResolvedValue([
+			{
+				...skillSession,
+				tools: [
+					{
+						...skill,
+						calls: 2,
+						invocations: [
+							{ at: "2026-08-01T11:00:00.000Z", ok: true, entryPath: "tool" },
+							{ at: "2026-08-01T10:00:00.000Z", ok: true, entryPath: "tool" },
+						],
+					},
+				],
+			},
+		]);
+		await dbBackfillRepo({ repo, dbPath });
+		expect(await loggedSessions("s1")).toBe(1);
+
+		// A compacted conversation: the older entry is gone from the transcript, and the
+		// count follows it down. `calls` moving is what makes this project once; the
+		// assertion that matters is that it settles instead of re-projecting forever.
+		vi.mocked(collectSessionEvents).mockResolvedValue([skillSession]);
+		await dbBackfillRepo({ repo, dbPath });
+		await dbBackfillRepo({ repo, dbPath });
+
+		expect(await loggedSessions("s1")).toBe(2);
+		expect(await query<{ n: number }>("SELECT COUNT(*) AS n FROM skill_invocations")).toEqual([{ n: 2 }]);
 	});
 });
 

--- a/cli/src/dashboard/DbBackfill.ts
+++ b/cli/src/dashboard/DbBackfill.ts
@@ -40,6 +40,7 @@ import type { StorageProvider } from "../core/StorageProvider.js";
 import { getIndex, resolveReadStorage } from "../core/SummaryStore.js";
 import type { SessionSourceDefinition } from "../core/sessions/SessionSourceDefinition.js";
 import { DAEMON_RESCAN_SOURCES, SESSION_SOURCES } from "../core/sessions/SessionSources.js";
+import { skillOutcomeConfidence } from "../core/skills/SkillOutcomeConfidence.js";
 import { createLogger, errMsg, ORPHAN_BRANCH } from "../Logger.js";
 import type { ToolCallCount, TranscriptSource } from "../Types.js";
 import {
@@ -185,8 +186,42 @@ const CURSOR_SOT = "sot-import";
  * resolves the identity from the remote — so they carry a read receipt and would be
  * skipped by `isAlreadyCurrent` forever, having never once been reached by a sweep.
  * One un-skipped pass is what lets the widened scope see them.
+ *
+ * `6` — a full read now attributes TOKENS to each skill bucket, not just calls
+ * (`skillExtractor` runs `attributeSkillUsage` over the session plus its subagent
+ * files, and `session_tool_use` gained the four columns to hold the result). This is
+ * exactly the "a token field" case the paragraph above names: every session already
+ * stored carries call counts with NULL tokens, and its instant cannot move on its own
+ * once the conversation has stopped — so without this bump the columns would fill only
+ * for conversations that happen to speak again, and every historical skill would read
+ * as unattributable forever. Measured before the bump: a full recovery pass over a real
+ * database left 0 of 113 skill rows with tokens, because every session was skipped as
+ * already-current.
+ *
+ * `7` — a full read now records each skill entry INDIVIDUALLY into `skill_invocations`
+ * (its outcome, entry mechanism, arguments and injected body size), alongside the
+ * per-session aggregate that was already there. Structurally the same case as `6` one
+ * step further: every session already stored carries a call COUNT with no rows behind
+ * it, and a conversation that has stopped never moves its own instant again — so
+ * without this bump the detail table would fill only for sessions that happen to speak
+ * again, and every historical skill would have no per-entry record forever.
+ *
+ * Note this heals the DASHBOARD path only. The 30-second daemon re-scan tests this
+ * cursor for PRESENCE rather than equality (see `dbRescanSessions` phase 1), so a bump
+ * does not make it re-read history — deliberately, since an equality test there turned
+ * every bump into a machine-wide off switch for that pass. Historical detail therefore
+ * arrives on the next `jolli dashboard` run, not on the next tick.
+ *
+ * `8` — the per-entry rows of the one path that can report an OUTCOME now survive the
+ * merge. `mergeToolCalls` folds the tool extractor's bucket and the skill extractor's
+ * into one, and it did not carry `invocations` across: `parseToolUse` re-attributes a
+ * `Skill` call to `input.skill`, so both produce a bucket for such a skill, and the
+ * tool side — which runs first and has no per-entry list — won. Measured before the
+ * fix: 72 detail rows on a real database and NOT ONE with `ok_confidence = 'observed'`,
+ * because every observed entry arrives by the `Skill` tool. A generation-7 database has
+ * those sessions logged as current, so only a bump re-reads them.
  */
-const SESSION_READ_GENERATION = "5";
+const SESSION_READ_GENERATION = "8";
 
 /**
  * Content fingerprint of the summary index — the summaries cursor value.
@@ -988,20 +1023,54 @@ interface StoredModelRow {
 	readonly cost: number | null;
 }
 
-/** A `session_tool_use` row, in the shape {@link sameToolSet} compares. */
+/**
+ * A `session_tool_use` row, in the shape {@link sameToolSet} compares.
+ *
+ * The token fields are here because a re-read that differs ONLY in them is a real
+ * write — and one that this comparison silently threw away. Measured: after skill
+ * token attribution landed, a full recovery pass over a real database left 0 of 113
+ * skill rows with tokens, because every session's call counts were unchanged and the
+ * event was reported identical. A column the writer persists but this shape omits is
+ * a column that can never be back-filled.
+ */
 interface StoredToolRow {
 	readonly server: string | null;
 	readonly calls: number;
 	readonly lastCallAtMs: number | null;
+	readonly inputTokens: number | null;
+	readonly outputTokens: number | null;
+	readonly cachedTokens: number | null;
+	readonly usageConfidence: string | null;
+	readonly plugin: string | null;
 }
 
 /**
- * One session as it is currently stored: its own row plus ALL THREE child tables.
+ * A `skill_invocations` row, in the shape {@link sameSkillInvocations} compares.
+ *
+ * Here for exactly the reason the token fields are on {@link StoredToolRow}: this is
+ * a third child table the projection writes, so a re-read that differs only in it is
+ * a real write — and one this comparison would otherwise report as identical.
+ * Measured when the table shipped: a full pass over a real database left 0 rows in
+ * it, because every session's call counts were unchanged and the event was called
+ * identical. Same failure, one table further along.
+ */
+interface StoredInvocationRow {
+	readonly ok: number;
+	readonly okConfidence: string;
+	readonly detection: string | null;
+	readonly entryPath: string | null;
+	readonly args: string | null;
+	readonly bodyChars: number | null;
+}
+
+/**
+ * One session as it is currently stored: its own row plus ALL FOUR child tables.
  *
  * The child maps are keyed the way their table is keyed — `session_model_usage`
- * by `model`, `session_tool_use` by `(tool_name, kind)` — so a comparison that
- * walks them cannot accidentally merge two rows the schema keeps apart (a skill
- * and a builtin may share a name; see that table's DDL).
+ * by `model`, `session_tool_use` by `(tool_name, kind)`, `skill_invocations` by
+ * `(skill_name, at_ms)` — so a comparison that walks them cannot accidentally merge
+ * two rows the schema keeps apart (a skill and a builtin may share a name; see that
+ * table's DDL).
  *
  * `buckets` is a bare set because `session_activity` has no payload beyond its own
  * key: a `(session, bucket)` pair either exists or does not.
@@ -1011,11 +1080,17 @@ interface StoredSession {
 	readonly models: ReadonlyMap<string, StoredModelRow>;
 	readonly tools: ReadonlyMap<string, StoredToolRow>;
 	readonly buckets: ReadonlySet<number>;
+	readonly invocations: ReadonlyMap<string, StoredInvocationRow>;
 }
 
 /** `(tool_name, kind)` — the `session_tool_use` primary key, minus the session. */
 function toolKey(name: string, kind: string): string {
 	return `${name}\0${kind}`;
+}
+
+/** `(skill_name, at_ms)` — the `skill_invocations` primary key, minus the session. */
+function invocationKey(skill: string, atMs: number): string {
+	return `${skill}\0${atMs}`;
 }
 
 /** The session rows this repo already has, in the shape {@link unchangedSessionEvent} compares against. */
@@ -1032,7 +1107,7 @@ function storedSessionRows(db: DashboardDbHandle, repoIdentity: string): Map<str
 	const sessions = new Map<string, StoredSession>(
 		rows.map((r) => [
 			`${r.source}\0${r.session_id}`,
-			{ row: r, models: new Map(), tools: new Map(), buckets: new Set<number>() },
+			{ row: r, models: new Map(), tools: new Map(), buckets: new Set<number>(), invocations: new Map() },
 		]),
 	);
 
@@ -1068,7 +1143,8 @@ function storedSessionRows(db: DashboardDbHandle, repoIdentity: string): Map<str
 
 	const toolRows = db
 		.prepare(
-			`SELECT s.source, s.session_id, t.tool_name, t.kind, t.server, t.calls, t.last_call_at_ms
+			`SELECT s.source, s.session_id, t.tool_name, t.kind, t.server, t.calls, t.last_call_at_ms,
+			        t.input_tokens, t.output_tokens, t.cached_tokens, t.usage_confidence, t.plugin
 			   FROM session_tool_use t
 			   JOIN sessions s ON s.event_id = t.session_event_id
 			   JOIN repos r    ON r.id = s.repo_id
@@ -1082,6 +1158,11 @@ function storedSessionRows(db: DashboardDbHandle, repoIdentity: string): Map<str
 		server: string | null;
 		calls: number;
 		last_call_at_ms: number | null;
+		plugin: string | null;
+		input_tokens: number | null;
+		output_tokens: number | null;
+		cached_tokens: number | null;
+		usage_confidence: string | null;
 	}>;
 	for (const r of toolRows) {
 		const target = sessions.get(`${r.source}\0${r.session_id}`);
@@ -1089,6 +1170,44 @@ function storedSessionRows(db: DashboardDbHandle, repoIdentity: string): Map<str
 			server: r.server,
 			calls: r.calls,
 			lastCallAtMs: r.last_call_at_ms,
+			inputTokens: r.input_tokens,
+			outputTokens: r.output_tokens,
+			cachedTokens: r.cached_tokens,
+			usageConfidence: r.usage_confidence,
+			plugin: r.plugin,
+		});
+	}
+
+	const invocationRows = db
+		.prepare(
+			`SELECT s.source, s.session_id, i.skill_name, i.at_ms, i.ok, i.ok_confidence,
+			        i.detection, i.entry_path, i.args, i.body_chars
+			   FROM skill_invocations i
+			   JOIN sessions s ON s.event_id = i.session_event_id
+			   JOIN repos r    ON r.id = s.repo_id
+			  WHERE r.repo_identity = ?`,
+		)
+		.all(repoIdentity) as ReadonlyArray<{
+		source: string;
+		session_id: string;
+		skill_name: string;
+		at_ms: number;
+		ok: number;
+		ok_confidence: string;
+		detection: string | null;
+		entry_path: string | null;
+		args: string | null;
+		body_chars: number | null;
+	}>;
+	for (const r of invocationRows) {
+		const target = sessions.get(`${r.source}\0${r.session_id}`);
+		(target?.invocations as Map<string, StoredInvocationRow>)?.set(invocationKey(r.skill_name, r.at_ms), {
+			ok: r.ok,
+			okConfidence: r.ok_confidence,
+			detection: r.detection,
+			entryPath: r.entry_path,
+			args: r.args,
+			bodyChars: r.body_chars,
 		});
 	}
 
@@ -1193,18 +1312,16 @@ function sameModelSplit(models: ReadonlyArray<StatsModelUsage>, stored: Readonly
  *     they merge, with `calls` taking the later entry's value, `last_call_at_ms`
  *     taking the MAX, and `server` keeping the FIRST entry's value because the
  *     conflict clause does not update it.
- *  2. `last_call_at_ms` is written through `NULLIF(MAX(...), 0)`, so an entry
- *     with no instant does not necessarily store NULL.
+ *  2. The writer snapshots the old rows before replacing the set. It keeps the
+ *     greatest `last_call_at_ms`, and carries token attribution and plugin through
+ *     a sparse re-read that cannot recover them.
  *  3. `server` is nullable on both sides, and `undefined` on the event becomes
  *     NULL in the row.
  *
- * Only the FIRST of those needs an answer here, and the answer is to refuse
- * rather than to restate it: a repeated key is reported CHANGED, so the event
- * projects and the merge stays where it is written. Facts 2 and 3 then stop
- * being reachable subtleties — the projection deletes before inserting, so with
- * no repeat inside the event there is no conflicting row for the MAX to consult
- * and each entry stores its own value, NULL included. That is what makes plain
- * equality exact for every list this branch actually compares.
+ * The first is handled by refusing to fold here: a repeated key is reported
+ * CHANGED, so the event projects and the merge stays where it is written. The
+ * second requires asymmetric comparisons below: missing or older evidence is
+ * already equal when the writer would preserve the stored value.
  *
  * Counting entries against stored rows does NOT subsume that refusal, though it
  * looks like it should: a repeat collapses, so `[Bash, Bash]` is two entries and
@@ -1220,7 +1337,68 @@ function sameToolSet(tools: ReadonlyArray<ToolCallCount>, stored: ReadonlyMap<st
 		if (!row) return false;
 		if (row.calls !== tool.calls) return false;
 		if (row.server !== (tool.server ?? null)) return false;
-		if (row.lastCallAtMs !== (tool.lastCallAtMs ?? null)) return false;
+		if (tool.lastCallAtMs !== undefined && (row.lastCallAtMs === null || tool.lastCallAtMs > row.lastCallAtMs))
+			return false;
+		// Tokens too — see StoredToolRow for what omitting them cost. A stored NULL
+		// against a freshly attributed figure is exactly the case a generation bump
+		// exists to re-read, and reporting it unchanged here would discard the re-read
+		// after paying for it. An absent figure is no difference, though: the writer
+		// preserves the stored attribution instead of replacing it with NULL.
+		const usage = tool.usage;
+		if (usage?.input !== undefined && row.inputTokens !== usage.input) return false;
+		if (usage?.output !== undefined && row.outputTokens !== usage.output) return false;
+		if (usage?.cached !== undefined && row.cachedTokens !== usage.cached) return false;
+		if (usage?.confidence !== undefined && row.usageConfidence !== usage.confidence) return false;
+		// `plugin` is COALESCE'd by the writer, so only a PRESENT value can move the
+		// stored one — the same rule `SESSION_COALESCED_COLUMNS` applies to the session
+		// row. Comparing an absent one against a stored label would report a change the
+		// projection cannot make and re-project the session on every pass forever.
+		if (tool.plugin !== undefined && row.plugin !== tool.plugin) return false;
+	}
+	return true;
+}
+
+/**
+ * True when every entry row this event would write is already stored as it would
+ * write it.
+ *
+ * ONE-SIDED on purpose, unlike {@link sameToolSet}: `skill_invocations` is written
+ * add-or-update with no preceding DELETE (see its DDL), so a stored row the event no
+ * longer mentions — a conversation the agent compacted — is not a difference this
+ * projection would resolve. Comparing sizes would report it as changed on every pass
+ * and re-project that session forever without ever removing the row.
+ *
+ * Which fields are compared mirrors the writer's conflict clause rather than the
+ * table's columns: `ok` / `ok_confidence` / `detection` / `entry_path` are overwritten,
+ * so a difference in any of them is a real write, while `args` and `body_chars` are
+ * COALESCE'd and therefore only movable by a present value.
+ */
+function sameSkillInvocations(
+	tools: ReadonlyArray<ToolCallCount>,
+	source: string,
+	stored: ReadonlyMap<string, StoredInvocationRow>,
+): boolean {
+	for (const tool of tools) {
+		if (tool.kind !== "skill") continue;
+		for (const invocation of tool.invocations ?? []) {
+			const atMs = Date.parse(invocation.at);
+			// Skipped by the writer too — an unparseable instant cannot key a row.
+			if (!Number.isFinite(atMs)) continue;
+			const row = stored.get(invocationKey(tool.name, atMs));
+			if (!row) return false;
+			const incomingConfidence = skillOutcomeConfidence(source, invocation.entryPath, invocation.outcomeObserved);
+			// The writer keeps an observed result when a later scan only has an
+			// unresolved fragment. Mirror that one-way merge here or backfill would
+			// re-enqueue the same no-op on every pass.
+			if (row.okConfidence !== "observed" || incomingConfidence === "observed") {
+				if (row.ok !== (invocation.ok ? 1 : 0)) return false;
+				if (row.okConfidence !== incomingConfidence) return false;
+			}
+			if (row.detection !== (tool.detection ?? null)) return false;
+			if (row.entryPath !== (invocation.entryPath ?? null)) return false;
+			if (invocation.args !== undefined && row.args !== invocation.args) return false;
+			if (invocation.bodyChars !== undefined && row.bodyChars !== invocation.bodyChars) return false;
+		}
 	}
 	return true;
 }
@@ -1309,6 +1487,11 @@ function unchangedSessionEvent(event: SessionUpsertedEvent, stored: StoredSessio
 	// agent but Claude — reaches that return, so gating this behind it would mean their
 	// presence never reached the table.
 	if (event.activityBuckets?.some((bucket) => !stored.buckets.has(bucket))) return false;
+	// The fourth child table, under the same replace-when-observed guard. Omitting it
+	// left the table permanently empty when it shipped — the projection re-read every
+	// transcript and this function threw the result away, which is the same trap the
+	// token fields on `StoredToolRow` document.
+	if (event.tools !== undefined && !sameSkillInvocations(event.tools, event.source, stored.invocations)) return false;
 
 	const sum = (read: (m: StatsModelUsage) => number): number => models.reduce((total, m) => total + read(m), 0);
 	// `COALESCE`d, so only a non-null derived value can move it — but compared

--- a/cli/src/dashboard/FeedCardAsset.test.ts
+++ b/cli/src/dashboard/FeedCardAsset.test.ts
@@ -499,10 +499,9 @@ describe("widget card heads", () => {
 		const head = headOf("Skills");
 		expect(head).toContain('class="has-hint"');
 		expect(hintOf("Skills")).toContain("Skill invocations, counted from the tool calls");
-		// Scope claim, pinned: only `Skill` tool calls become skill rows — a
-		// subagent is the `Task` builtin and a slash command is never a tool call
-		// — so the copy must not widen to either without the classifier widening.
-		expect(head).not.toContain("command");
+		// Codex's heuristic path is a command that read the skill file. It is named
+		// explicitly so the tooltip does not present that inference as an observed run.
+		expect(hintOf("Skills")).toContain("inferred from a command that");
 		expect(titleBlockOf("Skills")).not.toContain('<div class="sub">');
 	});
 

--- a/cli/src/dashboard/MigrationFingerprints.test.ts
+++ b/cli/src/dashboard/MigrationFingerprints.test.ts
@@ -55,6 +55,9 @@ const EXPECTED: ReadonlyArray<readonly [name: string, fingerprint: string]> = [
 	// the first release.
 	["SESSION_STATS_SYNC_DDL", "e0c166639049"],
 	["SESSION_ACTIVITY_DDL", "67be18551dae"],
+	["SKILL_TOKEN_USAGE_DDL", "7956cb682d2e"],
+	["SKILL_INVOCATIONS_DDL", "c81c934c4192"],
+	["SKILL_PLUGIN_DDL", "f34c01168b54"],
 ];
 
 describe("migration fingerprints", () => {

--- a/cli/src/dashboard/SessionPushManifest.ts
+++ b/cli/src/dashboard/SessionPushManifest.ts
@@ -109,6 +109,11 @@ export const NEVER_SYNCED_TABLES = [
 	// leaving the machine) to make when the manager view actually consumes them, not
 	// a default to reach for on sight.
 	"session_activity",
+	// Per-entry skill history is local-only for now. It carries invocation arguments
+	// and outcomes, and no cloud page or request schema consumes it; uploading it
+	// would therefore be a privacy expansion that buys nothing. The aggregate skill
+	// counts already travel through session_tool_use.
+	"skill_invocations",
 	// The memory half. It travels on the commit-push channel, which has its own
 	// binding rules, and `commit_aliases` answers a rebase-matching question that
 	// does not exist on a server where commits and memories arrive together.
@@ -201,9 +206,12 @@ export const EXCLUDED_COLUMNS: Readonly<Record<SyncedTable, ReadonlyArray<string
 	sessions: [],
 	session_model_usage: [],
 	session_usage_events: [],
-	// Dropped from the schema definition long ago (recall_receipts replaced it),
-	// but still present on databases created before that. No writer, no reader.
-	session_tool_use: ["metadata_json"],
+	// The skill-detail additions stay local until the cloud request schema and UI
+	// consume them. Listing them here preserves the channel's current payload rather
+	// than silently uploading every column a local dashboard feature adds. The legacy
+	// metadata_json column is also still present on databases created before it was
+	// dropped from the schema definition; no writer or reader uses it.
+	session_tool_use: ["input_tokens", "output_tokens", "cached_tokens", "usage_confidence", "plugin", "metadata_json"],
 };
 
 /**

--- a/cli/src/dashboard/ShellAsset.test.ts
+++ b/cli/src/dashboard/ShellAsset.test.ts
@@ -1073,19 +1073,19 @@ describe("JD.renderShell — optional nav rows", () => {
 	it("hides Knowledge and Graph when both flags are off", () => {
 		const h = loadJD();
 		h.JD.renderShell(model({ menus: menus(false, false) }));
-		expect(navViews(h)).toEqual(["stats", "standup", "memories"]);
+		expect(navViews(h)).toEqual(["stats", "standup", "skills", "memories"]);
 	});
 
 	it("shows each row only when its own flag is on, keeping NAV_MIDDLE's order", () => {
 		const h = loadJD();
 		h.JD.renderShell(model({ menus: menus(true, false) }));
-		expect(navViews(h)).toEqual(["stats", "standup", "memories", "knowledge"]);
+		expect(navViews(h)).toEqual(["stats", "standup", "skills", "memories", "knowledge"]);
 
 		h.JD.renderShell(model({ menus: menus(false, true) }));
-		expect(navViews(h)).toEqual(["stats", "standup", "memories", "graph"]);
+		expect(navViews(h)).toEqual(["stats", "standup", "skills", "memories", "graph"]);
 
 		h.JD.renderShell(model({ menus: menus(true, true) }));
-		expect(navViews(h)).toEqual(["stats", "standup", "memories", "knowledge", "graph"]);
+		expect(navViews(h)).toEqual(["stats", "standup", "skills", "memories", "knowledge", "graph"]);
 	});
 
 	// The rows carry their icon and path from the same tables the always-on rows
@@ -1097,10 +1097,12 @@ describe("JD.renderShell — optional nav rows", () => {
 		const html = h.element("sbNav").innerHTML;
 		expect(html).toContain('data-nav-path="/knowledge"');
 		expect(html).toContain('data-nav-path="/graph"');
-		// Per ROW, not per page: the two Dashboard children are `child` rows and carry
-		// no icon of their own (the group label above them has two), so a page total
-		// cannot tell a row that lost its icon from a label that grew one.
-		expect(iconsPerRow(h)).toEqual({ stats: 0, standup: 0, memories: 1, knowledge: 1, graph: 1 });
+		// Per ROW, not per page: the menu is one flat list where EVERY row draws
+		// exactly one mark, so a page total cannot tell a row that lost its icon from
+		// one that grew a second. `stats` and `standup` are the two that used to draw
+		// none — they were indented children under a group label that wore the mark
+		// belonging to My Dashboard.
+		expect(iconsPerRow(h)).toEqual({ stats: 1, standup: 1, skills: 1, memories: 1, knowledge: 1, graph: 1 });
 	});
 
 	// A payload with no `menus` at all is what a tab left open across an upgrade
@@ -1110,7 +1112,7 @@ describe("JD.renderShell — optional nav rows", () => {
 	it("treats an absent menus slice as both rows hidden", () => {
 		const h = loadJD();
 		h.JD.renderShell(model());
-		expect(navViews(h)).toEqual(["stats", "standup", "memories"]);
+		expect(navViews(h)).toEqual(["stats", "standup", "skills", "memories"]);
 	});
 
 	// A slice naming only one row, or holding a non-boolean, must degrade the same
@@ -1119,10 +1121,10 @@ describe("JD.renderShell — optional nav rows", () => {
 	it("treats a partial or non-boolean menus slice as hidden", () => {
 		const h = loadJD();
 		h.JD.renderShell(model({ menus: { knowledge: true } }));
-		expect(navViews(h)).toEqual(["stats", "standup", "memories", "knowledge"]);
+		expect(navViews(h)).toEqual(["stats", "standup", "skills", "memories", "knowledge"]);
 
 		h.JD.renderShell(model({ menus: { knowledge: "yes", graph: 1 } }));
-		expect(navViews(h)).toEqual(["stats", "standup", "memories"]);
+		expect(navViews(h)).toEqual(["stats", "standup", "skills", "memories"]);
 	});
 
 	// Only the ROW is gated. Landing on /graph with the flag off still renders the
@@ -1133,7 +1135,7 @@ describe("JD.renderShell — optional nav rows", () => {
 		const h = loadJD();
 		h.JD.renderShell(model({ view: "graph", menus: menus(false, false) }));
 		expect(h.element("pageTitle").textContent).toBe("Graph");
-		expect(navViews(h)).toEqual(["stats", "standup", "memories"]);
+		expect(navViews(h)).toEqual(["stats", "standup", "skills", "memories"]);
 	});
 
 	// Settings is built from NAV_BOTTOM, outside the filtered loop, so no change to

--- a/cli/src/dashboard/SkillsAsset.test.ts
+++ b/cli/src/dashboard/SkillsAsset.test.ts
@@ -1,0 +1,415 @@
+/** Runtime coverage for the plain-JavaScript Skills page. */
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { TOOL_ROWS_LIMIT } from "./DashboardModel.js";
+
+interface SkillRow {
+	readonly name: string;
+	readonly kind: "skill";
+	readonly sessions: number;
+	readonly calls: number;
+	readonly agents: ReadonlyArray<{ source: string; calls: number }>;
+}
+
+interface FakeButton {
+	onclick?: () => void;
+}
+
+/**
+ * The rows region, as `draw` sees it. `offsetHeight` is what the page measures to cap
+ * the region once Show more is pressed, and `scrollTop` is what it carries across a
+ * repaint — neither exists without a layout, so the harness supplies both.
+ */
+interface FakeList {
+	scrollTop: number;
+	offsetHeight: number;
+}
+
+interface Harness {
+	readonly requests: string[];
+	readonly list: FakeList;
+	html: () => string;
+	render: (model: unknown) => void;
+	clickMore: () => boolean;
+	respondWith: (handler: (path: string) => Promise<unknown>) => void;
+}
+
+const row = (i: number): SkillRow => ({
+	name: `skill${String(i).padStart(3, "0")}`,
+	kind: "skill",
+	sessions: 1,
+	calls: 1,
+	agents: [{ source: "claude", calls: 1 }],
+});
+
+/**
+ * The band's own day series, DELIBERATELY WIDER than `detail`'s two data points.
+ *
+ * That gap is what makes the pane charts' axis testable: they must lay out the
+ * window's days, not their own data's extent. The skill below runs on `2026-01-01`
+ * and `2026-01-02` only, so a chart that still starts at `2025-12-30` is one reading
+ * the window.
+ */
+const WINDOW_DAYS = ["2025-12-30", "2025-12-31", "2026-01-01", "2026-01-02", "2026-01-03"];
+
+function model(rows: ReadonlyArray<SkillRow>, total: number): unknown {
+	return {
+		view: "skills",
+		timeZone: "Asia/Shanghai",
+		stats: {
+			toolUsage: {
+				skills: rows,
+				skillsTotal: total,
+				skillCallsTotal: total,
+				skillAgents: [{ source: "claude", sessions: total, calls: total }],
+				sessionsWithTools: total,
+				sessionsInWindow: total,
+				skillDays: WINDOW_DAYS.map((date) => ({ date, bySeries: { skill000: 1 } })),
+			},
+		},
+	};
+}
+
+const detail = {
+	name: "skill000",
+	sessions: 2,
+	calls: 2,
+	agents: [{ source: "claude", sessions: 2, calls: 2 }],
+	usage: { input: 2, output: 2, cached: 0, confidence: "attributed", sessions: 2 },
+	sessionSeries: [
+		{ atMs: Date.parse("2025-12-31T20:00:00Z"), tokens: 2 },
+		{ atMs: Date.parse("2026-01-01T20:00:00Z"), tokens: 2 },
+	],
+	outcomes: { measured: 1, failed: 0, assumed: 1 },
+	invocations: [
+		{ atMs: Date.parse("2025-12-31T20:00:00Z"), ok: true, outcomeKnown: true },
+		{ atMs: Date.parse("2026-01-01T20:00:00Z"), ok: true, outcomeKnown: false },
+	],
+	entryPaths: ["tool"],
+	repos: ["jolliai"],
+	firstCallAtMs: Date.parse("2025-12-31T20:00:00Z"),
+	lastCallAtMs: Date.parse("2026-01-01T20:00:00Z"),
+};
+
+function loadHarness(): Harness {
+	const requests: string[] = [];
+	let html = "";
+	let moreButton: FakeButton | null = null;
+	/* 320 stands in for a laid-out first page. Any positive number does — what the
+	   assertions read is that the cap equals what was measured, not the figure itself —
+	   and a test sets it to 0 to stand in for a page that was never laid out. */
+	const list: FakeList = { scrollTop: 0, offsetHeight: 320 };
+	const app = {
+		get innerHTML() {
+			return html;
+		},
+		set innerHTML(next: string) {
+			html = next;
+			/* A repaint replaces the node, so the browser's own offset goes to 0 here. That
+			   is what makes the restore observable: an assertion that survives this reset
+			   can only have been written back by `draw`. */
+			list.scrollTop = 0;
+		},
+		querySelector: (selector: string) => {
+			if (selector === ".sk-list") return list;
+			if (selector === "[data-skillmore]") {
+				if (html.includes("data-skillmore")) {
+					moreButton = {};
+					return moreButton;
+				}
+				moreButton = null;
+			}
+			return null;
+		},
+		querySelectorAll: () => [] as ReadonlyArray<never>,
+	};
+	const document = { getElementById: (id: string) => (id === "app" ? app : null) };
+	const window = {
+		JD: {} as Record<string, unknown>,
+		location: new URL("http://127.0.0.1/skills"),
+		history: {
+			replaceState: (_state: unknown, _title: string, href: string) => {
+				window.location = new URL(href);
+			},
+		},
+	};
+	let responder = (path: string): Promise<unknown> =>
+		Promise.resolve(path.startsWith("/api/skill-detail") ? detail : { list: "skill", offset: 0, rows: [] });
+	const esc = (value: unknown) =>
+		String(value).replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+	Object.assign(window.JD, {
+		esc,
+		fmtTokens: (n: number) => String(n),
+		seriesColor: () => "#000",
+		sourceIndex: () => 0,
+		stackedBars: () => "",
+		dayKey: (atMs: number, timeZone: string) =>
+			new Intl.DateTimeFormat("en-CA", { timeZone, year: "numeric", month: "2-digit", day: "2-digit" }).format(
+				atMs,
+			),
+		/* The real one, because the assertions read the labels it produces — and it is
+		   pure string work over a day key, so there is nothing to stub. */
+		dayLabel: (key: string) => {
+			const parts = String(key).split("-");
+			const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+			const month = months[Number(parts[1]) - 1];
+			return month && parts[2] ? `${month} ${Number(parts[2])}` : String(key);
+		},
+		/* Stubbed down to one `day=value` pair per bucket: the SVG geometry belongs to
+		   `charts.js`, while what this page owns is WHICH days it hands over and what it
+		   put in each — so that is what the fake keeps legible. */
+		dayBars: (days: ReadonlyArray<string>, values: ReadonlyArray<number>, opts?: { fmt?: (n: number) => string }) =>
+			`<svg class="sk-daybars">${days
+				.map((day, index) => {
+					const value = values[index] ?? 0;
+					return `<rect><title>${day}=${opts?.fmt ? opts.fmt(value) : String(value)}</title></rect>`;
+				})
+				.join("")}</svg>`,
+		query: () => "?range=month",
+		withParams: (path: string, params: Record<string, string>) => {
+			const url = new URL(path, "http://127.0.0.1");
+			for (const [key, value] of Object.entries(params)) url.searchParams.set(key, value);
+			return url.pathname + url.search;
+		},
+		getJson: (path: string) => {
+			requests.push(path);
+			return responder(path);
+		},
+	});
+	const source = readFileSync(new URL("./assets/js/skills.js", import.meta.url), "utf8");
+	new Function("window", "document", source)(window, document);
+	return {
+		requests,
+		list,
+		html: () => html,
+		render: (next: unknown) => {
+			(window.JD as { renderSkills: (model: unknown) => void }).renderSkills(next);
+		},
+		clickMore: () => {
+			if (!moreButton?.onclick) return false;
+			moreButton.onclick();
+			return true;
+		},
+		respondWith: (handler) => {
+			responder = handler;
+		},
+	};
+}
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("Skills page asset", () => {
+	it("renders detail dates in the dashboard time zone without masking render exceptions as request failures", async () => {
+		const h = loadHarness();
+		h.render(model([row(0)], 1));
+		await settle();
+
+		expect(h.html()).toContain("Jan 1");
+		expect(h.html()).toContain("outcome not recorded");
+		expect(h.html()).not.toContain("Could not reach the dashboard server");
+	});
+
+	it("draws both pane charts over the band's window days rather than their own data's extent", async () => {
+		const h = loadHarness();
+		h.render(model([row(0)], 1));
+		await settle();
+		const html = h.html();
+
+		/* Both charts walk the WHOLE window. The regression this pins had the cadence
+		   chart bucketing by UTC epoch week and labelling its axis with the bucket edge,
+		   so it printed a date a week before anything had happened while the cost chart
+		   beside it printed the first real data point — two axes on one panel. */
+		for (const day of WINDOW_DAYS) {
+			expect(html.split(`<title>${day}=`).length - 1).toBe(2);
+		}
+		/* Quiet days are drawn as zero, never dropped: bars lay out by index, so a
+		   skipped day would shift every later one and compress the axis. */
+		expect(html).toContain("<title>2025-12-30=0 sessions</title>");
+		expect(html).toContain("<title>2026-01-01=1 session</title>");
+		/* The cost chart sums the same day's sessions and reads the same buckets. */
+		expect(html).toContain("<title>2025-12-30=0</title>");
+		expect(html).toContain("<title>2026-01-02=2</title>");
+
+		/* One axis, stated twice — and it is the window's, matching the band above. The
+		   record's own dates stay the data's, which is the distinction that used to be
+		   spelled as two disagreeing axes. */
+		expect(html.split("<span>Dec 30</span>").length - 1).toBe(2);
+		expect(html.split("<span>Jan 3</span>").length - 1).toBe(2);
+		/* The record's dates stay the DATA's — `Jan 1` is on no axis here. That split is
+		   the honest version of what used to be spelled as two disagreeing axes. */
+		expect(html).toContain("<b>First used</b><span>Jan 1</span>");
+		expect(html).toContain("<b>Last used</b><span>Jan 2</span>");
+	});
+
+	it("falls back to the skill's own days when the payload carried no band series", async () => {
+		const h = loadHarness();
+		const bandless = model([row(0)], 1) as { stats: { toolUsage: { skillDays: unknown[] } } };
+		bandless.stats.toolUsage.skillDays = [];
+		h.render(bandless);
+		await settle();
+		const html = h.html();
+
+		/* Narrower than the window but honest — the two days this skill ran, drawn on an
+		   axis that claims exactly them. Refusing to draw would cost the reader more than
+		   a short axis does, and the band emits a point per day of any window that
+		   exists, so this is reachable only from a payload with no band at all. */
+		expect(html).toContain("<title>2026-01-01=1 session</title>");
+		expect(html).toContain("<title>2026-01-02=1 session</title>");
+		expect(html).not.toContain("<title>2025-12-30=");
+		expect(html.split("<span>Jan 1</span>").length - 1).toBe(3);
+	});
+
+	it("says how many sessions attributed no spend, so an empty day in the cost chart reads", async () => {
+		const h = loadHarness();
+		h.respondWith((path) =>
+			Promise.resolve(
+				path.startsWith("/api/skill-detail")
+					? /* One priced session and one without: most agents attribute no spend at all,
+					     so a session missing from the cost chart is the common case rather than an
+					     edge one, and on a shared axis it shows up as a gap needing an explanation. */
+						{
+							...detail,
+							sessionSeries: [{ atMs: Date.parse("2025-12-31T20:00:00Z") }, detail.sessionSeries[1]],
+							usage: { input: 1, output: 1, cached: 0, confidence: "attributed", sessions: 1 },
+						}
+					: { list: "skill", offset: 0, rows: [] },
+			),
+		);
+		h.render(model([row(0)], 1));
+		await settle();
+
+		expect(h.html()).toContain("1 session attributed no spend, so it is not in this chart");
+		/* Still counted by the cadence chart, which is the whole point of saying it. */
+		expect(h.html()).toContain("<title>2026-01-01=1 session</title>");
+	});
+
+	it("pages beyond the server's 200-row per-request cap and preserves the expansion on poll", async () => {
+		const all = Array.from({ length: 205 }, (_, i) => row(i));
+		const h = loadHarness();
+		h.respondWith((path) => {
+			if (path.startsWith("/api/skill-detail")) return Promise.resolve(detail);
+			const url = new URL(path, "http://127.0.0.1");
+			const offset = Number(url.searchParams.get("offset") ?? 0);
+			const requested = Number(url.searchParams.get("limit") ?? TOOL_ROWS_LIMIT);
+			const limit = Math.min(requested, 200);
+			return Promise.resolve({
+				list: "skill",
+				offset,
+				rows: all.slice(offset, offset + limit),
+				totalCount: all.length,
+			});
+		});
+		const first = model(all.slice(0, TOOL_ROWS_LIMIT), all.length);
+		h.render(first);
+		await settle();
+
+		for (let clicks = 0; clicks < 30 && h.clickMore(); clicks++) await settle();
+		expect(h.html()).toContain("Showing 205 of 205 skills");
+		expect(h.html()).not.toContain("data-skillmore");
+		expect(h.requests.some((path) => path.includes("offset=200"))).toBe(true);
+
+		h.requests.length = 0;
+		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
+		await settle();
+		expect(h.html()).toContain("Showing 205 of 205 skills");
+		expect(h.requests.filter((path) => path.includes("/api/tool-usage"))).toEqual([
+			expect.stringContaining("offset=0"),
+			expect.stringContaining("offset=200"),
+		]);
+	});
+
+	it("keeps rows on failure, retries, and deduplicates a shifted boundary row", async () => {
+		const all = Array.from({ length: 10 }, (_, i) => row(i));
+		const h = loadHarness();
+		let fail = true;
+		h.respondWith((path) => {
+			if (path.startsWith("/api/skill-detail")) return Promise.resolve(detail);
+			if (fail) {
+				fail = false;
+				return Promise.reject(new Error("offline"));
+			}
+			return Promise.resolve({ list: "skill", offset: 8, rows: [all[7], all[8], all[9]], totalCount: 10 });
+		});
+		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
+		await settle();
+		expect(h.clickMore()).toBe(true);
+		await settle();
+		expect(h.html()).toContain("Showing 8 of 10 skills — could not load more");
+		expect(h.html()).toContain("Try again");
+
+		expect(h.clickMore()).toBe(true);
+		await settle();
+		expect(h.html()).toContain("Showing 10 of 10 skills");
+		expect(h.html().match(/data-skill="skill007"/g)).toHaveLength(1);
+	});
+
+	it("caps the rows region only once Show more is pressed, at the height the first page measured", async () => {
+		const all = Array.from({ length: 20 }, (_, i) => row(i));
+		const h = loadHarness();
+		h.respondWith((path) => {
+			if (path.startsWith("/api/skill-detail")) return Promise.resolve(detail);
+			const url = new URL(path, "http://127.0.0.1");
+			const offset = Number(url.searchParams.get("offset") ?? 0);
+			const limit = Number(url.searchParams.get("limit") ?? TOOL_ROWS_LIMIT);
+			return Promise.resolve({
+				list: "skill",
+				offset,
+				rows: all.slice(offset, offset + limit),
+				totalCount: all.length,
+			});
+		});
+		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
+		await settle();
+
+		/* The state every page load opens in. The column IS the whole first page, so it
+		   needs no window onto itself, and the page's own bar is the only one on screen. */
+		expect(h.html()).toContain('<div class="sk-list">');
+		expect(h.html()).not.toContain("sk-scroll");
+
+		expect(h.clickMore()).toBe(true);
+		await settle();
+		/* Capped at what the first page OCCUPIED, never at a declared constant: the region
+		   keeps the size it opened at, the twelve new rows land inside it, and the page
+		   below does not move. A constant would be a few pixels wrong on the corpora that
+		   carry the inferred footnote — and wrong LOW means a scrollbar on the first page,
+		   which is the one state that may not have one. */
+		expect(h.html()).toContain('<div class="sk-list sk-scroll" style="max-height:320px">');
+		expect(h.html()).toContain("Showing 16 of 20 skills");
+		/* The control that did this stays OUT of the region it capped. */
+		expect(h.html()).toContain('<div class="sk-paging">');
+
+		/* And the reader's place inside that region survives a repaint — the 30 s poll
+		   replaces the node, so without the carry the column would jump back to its first
+		   row every half minute, mid-read. The harness zeroes `scrollTop` on every write
+		   for exactly this reason, so 120 here can only have been written back. */
+		h.list.scrollTop = 120;
+		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
+		await settle();
+		expect(h.list.scrollTop).toBe(120);
+		expect(h.html()).toContain("sk-scroll");
+	});
+
+	it("leaves the rows region uncapped when the first page measured nothing", async () => {
+		const all = Array.from({ length: 20 }, (_, i) => row(i));
+		const h = loadHarness();
+		/* A page that has not been laid out measures 0, and capping there would collapse
+		   the region and hide every row — so nothing is recorded and the column simply
+		   stays tall. Uncapped is the safe way to be wrong; `stats.js` guards its own
+		   card cap the same way. */
+		h.list.offsetHeight = 0;
+		h.respondWith((path) =>
+			path.startsWith("/api/skill-detail")
+				? Promise.resolve(detail)
+				: Promise.resolve({ list: "skill", offset: 8, rows: all.slice(8, 16), totalCount: all.length }),
+		);
+		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
+		await settle();
+		expect(h.clickMore()).toBe(true);
+		await settle();
+
+		expect(h.html()).toContain("Showing 16 of 20 skills");
+		expect(h.html()).toContain('<div class="sk-list">');
+		expect(h.html()).not.toContain("sk-scroll");
+		expect(h.html()).not.toContain("max-height");
+	});
+});

--- a/cli/src/dashboard/SotSchema.ts
+++ b/cli/src/dashboard/SotSchema.ts
@@ -870,6 +870,162 @@ CREATE INDEX ix_activity_recorded ON session_activity(recorded_at_ms);
 `;
 
 /**
+ * Per-skill token spend, alongside the call count that was already there.
+ *
+ * The table's own comment says it "counts CALLS, nothing more", and that stays
+ * true of every other bucket: a builtin or MCP call is one step inside a turn
+ * whose spend belongs to the turn, and there is no principled way to split it.
+ * A skill is different in kind — it owns a bounded stretch of the conversation
+ * that attribution can delimit — so these columns are populated for
+ * \`kind = 'skill'\` alone. See \`ToolCallCount.usage\`, which carries the same
+ * restriction on the TS side.
+ *
+ * **NULLABLE with no DEFAULT, and that is the whole design.** Sources divide
+ * three ways: Claude tags each response with the owning skill (exact), OpenCode
+ * is delimited by interval (an estimate), and Codex / Kimi / Cursor report
+ * nothing this runtime reads today. A \`DEFAULT 0\` would spell the third group
+ * as "measured, and it was free" — which is the reading the markdown table
+ * already refuses by printing an em dash rather than a zero. It is not a
+ * hypothetical minority either: measured on one real machine, 100 of 112 skill
+ * calls came from Codex, so the unmeasured group is the MAJORITY of rows and a
+ * zero default would make the whole card read as near-free.
+ *
+ * \`usage_confidence\` is 'attributed' | 'estimated', mirroring
+ * \`SkillUsage.confidence\`, and is what tells the two measured groups apart at
+ * read time. It is NULL exactly when the three token columns are, so a reader
+ * that has it has all four. Stored as TEXT rather than a CHECK-constrained
+ * enum for the same reason \`SkillCommitRef.source\` is a plain string on the
+ * Kotlin side: a value from a newer build must degrade to "unknown", never make
+ * the row unwritable.
+ *
+ * Backfill is deliberately absent. Rows written before this existed stay NULL —
+ * the slice they were read from is behind a cursor by now, and re-deriving the
+ * figure would mean re-reading transcripts that may be gone. They become
+ * populated the next time their session is re-scanned, which the 30-second pass
+ * does on its own.
+ */
+export const SKILL_TOKEN_USAGE_DDL = `
+ALTER TABLE session_tool_use ADD COLUMN input_tokens INTEGER;
+ALTER TABLE session_tool_use ADD COLUMN output_tokens INTEGER;
+ALTER TABLE session_tool_use ADD COLUMN cached_tokens INTEGER;
+ALTER TABLE session_tool_use ADD COLUMN usage_confidence TEXT;
+`;
+
+/**
+ * One row per skill INVOCATION, beside the per-session aggregate.
+ *
+ * \`session_tool_use\` says so itself — it "counts CALLS, nothing more" — so the
+ * facts that differ between two entries into the same skill have nowhere to live
+ * there: when each ran, whether it failed, what arguments it carried, and how much
+ * text it injected. That last one is the clearest case against folding them: the
+ * same skill entered twice in one session measured 3,619 and 69 characters on a
+ * real machine, because a repeat entry injects an "already loaded above" stub
+ * instead of the body. An average would report neither.
+ *
+ * **Tokens are deliberately NOT here, and that is not an omission.** Attribution is
+ * per SESSION: the transcript marks each response with the owning skill, never with
+ * the owning invocation, so three entries into one skill share one indivisible
+ * figure. A per-invocation token column could only ever hold a split no record
+ * supports. The four token columns stay on the aggregate, which is the grain they
+ * exist at.
+ *
+ * **The key is (session, skill, instant), and the instant is what makes writes
+ * idempotent.** The producing scan is whole-conversation, so every pass re-reads
+ * every entry it already saw; keyed on time they land back on their own row instead
+ * of accumulating duplicates, which a surrogate id would guarantee. That also
+ * matches \`SkillStore.foldSkillUse\`, which dedupes invocations on \`at\` — one key
+ * for one fact, so the markdown mirror and this table cannot disagree about what
+ * counts as the same entry.
+ *
+ * **The foreign key points at \`sessions\`, NOT at \`session_tool_use\`.** The tuple
+ * (session, skill, 'skill') is that table's primary key and would look like the
+ * natural parent, but its writer DELETEs a session's rows and rebuilds them — so
+ * for the duration of that transaction the parent row does not exist and every
+ * child insert would fail the constraint. \`sessions\` is upserted in place.
+ *
+ * **Rows are only ever added or updated, never deleted with the aggregate.** An
+ * agent prunes its own transcripts, and once a conversation is gone its entries can
+ * never be re-derived; a delete-and-rebuild would discard history at the first scan
+ * that could no longer see it. The visible cost is that a truncated conversation
+ * (a compact) leaves rows the current transcript no longer mentions — kept on
+ * purpose, since those invocations did happen.
+ *
+ * That is also why \`session_tool_use.calls\` must stay independent rather than
+ * become \`COUNT(*)\` over this table: the aggregate survives a pruned transcript,
+ * the detail does not, and deriving the count would silently rewrite every such
+ * skill's history to zero. Codex CLI adds a second reason — it reports one entry
+ * per session by design, regardless of how many paged reads produced it.
+ *
+ * **\`ok\` is NOT NULL and its meaning is qualified by a sibling column**, mirroring
+ * how \`usage_confidence\` qualifies the token figures. Spelling "unknown" as a NULL
+ * \`ok\` was the obvious alternative and loses information: the scanner did assert an
+ * outcome, and \`ok_confidence = 'assumed'\` preserves that assertion while saying it
+ * was defaulted rather than read. Three of the six mechanisms have no result record
+ * at all — see \`skillOutcomeConfidence\`, which owns that verdict.
+ *
+ * Both values are CONSUMED, and separately: the skill detail counts \`observed\` rows
+ * into a failure rate and \`assumed\` rows into a plainly-worded "ran, result unknown",
+ * so a row is never dropped for having the second value. That is the payoff for
+ * storing the qualifier instead of a NULL \`ok\` — a NULL would have been indistinguishable
+ * from a row whose outcome was never asserted at all.
+ *
+ * \`entry_path\` reached a surface with the skill detail's "Entered by" row, and
+ * \`detection\` now reaches two — the Skills list's \`†\` and the detail pane's caveat on
+ * the run figures (\`ToolUsageRow.detection\`). Both were stored ahead of any reader
+ * because they are only knowable at scan time and cost one column each: the transcript
+ * that proves a Codex entry was inferred rather than observed is routinely deleted
+ * within days, so a later decision to show it could not have been served
+ * retroactively. \`detection\` is that decision, and it was served entirely from
+ * already-recorded rows — no backfill, and none possible.
+ *
+ * A READER MUST AGGREGATE THIS COLUMN, NOT JOIN TO IT. It is per-entry while
+ * \`session_tool_use\` is per (session, skill), so pulling it in with a join multiplies
+ * that table's SUMs by the entry count while leaving its COUNT(DISTINCT)s correct —
+ * measured at 5 calls reported as 7. See \`toolNameRowsPage\`, which uses a correlated
+ * EXISTS for exactly this reason.
+ */
+export const SKILL_INVOCATIONS_DDL = `
+CREATE TABLE skill_invocations (
+  session_event_id TEXT NOT NULL REFERENCES sessions(event_id) ON DELETE CASCADE,
+  skill_name       TEXT NOT NULL,
+  -- Epoch ms, matching every other instant in this schema. The invocation's own
+  -- moment from the transcript, never the row's write time: it is the identity.
+  at_ms            INTEGER NOT NULL,
+  ok               INTEGER NOT NULL,
+  -- 'observed' (read from a result record) | 'assumed' (defaulted, unknowable).
+  ok_confidence    TEXT NOT NULL,
+  -- NULL when the entry was observed; 'heuristic' when inferred from a file read.
+  detection        TEXT,
+  -- 'tool' (the agent decided) | 'command' (the user asked for it) | NULL unknown.
+  entry_path       TEXT,
+  args             TEXT,
+  -- Characters injected by THIS entry. See the docblock on why it cannot be folded.
+  body_chars       INTEGER,
+  PRIMARY KEY (session_event_id, skill_name, at_ms)
+) STRICT;
+-- Every read is "this skill's entries, oldest first". The primary key already
+-- serves the cascade delete, whose lookup is by session_event_id.
+CREATE INDEX ix_si_skill_time ON skill_invocations(skill_name, at_ms);
+`;
+
+/**
+ * Which plugin provides a skill, on the aggregate rather than the detail.
+ *
+ * A skill's namespace does not change between two entries into it, so a column on
+ * \`skill_invocations\` would store the same string once per invocation. It belongs
+ * with the other per-(session, skill) facts.
+ *
+ * NULL means an unprefixed skill, not an unknown one — most skills have no plugin.
+ * The value is the host's own answer where there is one (Claude reports
+ * \`attributionPlugin\` directly) and the namespace segment of the id otherwise; a
+ * contested name is stored NULL rather than attributed to whichever plugin was seen
+ * first, which \`observeSkillEntry\` decides.
+ */
+export const SKILL_PLUGIN_DDL = `
+ALTER TABLE session_tool_use ADD COLUMN plugin TEXT;
+`;
+
+/**
  * The memory tables, `context`, plan progress and the topic KB.
  *
  * Applied as one statement batch inside the caller's transaction. Ordering

--- a/cli/src/dashboard/StatsWriter.test.ts
+++ b/cli/src/dashboard/StatsWriter.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { LogLevel } from "../Types.js";
+import type { LogLevel, TranscriptSource } from "../Types.js";
 import type { DashboardDbHandle } from "./DashboardDb.js";
 import { withDashboardDb } from "./DashboardDb.js";
 import type {
@@ -884,6 +884,327 @@ describe("session_activity projection", () => {
 			},
 			{ dbPath },
 		);
+	});
+});
+
+describe("skill_invocations projection", () => {
+	/**
+	 * Buckets are typed loosely and cast through `unknown` on purpose: two cases below
+	 * build shapes no scanner produces — a builtin bucket carrying invocations, and an
+	 * entry whose instant is unparseable — because those are exactly the inputs the
+	 * writer's guards exist for, and a `ToolCallCount` literal cannot express them.
+	 */
+	const sessionEvent = (tools: ReadonlyArray<Record<string, unknown>>, source: TranscriptSource = "claude") =>
+		({
+			event: {
+				type: "session.upserted" as const,
+				repoIdentity: "repo-1",
+				source,
+				sessionId: "s1",
+				updatedAtMs: 1_700_000_000_000,
+				tools,
+			},
+			producerKind: "cli" as const,
+		}) as unknown as StatsEventEnvelope;
+
+	const invocations = async () =>
+		query<Record<string, unknown>>(
+			`SELECT skill_name, at_ms, ok, ok_confidence, detection, entry_path, args, body_chars
+			   FROM skill_invocations ORDER BY at_ms`,
+		);
+
+	const skillBucket = (over: Record<string, unknown> = {}) => ({
+		name: "code-review",
+		kind: "skill",
+		calls: 1,
+		invocations: [{ at: "2026-08-01T10:00:00.000Z", ok: true, entryPath: "tool" }],
+		...over,
+	});
+
+	it("writes one row per entry, with the outcome marked as READ for a mechanism that reports one", async () => {
+		await applyStatsEvents([sessionEvent([skillBucket()])], { producerKind: "cli", dbPath });
+		expect(await invocations()).toEqual([
+			{
+				skill_name: "code-review",
+				at_ms: Date.parse("2026-08-01T10:00:00.000Z"),
+				ok: 1,
+				ok_confidence: "observed",
+				detection: null,
+				entry_path: "tool",
+				args: null,
+				body_chars: null,
+			},
+		]);
+	});
+
+	it("marks the outcome as DEFAULTED for a mechanism with no result record", async () => {
+		// A slash command carries a hard-coded `ok: true` because failure is not knowable
+		// there. The row keeps that assertion and says it was not read — which is what
+		// stops the failure count treating it as a measured success.
+		await applyStatsEvents(
+			[
+				sessionEvent([
+					skillBucket({ invocations: [{ at: "2026-08-01T10:00:00.000Z", ok: true, entryPath: "command" }] }),
+				]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		expect(await invocations()).toMatchObject([{ ok: 1, ok_confidence: "assumed", entry_path: "command" }]);
+	});
+
+	it("marks an unresolved result-capable invocation as DEFAULTED", async () => {
+		await applyStatsEvents(
+			[
+				sessionEvent([
+					skillBucket({
+						invocations: [
+							{
+								at: "2026-08-01T10:00:00.000Z",
+								ok: true,
+								entryPath: "tool",
+								outcomeObserved: false,
+							},
+						],
+					}),
+				]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		expect(await invocations()).toMatchObject([{ ok: 1, ok_confidence: "assumed", entry_path: "tool" }]);
+	});
+
+	it("copies the skill-level heuristic mark onto every one of its entries", async () => {
+		await applyStatsEvents(
+			[
+				sessionEvent(
+					[
+						skillBucket({
+							detection: "heuristic",
+							invocations: [
+								{ at: "2026-08-01T10:00:00.000Z", ok: true, entryPath: "tool" },
+								{ at: "2026-08-01T11:00:00.000Z", ok: true, entryPath: "tool" },
+							],
+						}),
+					],
+					"codex",
+				),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		expect(await invocations()).toMatchObject([
+			{ detection: "heuristic", ok_confidence: "assumed" },
+			{ detection: "heuristic", ok_confidence: "assumed" },
+		]);
+	});
+
+	it("keeps args and the injected body size", async () => {
+		await applyStatsEvents(
+			[
+				sessionEvent([
+					skillBucket({
+						invocations: [
+							{
+								at: "2026-08-01T10:00:00.000Z",
+								ok: true,
+								entryPath: "tool",
+								args: "--changed",
+								bodyChars: 3619,
+							},
+						],
+					}),
+				]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		expect(await invocations()).toMatchObject([{ args: "--changed", body_chars: 3619 }]);
+	});
+
+	it("converges on the same row when the same entry is read again", async () => {
+		// The producing scan is whole-conversation, so every pass re-reads every entry it
+		// already saw. Keyed on the instant they land back on their own row.
+		await applyStatsEvents([sessionEvent([skillBucket()])], { producerKind: "cli", dbPath });
+		await applyStatsEvents([sessionEvent([skillBucket()])], { producerKind: "cli", dbPath });
+		expect(await invocations()).toHaveLength(1);
+	});
+
+	it("corrects an optimistic outcome on the next read", async () => {
+		// A window that closed mid-invocation reports `ok: true`; the re-read that sees the
+		// result must be able to overwrite it, not be coalesced away.
+		await applyStatsEvents(
+			[
+				sessionEvent([
+					skillBucket({
+						invocations: [
+							{
+								at: "2026-08-01T10:00:00.000Z",
+								ok: true,
+								entryPath: "tool",
+								outcomeObserved: false,
+							},
+						],
+					}),
+				]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		await applyStatsEvents(
+			[
+				sessionEvent([
+					skillBucket({
+						invocations: [
+							{
+								at: "2026-08-01T10:00:00.000Z",
+								ok: false,
+								entryPath: "tool",
+								outcomeObserved: true,
+							},
+						],
+					}),
+				]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		expect(await invocations()).toMatchObject([{ ok: 0, ok_confidence: "observed" }]);
+	});
+
+	it("does not let a later unresolved read downgrade an observed outcome", async () => {
+		const at = "2026-08-01T10:00:00.000Z";
+		await applyStatsEvents(
+			[
+				sessionEvent([
+					skillBucket({
+						invocations: [{ at, ok: false, entryPath: "tool", outcomeObserved: true }],
+					}),
+				]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		await applyStatsEvents(
+			[
+				sessionEvent([
+					skillBucket({
+						invocations: [{ at, ok: true, entryPath: "tool", outcomeObserved: false }],
+					}),
+				]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		expect(await invocations()).toMatchObject([{ ok: 0, ok_confidence: "observed" }]);
+	});
+
+	it("keeps a stored body size when a later read reports none", async () => {
+		// COALESCE'd, unlike the outcome: both describe one fixed past event, and a pass
+		// that read no body has nothing better to offer than what is already stored.
+		await applyStatsEvents(
+			[
+				sessionEvent([
+					skillBucket({
+						invocations: [{ at: "2026-08-01T10:00:00.000Z", ok: true, entryPath: "tool", bodyChars: 3619 }],
+					}),
+				]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		await applyStatsEvents([sessionEvent([skillBucket()])], { producerKind: "cli", dbPath });
+		expect(await invocations()).toMatchObject([{ body_chars: 3619 }]);
+	});
+
+	it("does NOT delete rows the newer read no longer mentions", async () => {
+		// A compacted conversation stops mentioning entries that did happen. The aggregate
+		// is rebuilt; the detail is add-or-update, so the history survives.
+		await applyStatsEvents(
+			[
+				sessionEvent([
+					skillBucket({
+						calls: 2,
+						invocations: [
+							{ at: "2026-08-01T10:00:00.000Z", ok: true, entryPath: "tool" },
+							{ at: "2026-08-01T11:00:00.000Z", ok: true, entryPath: "tool" },
+						],
+					}),
+				]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		await applyStatsEvents(
+			[
+				sessionEvent([
+					skillBucket({ invocations: [{ at: "2026-08-01T11:00:00.000Z", ok: true, entryPath: "tool" }] }),
+				]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		expect(await invocations()).toHaveLength(2);
+	});
+
+	it("skips an entry whose instant cannot be parsed — it could not key a row", async () => {
+		// Kimi's converter yields "" for a malformed wire timestamp.
+		await applyStatsEvents([sessionEvent([skillBucket({ invocations: [{ at: "", ok: true }] })])], {
+			producerKind: "cli",
+			dbPath,
+		});
+		expect(await invocations()).toEqual([]);
+	});
+
+	it("ignores invocations on a bucket that is not a skill", async () => {
+		await applyStatsEvents(
+			[
+				sessionEvent([
+					{
+						name: "Bash",
+						kind: "builtin",
+						calls: 1,
+						invocations: [{ at: "2026-08-01T10:00:00.000Z", ok: true, entryPath: "tool" }],
+					},
+				]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		expect(await invocations()).toEqual([]);
+	});
+
+	it("stores the providing plugin on the aggregate row", async () => {
+		await applyStatsEvents([sessionEvent([skillBucket({ plugin: "superpowers" })])], {
+			producerKind: "cli",
+			dbPath,
+		});
+		expect(
+			await query<{ plugin: string | null }>("SELECT plugin FROM session_tool_use WHERE kind = 'skill'"),
+		).toEqual([{ plugin: "superpowers" }]);
+	});
+
+	it("keeps stored skill enrichment when a later read cannot reproduce it", async () => {
+		await applyStatsEvents(
+			[
+				sessionEvent([
+					skillBucket({
+						plugin: "superpowers",
+						lastCallAtMs: 1_754_041_600_000,
+						usage: { input: 7, output: 11, cached: 5, confidence: "attributed" },
+					}),
+				]),
+			],
+			{
+				producerKind: "cli",
+				dbPath,
+			},
+		);
+		await applyStatsEvents([sessionEvent([skillBucket()])], { producerKind: "cli", dbPath });
+		expect(
+			await query<Record<string, unknown>>(
+				`SELECT last_call_at_ms, input_tokens, output_tokens, cached_tokens, usage_confidence, plugin
+				   FROM session_tool_use WHERE kind = 'skill'`,
+			),
+		).toEqual([
+			{
+				last_call_at_ms: 1_754_041_600_000,
+				input_tokens: 7,
+				output_tokens: 11,
+				cached_tokens: 5,
+				usage_confidence: "attributed",
+				plugin: "superpowers",
+			},
+		]);
 	});
 });
 

--- a/cli/src/dashboard/StatsWriter.ts
+++ b/cli/src/dashboard/StatsWriter.ts
@@ -44,6 +44,7 @@
 import { execGit } from "../core/GitOps.js";
 import { PRICES_AS_OF } from "../core/Pricing.js";
 import { classifyScanError } from "../core/SqliteHelpers.js";
+import { skillOutcomeConfidence } from "../core/skills/SkillOutcomeConfidence.js";
 // import type { KnowledgeGraph } from "../graph/GraphSchema.js"; // parked with recordRepoGraph
 import { createLogger, errMsg } from "../Logger.js";
 import type { DashboardDbHandle } from "./DashboardDb.js";
@@ -998,11 +999,38 @@ function projectSession(db: DashboardDbHandle, event: SessionUpsertedEvent, nowM
 	// transcripts carry no tool records sends `undefined`, never `[]`, so
 	// re-upserting such a session cannot delete what a Claude read collected.
 	if (event.tools !== undefined) {
+		// The set is still replaced wholesale, but the enrichment on a surviving key
+		// is not always reproducible: a later slice can count the call without carrying
+		// its original timestamp, token attribution or plugin namespace. Snapshot those
+		// fields before the delete so the replacement can preserve them. The SQL upsert
+		// below cannot do that by itself — after this DELETE there is no old row left to
+		// conflict with.
+		type PreviousTool = {
+			tool_name: string;
+			kind: string;
+			last_call_at_ms: number | null;
+			input_tokens: number | null;
+			output_tokens: number | null;
+			cached_tokens: number | null;
+			usage_confidence: string | null;
+			plugin: string | null;
+		};
+		const previousTools = new Map<string, PreviousTool>();
+		for (const row of db
+			.prepare(
+				`SELECT tool_name, kind, last_call_at_ms, input_tokens, output_tokens,
+				        cached_tokens, usage_confidence, plugin
+				   FROM session_tool_use WHERE session_event_id = ?`,
+			)
+			.all(eventId) as ReadonlyArray<PreviousTool>) {
+			previousTools.set(`${row.kind}\u0000${row.tool_name}`, row);
+		}
 		db.prepare("DELETE FROM session_tool_use WHERE session_event_id = ?").run(eventId);
 		const insertTool = db.prepare(
 			`INSERT INTO session_tool_use
-			   (session_event_id, tool_name, kind, server, calls, last_call_at_ms, updated_at_ms)
-			 VALUES (?, ?, ?, ?, ?, ?, ?)
+			   (session_event_id, tool_name, kind, server, calls, last_call_at_ms,
+			    input_tokens, output_tokens, cached_tokens, usage_confidence, plugin, updated_at_ms)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			 ON CONFLICT(session_event_id, tool_name, kind) DO UPDATE SET
 			     calls = excluded.calls,
 			     -- The stamp must be in THIS branch too: a conflict is still a write,
@@ -1019,18 +1047,113 @@ function projectSession(db: DashboardDbHandle, event: SessionUpsertedEvent, nowM
 			     -- epoch-0 instant, so the display's fallback to the session's own
 			     -- timestamp would never fire.
 			     last_call_at_ms = NULLIF(MAX(COALESCE(excluded.last_call_at_ms, 0),
-			                                  COALESCE(session_tool_use.last_call_at_ms, 0)), 0)`,
+			                                  COALESCE(session_tool_use.last_call_at_ms, 0)), 0),
+			     -- COALESCE keeps the stored figure when the incoming read has none, for
+			     -- the same reason the MAX above does: attribution needs the whole session
+			     -- from line 0, so a pass that read a later slice — or any build whose
+			     -- scanner cannot attribute — must not blank a number an earlier read
+			     -- established. The four move together (see SKILL_TOKEN_USAGE_DDL), so
+			     -- \`usage_confidence\` is keyed off the same side its tokens came from
+			     -- rather than coalesced independently, which could otherwise label one
+			     -- read's tokens with another read's confidence.
+			     input_tokens     = COALESCE(excluded.input_tokens,  session_tool_use.input_tokens),
+			     output_tokens    = COALESCE(excluded.output_tokens, session_tool_use.output_tokens),
+			     cached_tokens    = COALESCE(excluded.cached_tokens, session_tool_use.cached_tokens),
+			     usage_confidence = CASE WHEN excluded.input_tokens IS NOT NULL THEN excluded.usage_confidence
+			                             ELSE session_tool_use.usage_confidence END,
+			     -- COALESCE for the same reason as the token columns: a namespace is only
+			     -- recoverable while the transcript that named it is readable, and a pass that
+			     -- could not resolve one (a contested name, or a scanner that reports none)
+			     -- must not blank a label an earlier read established.
+			     plugin           = COALESCE(excluded.plugin, session_tool_use.plugin)`,
+		);
+		// Per-invocation rows, and deliberately NOT preceded by a DELETE — unlike the
+		// aggregate above. Once an agent prunes a conversation its entries can never be
+		// re-derived, so a rebuild would discard them at the first scan that can no longer
+		// see them. Converging on the (session, skill, instant) key is what makes the
+		// repeated whole-conversation re-reads idempotent instead of duplicating rows.
+		const insertInvocation = db.prepare(
+			`INSERT INTO skill_invocations (session_event_id, skill_name, at_ms, ok, ok_confidence,
+			                               detection, entry_path, args, body_chars)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+			 ON CONFLICT(session_event_id, skill_name, at_ms) DO UPDATE SET
+			     -- Outcome evidence upgrades in one direction. A completed re-read must
+			     -- replace an optimistic fragment, while a later partial read must not erase
+			     -- an outcome already observed for this same invocation.
+			     ok = CASE WHEN skill_invocations.ok_confidence = 'observed'
+			                         AND excluded.ok_confidence <> 'observed'
+			                    THEN skill_invocations.ok ELSE excluded.ok END,
+			     ok_confidence = CASE WHEN skill_invocations.ok_confidence = 'observed'
+			                                   OR excluded.ok_confidence = 'observed'
+			                          THEN 'observed' ELSE excluded.ok_confidence END,
+			     -- Also the latest reading: an observed entry supersedes an inferred one for
+			     -- the same name (see \`scanCodexSkillLines\`), so a later pass that found the
+			     -- injected block must be able to clear the heuristic mark.
+			     detection     = excluded.detection,
+			     entry_path    = excluded.entry_path,
+			     -- These two ARE coalesced: they describe one fixed past event, so a pass that
+			     -- read no argument string or no body length has nothing better to offer than
+			     -- what is already stored.
+			     args          = COALESCE(excluded.args, skill_invocations.args),
+			     body_chars    = COALESCE(excluded.body_chars, skill_invocations.body_chars)`,
 		);
 		for (const tool of event.tools) {
+			// All four are written together or not at all — a partially-filled row would
+			// let a reader take three tokens with no confidence to qualify them.
+			const previous = previousTools.get(`${tool.kind}\u0000${tool.name}`);
+			const incomingLastCallAtMs = tool.lastCallAtMs ?? null;
+			const previousLastCallAtMs = previous?.last_call_at_ms ?? null;
+			const lastCallAtMs =
+				incomingLastCallAtMs === null
+					? previousLastCallAtMs
+					: previousLastCallAtMs === null
+						? incomingLastCallAtMs
+						: Math.max(incomingLastCallAtMs, previousLastCallAtMs);
+			const inputTokens = tool.usage?.input ?? previous?.input_tokens ?? null;
+			const outputTokens = tool.usage?.output ?? previous?.output_tokens ?? null;
+			const cachedTokens = tool.usage?.cached ?? previous?.cached_tokens ?? null;
+			const usageConfidence = tool.usage ? tool.usage.confidence : (previous?.usage_confidence ?? null);
 			insertTool.run(
 				eventId,
 				tool.name,
 				tool.kind,
 				tool.server ?? null,
 				tool.calls,
-				tool.lastCallAtMs ?? null,
+				lastCallAtMs,
+				inputTokens,
+				outputTokens,
+				cachedTokens,
+				usageConfidence,
+				tool.plugin ?? previous?.plugin ?? null,
 				nowMs,
 			);
+			// Gated on the KIND, not merely on the field being present: the table holds skill
+			// entries, and a builtin bucket that somehow carried invocations would otherwise
+			// land in it silently. `ToolCallCount.invocations` documents the same restriction.
+			if (tool.kind !== "skill") continue;
+			for (const inv of tool.invocations ?? []) {
+				const atMs = Date.parse(inv.at);
+				// The instant IS the row's identity, so one that cannot be parsed is not a row —
+				// the same rule `parseInvocationLine` applies to the markdown mirror. Reachable
+				// rather than defensive: Kimi's converter yields "" for a malformed wire
+				// timestamp, and NaN in a primary key would be rejected by the STRICT table.
+				if (!Number.isFinite(atMs)) continue;
+				insertInvocation.run(
+					eventId,
+					tool.name,
+					atMs,
+					inv.ok ? 1 : 0,
+					// The source's own tag, never a guess from the bucket: whether an outcome could
+					// be read depends on the mechanism as well as the host.
+					skillOutcomeConfidence(event.source, inv.entryPath, inv.outcomeObserved),
+					// Skill-level, copied onto each row. Lossless — one scan pass emits a single
+					// nature per skill (see `ToolCallCount.detection`).
+					tool.detection ?? null,
+					inv.entryPath ?? null,
+					inv.args ?? null,
+					inv.bodyChars ?? null,
+				);
+			}
 		}
 	}
 

--- a/cli/src/dashboard/assets/index.html
+++ b/cli/src/dashboard/assets/index.html
@@ -20,7 +20,23 @@
 -->
 <div class="jd" data-tier="0" id="jdRoot">
 	<aside class="sidebar" aria-label="Jolli local web server">
-		<div class="sb-brand"><b>jolli</b><span>local web server</span></div>
+		<!--
+		  The brand mark, inlined from jolli-web's logo-mark.svg and stripped to
+		  geometry. Its palette is the marketing brand's own hexes, NOT this surface's
+		  token set, and deliberately so: a logo is a fixed asset, not a themed
+		  component, so re-tinting it to `currentColor` or to --s1..--s5 would make it
+		  a different logo per theme. Inlined rather than fetched because the shell is
+		  one document — a second request for a kilobyte of geometry would paint the
+		  sidebar without its mark on every cold load.
+
+		  The word beside it is "Local", not "local web server": the long form was the
+		  surface explaining itself in the one place the reader already knows where
+		  they are, and the short form keeps the only distinction that matters (this is
+		  your machine, not the hosted app) at a fraction of the width — which is what
+		  buys the room for the mark. The full name stays on the `aria-label` above,
+		  where a screen reader still needs it spelled out.
+		-->
+		<div class="sb-brand"><svg class="sb-mark" width="20" height="18" viewBox="0 0 120.43 108.72" aria-hidden="true" focusable="false"><g fill="none" stroke="#d1d2fa" stroke-width="2" stroke-miterlimit="10"><path d="M58.74 15.04v38.8M99.45 36.93 65.84 56.33M100.43 78.03 64.86 62.51M53.59 65.92 27.42 94.58"/><path d="M9.66 50.52 25.01 99.19M49.95 58.01 11.6 52.08M60.27 11.38 9.66 50.52M99.45 37.84 58.61 11.8"/><path d="M106.51 82.1 101.51 33.92M28.51 97.04 109.37 80.25"/></g><circle cx="58.74" cy="59.95" r="14.57" fill="#7e3dec"/><circle cx="100.6" cy="35.63" r="9.75" fill="#06b6d5"/><circle cx="107.57" cy="80.25" r="12.86" fill="#6466f1"/><circle cx="23.97" cy="97.73" r="11" fill="#ae95fb"/><circle cx="9.43" cy="50.52" r="9.43" fill="#61a6fb"/><circle cx="58.74" cy="12.94" r="12.94" fill="#3b83f6"/></svg><b>jolli</b><span>Local</span></div>
 		<div class="sb-label">Menu</div>
 		<nav class="sb-list" id="sbNav" aria-label="Menu"></nav>
 		<div class="sb-bottom" id="sbBottom"></div>

--- a/cli/src/dashboard/assets/js/charts.js
+++ b/cli/src/dashboard/assets/js/charts.js
@@ -15,6 +15,10 @@ window.JD = window.JD || {};
 		var month = MONTHS[Number(parts[1]) - 1];
 		return month && parts[2] ? month + " " + Number(parts[2]) : String(key);
 	};
+	/* Exported because the Skills pane's own charts label the SAME day keys, and a
+	   second copy of this would drift exactly on the `new Date(key)` trap the comment
+	   above exists to warn about. One spelling of a day, page-wide. */
+	JD.dayLabel = dayLabel;
 
 	/* The series palette holds FIVE colours and `JD.seriesColor` cycles them, so a
 	   sixth series is drawn in the first one's colour and the stack stops being
@@ -248,6 +252,76 @@ window.JD = window.JD || {};
 			svg += axis(left, "start", series[0].date);
 			if (series.length > 1) svg += axis(W - 8, "end", series[series.length - 1].date);
 		}
+		return svg + "</svg>";
+	};
+
+	/**
+	 * One value per LOCAL DAY of the window, as the Skills pane's small charts.
+	 *
+	 * SVG, not the flex row of `<i>` divs this replaced, and the reason is the axis
+	 * rather than the markup. These charts now span the whole window, so their bar
+	 * count is the window's day count — and a flex row cannot survive that: at
+	 * `min-width: 3px` with a 3px gap, 90 days needs 537px and a 366-day custom range
+	 * needs 2193px, so the row overflowed its own pane and the right-hand days were
+	 * simply not on screen while the axis label underneath still claimed them. A
+	 * viewBox scales instead, which is exactly how `JD.stackedBars` above already
+	 * survives 366 days in the band.
+	 *
+	 * `preserveAspectRatio="none"` with a CSS-fixed height: the bars stretch
+	 * horizontally to whatever width the pane has and the chart keeps its 46px, so
+	 * bar-to-gap ratio is constant at every range. Nothing here draws text — the two
+	 * endpoint labels stay HTML in `.sk-axis`, because text under a `none` aspect
+	 * ratio is text that has been stretched.
+	 *
+	 * A ZERO DAY IS A 6-UNIT STUB on `--heat-track`, never a skipped bar: a fortnight's
+	 * gap has to read as measured absence. That is the same rule the flex version
+	 * carried and the same rule the band follows by walking the window rather than the
+	 * data.
+	 *
+	 * The flex version's 2px top corners are gone rather than ported: under a `none`
+	 * aspect ratio an `rx` is scaled on one axis only, so a rounded corner becomes a
+	 * visibly lopsided one — and at a range's real bar width (~18px at 30 days, under
+	 * 5px at 90) there was nothing there to see anyway.
+	 */
+	JD.dayBars = (days, values, opts) => {
+		var options = opts || {};
+		/* `fmt` owns the WHOLE value, unit included, rather than taking a unit suffix
+		   beside it: a suffix cannot inflect, so one bar in `" sessions"` read `1
+		   sessions`. Same division of labour `JD.stackedBars` draws for its axis. */
+		var format = options.fmt || JD.fmtTokens;
+		/* One viewBox unit per day, so `slot` is 1 and the bar/gap split is the band's
+		   0.58 — the two charts thin out together as the range grows. */
+		var barW = 0.58;
+		var max = 0;
+		values.forEach((value) => {
+			if (value > max) max = value;
+		});
+		var svg =
+			'<svg class="sk-daybars" viewBox="0 0 ' +
+			Math.max(1, days.length) +
+			' 100" preserveAspectRatio="none" role="img" aria-label="' +
+			JD.esc(options.label || "Daily values") +
+			'">';
+		days.forEach((day, index) => {
+			var value = typeof values[index] === "number" ? values[index] : 0;
+			/* Floors at 20 so a lone call on a busy skill's chart is still a visible bar
+			   rather than a hairline indistinguishable from the empty stub. */
+			var h = value > 0 ? Math.max(20, max > 0 ? (value / max) * 100 : 100) : 6;
+			svg +=
+				'<rect x="' +
+				(index + (1 - barW) / 2).toFixed(3) +
+				'" y="' +
+				(100 - h).toFixed(2) +
+				'" width="' +
+				barW +
+				'" height="' +
+				h.toFixed(2) +
+				'" fill="' +
+				(value > 0 ? "var(--accent)" : "var(--heat-track)") +
+				'"><title>' +
+				JD.esc(dayLabel(day) + " · " + format(value)) +
+				"</title></rect>";
+		});
 		return svg + "</svg>";
 	};
 

--- a/cli/src/dashboard/assets/js/main.js
+++ b/cli/src/dashboard/assets/js/main.js
@@ -5,6 +5,9 @@
 	var VIEWS = {
 		stats: { render: (model) => window.JD.renderStats(model), grid: true },
 		standup: { render: (model) => window.JD.renderStandup(model), grid: false },
+		/* Page mode, not the card grid: the list is one full-height column, the same
+		   shape the browser pages below use. */
+		skills: { render: (model) => window.JD.renderSkills(model), grid: false },
 		memories: { render: (model) => window.JD.renderMemories(model), grid: false },
 		knowledge: { render: (model) => window.JD.renderKnowledge(model), grid: false },
 		graph: { render: (model) => window.JD.renderGraph(model), grid: false },

--- a/cli/src/dashboard/assets/js/shell.js
+++ b/cli/src/dashboard/assets/js/shell.js
@@ -115,6 +115,7 @@ window.JD = window.JD || {};
 	var DASHBOARDS = [
 		{ view: "stats", label: "My Dashboard", sub: "individual · local" },
 		{ view: "standup", label: "Daily Standup", sub: "sprint · local" },
+		{ view: "skills", label: "Skills", sub: "usage · per-skill" },
 		{ view: "memories", label: "Memories", sub: "browse · per-commit" },
 		{ view: "knowledge", label: "Knowledge", sub: "wiki · per-repo" },
 		{ view: "graph", label: "Graph", sub: "knowledge graph · per-repo" },
@@ -128,6 +129,7 @@ window.JD = window.JD || {};
 	var VIEW_PATH = {
 		stats: "/dashboard",
 		standup: "/dashboard/standup",
+		skills: "/skills",
 		memories: "/memories",
 		knowledge: "/knowledge",
 		graph: "/graph",
@@ -135,9 +137,18 @@ window.JD = window.JD || {};
 	};
 	JD.viewPath = (view) => VIEW_PATH[view] || "/" + view;
 
-	/* The nav list. Dashboard's two children render flat under a group label
-	   rather than behind an expand/collapse toggle — that interaction is a later
-	   polish pass, not a routing concern.
+	/* The nav list. EVERY ROW IS A PEER — there is no group label and no indent
+	   step. My Dashboard and Daily Standup used to render as children under a
+	   "Dashboard" label, and on a five-row menu that cost three things and bought
+	   nothing: the label was not a destination yet carried a chevron that read as
+	   expand/collapse (nothing collapsed — both rows were written out flat on
+	   every paint); it spent a row and an indent grouping two of five items under
+	   a word neither label was missing; and it cost the two most-visited pages
+	   their marks, because a child row drew no icon at all — so My Dashboard, the
+	   home of this surface and the fallback for every unroutable view, was the one
+	   destination in the menu with no glyph while the label above it wore the grid
+	   mark that belonged to it. Adding a nested group back means re-answering all
+	   three.
 
 	   NO ROW IS GATED BY REPO COUNT any more (the two optional rows below are a
 	   different question — they are hidden by preference, and their routes stay
@@ -163,13 +174,12 @@ window.JD = window.JD || {};
 	   new page needs its server route, view token and model payload too — a nav
 	   row on its own is not enough. */
 	var NAV_MIDDLE = [
-		{
-			label: "Dashboard",
-			kids: [
-				{ view: "stats", path: "/dashboard", label: "My Dashboard" },
-				{ view: "standup", path: "/dashboard/standup", label: "Daily Standup" },
-			],
-		},
+		{ view: "stats", path: "/dashboard", label: "My Dashboard" },
+		{ view: "standup", path: "/dashboard/standup", label: "Daily Standup" },
+		/* Its own destination rather than a section of My Dashboard: that page's
+		   Skills card is a summary of the same data, and this page answers a
+		   different question (one skill's whole history) at a different grain. */
+		{ view: "skills", path: "/skills", label: "Skills" },
 		{ view: "memories", path: "/memories", label: "Memories" },
 		/* Knowledge / Graph browse the Memory Bank FOLDER, whose repo set differs
 		   from the enabled dashboard repos — they carry their own empty state. */
@@ -193,24 +203,39 @@ window.JD = window.JD || {};
 	var NAV_ICONS = {
 		dashboard:
 			'<rect width="7" height="9" x="3" y="3" rx="1"/><rect width="7" height="5" x="14" y="3" rx="1"/><rect width="7" height="9" x="14" y="12" rx="1"/><rect width="7" height="5" x="3" y="16" rx="1"/>',
+		/* Lucide `calendar-days`. A calendar rather than a board or a checklist
+		   because the DAY is what separates Daily Standup from My Dashboard, and the
+		   page says so itself — one dated board of Yesterday and Today, where My
+		   Dashboard is a window the reader picks. A board glyph would name the
+		   layout, which is the part a reader can already see. */
+		calendar:
+			'<path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/><path d="M8 14h.01"/><path d="M12 14h.01"/><path d="M16 14h.01"/><path d="M8 18h.01"/><path d="M12 18h.01"/><path d="M16 18h.01"/>',
+		/* Lucide `puzzle` — a skill is a part that slots into a run. THE SAME MARK
+		   THE SKILLS CARD DRAWS (stats.js `skillsCard`, whose own comment records why
+		   it stopped being a star): a nav row for the same subject has to carry the
+		   same mark, or the card and the page read as two different features. It
+		   replaced a `zap` bolt, which said nothing about skills at all. */
+		puzzle:
+			'<path d="M15.39 4.39a1 1 0 0 0 1.68-.474 2.5 2.5 0 1 1 3.014 3.015 1 1 0 0 0-.474 1.68l1.683 1.682a2.414 2.414 0 0 1 0 3.414L19.61 15.39a1 1 0 0 1-1.68-.474 2.5 2.5 0 1 0-3.014 3.015 1 1 0 0 1 .474 1.68l-1.683 1.682a2.414 2.414 0 0 1-3.414 0L8.61 19.61a1 1 0 0 0-1.68.474 2.5 2.5 0 1 1-3.014-3.015 1 1 0 0 0 .474-1.68l-1.683-1.682a2.414 2.414 0 0 1 0-3.414L4.39 8.61a1 1 0 0 1 1.68.474 2.5 2.5 0 1 0 3.014-3.015 1 1 0 0 1-.474-1.68l1.683-1.682a2.414 2.414 0 0 1 3.414 0z"/>',
 		database:
 			'<ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5V19A9 3 0 0 0 21 19V5"/><path d="M3 12A9 3 0 0 0 21 12"/>',
-		chevron: '<path d="m6 9 6 6 6-6"/>',
 		book: '<path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>',
 		network:
 			'<rect x="9" y="2" width="6" height="6" rx="1"/><rect x="2" y="16" width="6" height="6" rx="1"/><rect x="16" y="16" width="6" height="6" rx="1"/><path d="M12 8v4"/><path d="M5 16v-2h14v2"/>',
 		settings:
 			'<path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/>',
 	};
-	var navIcon = (name, extraClass) =>
-		'<span class="sb-icon' +
-		(extraClass ? " " + extraClass : "") +
-		'"><svg viewBox="0 0 24 24" aria-hidden="true">' +
-		NAV_ICONS[name] +
-		"</svg></span>";
+	var navIcon = (name) =>
+		'<span class="sb-icon"><svg viewBox="0 0 24 24" aria-hidden="true">' + NAV_ICONS[name] + "</svg></span>";
+	/* EVERY row in the menu resolves a mark here — the pinned Settings row
+	   included. A view missing from this map renders a row with an empty
+	   `.sb-icon` box, which reads as a broken glyph rather than as no glyph, so
+	   adding a page means adding its mark in the same change. */
 	var navIconFor = (view) =>
 		({
 			stats: "dashboard",
+			standup: "calendar",
+			skills: "puzzle",
 			memories: "database",
 			knowledge: "book",
 			graph: "network",
@@ -252,7 +277,7 @@ window.JD = window.JD || {};
 	   removed. Kept as a table rather than collapsed to `true` so a future view
 	   that ignores the scope hides the control instead of lying about it; the
 	   picker hides rather than disables, same as the range control on standup. */
-	var SCOPED_VIEWS = { stats: true, standup: true, memories: true };
+	var SCOPED_VIEWS = { stats: true, standup: true, skills: true, memories: true };
 
 	/* Button label for a selection: the repo's name at one, a count past that.
 	   Names past one would either truncate or push the range control off the row,
@@ -634,36 +659,20 @@ window.JD = window.JD || {};
 		   switched on in Settings → Advanced — a preference, not a gate, so their
 		   routes stay open either way. */
 		var navRow = (item, active) =>
-			'<button type="button" class="sb-item' +
-			(item.child ? " child" : "") +
-			'" data-nav-path="' +
+			'<button type="button" class="sb-item" data-nav-path="' +
 			item.path +
 			'" data-nav-view="' +
 			(item.view || "") +
 			'"' +
 			(active ? ' aria-current="page"' : "") +
-			'>' +
-			(item.child ? "" : navIcon(navIconFor(item.view))) +
+			">" +
+			navIcon(navIconFor(item.view)) +
 			'<span class="name">' +
 			esc(item.label) +
 			"</span></button>";
 		var nav = "";
 		NAV_MIDDLE.forEach((item) => {
 			if (!navRowVisible(item, model)) return;
-			if (item.kids) {
-				nav +=
-				'<div class="sb-group-label">' +
-				navIcon("dashboard") +
-				'<span>' +
-				esc(item.label) +
-				"</span>" +
-				navIcon("chevron", "sb-group-chevron") +
-				"</div>";
-				item.kids.forEach((kid) => {
-					nav += navRow({ ...kid, child: true }, model.view === kid.view);
-				});
-				return;
-			}
 			nav += navRow(item, model.view === item.view);
 		});
 		document.getElementById("sbNav").innerHTML = nav;
@@ -1228,11 +1237,19 @@ window.JD = window.JD || {};
 			return data;
 		});
 
+	/* `status` rides the error, matching `postJson` above. Without it a caller cannot
+	   tell the server ANSWERING badly (a 404 from a build that predates the route)
+	   from the server not being there at all — `fetch` rejects with a bare TypeError
+	   whose message is "Failed to fetch", and those two need opposite advice. */
 	JD.getJson = (path) =>
 		fetch(path, { headers: { "X-Jolli-Dashboard-Token": window.__JOLLI_DASHBOARD_TOKEN__ || "" } }).then(
 			async (res) => {
 				var data = await res.json().catch(() => ({}));
-				if (!res.ok) throw new Error(data.error || "request failed (" + res.status + ")");
+				if (!res.ok) {
+					var err = new Error(data.error || "request failed (" + res.status + ")");
+					err.status = res.status;
+					throw err;
+				}
 				return data;
 			},
 		);

--- a/cli/src/dashboard/assets/js/skills.js
+++ b/cli/src/dashboard/assets/js/skills.js
@@ -1,0 +1,1241 @@
+/* Skills page — a chart band, a chooser column, and a reading pane.
+ *
+ * THE SELECTION LIVES IN THE URL (`?skill=`), not in a module variable. It survives
+ * the 30 s poll for free, it can be shared and reloaded, and it is what the Stats
+ * card's rows link into — so "open this skill" has one implementation rather than a
+ * modal here and a link there.
+ *
+ * THE FIRST ROW OPENS when the address names no skill, and that question is answered
+ * ONCE per page load. The left-hand nav links to a bare `/skills`, so arriving that
+ * way left a list with no current row beside a pane holding one sentence — the same
+ * page the Stats card opens fully populated, which reads as a load that failed. It is
+ * answered once because "no skill in the address" ALSO means "the reader just closed
+ * the pane": answering it again there would re-open the first row on the click that
+ * closed it, and the row's own toggle would be unusable.
+ *
+ * THE FIGURES ARE THE SERVER'S, never a sum over the rows on screen: `usage.skills`
+ * is ONE PAGE, so a header line computed from it changes every time more rows arrive
+ * (`stats.js:993` records the same rule for the card).
+ *
+ * HOW A TOKEN FIGURE MAY BE STATED comes from `core/SkillsAggregateMarkdown.ts`,
+ * which already renders these numbers in the VS Code sidebar, the memory detail and
+ * every committed memory: an em dash where nothing could be attributed (never a
+ * zero), a `~` on an estimate, untouched otherwise. A second dialect would make one
+ * number read two ways in one product.
+ *
+ * WHAT THE CHARTS MAY CLAIM is still decided by the grain the record holds, even now
+ * that two of them share an axis. Spend is attributed PER SESSION, so a day's cost bar
+ * is a SUM over that day's sessions — an aggregate of the recorded grain, never a
+ * subdivision of it, and a per-RUN cost curve remains a thing that does not exist to
+ * draw. Outcomes take NO date axis at all: the strip is one tick per recorded run in
+ * time order, because a run's result is not a quantity a day can hold, and stretching
+ * it over the window would draw an empty day as a claim about runs there were none of.
+ *
+ * ALL THREE CHARTS SHARE ONE TIME AXIS, and they share it by reading the SAME array
+ * rather than by each deriving the same bounds. `ToolUsage.skillDays` is the band's own
+ * series — one point per LOCAL DAY of the window, emitted whether or not anything ran
+ * (`buildSkillDays` walks the window, not the data) — and `windowDays` hands its day
+ * keys to the pane's two charts as their buckets. So the reader can read straight down
+ * the page: the same column is the same day in all three.
+ *
+ * THAT IS A FIX, not a preference. The pane's charts used to answer three different
+ * questions with three different axes, and the panel contradicted itself on screen.
+ * `cadenceHtml` bucketed by UTC epoch WEEK (`Math.floor(atMs / 604800000)`, so a
+ * boundary that always lands on a Thursday 00:00 UTC, one clock the rest of the page
+ * never uses) and then labelled its axis with the BUCKET EDGE — a date no data point
+ * had to sit on. `costHtml` labelled its axis with its first and last real point.
+ * Measured on one machine: the record said `First used Aug 13`, the cost chart said
+ * `Aug 13`, and the cadence chart above them both said `Aug 6` — a week earlier than
+ * anything that had happened, because the earliest session fell in the Aug 6–13 UTC
+ * bucket. Neither chart was reachable from the band's `Jul 22 → Aug 20` either.
+ *
+ * WHAT THE CHARTS COUNT still differs, and that difference is real: cadence counts
+ * every session, cost counts only the sessions whose spend could be attributed (most
+ * agents attribute none). That used to show up as an unexplained gap between two axes;
+ * now the axes agree and `costHtml` says the gap out loud instead.
+ */
+(function (JD) {
+	"use strict";
+
+	/* How many rows ONE Show more click adds — matching the model's own first page (the
+	   Stats card's `TOOL_ROWS_LIMIT`), so the column pages in the size it opened at.
+
+	   IT WAS 60, and that number quietly deleted the control it was paging: one fetch
+	   loaded past it in a single go, so on any real corpus `shown >= total` held on the
+	   first paint and the button never existed (measured: 23 skills, every range, all
+	   ≤ 60 — the column read "Showing 23 of 23 skills" with nothing to click, which
+	   reads as a broken control rather than as a finished list). The design mock pages
+	   at its first page for this reason and its button is on screen doing its job. */
+	var PAGE_ROWS = 8;
+
+	/* Series kept in the band before the rest rolls into "Other". FIVE is the whole
+	   reason: the categorical ramp holds five CVD-validated colours, so four plus
+	   Other is what can be told apart. */
+	var BAND_SERIES = 4;
+
+	/* The `†` a row takes when any entry behind it was inferred rather than observed,
+	   and the sentence that spells it out.
+
+	   ONE SENTENCE, THREE PLACES, and that is the point: it rides in the dagger's
+	   `title` on every marked row, is printed once under the column, and is stated
+	   again in the pane. `core/SkillsAggregateMarkdown.ts` makes the same split
+	   between its `†` and its footnote, and `buildSkillsSummaryLabel` leaves the
+	   marker to its caller for the same reason — a dagger where a footnote is in
+	   reach, words where it is not. Here the footnote IS in reach: it sits at the end of
+	   the rows, which on the first screenful is the page's own scroll and after a Show
+	   more is the bottom of the rows' own window — either way, the scroll that reaches
+	   the last row reaches it. So the column gets both. The paging row is NOT in there —
+	   it is a control, and a control may not be reachable only by scrolling the rows it
+	   pages; see `navPagingHtml`.
+
+	   IT NAMES THE COUNT, not just the inference. A reader who learns only "this was
+	   inferred" still reads `47 runs` as 47 runs; the count is the figure the
+	   heuristic actually changes, since Codex CLI reports one entry per session however
+	   many paged reads produced it. That is the half worth the characters. */
+	var INFERRED_TITLE =
+		"Inferred from a file read rather than an observed invocation: a person reading the skill file " +
+		"looks the same, and the run count is per session rather than per call.";
+	var INFERRED_MARK = ' <span class="sk-inferred" title="' + INFERRED_TITLE + '">†</span>';
+
+	/* Everything an async answer can land in, so the two fetches below do not have to
+	   re-render each other's half. Module-scoped because the poll re-enters
+	   `renderSkills`, and a local would be re-seeded from the payload on every tick —
+	   dropping a pane the reader is in the middle of. */
+	var state = { rows: null, paneName: null, pane: null, paneError: null };
+
+	/* Which render is current. An answer from an earlier one must not paint over a
+	   later one — the same staleness any polled surface has. */
+	var seq = 0;
+
+	/* How many rows the column asks the server for, or ZERO while the model's own first
+	   page is still the whole column — the state every page load opens in, so the common
+	   case costs no request at all and the first paint is the only paint.
+
+	   Grown by Show more, and THE POLL READS THE SAME FIGURE: the 30 s refresh re-fetches
+	   this list, so a fixed `PAGE_ROWS` there would silently throw away every click the
+	   reader had made and shrink the column back under them. Reset by a range change for
+	   free, since changing the range is a full page load.
+
+	   Its two companions are the button's own state. `moreError` is deliberately set
+	   by the POLL's failure too: once the column is short of the total, "could not
+	   load more" is the honest label for a list that may be missing rows, whoever
+	   asked last. */
+	var pageWidth = 0;
+	/* The next ranked position for a Show more read. Usually equal to rows.length;
+	   kept separately because a row can shift across an offset boundary and be
+	   deduped without changing the server position already consumed. */
+	var pageOffset = 0;
+	/* The freshest total belongs to the latest page response. A new polled model
+	   resets it before that model's expanded list is verified. */
+	var rowsTotal = null;
+	var renderedModel = null;
+	var moreLoading = false;
+	var moreError = false;
+
+	/* The height the rows region is capped at once the reader has paged past the column's
+	   first screenful — MEASURED off that screenful, never declared.
+	 *
+	 * THE FIRST PAGE MUST NOT SCROLL. What it comes to in pixels is not something this
+	 * file can know: it is `PAGE_ROWS` rows plus the column header, plus a footnote that
+	 * is present only on a corpus with an inferred row. A declared constant is therefore
+	 * a few pixels wrong on one of those shapes, and being wrong LOW grows a scrollbar on
+	 * exactly the state that is supposed to have none. So the first paint is laid out
+	 * free, its own height is read back, and that becomes the cap: Show more then grows
+	 * the list INSIDE the region it opened at, instead of pushing the page down.
+	 *
+	 * `offsetHeight` is the BORDER box, and `.jd * { box-sizing: border-box }` makes
+	 * `max-height` mean the same box — so the cap is exactly the height just measured. If
+	 * that reset ever goes, this becomes 16px of padding short and the first page scrolls.
+	 *
+	 * RE-MEASURED ON EVERY UNPAGED PAINT rather than latched once, so it tracks what the
+	 * first page actually looks like now: a poll can bring in the row that adds the
+	 * footnote, and a window resize between load and click would otherwise leave a stale
+	 * figure. A HIDDEN page measures 0 and is never recorded (`stats.js` guards its own
+	 * cap the same way) — capping at 0 would collapse the region and hide every row, so
+	 * null stands for "no cap yet" and an uncapped column is the safe way to be wrong. */
+	var listCapPx = null;
+
+	/* Whether "the address names no skill" has already been answered for this page
+	   load — see the header. Nav is a full page reload, so this starts false on every
+	   arrival; it is set by the default pick AND by any click, because a click is the
+	   reader answering the same question themselves. */
+	var defaultAnswered = false;
+
+	/** The selected skill, read from the address rather than from a variable. */
+	function selectedSkill() {
+		try {
+			return new URLSearchParams(window.location.search).get("skill") || null;
+		} catch (_err) {
+			return null;
+		}
+	}
+
+	/**
+	 * Writes the selection into the address without adding a history entry.
+	 *
+	 * `replaceState`, not `pushState`: choosing a skill is a view state of one page,
+	 * so Back should leave the page rather than walk the reader through every skill
+	 * they looked at.
+	 */
+	function setSelectedSkill(name) {
+		try {
+			var url = new URL(window.location.href);
+			if (name) url.searchParams.set("skill", name);
+			else url.searchParams.delete("skill");
+			window.history.replaceState(null, "", url.toString());
+		} catch (_err) {
+			/* A blocked History API must not stop the pane from opening — the render
+			   below reads `state.paneName`, which is set either way. */
+		}
+	}
+
+	/**
+	 * The rows the column is showing: the fetched page once it lands, else the first
+	 * page the model already carries (`skills` view shares the Stats payload, so the
+	 * first paint is never empty for a window that has data).
+	 *
+	 * One helper rather than the same expression twice, because the default pick below
+	 * must name a row the reader can actually see — picking from a different list would
+	 * open a skill with no current row anywhere in the column.
+	 */
+	function visibleRows(model) {
+		return state.rows || modelFirstPage(model);
+	}
+
+	/**
+	 * The page the model already carries, which IS the column's first page — the Stats
+	 * payload this view shares, capped at the card's `TOOL_ROWS_LIMIT`.
+	 *
+	 * Named rather than inlined because two callers ask different questions of it: the
+	 * fallback above ("what do I draw before a fetch lands") and the fetch guard in
+	 * `renderSkills` ("is a fetch needed at all"). The second is what keeps a fresh page
+	 * load at zero requests, so the two must read the same list.
+	 */
+	function modelFirstPage(model) {
+		var usage = (model.stats && model.stats.toolUsage) || {};
+		return usage.skills || [];
+	}
+
+	/**
+	 * The skill to open when the address names none — the top row, which is the
+	 * server's adoption order.
+	 *
+	 * IT IS WRITTEN INTO THE ADDRESS, not just into `state`: every render re-reads the
+	 * address, so a selection living only in `state` is wiped by the next one, and a
+	 * reload or a shared link would land back on the empty pane.
+	 *
+	 * AN EMPTY LIST LEAVES THE QUESTION OPEN (the flag stays down): there is no row to
+	 * open, and "no skill invocations in this window" is what both halves of the page
+	 * already say. A wider range is a fresh page load, so it asks again from scratch.
+	 *
+	 * The fetched page below is deliberately NOT re-asked: `skills` and `skillsTotal`
+	 * come from one WHERE, so an empty first page means a total of zero and no further
+	 * page is ever requested — there is no late arrival that could hold the top row.
+	 */
+	function defaultSelection(model) {
+		if (defaultAnswered) return null;
+		var rows = visibleRows(model);
+		if (rows.length === 0) return null;
+		defaultAnswered = true;
+		setSelectedSkill(rows[0].name);
+		return rows[0].name;
+	}
+
+	function renderSkills(model) {
+		var app = document.getElementById("app");
+		if (!app) return;
+		var mine = ++seq;
+		if (renderedModel !== model) {
+			renderedModel = model;
+			var freshUsage = (model.stats && model.stats.toolUsage) || {};
+			rowsTotal = freshUsage.skillsTotal || 0;
+			if (pageWidth === 0) pageOffset = modelFirstPage(model).length;
+		}
+		var selected = selectedSkill();
+		if (!selected) selected = defaultSelection(model);
+		/* A different skill invalidates the cached pane, so the reader never sees the
+		   previous skill's figures under the new skill's name. */
+		if (state.paneName !== selected) state = { rows: state.rows, paneName: selected, pane: null, paneError: null };
+
+		draw(app, model);
+
+		/* ONLY once a click has asked for more than the model already carries. The model's
+		   first page IS the column's first page, so an unconditional fetch re-requests
+		   rows already in hand — and while `PAGE_ROWS` was 60 it also loaded straight past
+		   the paging control, which is what made the control unreachable. */
+		if (pageWidth > modelFirstPage(model).length) {
+			fetchRows(app, model, mine, [], 0, Math.min(pageWidth, skillTotal(model)));
+		}
+
+		if (!selected) return;
+		JD.getJson(JD.withParams("/api/skill-detail" + JD.query(model, {}), { name: selected }))
+			.then(
+				(detail) => {
+					if (mine !== seq || state.paneName !== selected) return false;
+					state.pane = detail;
+					return true;
+				},
+				/* THE TWO-CALLBACK FORM, never a trailing `.catch`, and the repaint moved out
+				   of both: this handler must see the REQUEST's failure and nothing else.
+				   While the repaint sat inside the success callback, a throw from ANY chart
+				   in the pane landed here instead — and `paneErrorText` reads a missing
+				   `status` as "nothing reached a server", so a `ReferenceError` in a tick
+				   title was reported to the reader as a dashboard that had stopped, while it
+				   was answering fine. A render fault is now unhandled and reaches the
+				   console, which is where a bug in this file belongs. */
+				(err) => {
+					if (mine !== seq || state.paneName !== selected) return false;
+					state.paneError = paneErrorText(err);
+					return true;
+				},
+			)
+			.then((changed) => {
+				if (changed) draw(app, model);
+			});
+	}
+
+	/**
+	 * Reads enough ranked pages to reach `wanted`, starting at one explicit server
+	 * offset and deduping against rows already held.
+	 *
+	 * Show more starts after the current page and appends. The poll starts from zero and
+	 * rebuilds the width on screen; when that width exceeds the route's per-request cap,
+	 * the short response advances `offset` and the next request finishes it. Progress is
+	 * measured in raw server rows while identity dedupe is measured by skill name, so a
+	 * row shifting across a page boundary neither duplicates nor stalls the control.
+	 */
+	function collectRows(model, mine, initialRows, initialOffset, wanted) {
+		var rows = initialRows.slice();
+		var names = Object.create(null);
+		rows.forEach((row) => {
+			names[row.name] = true;
+		});
+		var offset = initialOffset;
+		var total = skillTotal(model);
+
+		function next() {
+			if (mine !== seq || rows.length >= wanted || offset >= total) {
+				if (offset >= total && rows.length < total) total = rows.length;
+				return Promise.resolve({ rows: rows, offset: offset, total: total });
+			}
+			return JD.getJson(
+				JD.withParams("/api/tool-usage" + JD.query(model, {}), {
+					list: "skill",
+					offset: String(offset),
+					limit: String(wanted - rows.length),
+				}),
+			).then((page) => {
+				if (mine !== seq) return { rows: rows, offset: offset, total: total };
+				var incoming = (page && page.rows) || [];
+				if (page && typeof page.totalCount === "number") total = page.totalCount;
+				incoming.forEach((row) => {
+					if (!names[row.name]) {
+						names[row.name] = true;
+						rows.push(row);
+					}
+				});
+				offset += incoming.length;
+				if (incoming.length === 0) total = rows.length;
+				return next();
+			});
+		}
+
+		return next();
+	}
+
+	function fetchRows(app, model, mine, initialRows, initialOffset, wanted) {
+		collectRows(model, mine, initialRows, initialOffset, wanted)
+			.then(
+				(result) => {
+					if (mine !== seq) return false;
+					state.rows = result.rows;
+					pageWidth = result.rows.length;
+					pageOffset = result.offset;
+					rowsTotal = result.total;
+					moreLoading = false;
+					moreError = false;
+					return true;
+				},
+				/* Two callbacks, for the reason `renderSkills` states: under a trailing
+				   `.catch` a throw from the repaint would land here and paint "could not
+				   load more" over a page of rows that had just arrived intact. */
+				() => {
+					if (mine !== seq) return false;
+					/* THE ROWS ARE LEFT ALONE — a list that empties itself over one failed
+					   fetch is worse than a short one, and the poll asks again in 30 s. Only
+					   the button's state moves, because a click that silently stayed on
+					   "Loading…" forever is the one failure the reader cannot wait out. */
+					moreLoading = false;
+					moreError = true;
+					return true;
+				},
+			)
+			.then((changed) => {
+				if (changed) draw(app, model);
+			});
+	}
+
+	/**
+	 * One more page, on the reader's ask.
+	 *
+	 * Deliberately NOT `renderSkills`, which would also re-fetch the open pane's detail
+	 * — a second round trip for a pane whose skill has not changed. This grows the
+	 * width, paints the button as busy, and re-reads the rows and nothing else.
+	 */
+	function loadMoreRows(app, model) {
+		if (moreLoading) return;
+		var current = visibleRows(model);
+		var shown = current.length;
+		var total = skillTotal(model);
+		if (shown >= total) return;
+		pageWidth = Math.min(shown + PAGE_ROWS, total);
+		moreLoading = true;
+		moreError = false;
+		/* Paint the busy label before the request, so a slow answer is visibly pending
+		   rather than a click that appeared to do nothing. */
+		draw(app, model);
+		fetchRows(app, model, seq, current, pageOffset || shown, pageWidth);
+	}
+
+	function skillTotal(model) {
+		if (rowsTotal !== null) return rowsTotal;
+		var usage = (model.stats && model.stats.toolUsage) || {};
+		return usage.skillsTotal || 0;
+	}
+
+	/**
+	 * What to tell the reader when the detail could not be loaded.
+	 *
+	 * The two failures need OPPOSITE advice, and they used to be reported as one:
+	 *
+	 *   - **No `status`** — `fetch` itself rejected, so nothing reached a server. Its
+	 *     message is the browser's own "Failed to fetch", which said nothing about a
+	 *     server having gone away and read as "HTTP Failed to fetch" once a caller
+	 *     labelled it. The dashboard is not running any more; start it again.
+	 *   - **A `status`** — a server answered and refused. A build predating this route
+	 *     404s exactly as a skill with no calls in the window does, and only the first
+	 *     of those is fixed by restarting.
+	 *
+	 * `status` rather than a message pattern, because the message is a browser string
+	 * on one path and a server's `error` field on the other — neither is ours to match on.
+	 *
+	 * IT IS ONLY EVER ASKED ABOUT THE REQUEST, which is what makes that reading sound.
+	 * `renderSkills` calls it from the fetch's own rejection callback, never from a
+	 * `.catch` spanning the repaint as well: "no `status`, so the server is gone" is a
+	 * fair reading of a failed fetch and a plainly false one for an error thrown while
+	 * drawing a chart, and it was reported to readers as a stopped dashboard for as long
+	 * as the two shared a handler.
+	 */
+	function paneErrorText(err) {
+		if (err && typeof err.status === "number") {
+			return (
+				"Could not load this skill — the dashboard answered " +
+				err.status +
+				". If it has been running since before this view existed, restart it." +
+				" This view needs a current server."
+			);
+		}
+		return "Could not reach the dashboard server. It may have stopped — run `jolli dashboard` again.";
+	}
+
+	/**
+	 * Whether the reader has asked for rows beyond the page the column opened with.
+	 *
+	 * `pageWidth` is the one thing that answers it: it is zero for the whole life of a
+	 * page load that never presses Show more, and only `loadMoreRows` (and the fetch it
+	 * starts) ever raises it. Row COUNTS cannot answer it — the poll can return a
+	 * different number of first-page rows without the reader having asked for anything.
+	 */
+	function isPaged() {
+		return pageWidth > 0;
+	}
+
+	/**
+	 * The rows region's opening tag — a scroll region ONLY once Show more has been
+	 * pressed, and then only as tall as the first page measured.
+	 *
+	 * THE FIRST SCREENFUL HAS ONE SCROLLBAR, the window's. That is the whole rule: a
+	 * column showing everything it has needs no window onto itself, and a second bar
+	 * there on arrival is one more scroll region for the reader to discover before they
+	 * have asked for anything. A click asking for more rows than the column opened with
+	 * is what puts them behind a window — an outcome the reader can attribute to what
+	 * they just did.
+	 *
+	 * THE CAP IS AN INLINE STYLE because it is a measured pixel value (see `listCapPx`),
+	 * which no stylesheet constant can stand in for; `.sk-list.sk-scroll` in `main.css`
+	 * carries everything about it that is not that number, including the visible
+	 * scrollbar the platform will not draw. With no cap recorded yet the region stays
+	 * uncapped — the safe direction, since an uncapped column is merely tall.
+	 */
+	function listOpenTag() {
+		if (!isPaged() || listCapPx === null) return '<div class="sk-list">';
+		return '<div class="sk-list sk-scroll" style="max-height:' + Math.round(listCapPx) + 'px">';
+	}
+
+	function draw(app, model) {
+		var usage = (model.stats && model.stats.toolUsage) || {};
+		var rows = visibleRows(model);
+		/* THE ROWS' OFFSET IS CARRIED ACROSS BY HAND, because the write below replaces the
+		   node that holds it — and only that node scrolls, so this is the whole of it.
+		 *
+		 * Every path here repaints the WHOLE page — a row click, that row's detail landing
+		 * moments later, a Show more, the 30 s poll — so without this the column snapped
+		 * back to its first row on all four. Clicking the 18th skill scrolled the list away
+		 * from the row that was just clicked, which also takes the `aria-current` row off
+		 * screen; and the poll did it unprompted every 30 s, mid-read.
+		 *
+		 * A whole-page repaint is what this view is built on (`renderSkills` re-reads the
+		 * address on every render), so restoring the offset is the fix that fits it —
+		 * repainting only the changed region, as `memories.js` does, is a bigger change
+		 * for the same outcome here. */
+		var previous = app.querySelector(".sk-list");
+		var offset = previous ? previous.scrollTop : 0;
+		app.innerHTML =
+			'<section class="skills-page">' +
+			bandHtml(usage) +
+			'<aside class="sk-nav" aria-label="Skills browser">' +
+			navHeadHtml(usage) +
+			listOpenTag() +
+			listHtml(rows) +
+			"</div>" +
+			navPagingHtml(rows, usage) +
+			navFootHtml(usage) +
+			"</aside>" +
+			'<article class="sk-pane" aria-label="Skill detail">' +
+			paneHtml(usage, model.timeZone) +
+			"</article>" +
+			"</section>";
+		/* Both halves address the NEW node. The measurement runs BEFORE the restore for no
+		   reason beyond reading order — they touch different properties — but it must run
+		   while the region is still uncapped, which `isPaged` is what guarantees.
+		 *
+		 * The restore is conditional because assigning 0 to a fresh render is a no-op that
+		 * would still cost a layout write. A shrunk list (the poll returning fewer rows) is
+		 * clamped by the browser, so this cannot leave the column past its own content. */
+		var list = app.querySelector(".sk-list");
+		if (list) {
+			if (!isPaged() && rows.length > 0 && list.offsetHeight > 0) listCapPx = list.offsetHeight;
+			if (offset > 0) list.scrollTop = offset;
+		}
+		bindSelection(app, model);
+		bindMore(app, model);
+	}
+
+	// ── The band ────────────────────────────────────────────────────────────────
+
+	/**
+	 * Every skill's adoption, day by day.
+	 *
+	 * THE KEPT SET FOLLOWS THE SELECTION, which is the one rule `JD.topSeries` cannot
+	 * express: a selected skill outside the top four is swapped into the fourth slot,
+	 * because otherwise "highlight this skill" fails for exactly the skills the
+	 * roll-up hides — and dimming the Other segments instead would claim several
+	 * skills' aggregate is one skill.
+	 */
+	function bandHtml(usage) {
+		var series = usage.skillDays || [];
+		var head =
+			'<div class="sk-band"><div class="sk-nav-head" style="padding:0 0 10px;border-bottom:0">' +
+			"<b>All skills, day by day</b> · sessions that reached for each skill · " +
+			"a session using several skills counts once per skill</div>";
+
+		var totals = {};
+		series.forEach((point) => {
+			Object.keys(point.bySeries || {}).forEach((name) => {
+				totals[name] = (totals[name] || 0) + point.bySeries[name];
+			});
+		});
+		var names = Object.keys(totals);
+		/* THE EMPTY TEST IS "no series", NOT "no points". `skillDays` carries one point
+		   per day of the window whether or not anything ran, so it is never empty once
+		   a window exists — a `series.length` test (what the week buckets needed, since
+		   they were derived from the data's own range) would draw an axis, four
+		   gridlines and an empty legend for a window with no skill use at all. */
+		if (names.length === 0) {
+			return head + '<div class="empty-note">No skill invocations recorded in this window.</div></div>';
+		}
+		var selected = state.paneName && totals[state.paneName] !== undefined ? state.paneName : null;
+		var ranked = names.slice().sort((a, b) => totals[b] - totals[a] || (a < b ? -1 : a > b ? 1 : 0));
+		var kept = ranked.slice(0, BAND_SERIES);
+		if (selected && kept.indexOf(selected) === -1) kept = kept.slice(0, BAND_SERIES - 1).concat([selected]);
+		var keptSet = {};
+		kept.forEach((name) => {
+			keptSet[name] = true;
+		});
+
+		var rolled = series.map((point) => {
+			var bySeries = {};
+			var other = 0;
+			Object.keys(point.bySeries || {}).forEach((name) => {
+				if (keptSet[name]) bySeries[name] = point.bySeries[name];
+				else other += point.bySeries[name];
+			});
+			bySeries.Other = other;
+			return { date: point.date, bySeries: bySeries };
+		});
+		var keys = kept.concat(["Other"]);
+		var otherTotal = names.reduce((sum, name) => sum + (keptSet[name] ? 0 : totals[name]), 0);
+
+		var legend = keys
+			.map((key, index) => {
+				var value = key === "Other" ? otherTotal : totals[key];
+				var body =
+					'<i style="background:' + JD.seriesColor(index) + '"></i><b>' + JD.esc(key) + "</b> " + value;
+				/* Other is a span, not a button: an aggregate of several skills is not a
+				   subject a reader can open. */
+				if (key === "Other") return '<span class="sk-legend' + (selected ? " sk-dim" : "") + '">' + body + "</span>";
+				return (
+					'<button type="button" class="sk-legend' +
+					(selected && key !== selected ? " sk-dim" : "") +
+					'" data-skill="' +
+					JD.esc(key) +
+					'" aria-pressed="' +
+					String(key === selected) +
+					'">' +
+					body +
+					"</button>"
+				);
+			})
+			.join("");
+
+		return (
+			head +
+			'<div class="sk-bandrow"><div class="chart-box">' +
+			/* An integer formatter, not the default `fmtTokens`: "0.5" on an axis counting
+			   sessions is a claim the unit cannot make. */
+			JD.stackedBars(rolled, keys, "skill sessions", (n) => String(Math.round(n))) +
+			'</div><div class="sk-key">' +
+			legend +
+			"</div></div></div>"
+		);
+	}
+
+	// ── The chooser column ──────────────────────────────────────────────────────
+
+	function navHeadHtml(usage) {
+		var runs = usage.skillCallsTotal || 0;
+		var skills = rowsTotal === null ? usage.skillsTotal || 0 : rowsTotal;
+		var agents = (usage.skillAgents || []).length;
+		return (
+			'<div class="sk-nav-head"><b>' +
+			runs +
+			(runs === 1 ? "</b> run · <b>" : "</b> runs · <b>") +
+			skills +
+			(skills === 1 ? "</b> skill · <b>" : "</b> skills · <b>") +
+			agents +
+			(agents === 1 ? "</b> agent</div>" : "</b> agents</div>")
+		);
+	}
+
+	/**
+	 * The list. THE ORDER IS THE SERVER'S (adoption) and the header is NOT a sort
+	 * control: these rows are one page of a ranked list, so re-sorting them by tokens
+	 * would name a "heaviest" that may sit unloaded on the next page.
+	 */
+	function listHtml(rows) {
+		if (rows.length === 0) return '<div class="empty-note">No skill invocations recorded in this window.</div>';
+		var selected = state.paneName;
+		var html =
+			'<div class="sk-cols" aria-hidden="true"><span>Skill</span><span>Runs</span><span>Tokens</span></div><ul class="ranklist">';
+		rows.forEach((row) => {
+			html +=
+				'<li><button type="button" class="sk-row" data-skill="' +
+				JD.esc(row.name) +
+				'"' +
+				(row.name === selected ? ' aria-current="true"' : "") +
+				' aria-label="' +
+				(row.name === selected ? "Clear selection of " : "Read ") +
+				JD.esc(row.name) +
+				": " +
+				row.calls +
+				(row.calls === 1 ? " run" : " runs") +
+				/* Spelled into the label too, because the `†` below is a `title` and a
+				   screen reader is not obliged to announce one. "Inferred" alone would
+				   also be the wrong half — the reader has just been told a run count. */
+				(row.detection === "heuristic" ? ", inferred, run count is per session" : "") +
+				'">' +
+				'<span class="sk-name mono" title="' +
+				JD.esc(row.name) +
+				'">' +
+				JD.esc(row.name) +
+				(row.plugin ? ' <span class="sk-plugin">' + JD.esc(row.plugin) + "</span>" : "") +
+				/* After the plugin chip: the chip is part of the skill's identity and the
+				   dagger is a qualifier on the row's figures, so it reads last. */
+				(row.detection === "heuristic" ? INFERRED_MARK : "") +
+				"</span>" +
+				'<span class="num">' +
+				row.calls +
+				"</span>" +
+				'<span class="num sk-tok">' +
+				tokenCell(row) +
+				"</span>" +
+				"</button></li>";
+		});
+		return html + "</ul>" + inferredFootnoteHtml(rows);
+	}
+
+	/**
+	 * The paging row, PINNED BELOW THE ROWS rather than inside them.
+	 *
+	 * IT IS A CONTROL, so it may not be reachable only by scrolling the very rows it
+	 * pages — and from the first Show more onwards those rows ARE a capped region, so
+	 * inside it that is exactly what it would be. Measured back when the region was
+	 * capped from the first paint: at a 1440x900 viewport the list showed 7 of 23 rows
+	 * and the row sat 882px past its fold, while the window itself scrolled 3px, so a
+	 * reader spinning the wheel over the page never moved the list at all. The first
+	 * screenful no longer has that problem (nothing is capped until a click), but the
+	 * click that creates the cap is the same click that needs this button again, so the
+	 * placement is what keeps it in reach. The head and the coverage foot are pinned for
+	 * this same reason; this belongs with them, and the region keeps only the rows and
+	 * their footnote.
+	 *
+	 * NOTHING AT ALL on an empty column, which is what a row inside `listHtml` got for
+	 * free from its early return: `Showing 0 of 0 skills` under a note that already
+	 * says there are no invocations is the same sentence twice.
+	 */
+	function navPagingHtml(rows, usage) {
+		if (rows.length === 0) return "";
+		return '<div class="sk-paging">' + moreRowHtml(rows, usage) + "</div>";
+	}
+
+	/**
+	 * `Showing 12 of 40 skills`, plus the button that fetches the next page.
+	 *
+	 * ALWAYS PRESENT once there is a row, unlike the Stats cards' version which hides
+	 * itself until a click has grown the list. That rule exists because those three
+	 * cards share one equal-third band and dropping the row resized the card under the
+	 * reader; here the row is the last band of a column whose height is its own content,
+	 * so keeping it costs one line — and it is the only place the reader is told the
+	 * column IS the whole list. Without it a 60-row column and a 60-of-300 column look
+	 * identical.
+	 *
+	 * Same classes and same wording as `stats.js`'s `toolMoreRow`, so the two read as
+	 * one control at two zooms rather than two conventions.
+	 */
+	function moreRowHtml(rows, usage) {
+		var shown = rows.length;
+		var total = rowsTotal === null ? (usage && usage.skillsTotal) || shown : rowsTotal;
+		var count =
+			'<span class="more-count">Showing ' +
+			shown +
+			" of " +
+			total +
+			(total === 1 ? " skill" : " skills") +
+			/* The failure belongs beside the count it stopped from growing: this button
+			   still being here IS why it matters. */
+			(moreError && !moreLoading ? " — could not load more" : "") +
+			"</span>";
+		if (shown >= total) return '<div class="more-row is-done">' + count + "</div>";
+		var label = moreLoading ? "Loading…" : moreError ? "Try again" : "Show more";
+		return (
+			'<div class="more-row">' +
+			count +
+			'<button type="button" class="cta ghost sm" data-skillmore' +
+			(moreLoading ? " disabled" : "") +
+			">" +
+			label +
+			"</button></div>"
+		);
+	}
+
+	/**
+	 * The `†` spelled out under the column, and only when a loaded row wears one.
+	 *
+	 * ON THE ROWS IN HAND, not on a window-wide flag: a footnote explaining a mark that
+	 * is nowhere on screen is a reader hunting for something that is not there. So a
+	 * Show more click can bring the footnote in, which is correct — the mark arrived
+	 * with it.
+	 */
+	function inferredFootnoteHtml(rows) {
+		var marked = rows.some((row) => row.detection === "heuristic");
+		if (!marked) return "";
+		return '<span class="sk-basis">† ' + INFERRED_TITLE + "</span>";
+	}
+
+	/**
+	 * The Tokens cell: an em dash where nothing was attributed, `~` on an estimate.
+	 *
+	 * The dash is load-bearing. Most agents attribute no spend to a skill at all
+	 * (measured on one machine: 105 of 116 rows came from Codex, which reports none),
+	 * and a `0` there reads as "measured, and it was free".
+	 */
+	function tokenCell(row) {
+		var usage = row.usage;
+		if (!usage) return "&mdash;";
+		var total = usage.input + usage.output + usage.cached;
+		return (usage.confidence === "estimated" ? "~" : "") + JD.fmtTokens(total);
+	}
+
+	/**
+	 * The coverage denominator, in the grammar the Skills and MCPs cards print: how
+	 * many of the window's sessions could be read for tool calls at all. Without it
+	 * every figure above reads as if it covered every session.
+	 */
+	function navFootHtml(usage) {
+		var withTools = usage.sessionsWithTools || 0;
+		var inWindow = usage.sessionsInWindow || 0;
+		return (
+			'<div class="w-foot"><span class="w-measure">ⓘ from <b>' +
+			withTools +
+			"</b> of " +
+			inWindow +
+			(inWindow === 1 ? " session" : " sessions") +
+			" in this window</span></div>"
+		);
+	}
+
+	// ── The reading pane ────────────────────────────────────────────────────────
+
+	function paneHtml(usage, timeZone) {
+		if (!state.paneName) {
+			return '<div class="sk-pane-empty">Select a skill to read how its use, cost and reliability moved over time.</div>';
+		}
+		if (state.paneError) return '<div class="sk-pane-empty">' + JD.esc(state.paneError) + "</div>";
+		var detail = state.pane;
+		if (!detail) return '<div class="sk-pane-empty">Loading…</div>';
+
+		var callsTotal = usage.skillCallsTotal || 0;
+		var share = callsTotal ? Math.round((detail.calls / callsTotal) * 100) : 0;
+		var perSession = detail.sessions ? (detail.calls / detail.sessions).toFixed(1) : "—";
+
+		var html =
+			'<div class="sk-panebody"><div class="sk-title mono">' +
+			JD.esc(detail.name) +
+			(detail.plugin
+				? ' <span class="sk-plugin">' + JD.esc(detail.plugin) + "</span>"
+				: '<span class="sk-kind">skill</span>') +
+			(detail.detection === "heuristic" ? INFERRED_MARK : "") +
+			"</div>" +
+			'<div class="sk-figs">' +
+			fig(detail.calls, "runs") +
+			fig(detail.sessions, "sessions") +
+			fig(perSession, "runs per session") +
+			fig(share + "%", "of all skill runs") +
+			"</div>" +
+			inferredCaveatHtml(detail);
+
+		/* FIVE SECTIONS, and the mockup's set exactly. `SkillDetail` also carries
+		   `commits` and `categories`, and a sixth "What it produced" section rendering
+		   them was tried and removed: measured on one machine only 27 of 111 skill rows
+		   linked to a commit at all, so the section it produced read "None of this
+		   skill's work is committed yet" on three rows in four — and when it did have
+		   rows, the churn figures on them were the COMMIT's, not the skill's, on commits
+		   that usually carry other work too. The server still computes both fields; they
+		   have no reader here on purpose, the way `MemoriesModel.vitals` does. */
+		var days = windowDays(usage);
+		html += section("How often it ran", cadenceHtml(detail, days, timeZone));
+		html += section(costTitle(detail), costHtml(detail, days, timeZone));
+		html += section("Run outcomes", outcomeHtml(detail, timeZone));
+		html += section("The record", recordHtml(detail, timeZone));
+		html += section("Who ran it", agentsHtml(detail));
+
+		html +=
+			'<span class="sk-basis">Runs, sessions and the agent split are counted over this window. The two ' +
+			"charts above share the day axis the chart at the top of the page uses, so a column is the same day " +
+			"in all three; spend is attributed per session and summed per day, never per run. Outcomes are per " +
+			"recorded run and carry no date axis.</span>";
+		return html + "</div>";
+	}
+
+	function fig(value, label) {
+		return '<div class="sk-fig"><b class="num">' + JD.esc(String(value)) + "</b><span>" + label + "</span></div>";
+	}
+
+	/**
+	 * What qualifies the four figures above it, when any entry behind them was inferred
+	 * from a file read rather than observed.
+	 *
+	 * DIRECTLY UNDER THE FIGURES, not folded into `sk-basis` at the foot of the pane.
+	 * Three of those four are run counts — `runs`, `runs per session`, `of all skill
+	 * runs` — and the count is precisely what the inference changes: an inferred entry
+	 * is recorded once per session however many paged reads produced it, so the number
+	 * is a floor rather than a measurement. A caveat two screens below the figure it
+	 * qualifies is one the reader meets after having already believed the figure.
+	 *
+	 * "AT LEAST ONE ENTRY", never "this skill" or "this agent". The mark is any-one-taints
+	 * across the whole window, so a skill entered properly in one session and inferred in
+	 * another carries it — naming the skill or its host would overstate what is known and
+	 * be plainly wrong on a row that mixes the two.
+	 */
+	function inferredCaveatHtml(detail) {
+		if (detail.detection !== "heuristic") return "";
+		return (
+			'<div class="sk-caveat">† At least one entry here was inferred from a command that read the skill ' +
+			"file, not from an observed invocation — a person reading that file leaves the same trace, and " +
+			"reading it is not the same as using it. Inferred entries are counted once per session however " +
+			"many reads produced them, so the run figures above are a floor rather than a count.</div>"
+		);
+	}
+
+	function section(title, body) {
+		return '<div class="sk-sec"><h4>' + title + "</h4>" + body + "</div>";
+	}
+
+	function line(label, value, swatch) {
+		return (
+			'<div class="sk-line">' +
+			(swatch ? '<i style="background:' + swatch + '"></i>' : "") +
+			"<b>" +
+			JD.esc(label) +
+			"</b><span>" +
+			JD.esc(value) +
+			"</span></div>"
+		);
+	}
+
+	/**
+	 * `Aug 17`, from an epoch instant, in the same zone as the server's day buckets.
+	 *
+	 * ROUTED THROUGH THE DAY KEY rather than formatting the instant directly, so the
+	 * record's dates and the charts' axis labels are the same two functions in the same
+	 * order. They used to be two independent formatters that happened to agree, and this
+	 * pane has already shipped one bug of exactly that shape (see the header: an axis
+	 * labelled from a bucket edge beside a record labelled from the data).
+	 *
+	 * THE ZONE IS A PARAMETER, never read off an enclosing `model`. Everything in this
+	 * pane is reached from `draw`, which does hold the model — but `paneHtml` and its
+	 * sections took only the data they rendered, so a free `model` here resolved to
+	 * nothing at all, and the old `catch` hid it by quietly printing `2026-08-20` where
+	 * `Aug 20` belonged. The sibling pages (`stats.js`, `memories.js`, `standup.js`)
+	 * thread the zone down the same way.
+	 */
+	function shortDay(atMs, timeZone) {
+		return JD.dayLabel(JD.dayKey(atMs, timeZone));
+	}
+
+	/**
+	 * The window's local days, taken from the BAND'S OWN series.
+	 *
+	 * Not recomputed from the range: `buildSkillDays` walks the window with
+	 * `addLocalDays` precisely because a fixed 86,400,000 skips or repeats a bucket on
+	 * a DST day, and a client-side second implementation of that would disagree with
+	 * the band exactly on those days, silently. Reading its keys makes the three charts
+	 * share an axis by construction rather than by two calculations agreeing.
+	 *
+	 * EMPTY IS A REAL ANSWER and the charts fall back to their own data's days — the
+	 * band emits a point per day of any window that exists, so this is empty only when
+	 * the payload carried no band at all. A chart drawn over its own extent is narrower
+	 * than the window but still honest; refusing to draw would lose the reader more.
+	 */
+	function windowDays(usage) {
+		return (usage.skillDays || []).map((point) => point.date);
+	}
+
+	/**
+	 * Which day keys a pane chart lays out: the window's, or its own points' as the
+	 * fallback above describes. De-duplicated and sorted, since a fallback built from
+	 * session points has one entry per session rather than per day.
+	 */
+	function chartDays(days, points, timeZone) {
+		if (days.length > 0) return days;
+		var seen = Object.create(null);
+		points.forEach((point) => {
+			seen[JD.dayKey(point.atMs, timeZone)] = true;
+		});
+		return Object.keys(seen).sort();
+	}
+
+	/** A day-bucketed chart plus the two endpoint labels — the shape both charts share. */
+	function barsHtml(days, values, label, fmt) {
+		if (days.length === 0) return "";
+		return (
+			JD.dayBars(days, values, { label: label, fmt: fmt }) +
+			'<div class="sk-axis"><span>' +
+			JD.esc(JD.dayLabel(days[0])) +
+			"</span>" +
+			/* One label on a single-day window: the same day at both ends would read as a
+			   range that is not one — the rule `JD.stackedBars` states for the band. */
+			(days.length > 1 ? "<span>" + JD.esc(JD.dayLabel(days[days.length - 1])) + "</span>" : "") +
+			"</div>"
+		);
+	}
+
+	/**
+	 * Sessions per day over the window — "was it used more or less".
+	 *
+	 * Every day of the window is drawn, empty ones included, for the reason the band
+	 * walks the window: bars are laid out by index, so dropping a quiet day compresses
+	 * the axis and makes a fortnight's gap look like a busy stretch.
+	 */
+	function cadenceHtml(detail, days, timeZone) {
+		var points = detail.sessionSeries || [];
+		if (points.length === 0) return '<div class="sk-note">No per-session record survives for this skill.</div>';
+		var buckets = chartDays(days, points, timeZone);
+		var index = Object.create(null);
+		buckets.forEach((day, position) => {
+			index[day] = position;
+		});
+		var counts = buckets.map(() => 0);
+		points.forEach((point) => {
+			/* A point outside the window is dropped, never clamped onto an edge bucket —
+			   `buildSkillDays` states the same rule for the same reason: the SQL filters on
+			   epoch bounds while these buckets are local day keys, so the only points this
+			   can reject are the boundary's own rounding, and filing one under a day it did
+			   not happen on would be worse than leaving it out. */
+			var position = index[JD.dayKey(point.atMs, timeZone)];
+			if (position !== undefined) counts[position]++;
+		});
+		return barsHtml(buckets, counts, "Sessions per day", (n) => n + (n === 1 ? " session" : " sessions"));
+	}
+
+	function costTitle(detail) {
+		if (!detail.usage) return "What it cost";
+		return detail.usage.confidence === "estimated" ? "What it cost (estimated)" : "What it cost";
+	}
+
+	/**
+	 * Tokens per DAY over the window — the "did it get cheaper" read, on the cadence
+	 * chart's own axis so the two can be read against each other.
+	 *
+	 * SPEND IS STILL ATTRIBUTED PER SESSION and this does not claim otherwise: a day's
+	 * bar is the sum of the sessions that landed in it, which is an aggregate of the
+	 * grain the record holds rather than a subdivision of it. A per-RUN curve remains
+	 * the thing that does not exist to draw.
+	 *
+	 * IT DRAWS FROM THE PRICED POINTS ONLY, which is why the gap sentence below exists.
+	 * Most agents attribute no spend to a skill at all, so a session with no `tokens`
+	 * cannot enter this chart — filling it with a zero would claim the session was free.
+	 * Before the two charts shared an axis that omission was invisible and showed up
+	 * only as two axes disagreeing; on one axis it is a run of empty days at the left
+	 * that the cadence chart above fills, so the count is stated in words.
+	 */
+	function costHtml(detail, days, timeZone) {
+		if (!detail.usage) {
+			return '<div class="sk-note">This agent cannot attribute spend to a skill. No figure is shown rather than a zero.</div>';
+		}
+		var usage = detail.usage;
+		var mark = usage.confidence === "estimated" ? "~" : "";
+		var points = detail.sessionSeries || [];
+		var priced = points.filter((point) => point.tokens != null);
+		var chart = "";
+		/* ONE priced session is now enough, where the per-session version needed two.
+		   That rule existed because a lone bar has no slope to read — true of a chart
+		   whose x-axis was just "the points, in order", and false of one whose x-axis is
+		   the window: a single bar against 30 dated days says WHEN the spend happened,
+		   which is a reading the old chart could not offer. */
+		if (priced.length > 0) {
+			/* The CADENCE chart's buckets, not the priced points' own: the whole point is
+			   that a column means the same day in both. The fallback extent is likewise
+			   taken from every session rather than from the priced ones. */
+			var buckets = chartDays(days, points, timeZone);
+			var index = Object.create(null);
+			buckets.forEach((day, position) => {
+				index[day] = position;
+			});
+			var totals = buckets.map(() => 0);
+			priced.forEach((point) => {
+				var position = index[JD.dayKey(point.atMs, timeZone)];
+				if (position !== undefined) totals[position] += point.tokens;
+			});
+			chart = barsHtml(buckets, totals, "Tokens per day", (n) => mark + JD.fmtTokens(n));
+		}
+		var unpriced = points.length - priced.length;
+		var total = usage.input + usage.output + usage.cached;
+		return (
+			chart +
+			/* Beside the chart it qualifies, not folded into the coverage line below: that
+			   line is a fraction of SESSIONS while this explains why the bars start where
+			   they do. Only when the chart is actually drawn — with no chart there is
+			   nothing for it to be about, and the coverage line already carries the count. */
+			(chart && unpriced > 0
+				? '<div class="sk-note">' +
+					unpriced +
+					(unpriced === 1
+						? " session attributed no spend, so it is"
+						: " sessions attributed no spend, so they are") +
+					" not in this chart — a quiet day here may still be a busy one above.</div>"
+				: "") +
+			line("Total", mark + JD.fmtTokens(total)) +
+			'<div class="sk-note">' +
+			mark +
+			JD.fmtTokens(usage.input) +
+			" in · " +
+			mark +
+			JD.fmtTokens(usage.output) +
+			" out · " +
+			mark +
+			JD.fmtTokens(usage.cached) +
+			" cached · " +
+			usage.sessions +
+			" of " +
+			detail.sessions +
+			" sessions carry usage</div>"
+		);
+	}
+
+	/**
+	 * The recorded runs as ticks, oldest first, plus the counts.
+	 *
+	 * EVERY entry is drawn, because every entry is a run that happened, in the mockup's
+	 * TWO colours: red for a measured failure, quiet green for everything else. Drawing
+	 * only the measured ones used to empty this entire section on the common machine,
+	 * where nearly every Claude skill is entered by slash command — runs that were fully
+	 * on record, described to the reader as nothing.
+	 *
+	 * A run whose result the agent never wrote down (three of the six entry mechanisms
+	 * write none, so their stored `ok: true` is the absence of a failure report rather
+	 * than a report of success) takes the same green tick and is named in WORDS below.
+	 * A grey third state was tried for it and read as "empty" rather than "unmeasured",
+	 * which is the wrong signal on a skill where every run is in that class. The hover
+	 * title still says "outcome not recorded" per tick.
+	 *
+	 * The percentage stays over `measured` alone and the unknowable runs are stated in
+	 * words instead. A rate computed over both would read as "nothing failed" about runs
+	 * nobody can speak for, which is the one sentence this data cannot support.
+	 */
+	function outcomeHtml(detail, timeZone) {
+		/* Absent outcomes means "no entry row at all" — an archived commit's merged count,
+		   or a transcript the agent pruned — not "the result was unknowable", which is the
+		   case the `assumed` sentence below covers. */
+		if (!detail.outcomes) {
+			return '<div class="sk-note">No per-entry record survives for this skill, so no run outcome is shown.</div>';
+		}
+		var measured = detail.outcomes.measured;
+		var failed = detail.outcomes.failed;
+		var assumed = detail.outcomes.assumed || 0;
+		var invocations = detail.invocations || [];
+		var ticks = invocations
+			.map(
+				(inv) =>
+					'<i class="' +
+					(inv.outcomeKnown && !inv.ok ? "bad" : "") +
+					'" title="' +
+					JD.esc(JD.dayKey(inv.atMs, timeZone)) +
+					(inv.args ? " · " + JD.esc(inv.args) : "") +
+					" · " +
+					(inv.outcomeKnown ? (inv.ok ? "ok" : "failed") : "outcome not recorded") +
+					'"></i>',
+			)
+			.join("");
+		var strip = ticks
+			? '<div class="sk-ticks" role="img" aria-label="Recorded runs, oldest to newest">' + ticks + "</div>"
+			: "";
+		/* Empty when nothing was measured, rather than "0 runs failed": with no reading
+		   there is no denominator, and the sentence below is the whole answer. */
+		var counts = "";
+		if (measured > 0) {
+			counts =
+				failed > 0
+					? line(failed + " of " + measured + (measured === 1 ? " run failed" : " runs failed"), Math.round((failed / measured) * 100) + "%")
+					: '<div class="sk-note">' + measured + (measured === 1 ? " run" : " runs") + " recorded an outcome; none failed.</div>";
+		}
+		/* Phrased as what the record is missing, never as "N succeeded". Where nothing at
+		   all was measured the mechanism is named as the reason, so the reader learns this
+		   is a property of how the skill was entered rather than a gap in their own data. */
+		var unknown = "";
+		if (assumed > 0) {
+			unknown =
+				'<div class="sk-note">' +
+				(measured > 0
+					? assumed +
+						(assumed === 1 ? " further run" : " further runs") +
+						" recorded no outcome, so success or failure is unknown for those."
+					: assumed +
+						(assumed === 1 ? " run is" : " runs are") +
+						" on record, but this skill's entry mechanism writes no result, so success or failure is unknown.") +
+				"</div>";
+		}
+		/* Against `calls`, the exact total — not against the strip, which is capped and
+		   would overstate the gap on a busy skill. BOTH counted classes come off it, so
+		   what remains is the runs that left no entry row at all. */
+		var unrecorded = detail.calls - measured - assumed;
+		var gap =
+			unrecorded > 0
+				? '<div class="sk-note">' +
+					unrecorded +
+					(unrecorded === 1 ? " further run" : " further runs") +
+					" left no per-entry record.</div>"
+				: "";
+		/* Both classes again: the strip draws every entry now, so the cap is against the
+		   entry total rather than against the measured ones. */
+		var entries = measured + assumed;
+		var capped =
+			invocations.length > 0 && entries > invocations.length
+				? '<div class="sk-note">Ticks are the ' +
+					invocations.length +
+					" most recent of " +
+					entries +
+					" recorded runs; the counts above stay exact.</div>"
+				: "";
+		return strip + counts + unknown + gap + capped;
+	}
+
+	/** Everything that is a fact rather than a trend, in one two-column grid. */
+	function recordHtml(detail, timeZone) {
+		var rows = "";
+		var entered = enteredBy(detail.entryPaths);
+		if (entered) rows += line("Entered by", entered);
+		/* Chars, not tokens — this is a body length. `fmtTokens` is reused only as the
+		   compact-number formatter both surfaces share. */
+		if (detail.bodyChars != null) rows += line("Skill body", JD.fmtTokens(detail.bodyChars) + " chars");
+		if (detail.firstCallAtMs) rows += line("First used", shortDay(detail.firstCallAtMs, timeZone));
+		if (detail.lastCallAtMs) rows += line("Last used", shortDay(detail.lastCallAtMs, timeZone));
+		if ((detail.repos || []).length > 0) rows += line("Ran in", detail.repos.join(", "));
+		if (!rows) return '<div class="sk-note">No per-entry record survives for this skill.</div>';
+		return '<div class="sk-facts">' + rows + "</div>";
+	}
+
+	/**
+	 * `the agent`, `you`, or both — the entry mechanisms in the reader's terms.
+	 *
+	 * `tool` is the agent deciding to invoke a skill, `command` is a person asking for
+	 * it by name. Named after who reached for it rather than after the transcript
+	 * mechanism, which would put the schema on screen.
+	 */
+	function enteredBy(paths) {
+		var list = paths || [];
+		var tool = list.indexOf("tool") !== -1;
+		var command = list.indexOf("command") !== -1;
+		if (tool && command) return "the agent and you";
+		if (tool) return "the agent";
+		return command ? "you" : null;
+	}
+
+	/** Per-agent runs, most first. The swatch is the agent's colour, page-wide. */
+	function agentsHtml(detail) {
+		var agents = (detail.agents || []).slice().sort((a, b) => b.calls - a.calls);
+		if (agents.length === 0) return '<div class="sk-note">No agent recorded against this skill.</div>';
+		return agents
+			.map((agent) =>
+				line(
+					agent.source,
+					agent.calls + (agent.calls === 1 ? " run" : " runs"),
+					JD.seriesColor(JD.sourceIndex(agent.source)),
+				),
+			)
+			.join("");
+	}
+
+	// ── Interaction ─────────────────────────────────────────────────────────────
+
+	/**
+	 * One binder for the list rows AND the band's key: both carry `data-skill`, and a
+	 * click on either toggles, so the empty pane stays reachable once something has
+	 * been opened.
+	 */
+	function bindSelection(app, model) {
+		Array.prototype.forEach.call(app.querySelectorAll("[data-skill]"), (element) => {
+			element.onclick = () => {
+				var name = element.getAttribute("data-skill");
+				var next = state.paneName === name ? null : name;
+				/* The reader has now answered "which skill" themselves, so the default pick
+				   must not run again — otherwise the click that closes the pane re-opens the
+				   top row on the very next render. */
+				defaultAnswered = true;
+				setSelectedSkill(next);
+				state.paneName = next;
+				state.pane = null;
+				state.paneError = null;
+				renderSkills(model);
+			};
+		});
+	}
+
+	/** The paging button. Absent on a fully-loaded column, so this binds nothing. */
+	function bindMore(app, model) {
+		var button = app.querySelector("[data-skillmore]");
+		if (button) button.onclick = () => loadMoreRows(app, model);
+	}
+
+	JD.renderSkills = renderSkills;
+})(window.JD);

--- a/cli/src/dashboard/assets/js/stats.js
+++ b/cli/src/dashboard/assets/js/stats.js
@@ -788,8 +788,22 @@ window.JD = window.JD || {};
 			   that gives (the name, which truncates). A bare string was falsy here and
 			   so emitted no slot at all; this keeps that. */
 			var kind = kindOf ? kindOf(row) : null;
+			/* Only the Skills list opens a detail view, so only its rows carry the
+			   affordance. The MCP lists would need their own endpoint and their own
+			   answer to "what is a server's detail", and a row that looks clickable
+			   and does nothing is worse than a row that does not. */
+			var clickable =
+				list === "skill"
+					? ' class="rl-click" tabindex="0" role="button" data-skill="' +
+						JD.esc(row.name) +
+						'" title="Open detail for ' +
+						JD.esc(row.name) +
+						'"'
+					: "";
 			html +=
-				'<li><div class="rl-top">' +
+				"<li" +
+				clickable +
+				'><div class="rl-top">' +
 				// Emitted for every row of a list that HAS a lead, including rows whose
 				// own lead comes back empty. The span is a fixed-width column (see
 				// .rl-lead), so skipping it on a row with no agents would put that row's
@@ -957,9 +971,15 @@ window.JD = window.JD || {};
 	   classifies as a builtin, and a slash command is a prompt expansion that
 	   never becomes a tool call at all. Widening this sentence means widening
 	   that classifier first. */
+	/* The dagger is explained HERE rather than on the row, because this card has no
+	   room for a footnote and the rows are already at their narrowest — the Skills page
+	   the rows link into prints the full sentence under the figures it qualifies. The
+	   mark itself still has to appear on the row: a skill shown clean here and daggered
+	   one click later reads as two different measurements of the same thing. */
 	var SKILLS_HINT =
 		"Skill invocations, counted from the tool calls in your local transcripts. A skill invoked inside a " +
-		"subagent counts once, against the session that spawned it.";
+		"subagent counts once, against the session that spawned it. A † marks a skill whose use was inferred " +
+		"from a command that read its file rather than observed, so its run count is per session.";
 
 	function skillsCard(model) {
 		var usage = model.stats.toolUsage;
@@ -1003,7 +1023,12 @@ window.JD = window.JD || {};
 			"--s2",
 			(r) => r.calls,
 			agentBadges,
-			(r) => "/" + r.name,
+			/* The dagger rides IN the label rather than in a slot of its own. Both slots
+			   are taken here — the lead carries `agentBadges`, and the kind is null on
+			   purpose (see `rankedList`) — and the label is plain text escaped downstream,
+			   which a bare `†` survives. It also lands in the row's `title`, so the mark
+			   is reachable on hover even before the card head explains it. */
+			(r) => "/" + r.name + (r.detection === "heuristic" ? " †" : ""),
 			null,
 			"run",
 			"skill",
@@ -1993,6 +2018,35 @@ window.JD = window.JD || {};
 		revealToolRows(stats.toolUsage);
 		document.querySelectorAll("[data-toolmore]").forEach((button) => {
 			button.onclick = () => loadMoreToolRows(model, button.getAttribute("data-toolmore"));
+		});
+
+		/* The Skills rows LINK INTO the Skills page, which has a reading pane of its
+		   own. They used to open a modal over this card — a second renderer of the same
+		   figures, and one that could not be shared or reloaded. `?skill=` is that
+		   page's own selection state, so this navigation and a click over there land on
+		   the identical view.
+
+		   Re-bound on every repaint like the button above, because a repaint replaces
+		   the whole of `#app` and takes the old rows' handlers with it.
+
+		   Keyboard as well as pointer: the row carries `role="button"` and a tabindex,
+		   so leaving it click-only would put a focusable control on the page that the
+		   keyboard cannot activate. */
+		document.querySelectorAll("[data-skill]").forEach((row) => {
+			var open = () => {
+				/* Through `JD.viewPath`, never a literal "/skills": that table is the one
+				   place a view's URL is spelled, so the nav row and this link cannot end up
+				   disagreeing about where the page lives. */
+				var query = JD.withParams(JD.query(model, {}), { skill: row.getAttribute("data-skill") });
+				window.location.href = JD.viewPath("skills") + query;
+			};
+			row.onclick = open;
+			row.onkeydown = (event) => {
+				if (event.key === "Enter" || event.key === " ") {
+					event.preventDefault();
+					open();
+				}
+			};
 		});
 	};
 

--- a/cli/src/dashboard/assets/styles/main.css
+++ b/cli/src/dashboard/assets/styles/main.css
@@ -338,6 +338,11 @@ body {
   .sb-brand { display: flex; align-items: baseline; gap: 7px; padding: 2px 10px 10px; }
   .sb-brand b { font-size: 16px; letter-spacing: -.01em; }
   .sb-brand span { font-size: 11px; color: var(--muted); }
+  /* The mark carries its own size on the element (20x18) and its own brand hexes
+     inline — see index.html for why it is not themed. The only thing it needs
+     from here is `flex: none`, so a longer word beside it squeezes the text
+     rather than distorting a logo. */
+  .sb-brand .sb-mark { flex: none; }
   .sb-label { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: .06em; padding: 12px 10px 6px; }
   .sb-label small { font-size: 11px; text-transform: none; letter-spacing: 0; }
   .sb-list { display: grid; gap: 2px; }
@@ -368,20 +373,18 @@ body {
     padding-top: 10px; border-top: 1px solid var(--border); background: var(--surface);
   }
 
-  /* ---------- nav: Dashboard's two children ----------
-     Dashboard (two children) and Memories in the scrolling list, Settings in the
-     pinned bottom slot. Children render indented under a group label rather than
-     behind an expand/collapse toggle — that interaction is a later polish pass
-     over the same markup, not a routing concern.
+  /* ---------- nav: one flat list ----------
+     Every menu row is a peer of every other, at one indent, each with its own
+     mark — see NAV_MIDDLE in shell.js for why the "Dashboard" group label and its
+     two indented children went away. The rules that drew them (`.sb-group-label`,
+     `.sb-group-chevron`, `.sb-item.child`) went with the markup; nothing here
+     styles a nesting level, and re-adding one starts with that comment.
 
      The `[aria-disabled]` rules below are unreachable at HEAD: rows used to
      disable themselves until a repository was enabled, mirroring the server's
      redirect to the Repositories page. Both that page and the gate are gone (see
      NAV_MIDDLE in shell.js), so nothing sets the attribute. Kept because the
      treatment is the obvious one for any row that gains a disabled state. */
-  .sb-group-label { display: flex; align-items: center; gap: 8px; color: var(--ink-2); padding: 8px 10px 2px; font-size: 13px; }
-  .sb-group-label .sb-group-chevron { width: 14px; height: 14px; margin-left: auto; color: var(--accent); }
-  .sb-item.child { padding-left: 34px; font-size: 12.5px; }
   .sb-item[aria-disabled="true"] { color: var(--muted); opacity: .55; cursor: not-allowed; }
   .sb-item[aria-disabled="true"]:hover { background: transparent; color: var(--muted); }
 
@@ -1365,6 +1368,17 @@ body {
   .conv-note { font-size: 12px; color: var(--muted); margin: 8px 0 0; }
   .sheet .row { display: flex; gap: 10px; margin-top: 10px; align-items: center; }
 
+  /* A ranked row that opens the Skills page for its own skill. Only the Skills list
+     gets this class — see `rankedList` — so the pointer never promises a destination
+     that does not exist.
+
+     The skill-detail SHEET that used to live here is gone: the Skills page has a
+     reading pane of its own, and a modal over the card was a second renderer of the
+     same figures. The card's rows now link into that page instead. */
+  .rl-click { cursor: pointer; border-radius: 6px; }
+  .rl-click:hover { background: var(--page); }
+  .rl-click:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+
   /* ---------- popover ---------- */
   .pop {
     position: absolute; z-index: 40; width: 264px; background: var(--surface);
@@ -1799,3 +1813,279 @@ body {
 }
 .jd .wiki-freshness .wiki-dismiss:hover { opacity: 1; }
 .jd .wiki-freshness .wiki-dismiss:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+
+/* ══ Skills page ══════════════════════════════════════════════════════════════
+   A chart band across the top, then a chooser column and a reading pane — the
+   same grammar Memories uses, so the two pages are navigated the same way.
+   `.mem-*` above is the reference for every chrome value here.
+
+   THE WRAP'S 1200px CAP STAYS HERE, which is where this page parts from
+   `.memories-page`. Releasing it is what a full-bleed browser needs, and this page
+   is not one: the band's chart is capped at 760px and the list column is a fixed
+   344px, so every pixel the release adds lands in the reading pane alone — 802px
+   of pane in the mockup against 982px full-bleed at a 1600px viewport, which is
+   wider than the 560px the pane's own figures and caveat are capped at.
+
+   THE PAGE IS WHAT SCROLLS, with ONE earned exception — and this is the height rule
+   the rest of the section is written against. Every box here is as tall as what it
+   holds and the page grows past the fold like every other view; the single exception
+   is the chooser's rows, which take a MEASURED cap the moment the reader presses Show
+   more (`listOpenTag` in skills.js owns that, and `.sk-list.sk-scroll` below styles
+   it). So the first screenful has exactly one scrollbar, the window's, and a second
+   appears only as the visible result of a click asking for more rows than the column
+   opened with.
+
+   It used to be three viewport-height boxes summing to exactly 100vh: a declared
+   `--sk-band-h`, a `--sk-col-h` deriving the rest from `100vh`, and a scroll region
+   inside each column, present from the first paint. That bought a fixed frame and
+   charged the reader three scroll regions to find — measured at 1440x900, the wheel
+   over the rows moved the WINDOW 3px while the list itself stayed put, the pane
+   carried a second bar of its own, and anything at the end of either box (the paging
+   control, the coverage foot, the pane's basis line) was reachable only by
+   discovering which box it lived in. The `100vh` arithmetic went with it, and so did
+   `.main`'s dropped bottom padding — that override existed only to stop the exact
+   sum spilling 20px past the fold. What came back is the ONE region that earns a
+   window: the rows, once there are more of them than the reader asked to see. */
+.jd .grid:has(.skills-page) { display: block; }
+
+.jd .skills-page {
+	display: grid; grid-template-columns: 344px minmax(0, 1fr); gap: 6px;
+	/* `start`, not the default stretch: the two columns hold unrelated amounts of
+	   content, so stretching makes the shorter card as tall as the taller one and
+	   leaves its own foot floating in the middle of an empty card. */
+	align-items: start;
+}
+
+/* Same chrome as the chooser column, spanning both. */
+.jd .sk-band {
+	grid-column: 1 / -1; min-width: 0; overflow: hidden;
+	border: 1px solid var(--border); border-radius: 12px; background: var(--surface);
+	box-shadow: 0 2px 5px rgba(20, 30, 50, .05); padding: 14px 20px 10px;
+	display: flex; flex-direction: column;
+}
+.jd .sk-bandrow { display: flex; gap: 28px; align-items: flex-start; min-height: 0; }
+/* Capped and left-aligned rather than stretched: `JD.stackedBars` is an SVG with a
+   fixed 660-wide viewBox and `width: 100%`, so at full page width it scales to
+   roughly 400px tall. The cap keeps it chart-sized and the slack carries the key. */
+.jd .sk-band .chart-box { flex: 1; max-width: 760px; min-width: 0; }
+/* The key, stacked in that spare width. INSIDE THIS BAND THE RAMP MEANS SKILL,
+   while everywhere else on the dashboard it means agent — which is why the key sits
+   against the chart rather than at the page edge. A colour may not be read across
+   this boundary. */
+.jd .sk-key { display: flex; flex-direction: column; align-items: flex-start; gap: 7px; margin-top: 8px; flex: none; }
+.jd .sk-legend {
+	display: inline-flex; align-items: center; gap: 6px; background: none; border: 0;
+	padding: 2px 6px; margin: -2px -6px; border-radius: 6px; font: inherit; font-size: 11.5px;
+	color: var(--ink-2); cursor: pointer;
+}
+.jd .sk-legend i { width: 9px; height: 9px; border-radius: 3px; flex: none; }
+.jd .sk-legend b { color: var(--ink); font-weight: 600; }
+.jd .sk-legend:hover { background: var(--lock-bg); }
+.jd .sk-legend:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+/* The pressed key row wears the same accent edge the selected list row does, so
+   "selected" is ONE visual fact wherever it appears on the page. */
+.jd .sk-legend[aria-pressed="true"] { box-shadow: inset 2px 0 0 var(--accent); background: var(--lock-bg); }
+/* Recessed, not recoloured: a dimmed series must stay recognisably itself. */
+.jd .sk-dim { opacity: .38; }
+
+/* The chooser column: `.mem-navigator`'s chrome at the height of its own content.
+   Head, rows, paging row and coverage foot stack, so the card is as tall as the four
+   of them — the rows are the only one that can be capped, and the card follows that
+   cap rather than setting it. `overflow: hidden` is here for the rounded corners. */
+.jd .sk-nav {
+	min-width: 0; overflow: hidden;
+	border: 1px solid var(--border); border-radius: 12px; background: var(--surface);
+	box-shadow: 0 2px 5px rgba(20, 30, 50, .05); display: flex; flex-direction: column;
+}
+/* The counts belong to the LIST, so they sit at the top of the list's column rather
+   than in a page-wide band — this surface has twice declined top-of-page aggregates. */
+.jd .sk-nav-head {
+	flex: none; padding: 14px 20px 12px; font-size: 12px; color: var(--muted);
+	border-bottom: 1px solid var(--grid);
+}
+.jd .sk-nav-head b { color: var(--ink); font-weight: 600; }
+/* Every row — with no height and no scrollbar of its own until the reader pages past
+   the column's first screenful. `sk-scroll` and the inline `max-height` are written by
+   `listOpenTag` in skills.js, which records why the cap is measured rather than
+   declared and why the first page may not scroll.
+ *
+ * THE THIN BAR IS NOT DECORATION, and it is copied off `.ranklist.rl-scroll` so the
+ * page's two scrollers read alike. macOS overlay bars are absent until a scroll is
+ * already under way, so a capped region carrying only the platform's own bar is a
+ * window with a hard bottom edge and nothing saying fifteen more rows sit below it —
+ * and the reader has to know this region scrolls before the footnote at its end is
+ * reachable at all. It hangs off `.sk-scroll` rather than off `.sk-list` because the
+ * uncapped state has nothing to mark. */
+.jd .sk-list { min-width: 0; padding: 8px 14px; }
+.jd .sk-list.sk-scroll {
+	overflow-y: auto;
+	scrollbar-width: thin; scrollbar-color: color-mix(in srgb, var(--muted) 42%, transparent) transparent;
+}
+.jd .sk-list.sk-scroll::-webkit-scrollbar { width: 10px; }
+.jd .sk-list.sk-scroll::-webkit-scrollbar-track { background: transparent; }
+.jd .sk-list.sk-scroll::-webkit-scrollbar-thumb {
+	background: color-mix(in srgb, var(--muted) 38%, transparent); border-radius: 999px;
+	border: 3px solid transparent; background-clip: padding-box;
+}
+.jd .sk-list.sk-scroll:hover::-webkit-scrollbar-thumb {
+	background: color-mix(in srgb, var(--muted) 55%, transparent); background-clip: padding-box;
+}
+/* The paging row's own band, between the rows and the coverage foot — `flex: none` is
+   what holds it OUT of the rows' region, which is exactly where it may not be: from the
+   first Show more onwards that region is capped, so a control living inside it would be
+   reachable only by scrolling the very list it grows (see `navPagingHtml`). The head and
+   the coverage foot are out for the same reason; the region keeps only the rows and their
+   footnote. `.more-row`'s `margin-top` is dropped because this rule's own border and
+   padding already separate it from the last row. */
+.jd .sk-paging { flex: none; padding: 9px 20px; border-top: 1px solid var(--grid); }
+.jd .sk-paging .more-row { margin-top: 0; }
+/* `.w-foot` / `.w-measure` are reused verbatim; this only pins the row into the flex
+   column and restores the side padding a card context would have supplied. */
+.jd .sk-nav .w-foot { flex: none; margin: 0; padding: 11px 20px 14px; }
+
+/* A COLUMNAR ROW, NOT A RANKED BAR. The list is a chooser and an index now that the
+   pane carries the charts, so a bar restating the runs column would be noise. One
+   grid template shared with the header below, so the columns cannot drift apart. */
+.jd .sk-cols,
+.jd .sk-row { display: grid; grid-template-columns: minmax(0, 1fr) 44px 76px; gap: 10px; align-items: baseline; }
+.jd .sk-cols {
+	padding: 4px 8px 6px; font-size: 10.5px; letter-spacing: .04em;
+	text-transform: uppercase; color: var(--muted);
+}
+.jd .sk-cols span:not(:first-child) { text-align: right; }
+.jd .sk-row {
+	width: 100%; text-align: left; background: none; border: 0; margin: 0;
+	padding: 7px 8px; border-radius: 8px; cursor: pointer; color: inherit; font: inherit;
+}
+.jd .sk-row:hover { background: var(--lock-bg); }
+/* SELECTION IS --accent AND MAY NOT BE AN --s* COLOUR. On this page the categorical
+   ramp means WHICH SKILL in the band and which agent in the pane, so a selected row
+   in `--s2` would read as one more series. `--accent` sits outside the ramp and is
+   already what the nav uses for `aria-current`. */
+.jd .sk-row[aria-current="true"] { background: var(--lock-bg); box-shadow: inset 2px 0 0 var(--accent); }
+.jd .sk-row:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.jd .sk-row .num { text-align: right; font-variant-numeric: tabular-nums; }
+/* `min-width: 0` is what lets the name truncate: a grid item's automatic minimum is
+   its content, so without it a long id widens the column and pushes the numbers off. */
+.jd .sk-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; }
+.jd .sk-tok { font-size: 11.5px; color: var(--ink-2); }
+
+/* The reading pane, mirroring `.mem-detail` MINUS its scroll: recessed on `--page`
+   against the chooser's `--surface` so the two columns read as chooser and reader,
+   and as tall as the sections it holds so the page is what scrolls them. */
+.jd .sk-pane {
+	min-width: 0;
+	border: 1px solid var(--border); border-radius: 10px; padding: 20px 24px 28px; background: var(--page);
+}
+/* Sections flow into as many columns as the pane's width affords. `auto-fit` against
+   a 300px floor rather than a fixed count, so one markup serves every width; the
+   identity row, the figures and the basis line span all columns because they are
+   about the whole skill rather than one reading of it. */
+.jd .sk-panebody { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 0 32px; align-items: start; }
+.jd .sk-panebody > .sk-title,
+.jd .sk-panebody > .sk-figs,
+.jd .sk-panebody > .sk-caveat,
+.jd .sk-panebody > .sk-basis { grid-column: 1 / -1; }
+.jd .sk-panebody > .sk-figs { max-width: 560px; }
+.jd .sk-pane-empty { color: var(--ink-2); font-size: 12.5px; }
+.jd .sk-title { font-size: 14px; font-weight: 600; color: var(--ink); word-break: break-all; }
+.jd .sk-kind { display: inline-block; margin-left: 6px; font-size: 11px; color: var(--ink-2); font-weight: 400; }
+
+/* Two across, because four figures on one row at this width wrapped their labels. */
+.jd .sk-figs { display: grid; grid-template-columns: 1fr 1fr; gap: 10px 12px; margin-top: 12px; }
+.jd .sk-fig b { display: block; font-size: 17px; font-weight: 600; color: var(--ink); line-height: 1.2; }
+.jd .sk-fig span { display: block; font-size: 11px; color: var(--ink-2); margin-top: 2px; }
+
+.jd .sk-sec { margin-top: 14px; padding-top: 12px; border-top: 1px solid var(--border); }
+.jd .sk-sec h4 {
+	margin: 0 0 8px; font-size: 11px; font-weight: 600; letter-spacing: .04em;
+	text-transform: uppercase; color: var(--ink-2);
+}
+.jd .sk-line { display: flex; align-items: center; gap: 8px; font-size: 12px; margin-top: 6px; }
+.jd .sk-line i { width: 9px; height: 9px; border-radius: 3px; flex: none; }
+.jd .sk-line b { font-weight: 600; color: var(--ink); }
+.jd .sk-line span { margin-left: auto; color: var(--ink-2); font-variant-numeric: tabular-nums; }
+
+/* The fact grid: two columns of the same label/value line the sections use, so short
+   facts pack instead of stacking one per row. */
+.jd .sk-facts { display: grid; grid-template-columns: 1fr 1fr; gap: 0 18px; }
+.jd .sk-facts .sk-line { min-width: 0; }
+.jd .sk-facts .sk-line span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* The pane's two bar charts. Bars rather than `JD.spark`: a polyline interpolates
+   BETWEEN points and every series here is discrete, so bars claim exactly what the
+   record holds. A zero day renders as a stub on `--heat-track`, so absence reads as
+   measured absence rather than a gap.
+
+   AN SVG WITH A FIXED HEIGHT, and the `preserveAspectRatio="none"` in `JD.dayBars`
+   is what that height is for: these charts now span the whole window, so their bar
+   count is the window's day count. The flex row of `<i>` divs this replaced could
+   not hold that — its `min-width: 3px` and 3px gap needed 537px for a 90-day range
+   and 2193px for a 366-day one, so the bars overflowed the pane and the right-hand
+   days were off screen while the axis label still claimed them. Width is free to
+   stretch; only the height is pinned, so no text is inside the SVG to be stretched
+   with it (the endpoint labels are the `.sk-axis` row below).
+
+   BOTH charts read in `--accent` and neither may take an `--s*` colour: the ramp
+   means agent two sections below, so a cadence chart in codex's orange would read as
+   "codex's sessions". Same reasoning as the selected row's edge. */
+.jd .sk-daybars { display: block; width: 100%; height: 46px; margin-top: 2px; opacity: .85; }
+.jd .sk-axis { display: flex; justify-content: space-between; margin-top: 4px; font-size: 10.5px; color: var(--muted); }
+
+/* Outcome ticks — one per recorded run, oldest left. TWO states, matching the mockup:
+   failure is the one that takes a colour of its own, so a bad run is findable without
+   counting, and every other tick stays quiet green. A run whose result the agent never
+   wrote down draws as that same quiet green and is named in words underneath instead —
+   a grey third state was tried and read as "empty" rather than "unmeasured", which is
+   the wrong signal on a skill whose entry mechanism never writes a result at all. */
+.jd .sk-ticks { display: flex; flex-wrap: wrap; gap: 3px; margin: 4px 0 8px; }
+.jd .sk-ticks i { width: 13px; height: 13px; border-radius: 3px; background: var(--good); opacity: .55; }
+.jd .sk-ticks i.bad { background: var(--crit); opacity: 1; }
+
+/* Explanatory prose inside a section — NOT the invocation row, which truncates on
+   purpose. An argument string is not worth three lines of a reading pane, but a
+   sentence explaining what a figure means is exactly the thing that must not lose
+   its ending. */
+.jd .sk-note { margin-top: 6px; font-size: 11px; line-height: 1.5; color: var(--ink-2); }
+/* Small print naming where the figures came from, in the voice the cards use. */
+.jd .sk-basis {
+	display: block; margin-top: 14px; padding-top: 12px; border-top: 1px solid var(--border);
+	font-size: 11px; line-height: 1.5; color: var(--ink-2);
+}
+/* A chip rather than more grey text: the plugin is the one identity fact on the row
+   that is not a measurement. */
+.jd .sk-plugin {
+	display: inline-block; padding: 1px 6px; border-radius: 999px;
+	border: 1px solid var(--border); font-size: 10.5px; color: var(--ink-2);
+}
+/* The inferred dagger — deliberately NOT a chip like `.sk-plugin` beside it, and NOT a
+   colour. A chip reads as another identity fact and a warning colour reads as a fault,
+   where this is neither: the entry is real and its provenance is weaker than observed.
+   `help` is the cursor for exactly that, and it is what makes the `title` discoverable
+   in the column, where there is no room for the sentence the pane prints in full. */
+.jd .sk-inferred { color: var(--muted); font-weight: 400; cursor: help; }
+/* The pane's qualifier on the four figures directly above it. Same size and colour as
+   `.sk-note` — it is prose about a measurement, not an alert — but its own class,
+   because it must span every column of `.sk-panebody` and `.sk-note` sits inside one. */
+.jd .sk-caveat {
+	margin-top: 10px; max-width: 560px;
+	font-size: 11px; line-height: 1.5; color: var(--ink-2);
+}
+
+/* No wrap-padding overrides at either breakpoint: the wrap keeps its own 24px and
+   its cap is already inert below 1200px, so there is nothing left to reclaim. */
+@media (max-width: 1180px) {
+	.jd .skills-page { grid-template-columns: 320px minmax(0, 1fr); }
+}
+@media (max-width: 899px) {
+	/* The columns stack — and the rows' cap comes off with them. A scroll region nested
+	   in a scrolling page is awkward under a mouse and worse under a thumb, and at this
+	   width there is no second column beside it for a short list to be keeping room for.
+	   `!important` is not a preference here: the cap is an inline style (a measured pixel
+	   value, which no stylesheet constant can stand in for), and nothing else outranks
+	   one. The rest of what this block used to release now describes the desktop layout
+	   too, so it is gone from both. */
+	.jd .skills-page { grid-template-columns: minmax(0, 1fr); }
+	.jd .sk-list.sk-scroll { max-height: none !important; overflow: visible; }
+}

--- a/cli/src/hooks/PluginDashboardAssets.test.ts
+++ b/cli/src/hooks/PluginDashboardAssets.test.ts
@@ -42,7 +42,7 @@ function requiredDist(plugin: string): string[] {
 	return block.split(/\s+/u).filter((entry) => entry.length > 0 && !entry.startsWith("#"));
 }
 
-const PLUGINS = ["claude-plugin", "codex-plugin"] as const;
+const PLUGINS = ["claude-plugin", "codex-plugin", "cursor-plugin"] as const;
 
 describe.each(PLUGINS)("%s publish inventory tracks the dashboard page", (plugin) => {
 	it("lists exactly DASHBOARD_SCRIPT_FILES, in the same order", () => {
@@ -79,7 +79,8 @@ describe.each(PLUGINS)("%s publish inventory tracks the dashboard page", (plugin
 // bootstrap + McpLauncher). Asserted directly so a fix applied to one lib and not
 // the other is a failure here rather than a plugin that publishes fine while its
 // sibling refuses.
-it("both plugin libs require the same dashboard assets", () => {
+it("all plugin libs require the same dashboard assets", () => {
 	const dashboardOnly = (plugin: string) => requiredDist(plugin).filter((e) => e.startsWith("dashboard-assets/"));
 	expect(dashboardOnly("codex-plugin")).toEqual(dashboardOnly("claude-plugin"));
+	expect(dashboardOnly("cursor-plugin")).toEqual(dashboardOnly("claude-plugin"));
 });

--- a/cli/src/hooks/QueueWorker.test.ts
+++ b/cli/src/hooks/QueueWorker.test.ts
@@ -3188,6 +3188,167 @@ describe("QueueWorker", () => {
 		});
 	});
 
+	describe("mergeToolCallSlice", () => {
+		const invocation = (at: string, ok = true) => ({
+			at,
+			ok,
+			entryPath: "tool" as const,
+			outcomeObserved: true,
+		});
+
+		it("adds every enrichment from disjoint slices and keeps conservative confidence", () => {
+			const claims = new Set<string>();
+			const first = __test__.mergeToolCallSlice(
+				undefined,
+				{
+					name: "review",
+					kind: "skill",
+					calls: 1,
+					lastCallAtMs: 1_000,
+					usage: { input: 1, output: 2, cached: 3, confidence: "attributed" },
+					invocations: [invocation("2026-08-01T10:00:00.000Z")],
+					plugin: "team-a",
+				},
+				claims,
+			);
+			const merged = __test__.mergeToolCallSlice(
+				first,
+				{
+					name: "review",
+					kind: "skill",
+					calls: 2,
+					lastCallAtMs: 2_000,
+					usage: { input: 10, output: 20, cached: 30, confidence: "estimated" },
+					invocations: [invocation("2026-08-01T11:00:00.000Z", false)],
+					detection: "heuristic",
+					plugin: "team-a",
+				},
+				claims,
+			);
+
+			expect(merged).toEqual({
+				name: "review",
+				kind: "skill",
+				calls: 3,
+				lastCallAtMs: 2_000,
+				usage: { input: 11, output: 22, cached: 33, confidence: "estimated" },
+				invocations: [invocation("2026-08-01T11:00:00.000Z", false), invocation("2026-08-01T10:00:00.000Z")],
+				detection: "heuristic",
+				plugin: "team-a",
+			});
+		});
+
+		it("keeps enrichment when a later slice only carries a count", () => {
+			const claims = new Set<string>();
+			const first = __test__.mergeToolCallSlice(
+				undefined,
+				{
+					name: "review",
+					kind: "skill",
+					calls: 1,
+					lastCallAtMs: 1_000,
+					usage: { input: 1, output: 2, cached: 3, confidence: "attributed" },
+					invocations: [invocation("2026-08-01T10:00:00.000Z")],
+					detection: "heuristic",
+					plugin: "team-a",
+				},
+				claims,
+			);
+			const merged = __test__.mergeToolCallSlice(first, { name: "review", kind: "skill", calls: 2 }, claims);
+
+			expect(merged).toMatchObject({
+				calls: 3,
+				lastCallAtMs: 1_000,
+				usage: { input: 1, output: 2, cached: 3, confidence: "attributed" },
+				invocations: [invocation("2026-08-01T10:00:00.000Z")],
+				detection: "heuristic",
+				plugin: "team-a",
+			});
+		});
+
+		it("keeps a plugin conflict omitted when a later slice repeats the first claimant", () => {
+			const claims = new Set<string>();
+			let merged = __test__.mergeToolCallSlice(
+				undefined,
+				{ name: "review", kind: "skill", calls: 1, plugin: "team-a" },
+				claims,
+			);
+			merged = __test__.mergeToolCallSlice(
+				merged,
+				{ name: "review", kind: "skill", calls: 1, plugin: "team-b" },
+				claims,
+			);
+			expect(merged).not.toHaveProperty("plugin");
+
+			merged = __test__.mergeToolCallSlice(
+				merged,
+				{ name: "review", kind: "skill", calls: 1, plugin: "team-a" },
+				claims,
+			);
+			expect(merged.calls).toBe(3);
+			expect(merged).not.toHaveProperty("plugin");
+		});
+	});
+
+	describe("readAllTranscripts — repeated conversation slices", () => {
+		it("persists all skill details from every slice in the shared bucket", async () => {
+			const firstAt = "2026-08-01T10:00:00.000Z";
+			const secondAt = "2026-08-01T11:00:00.000Z";
+			vi.mocked(readTranscript).mockImplementation(async (transcriptPath: string) => {
+				const second = transcriptPath.endsWith("slice-b.jsonl");
+				return {
+					entries: [{ role: "human" as const, content: second ? "second" : "first", timestamp: secondAt }],
+					newCursor: { transcriptPath, lineNumber: 1, updatedAt: secondAt },
+					totalLinesRead: 1,
+					toolUse: [
+						{
+							name: "review",
+							kind: "skill" as const,
+							calls: second ? 2 : 1,
+							lastCallAtMs: second ? 2_000 : 1_000,
+							usage: second
+								? { input: 10, output: 20, cached: 30, confidence: "attributed" as const }
+								: { input: 1, output: 2, cached: 3, confidence: "attributed" as const },
+							invocations: [
+								{
+									at: second ? secondAt : firstAt,
+									ok: !second,
+									outcomeObserved: true,
+									entryPath: "tool" as const,
+								},
+							],
+							...(second ? { detection: "heuristic" as const, plugin: "team-a" } : {}),
+						},
+					],
+				};
+			});
+
+			const result = await __test__.readAllTranscripts(
+				[
+					{ sessionId: "same", transcriptPath: "/tmp/slice-a.jsonl", source: "claude" },
+					{ sessionId: "same", transcriptPath: "/tmp/slice-b.jsonl", source: "claude" },
+				],
+				"/repo",
+			);
+			const tool = result.perSessionTokens.get("claude:same")?.byTool?.get("skill:review");
+
+			expect(tool).toEqual({
+				name: "review",
+				kind: "skill",
+				calls: 3,
+				lastCallAtMs: 2_000,
+				usage: { input: 11, output: 22, cached: 33, confidence: "attributed" },
+				invocations: [
+					{ at: secondAt, ok: false, outcomeObserved: true, entryPath: "tool" },
+					{ at: firstAt, ok: true, outcomeObserved: true, entryPath: "tool" },
+				],
+				detection: "heuristic",
+				plugin: "team-a",
+			});
+			expect(result.sessionTranscripts).toHaveLength(2);
+		});
+	});
+
 	describe("attachPerSessionUsage", () => {
 		const bucket = (input: number, output: number, cached: number) => ({
 			tokens: input + output + cached,

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -4202,6 +4202,98 @@ export interface SessionTokenBucket {
 }
 
 /**
+ * Adds one DISJOINT transcript slice's view of a tool to its conversation total.
+ *
+ * This is deliberately not {@link mergeToolCalls}. That helper combines two
+ * extractors looking at the SAME records and therefore takes the larger count;
+ * the queue worker combines cursor-separated slices, so their calls, usage and
+ * invocation rows are separate contributions and must be added/concatenated.
+ *
+ * `pluginClaims` outlives the returned bucket. An omitted `plugin` has two
+ * meanings (no named claimant, or conflicting claimants), so the bucket alone
+ * cannot remember a conflict: after A + B omitted the field, a later A would
+ * otherwise look uncontested and restore a label already proven ambiguous.
+ */
+function mergeToolCallSlice(
+	prev: ToolCallCount | undefined,
+	incoming: ToolCallCount,
+	pluginClaims: Set<string>,
+): ToolCallCount {
+	if (prev?.plugin !== undefined) pluginClaims.add(prev.plugin);
+	if (incoming.plugin !== undefined) pluginClaims.add(incoming.plugin);
+	const plugin = pluginClaims.size === 1 ? pluginClaims.values().next().value : undefined;
+
+	if (prev === undefined) {
+		const { plugin: _incomingPlugin, ...rest } = incoming;
+		return { ...rest, ...(plugin !== undefined ? { plugin } : {}) };
+	}
+
+	const usage =
+		prev.usage === undefined || incoming.usage === undefined
+			? (prev.usage ?? incoming.usage)
+			: {
+					input: prev.usage.input + incoming.usage.input,
+					output: prev.usage.output + incoming.usage.output,
+					cached: prev.usage.cached + incoming.usage.cached,
+					confidence:
+						prev.usage.confidence === "attributed" && incoming.usage.confidence === "attributed"
+							? ("attributed" as const)
+							: ("estimated" as const),
+				};
+	const invocations =
+		prev.invocations === undefined || incoming.invocations === undefined
+			? (prev.invocations ?? incoming.invocations)
+			: [...prev.invocations, ...incoming.invocations].sort((a, b) => {
+					if (a.at === b.at) return 0;
+					return a.at < b.at ? 1 : -1;
+				});
+	const lastCallAtMs =
+		prev.lastCallAtMs === undefined
+			? incoming.lastCallAtMs
+			: incoming.lastCallAtMs === undefined
+				? prev.lastCallAtMs
+				: Math.max(prev.lastCallAtMs, incoming.lastCallAtMs);
+	const server = prev.server ?? incoming.server;
+	const detection = prev.detection ?? incoming.detection;
+
+	// Managed fields are stripped from both spreads before being re-added below.
+	// Besides preventing an absent merged value from leaking out of `prev`, this
+	// lets a future, unrelated ToolCallCount field follow the newest slice without
+	// silently repeating the exact missed-caller bug this helper closes.
+	const {
+		server: _prevServer,
+		plugin: _prevPlugin,
+		calls: _prevCalls,
+		lastCallAtMs: _prevLastCallAtMs,
+		usage: _prevUsage,
+		invocations: _prevInvocations,
+		detection: _prevDetection,
+		...prevRest
+	} = prev;
+	const {
+		server: _incomingServer,
+		plugin: _incomingPlugin,
+		calls: _incomingCalls,
+		lastCallAtMs: _incomingLastCallAtMs,
+		usage: _incomingUsage,
+		invocations: _incomingInvocations,
+		detection: _incomingDetection,
+		...incomingRest
+	} = incoming;
+	return {
+		...prevRest,
+		...incomingRest,
+		...(server !== undefined ? { server } : {}),
+		calls: prev.calls + incoming.calls,
+		...(lastCallAtMs !== undefined ? { lastCallAtMs } : {}),
+		...(usage !== undefined ? { usage } : {}),
+		...(invocations !== undefined ? { invocations } : {}),
+		...(detection !== undefined ? { detection } : {}),
+		...(plugin !== undefined ? { plugin } : {}),
+	};
+}
+
+/**
  * Attaches each surviving conversation's own token attribution to its
  * `SessionTranscript` so `buildStoredTranscript` can persist it alongside the
  * entries. Without this the per-session split dies with the local
@@ -4373,6 +4465,10 @@ async function readAllTranscripts(
 	// populated even when a slice yields zero merged entries (a usage-only slice),
 	// so the subtraction stays exact.
 	const perSessionTokens = new Map<string, SessionTokenBucket>();
+	// A bare `ToolCallCount.plugin` cannot distinguish "no claimant" from "two
+	// claimants conflicted". Keep every named claim beside the conversation while
+	// its slices are folded, so a conflict remains sticky for the whole pass.
+	const pluginClaimsByConversation = new Map<string, Map<string, Set<string>>>();
 	// Session identity per conversationKey, so a conversation that produced tokens
 	// but no merged entries can still be given a persistence carrier after the loop
 	// (see the usage-only reconciliation below). `perSessionTokens` is keyed by
@@ -4621,11 +4717,15 @@ async function readAllTranscripts(
 		// would look like a source that cannot report tools at all.
 		if (result.toolUse) {
 			const byTool = bucket.byTool ?? new Map<string, ToolCallCount>();
+			const pluginClaims = pluginClaimsByConversation.get(convKey) ?? new Map<string, Set<string>>();
 			for (const t of result.toolUse) {
 				const key = `${t.kind}:${t.name}`;
 				const prev = byTool.get(key);
-				byTool.set(key, prev ? { ...prev, calls: prev.calls + t.calls } : { ...t });
+				const claims = pluginClaims.get(key) ?? new Set<string>();
+				byTool.set(key, mergeToolCallSlice(prev, t, claims));
+				pluginClaims.set(key, claims);
 			}
+			pluginClaimsByConversation.set(convKey, pluginClaims);
 			bucket.byTool = byTool;
 		}
 		perSessionTokens.set(convKey, bucket);
@@ -4797,7 +4897,9 @@ export const __test__ = {
 	handleSquashFromQueue,
 	handleRebaseSquashFromQueue,
 	loadSessionTranscripts,
+	readAllTranscripts,
 	commitConsumedTranscripts,
+	mergeToolCallSlice,
 	attachPerSessionUsage,
 	appendUsageOnlyCarriers,
 	buildStoredTranscript,

--- a/cli/vite.config.ts
+++ b/cli/vite.config.ts
@@ -167,6 +167,7 @@ const SLOW_TEST_FILES = [
 	"src/core/repair/GitReachability.realgit.test.ts",
 	"src/core/repair/ReflogPairing.realgit.test.ts",
 	"src/core/RepoProfile.test.ts",
+	"src/core/SessionDirMatch.realgit.test.ts",
 	"src/core/SpaceBindingCache.test.ts",
 	"src/daemon/DaemonServer.test.ts",
 	// The dashboard/cutover six. Added later than the rest and easy to miss why

--- a/codex-plugin/scripts/_publish-lib.sh
+++ b/codex-plugin/scripts/_publish-lib.sh
@@ -42,6 +42,7 @@ PUBLISH_REQUIRED_DIST=(
 	dashboard-assets/js/charts.js
 	dashboard-assets/js/shell.js
 	dashboard-assets/js/stats.js
+	dashboard-assets/js/skills.js
 	dashboard-assets/js/standup.js
 	dashboard-assets/js/memories.js
 	dashboard-assets/js/knowledge.js

--- a/cursor-plugin/scripts/_publish-lib.sh
+++ b/cursor-plugin/scripts/_publish-lib.sh
@@ -37,9 +37,12 @@ PUBLISH_REQUIRED_DIST=(
 	dashboard-assets/js/charts.js
 	dashboard-assets/js/shell.js
 	dashboard-assets/js/stats.js
+	dashboard-assets/js/skills.js
 	dashboard-assets/js/standup.js
-	dashboard-assets/js/repositories.js
 	dashboard-assets/js/memories.js
+	dashboard-assets/js/knowledge.js
+	dashboard-assets/js/graph.js
+	dashboard-assets/js/settings.js
 	dashboard-assets/js/main.js
 )
 


### PR DESCRIPTION
## Summary

- persist per-invocation skill details and attributed usage across Claude, Codex, Kimi, and OpenCode transcripts
- add the Skills dashboard page, skill detail API, local-time cadence charts, navigation, and packaged plugin assets
- preserve existing tool enrichment during session reprojection and keep skill invocation data outside sync uploads
- add regression coverage for backfill idempotency, sparse transcripts, database read failures, plugin manifests, and dashboard interactions

## Testing

- `npm run all`
  - CLI: 14,656 tests passed, 1 todo; 96.00% branch coverage
  - acceptance: 9 tests passed
  - VS Code: 4,661 tests passed, 8 skipped