### PR TITLE
Add the agent telemetry dimension: which AI host the work happened in

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -88,7 +88,7 @@ disk **before** they are sent.
 | `ai_provider_selected` | User chose jolli vs anthropic for LLM. Props: provider (discriminator). |
 | `memory_bank_migrated` | Migrate-to-Memory-Bank run. Props: outcome, repos, entries_bucket. |
 | `onboarding_progressed` | Per-install onboarding-funnel snapshot, emitted from a repo context and deduped by state tuple (+ daily heartbeat). Content-free — answers 'after install, where do people stall'. Props: in_git_repo, repo_enabled, capture_configured, capture_method (discriminator: local-agent/anthropic/jolli/none), memories_generated, memories_bucket. |
-| `command_invoked` | Any CLI command ran (auto-emitted). Props: command (discriminator), ok, duration_ms; via (discriminator: skill:<name> from a closed skill-name set — present only when a Jolli skill's recipe invoked the command, omitted for a directly-typed one). MCP tool calls carry a `tool` property and are emitted per call (not per session); the session-level `command:"mcp"` event is suppressed. |
+| `command_invoked` | Any CLI command ran (auto-emitted). Props: command (discriminator), ok, duration_ms; via (discriminator: skill:<name> from a closed skill-name set — present when a Jolli skill's recipe invoked the command; absent means directly typed OR a pre-upgrade skill copy that predates the stamp, so absence is not proof of direct use). MCP tool calls carry a `tool` property and are emitted per call (not per session); the session-level `command:"mcp"` event is suppressed. |
 | `recall_performed` | A recall was run. Props: hit, result_count_bucket. |
 | `search_performed` | A search was run. Props: query_len_bucket, result_count_bucket. |
 | `memory_pushed` | Memories pushed to a Space. Props: kind, created, plans_bucket. |

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -88,7 +88,7 @@ disk **before** they are sent.
 | `ai_provider_selected` | User chose jolli vs anthropic for LLM. Props: provider (discriminator). |
 | `memory_bank_migrated` | Migrate-to-Memory-Bank run. Props: outcome, repos, entries_bucket. |
 | `onboarding_progressed` | Per-install onboarding-funnel snapshot, emitted from a repo context and deduped by state tuple (+ daily heartbeat). Content-free — answers 'after install, where do people stall'. Props: in_git_repo, repo_enabled, capture_configured, capture_method (discriminator: local-agent/anthropic/jolli/none), memories_generated, memories_bucket. |
-| `command_invoked` | Any CLI command ran (auto-emitted). Props: command (discriminator), ok, duration_ms. MCP tool calls carry a `tool` property and are emitted per call (not per session); the session-level `command:"mcp"` event is suppressed. |
+| `command_invoked` | Any CLI command ran (auto-emitted). Props: command (discriminator), ok, duration_ms; via (discriminator: skill:<name> from a closed skill-name set — present only when a Jolli skill's recipe invoked the command, omitted for a directly-typed one). MCP tool calls carry a `tool` property and are emitted per call (not per session); the session-level `command:"mcp"` event is suppressed. |
 | `recall_performed` | A recall was run. Props: hit, result_count_bucket. |
 | `search_performed` | A search was run. Props: query_len_bucket, result_count_bucket. |
 | `memory_pushed` | Memories pushed to a Space. Props: kind, created, plans_bucket. |

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -97,7 +97,7 @@ disk **before** they are sent.
 | `settings_opened` | Settings UI opened (vscode/intellij). Props: tab (discriminator). |
 | `ingest_completed` | A drainIngest run finished. Props: outcome, ingested, idle (no-op when ingested=0), batches, route_calls, reconcile_calls, touched_slugs, topic_failures, duration_ms. Filter idle=true out for real-ingest latency/health metrics. |
 | `error_occurred` | A structured error was raised. Content-free schema: { where (stage/subsystem), code (enumerated), source? , retryable? }. Emitted via trackError(); never carries a message/stack/path. |
-| `queue_drained` | QueueWorker finished a drain. Props: ops, duration_ms. |
+| `queue_drained` | QueueWorker finished a drain. Props: ops, duration_ms; trigger (discriminator: agent/ui/terminal/unknown — who set the drained commits in motion) and agent (which AI host, when trigger=agent) are present only when every drained entry agrees, and omitted for mixed or unstamped drains. |
 | `sync_completed` | A memory-bank sync round finished. Props: outcome (discriminator), duration_ms. |
 | `toolwindow_opened` | The memory tool window was opened. Props: view. |
 | `view_switched` | Tool window view switched (current/bank/knowledge). Props: view (discriminator). |

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,5 +1,6 @@
 <!-- GENERATED FILE — do not edit by hand.
-     Regenerate with `npm run gen:telemetry-doc` (source: cli/src/core/TelemetryEvents.ts). -->
+     Regenerate with `npm run gen:telemetry-doc` (sources: cli/src/core/TelemetryEvents.ts,
+     cli/src/core/TelemetryAgent.ts, cli/src/core/Telemetry.ts). -->
 
 # Jolli Memory telemetry
 
@@ -10,12 +11,35 @@ collected — generated from the event registry the code actually uses.
 
 ## What we collect
 
-- A random per-machine identifier (`installId`) and the surface (`cli`,
-  `vscode`, `intellij`, `claude-plugin`, or `codex-plugin`) + version.
+- A random per-machine identifier (`installId`) and the surface — which Jolli
+  build sent the event — plus its version. The surfaces are:
+  `cli`, `vscode`, `intellij`, `claude-plugin`, `codex-plugin`,
+  `cursor-plugin`, `web-local`, `web`.
+- The `agent` property: which AI coding tool the work happened in, when that
+  is known. It is a fixed, low-cardinality list of tool names, never free-form:
+  `claude`, `codex`, `gemini`, `opencode`, `cursor`, `cursor-cli`,
+  `copilot`, `copilot-chat`, `cline`, `cline-cli`, `devin`, `antigravity`,
+  `kimi`. See below for when it is omitted.
 - Coarse environment facts: OS, architecture, runtime version, and which Jolli
   environment your client is pointed at (`local` / `dev` / `preview` / `prod`).
 - The events listed below, each with a small bag of **bucketed or boolean**
   properties (e.g. a result count as `"1-5"`, not the actual number).
+
+### About the `agent` property
+
+`agent` records the AI host — Claude Code, Codex, Cursor, Gemini, and so on —
+because the surface above only identifies which of our own builds ran, which is
+often not the tool you were using. It is a tool name and nothing else: not
+identity, not content, not a path, and not anything you typed.
+
+It is **omitted whenever the host is not actually known**, rather than defaulted
+to a guess. An absent `agent` means "not measured", never "the CLI". A host we
+do not recognise is omitted too — the value can only ever be one of the tokens
+listed above.
+
+Events recorded by earlier client versions carry no `agent` at all, and nothing
+reconstructs it retroactively. The first version to emit it is
+`0.99.14`.
 
 ## What we never collect
 
@@ -98,5 +122,7 @@ disk **before** they are sent.
 | `chart_split_changed` | A dashboard card's split-by control was changed. Props: card (discriminator: tokens/mcp), split (discriminator). |
 
 ---
-*Generated from `cli/src/core/TelemetryEvents.ts`. The IntelliJ plugin is an
-independent implementation that sends the same event names and envelope.*
+*Generated from `cli/src/core/TelemetryEvents.ts` (events),
+`cli/src/core/TelemetryAgent.ts` (agents) and `cli/src/core/Telemetry.ts`
+(surfaces). The IntelliJ plugin is an independent implementation that sends the
+same event names and envelope.*

--- a/claude-plugin/plugins/jolli/skills/dashboard/SKILL.md
+++ b/claude-plugin/plugins/jolli/skills/dashboard/SKILL.md
@@ -56,7 +56,7 @@ server prints once it is listening:
 ```bash
 LOG=$(mktemp "${TMPDIR:-/tmp}/jolli-dashboard.XXXXXX")
 echo "LOG $LOG"
-nohup "$HOME/.jolli/jollimemory/run-cli" dashboard >"$LOG" 2>&1 &
+JOLLI_INVOKED_VIA=skill:dashboard nohup "$HOME/.jolli/jollimemory/run-cli" dashboard >"$LOG" 2>&1 &
 echo "PID $!"
 for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
 	URL=$(grep -o 'http://127\.0\.0\.1:[0-9]*/dashboard' "$LOG" | head -1)

--- a/claude-plugin/plugins/jolli/skills/recall/SKILL.md
+++ b/claude-plugin/plugins/jolli/skills/recall/SKILL.md
@@ -35,7 +35,7 @@ prompt-injection payload (a line that closes the here-doc early to smuggle
 shell) useless — do NOT hardcode a fixed delimiter.
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" recall --arg-stdin --format json <<'JOLLI_ARG_<DELIM>_END'
+JOLLI_INVOKED_VIA=skill:recall "$HOME/.jolli/jollimemory/run-cli" recall --arg-stdin --format json <<'JOLLI_ARG_<DELIM>_END'
 <user-arg>
 JOLLI_ARG_<DELIM>_END
 ```

--- a/claude-plugin/plugins/jolli/skills/search/SKILL.md
+++ b/claude-plugin/plugins/jolli/skills/search/SKILL.md
@@ -30,7 +30,7 @@ payload (a line that closes the here-doc early to smuggle shell) useless — do
 NOT hardcode a fixed delimiter.
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" search --arg-stdin <<'JOLLI_ARG_<DELIM>_END'
+JOLLI_INVOKED_VIA=skill:search "$HOME/.jolli/jollimemory/run-cli" search --arg-stdin <<'JOLLI_ARG_<DELIM>_END'
 <user-arg>
 JOLLI_ARG_<DELIM>_END
 ```

--- a/cli/src/Cli.test.ts
+++ b/cli/src/Cli.test.ts
@@ -60,6 +60,30 @@ describe("isDetachedDaemonInvocation", () => {
 		expect(isDetachedDaemonInvocation(["mcp-serve-status"])).toBe(false);
 		expect(isDetachedDaemonInvocation(["global-daemon-status"])).toBe(false);
 	});
+
+	/**
+	 * This predicate has a SECOND consumer in `main()`: it also decides whether the
+	 * process may infer its telemetry `agent` from the env markers. Recorded here
+	 * because the two uses justify the same answer for different reasons, and a
+	 * future edit that widens it for the stderr policy alone would silently change
+	 * attribution too.
+	 *
+	 * A daemon must not infer. `mcp-serve` is keyed by WORKTREE and shared — a
+	 * version tie attaches rather than evicting — so several hosts' sessions reach
+	 * one daemon, and it is the process that runs the tools and emits their
+	 * `command_invoked`. Its env is frozen at spawn from whichever proxy was first.
+	 * Measured on one machine: an `mcp-serve` at ppid 1 carrying CLAUDECODE beside
+	 * two carrying nothing. Inferring there reports `agent: "claude"` for a Cursor
+	 * or Codex session — a wrong value, not a missing one.
+	 */
+	it("covers every process that emits telemetry for sessions it does not own", () => {
+		for (const argv of [["mcp-serve"], ["global-daemon"], ["global-daemon-ensure"]]) {
+			expect(isDetachedDaemonInvocation(argv)).toBe(true);
+		}
+		// The per-session proxy is the counter-case: the host spawned it for one
+		// session, nothing else attaches to it, so its env does name its host.
+		expect(isDetachedDaemonInvocation(["mcp"])).toBe(false);
+	});
 });
 
 describe("serveMcpInProcess (the fast path's fallback)", () => {

--- a/cli/src/Cli.test.ts
+++ b/cli/src/Cli.test.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
-import { isBareMcpInvocation, isDetachedDaemonInvocation } from "./Cli.js";
+import { isAgentInferenceExempt, isBareMcpInvocation, isDetachedDaemonInvocation } from "./Cli.js";
 import { MCP_DAEMON_COMMAND, MCP_NO_DAEMON_ENV } from "./commands/McpCommand.js";
 import { GLOBAL_DAEMON_ENSURE_COMMAND } from "./daemon/EnsureGlobalDaemon.js";
 import { GLOBAL_DAEMON_COMMAND } from "./daemon/GlobalDaemonProtocol.js";
@@ -83,6 +83,30 @@ describe("isDetachedDaemonInvocation", () => {
 		// The per-session proxy is the counter-case: the host spawned it for one
 		// session, nothing else attaches to it, so its env does name its host.
 		expect(isDetachedDaemonInvocation(["mcp"])).toBe(false);
+	});
+});
+
+describe("isAgentInferenceExempt", () => {
+	it("exempts every detached daemon AND the ide-bridge server", () => {
+		// The bridge is the member the daemon predicate cannot cover: it is not
+		// detached (IntelliJ reads its stderr, so it must keep the telemetry
+		// notice behavior of an ordinary command), but its env belongs to whatever
+		// launched the IDE — an IntelliJ cold-started from a Claude shell would
+		// otherwise stamp agent:"claude" on the bridge's own lifecycle events.
+		for (const argv of [["mcp-serve"], ["global-daemon"], ["global-daemon-ensure"], ["ide-bridge-serve"]]) {
+			expect(isAgentInferenceExempt(argv)).toBe(true);
+		}
+	});
+
+	it("leaves ordinary short-lived commands inferring", () => {
+		for (const argv of [["recall"], ["status"], ["mcp"], ["enable"], []]) {
+			expect(isAgentInferenceExempt(argv)).toBe(false);
+		}
+	});
+
+	it("does not match a command that merely starts with the bridge's name", () => {
+		expect(isAgentInferenceExempt(["ide-bridge-serve-status"])).toBe(false);
+		expect(isAgentInferenceExempt(["ide-bridge"])).toBe(false);
 	});
 });
 

--- a/cli/src/Cli.ts
+++ b/cli/src/Cli.ts
@@ -144,8 +144,10 @@ export async function serveMcpInProcess(dir: string): Promise<void> {
 		// Two other measurements from the same sweep, both narrowing what env can
 		// answer: an `mcp` proxy spawned by `cursor-agent` carried no `CURSOR_*` at
 		// all, and one spawned by Codex carried no `CODEX_THREAD_ID`. So of the
-		// hosts checked, only Claude passes its marker down to an MCP child — the
-		// MCP path is largely unattributed even where the CLI path is not.
+		// hosts checked, only Claude passes its marker down to an MCP child — which
+		// is why tool calls are attributed from the initialize handshake's
+		// clientInfo instead (CLIENTINFO_AGENTS); this env inference survives as
+		// the fallback for a mapped-marker host whose clientInfo is not mapped yet.
 		//
 		// The same sweep also caught the misattribution this dimension exists for,
 		// twice over: Claude Code serving from the CODEX plugin's dist, and Codex
@@ -291,8 +293,9 @@ if (!process.env.VITEST) {
 				//
 				// The right signal for a shared daemon is the MCP `initialize`
 				// handshake's `clientInfo`, which names the host per connection rather
-				// than per process. Not attempted here: mapping those strings onto the
-				// vocabulary needs its own capture, and absent is the honest interim.
+				// than per process — and that is what the CallTool handler now uses
+				// (CLIENTINFO_AGENTS in TelemetryAgent.ts), so keeping inference off
+				// here costs nothing the handshake does not give back better.
 				await bootstrapTelemetry({
 					cwd: resolveProjectDir(),
 					inferAgentFromEnv: !isDetachedDaemonInvocation(argv),

--- a/cli/src/Cli.ts
+++ b/cli/src/Cli.ts
@@ -133,11 +133,24 @@ export async function serveMcpInProcess(dir: string): Promise<void> {
 	let telemetry: typeof import("./core/TelemetryStartup.js") | null = null;
 	try {
 		telemetry = await import("./core/TelemetryStartup.js");
-		// `inferAgentFromEnv`: this server was spawned by the AI host for this
-		// session, so its env markers name that host. Measured: a Claude-spawned
-		// `mcp-serve` really does carry CLAUDECODE — which is also how the
-		// `surface` misattribution becomes visible, since the dist that wins
-		// arbitration may be a different host's plugin bundle entirely.
+		// `inferAgentFromEnv` is right HERE and wrong in the daemon, and the
+		// difference is sharing, not lifetime. This is the in-process fallback: it
+		// runs inside the per-session `mcp` proxy, which the host spawned for this
+		// session alone, so its env names that host and nothing else attaches to
+		// it. Measured: an `mcp` proxy whose parent is `claude` carries CLAUDECODE.
+		// `mcp-serve` is keyed by worktree and shared across hosts, so it must not
+		// infer — see the daemon note in `main()`.
+		//
+		// Two other measurements from the same sweep, both narrowing what env can
+		// answer: an `mcp` proxy spawned by `cursor-agent` carried no `CURSOR_*` at
+		// all, and one spawned by Codex carried no `CODEX_THREAD_ID`. So of the
+		// hosts checked, only Claude passes its marker down to an MCP child — the
+		// MCP path is largely unattributed even where the CLI path is not.
+		//
+		// The same sweep also caught the misattribution this dimension exists for,
+		// twice over: Claude Code serving from the CODEX plugin's dist, and Codex
+		// serving from the CURSOR plugin's dist. `surface` names the bundle that
+		// won dist arbitration, never the host.
 		await telemetry.bootstrapTelemetry({ cwd: dir, inferAgentFromEnv: true });
 	} catch (error: unknown) {
 		// stderr, never stdout — stdout is this session's JSON-RPC stream.
@@ -258,11 +271,32 @@ if (!process.env.VITEST) {
 				// Then prime telemetry before command dispatch so the commander preAction
 				// auto-emit and any in-command track() calls have a live context. Never
 				// throws; the VITEST guard keeps it (and its installId mint) out of tests.
-				// `inferAgentFromEnv`: a `jolli` invocation is short-lived and was
-				// launched by whoever is running it right now, so an inherited marker
-				// still names the current host. This is what attributes
-				// `command_invoked` for every CLI command.
-				await bootstrapTelemetry({ cwd: resolveProjectDir(), inferAgentFromEnv: true });
+				// `inferAgentFromEnv` for an ordinary invocation, NEVER for a detached
+				// daemon — the same predicate, for a related reason. A `jolli` command
+				// is short-lived and was launched by whoever is running it right now,
+				// so an inherited marker still names the current host; this is what
+				// attributes `command_invoked` for every CLI command.
+				//
+				// The daemons are the opposite case, and `mcp-serve` is the one that
+				// makes it concrete rather than theoretical. It is keyed by WORKTREE and
+				// shared: a tie attaches instead of evicting, so several hosts' sessions
+				// reach the same daemon, and it is the process that runs the tools and
+				// emits their `command_invoked`. Its env is frozen at spawn from
+				// whichever proxy happened to be first. Measured on one machine: an
+				// `mcp-serve` at ppid 1 carrying CLAUDECODE beside two carrying nothing.
+				// So inferring here would report `agent: "claude"` for a Cursor or Codex
+				// session's tool calls — a WRONG value, not a missing one, which is the
+				// exact failure `inferAgentFromEnv` defaults off to prevent. The global
+				// daemon is machine-wide and even further from any one session.
+				//
+				// The right signal for a shared daemon is the MCP `initialize`
+				// handshake's `clientInfo`, which names the host per connection rather
+				// than per process. Not attempted here: mapping those strings onto the
+				// vocabulary needs its own capture, and absent is the honest interim.
+				await bootstrapTelemetry({
+					cwd: resolveProjectDir(),
+					inferAgentFromEnv: !isDetachedDaemonInvocation(argv),
+				});
 				let failed = false;
 				try {
 					await main();

--- a/cli/src/Cli.ts
+++ b/cli/src/Cli.ts
@@ -133,7 +133,12 @@ export async function serveMcpInProcess(dir: string): Promise<void> {
 	let telemetry: typeof import("./core/TelemetryStartup.js") | null = null;
 	try {
 		telemetry = await import("./core/TelemetryStartup.js");
-		await telemetry.bootstrapTelemetry({ cwd: dir });
+		// `inferAgentFromEnv`: this server was spawned by the AI host for this
+		// session, so its env markers name that host. Measured: a Claude-spawned
+		// `mcp-serve` really does carry CLAUDECODE — which is also how the
+		// `surface` misattribution becomes visible, since the dist that wins
+		// arbitration may be a different host's plugin bundle entirely.
+		await telemetry.bootstrapTelemetry({ cwd: dir, inferAgentFromEnv: true });
 	} catch (error: unknown) {
 		// stderr, never stdout — stdout is this session's JSON-RPC stream.
 		console.error("telemetry unavailable for this MCP session:", error);
@@ -253,7 +258,11 @@ if (!process.env.VITEST) {
 				// Then prime telemetry before command dispatch so the commander preAction
 				// auto-emit and any in-command track() calls have a live context. Never
 				// throws; the VITEST guard keeps it (and its installId mint) out of tests.
-				await bootstrapTelemetry({ cwd: resolveProjectDir() });
+				// `inferAgentFromEnv`: a `jolli` invocation is short-lived and was
+				// launched by whoever is running it right now, so an inherited marker
+				// still names the current host. This is what attributes
+				// `command_invoked` for every CLI command.
+				await bootstrapTelemetry({ cwd: resolveProjectDir(), inferAgentFromEnv: true });
 				let failed = false;
 				try {
 					await main();

--- a/cli/src/Cli.ts
+++ b/cli/src/Cli.ts
@@ -92,6 +92,26 @@ export function isDetachedDaemonInvocation(argv: ReadonlyArray<string>): boolean
 }
 
 /**
+ * Commands whose process must NOT infer its telemetry `agent` from the env
+ * markers: every detached daemon, plus `ide-bridge-serve`.
+ *
+ * A separate predicate rather than widening {@link isDetachedDaemonInvocation},
+ * because the two lists answer different questions and only coincide today.
+ * That one gates the one-time telemetry notice (its members' stderr goes to
+ * `/dev/null`, so printing there burns the flag on an audience of nobody);
+ * `ide-bridge-serve` does not belong on it — IntelliJ reads its stderr — but it
+ * shares the daemons' attribution problem exactly: it is a long-lived server
+ * whose env belongs to whatever launched the IDE, possibly days ago, and it
+ * emits for sessions it does not own. An IntelliJ cold-started from a Claude
+ * shell would otherwise stamp `agent: "claude"` on the bridge's own lifecycle
+ * events (the JVM UI events it forwards are already safe — the
+ * `telemetry-track` action re-bootstraps without inference before tracking).
+ */
+export function isAgentInferenceExempt(argv: ReadonlyArray<string>): boolean {
+	return isDetachedDaemonInvocation(argv) || argv[0] === "ide-bridge-serve";
+}
+
+/**
  * Runs the MCP proxy fast path — the per-session process, kept as small as this
  * file can make it.
  *
@@ -298,7 +318,7 @@ if (!process.env.VITEST) {
 				// here costs nothing the handshake does not give back better.
 				await bootstrapTelemetry({
 					cwd: resolveProjectDir(),
-					inferAgentFromEnv: !isDetachedDaemonInvocation(argv),
+					inferAgentFromEnv: !isAgentInferenceExempt(argv),
 				});
 				let failed = false;
 				try {

--- a/cli/src/Types.ts
+++ b/cli/src/Types.ts
@@ -509,6 +509,21 @@ export interface CommitGitOperation {
 	readonly sourceHashes?: ReadonlyArray<string>;
 	/** Whether the operation was triggered from the VSCode plugin or CLI */
 	readonly commitSource?: CommitSource;
+	/**
+	 * Who set this commit in motion, resolved at enqueue time — see
+	 * {@link CommitTrigger} for why the hook's process is the only honest place
+	 * to read it. Optional to tolerate entries written by older code; the worker
+	 * treats absence as unknown, never as a default.
+	 */
+	readonly trigger?: CommitTrigger;
+	/**
+	 * The AI host driving the session that made this commit, when
+	 * `trigger === "agent"` named one. Stamped beside {@link trigger} so the
+	 * worker can attribute this entry's telemetry per entry (via
+	 * `setTelemetryAgent`) instead of trusting its own inherited environment,
+	 * which belongs to whichever commit spawned the worker chain.
+	 */
+	readonly agent?: TranscriptSource;
 	/** Creation time — used for queue ordering and transcript time-based attribution */
 	readonly createdAt: string; // ISO 8601
 	/**
@@ -640,6 +655,26 @@ export type CommitType = "commit" | "amend" | "squash" | "rebase" | "cherry-pick
 
 /** Whether the operation was triggered from the VSCode plugin or CLI/other git client */
 export type CommitSource = "cli" | "plugin";
+
+/**
+ * Who set a commit in motion — the `trigger` telemetry dimension, resolved at
+ * ENQUEUE time by `resolveCommitOrigin` (core/TelemetryAgent.ts) and stamped on
+ * the queue entry, because only the post-commit hook's own process still holds
+ * the truth: the worker that drains the entry may be a chain-spawned survivor
+ * of an earlier commit, carrying that commit's environment.
+ *
+ *  - `ui`        — an IDE's Commit button (the `plugin-source` marker; the same
+ *                  signal `commitSource: "plugin"` reads).
+ *  - `agent`     — an AI host's session (env markers / families).
+ *  - `terminal`  — a human in a TTY.
+ *  - `unknown`   — none of the above (GUI git clients, cron, CI).
+ *
+ * Closed set; telemetry-safe by construction. Distinct from `CommitSource`,
+ * which answers a narrower question (plugin vs everything-else) and is stored
+ * on the summary itself — this one exists for telemetry and rides queue
+ * entries only.
+ */
+export type CommitTrigger = "agent" | "ui" | "terminal" | "unknown";
 
 /**
  * Closed enumeration of summary-error markers. Extend by adding a new

--- a/cli/src/commands/EnableCommand.test.ts
+++ b/cli/src/commands/EnableCommand.test.ts
@@ -620,10 +620,18 @@ describe("EnableCommand — repo-hooks-only onboarding funnel", () => {
 		vi.restoreAllMocks();
 	});
 
-	async function runRepoHooksOnly(): Promise<void> {
+	async function runRepoHooksOnly(sourceTag?: string): Promise<void> {
 		const program = new Command();
 		registerEnableCommand(program);
-		await program.parseAsync(["node", "jolli", "enable", "--cwd", "/repo", "--repo-hooks-only"]);
+		await program.parseAsync([
+			"node",
+			"jolli",
+			"enable",
+			"--cwd",
+			"/repo",
+			"--repo-hooks-only",
+			...(sourceTag ? ["--source-tag", sourceTag] : []),
+		]);
 	}
 
 	it("captures the shared onboarding snapshot on success, keyed on the requested cwd", async () => {
@@ -635,7 +643,24 @@ describe("EnableCommand — repo-hooks-only onboarding funnel", () => {
 		// --cwd), and its explicit flush replaces the exit flush that
 		// markSkipExitFlush() disarmed for this mode.
 		expect(h.capturePluginOnboardingSnapshot).toHaveBeenCalledTimes(1);
-		expect(h.capturePluginOnboardingSnapshot).toHaveBeenCalledWith("/repo");
+		// No source tag, so no host is known — the `agent` telemetry dimension is
+		// passed as undefined rather than guessed. See below.
+		expect(h.capturePluginOnboardingSnapshot).toHaveBeenCalledWith("/repo", undefined, undefined);
+	});
+
+	it("passes the host as the agent dimension when a plugin source tag names one", async () => {
+		h.isValidSourceTag.mockReturnValue(true);
+		await runRepoHooksOnly("codex-plugin");
+		expect(h.capturePluginOnboardingSnapshot).toHaveBeenCalledWith("/repo", undefined, "codex");
+	});
+
+	it("passes no agent for a source tag that is not a plugin host, rather than defaulting to claude", async () => {
+		// pluginBootstrapAgent, not pluginBootstrapHost: the latter falls back to
+		// "claude" so a hand-run --repo-hooks-only still gets Claude's assets, but
+		// that run proves nothing about which host the user is typing into.
+		h.isValidSourceTag.mockReturnValue(true);
+		await runRepoHooksOnly("cli");
+		expect(h.capturePluginOnboardingSnapshot).toHaveBeenCalledWith("/repo", undefined, undefined);
 	});
 
 	it("captures on the failure branch too — a reconciliation that fails is exactly the drop-off the funnel observes", async () => {
@@ -644,7 +669,7 @@ describe("EnableCommand — repo-hooks-only onboarding funnel", () => {
 		await runRepoHooksOnly();
 
 		expect(process.exitCode).toBe(1);
-		expect(h.capturePluginOnboardingSnapshot).toHaveBeenCalledWith("/repo");
+		expect(h.capturePluginOnboardingSnapshot).toHaveBeenCalledWith("/repo", undefined, undefined);
 	});
 
 	it("waits for the snapshot chain before returning", async () => {

--- a/cli/src/commands/EnableCommand.ts
+++ b/cli/src/commands/EnableCommand.ts
@@ -17,6 +17,7 @@ import {
 	listPresentLocalAgents,
 	localAgentOverrideFrom,
 } from "../core/localagent/DetectAgents.js";
+import { pluginBootstrapAgent } from "../core/localagent/PluginDefaults.js";
 import { LOCAL_AGENT_TOOLS, localAgentToolLabel, localAgentToolLoginHint } from "../core/localagent/ToolMeta.js";
 import { maybeEmitOnboardingProgress } from "../core/OnboardingFunnel.js";
 import { getGlobalConfigDir, loadConfig, loadConfigFromDir, saveConfigScoped } from "../core/SessionTracker.js";
@@ -454,7 +455,16 @@ export function registerEnableCommand(program: Command): void {
 					// and its explicit flush is what markSkipExitFlush() above made
 					// necessary. Nothing here writes to stdout, which the automatic
 					// (SessionStart bootstrap) callers need kept byte-clean.
-					await capturePluginOnboardingSnapshot(options.cwd).done;
+					// The `agent` dimension comes from the SOURCE TAG, via
+					// pluginBootstrapAgent rather than pluginBootstrapHost: this mode
+					// is also reachable as a hand-run `enable --repo-hooks-only` with
+					// no tag, where the host is genuinely unknown and must be omitted
+					// rather than defaulted to claude.
+					await capturePluginOnboardingSnapshot(
+						options.cwd,
+						undefined,
+						pluginBootstrapAgent(options.sourceTag),
+					).done;
 					return;
 				}
 

--- a/cli/src/commands/IdeBridgeCommand.ts
+++ b/cli/src/commands/IdeBridgeCommand.ts
@@ -2226,6 +2226,11 @@ export async function runIdeBridgeAction(action: string, cwd: string, request: J
 		case "telemetry-track": {
 			const { bootstrapTelemetry } = await import("../core/TelemetryStartup.js");
 			const { bucket, track } = await import("../core/Telemetry.js");
+			// No `inferAgentFromEnv`: this runs inside the long-lived
+			// `ide-bridge-serve` process, whose env belongs to whatever launched the
+			// IDE, and the events it forwards describe the JVM host's own UI anyway.
+			// (Currently defensive — nothing in `intellij/` calls this action; the
+			// plugin still emits through its own Kotlin telemetry stack.)
 			await bootstrapTelemetry({ cwd, platformDisabled: request.platformDisabled === true });
 			const properties = {
 				...((request.properties as Readonly<Record<string, unknown>> | undefined) ?? {}),
@@ -2248,6 +2253,7 @@ export async function runIdeBridgeAction(action: string, cwd: string, request: J
 			const { loadConfig } = await import("../core/SessionTracker.js");
 			const { shouldShowTelemetryNotice } = await import("../core/TelemetryConsent.js");
 			const platformDisabled = request.platformDisabled === true;
+			// No `inferAgentFromEnv` — same reasoning as `telemetry-track` above.
 			await bootstrapTelemetry({ cwd, platformDisabled });
 			return { shouldShowNotice: shouldShowTelemetryNotice({ config: await loadConfig(), platformDisabled }) };
 		}

--- a/cli/src/core/Telemetry.test.ts
+++ b/cli/src/core/Telemetry.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { PLUGIN_BUNDLE_KINDS } from "./ClientHeader.js";
 import {
 	bucket,
 	getTelemetryContext,
@@ -10,7 +11,9 @@ import {
 	resolveTelemetryEnv,
 	saltedHash,
 	scrubProperties,
+	setTelemetryAgent,
 	shutdownTelemetry,
+	TELEMETRY_SURFACES,
 	track,
 	trackAs,
 	trackError,
@@ -321,5 +324,196 @@ describe("trackAs", () => {
 		const [e] = await readTelemetryEvents(cwd);
 		// The always-drop `token` key is gone; the safe discriminators survive.
 		expect(e.properties).toEqual({ card: "tokens", split: "model" });
+	});
+});
+
+describe("TELEMETRY_SURFACES", () => {
+	// The doc's surface list used to be hand-written prose inside the generator's
+	// own template, which the drift test cannot see — it had gone stale by three
+	// entries. These assertions are what the generated list now rests on.
+	it("contains every surface a plugin bundle's client kind produces", () => {
+		for (const kind of PLUGIN_BUNDLE_KINDS) {
+			expect(TELEMETRY_SURFACES).toContain(parseSurface(`${kind}/1.0.0`).surface);
+		}
+	});
+
+	it("contains the two surfaces parseSurface normalizes or passes through", () => {
+		expect(TELEMETRY_SURFACES).toContain(parseSurface("cli/1.2.0").surface);
+		expect(TELEMETRY_SURFACES).toContain(parseSurface("vscode-plugin/0.99.4").surface);
+	});
+
+	it("contains the surfaces no client kind can produce (independent Kotlin stack, hosted app, beacon)", () => {
+		expect(TELEMETRY_SURFACES).toContain("intellij");
+		expect(TELEMETRY_SURFACES).toContain("web");
+		expect(TELEMETRY_SURFACES).toContain("web-local");
+	});
+
+	it("holds no duplicates", () => {
+		expect(new Set(TELEMETRY_SURFACES).size).toBe(TELEMETRY_SURFACES.length);
+	});
+});
+
+describe("agent dimension", () => {
+	const baseInit = () => ({ cwd, installId: "install-1", origin: "https://acme.jolli.ai", config: {} });
+
+	it("stamps a known host into properties, not the envelope", async () => {
+		initTelemetry({ ...baseInit(), agent: "kimi" });
+		track("recall_performed", { hit: true });
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.properties).toEqual({ hit: true, agent: "kimi" });
+		// Deliberately NOT a top-level envelope field: the ingest handler builds
+		// its record from named fields only, so an unknown one is 204'd and dropped.
+		expect(e).not.toHaveProperty("agent");
+	});
+
+	it("omits the property entirely when the host is unknown — never defaults to the surface", async () => {
+		initTelemetry(baseInit());
+		track("recall_performed", { hit: true });
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.properties).toEqual({ hit: true });
+		expect(e.properties).not.toHaveProperty("agent");
+		expect(e.surface).toBe("cli"); // the surface is known; the agent is not
+	});
+
+	it("omits it for an unrecognised host rather than passing the string through", async () => {
+		initTelemetry({ ...baseInit(), agent: "windsurf" });
+		expect(getTelemetryContext()?.agent).toBeUndefined();
+		track("recall_performed");
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.properties).not.toHaveProperty("agent");
+	});
+
+	it("drops a free-form agent a caller put in properties (the value can never be free-form)", async () => {
+		initTelemetry(baseInit());
+		track("ai_source_detected", { source: "claude", agent: "totally-made-up" });
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.properties).toEqual({ source: "claude" });
+	});
+
+	it("lets a call site that knows its host override the ambient one", async () => {
+		// The QueueWorker case: the worker's env says one thing, the session being
+		// walked is authoritative about the transcript it produced.
+		initTelemetry({ ...baseInit(), agent: "claude" });
+		track("ai_source_detected", { source: "gemini", agent: "gemini" });
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.properties).toEqual({ source: "gemini", agent: "gemini" });
+	});
+
+	it("suppresses rather than falls back when the per-call value is rejected", async () => {
+		// The caller claimed to know the host and named something unusable, so the
+		// process's own host must NOT stand in — that would relabel the event as a
+		// host the caller explicitly said it was not.
+		initTelemetry({ ...baseInit(), agent: "codex" });
+		track("recall_performed", { agent: "nonsense" });
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.properties).not.toHaveProperty("agent");
+	});
+
+	it("uses the ambient host when the caller does not mention agent at all", async () => {
+		initTelemetry({ ...baseInit(), agent: "codex" });
+		track("recall_performed", { hit: true });
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.properties).toEqual({ hit: true, agent: "codex" });
+	});
+
+	it("treats an explicitly-undefined agent as unmentioned, not as a claim", async () => {
+		// `{ agent: undefined }` is what a spread of an optional field degrades to;
+		// reading it as "the caller owns this field" would silently drop the ambient
+		// host for callers who never meant to say anything.
+		initTelemetry({ ...baseInit(), agent: "codex" });
+		track("recall_performed", { agent: undefined });
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.properties).toEqual({ agent: "codex" });
+	});
+
+	it("does NOT stamp the ambient host on a trackAs event", async () => {
+		// A surface override means the event did not originate in this process, so
+		// this process's host is not the event's host either — otherwise a browser
+		// click in the local dashboard inherits whatever shell launched the server.
+		initTelemetry({ ...baseInit(), agent: "cursor" });
+		trackAs("web-local", "dashboard_opened", { first_run: true });
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.surface).toBe("web-local");
+		expect(e.properties).toEqual({ first_run: true });
+	});
+
+	it("still honours an agent a trackAs caller states explicitly", async () => {
+		initTelemetry({ ...baseInit(), agent: "cursor" });
+		trackAs("web-local", "dashboard_opened", { agent: "claude" });
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.properties).toEqual({ agent: "claude" });
+	});
+
+	it("stamps it on trackError events too", async () => {
+		initTelemetry({ ...baseInit(), agent: "devin" });
+		trackError("ingest", "ROUTE_FAILED");
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.properties).toEqual({ where: "ingest", code: "ROUTE_FAILED", agent: "devin" });
+	});
+});
+
+describe("setTelemetryAgent", () => {
+	const init = (agent?: string) =>
+		initTelemetry({
+			cwd,
+			installId: "install-1",
+			origin: "https://acme.jolli.ai",
+			config: {},
+			...(agent ? { agent } : {}),
+		});
+
+	it("records a host learned after initialization", async () => {
+		init();
+		setTelemetryAgent("cline-cli");
+		expect(getTelemetryContext()?.agent).toBe("cline-cli");
+		track("recall_performed");
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.properties).toEqual({ agent: "cline-cli" });
+	});
+
+	it("clears the dimension when handed undefined or an unknown host", async () => {
+		// Clearing is the safe direction: a stale agent is a wrong positive claim,
+		// an absent one correctly reads as unknown.
+		init("claude");
+		setTelemetryAgent(undefined);
+		expect(getTelemetryContext()?.agent).toBeUndefined();
+		setTelemetryAgent("claude");
+		setTelemetryAgent("windsurf");
+		expect(getTelemetryContext()?.agent).toBeUndefined();
+		track("recall_performed");
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.properties).not.toHaveProperty("agent");
+	});
+
+	it("leaves every other context field untouched", () => {
+		init();
+		const before = getTelemetryContext();
+		setTelemetryAgent("copilot-chat");
+		const after = getTelemetryContext();
+		expect(after).toMatchObject({
+			enabled: before?.enabled,
+			cwd: before?.cwd,
+			installId: before?.installId,
+			surface: before?.surface,
+			surfaceVersion: before?.surfaceVersion,
+			env: before?.env,
+		});
+	});
+
+	it("preserves a sessionId across the update", () => {
+		initTelemetry({
+			cwd,
+			installId: "install-1",
+			sessionId: "sess-9",
+			origin: "https://acme.jolli.ai",
+			config: {},
+		});
+		setTelemetryAgent("antigravity");
+		expect(getTelemetryContext()).toMatchObject({ sessionId: "sess-9", agent: "antigravity" });
+	});
+
+	it("is a no-op before initialization", () => {
+		setTelemetryAgent("claude");
+		expect(getTelemetryContext()).toBeNull();
 	});
 });

--- a/cli/src/core/Telemetry.ts
+++ b/cli/src/core/Telemetry.ts
@@ -24,6 +24,7 @@
  */
 import { createHash, randomUUID } from "node:crypto";
 import { JOLLI_CLIENT_HEADER } from "./ClientHeader.js";
+import { resolveTelemetryAgent, type TelemetryAgent } from "./TelemetryAgent.js";
 import { appendTelemetryEvent, type TelemetryEnvelope } from "./TelemetryBuffer.js";
 import { resolveTelemetryConsent } from "./TelemetryConsent.js";
 import { isTelemetryEventName, type TelemetryEventName } from "./TelemetryEvents.js";
@@ -44,6 +45,15 @@ export interface TelemetryInit {
 	readonly installId: string;
 	/** Current AI/editor session id, when one exists. */
 	readonly sessionId?: string;
+	/**
+	 * The AI host this process is working in, when it is actually known — a
+	 * structural fact (a plugin bootstrap runs inside its own host) or a marker
+	 * the host set itself (`TelemetryAgent.detectAgentFromEnv`). Passed as a
+	 * plain string and gated through `resolveTelemetryAgent`, so an unrecognised
+	 * value leaves the dimension ABSENT rather than defaulted. See
+	 * `TelemetryAgent` for why absent must keep reading as *unknown*.
+	 */
+	readonly agent?: string;
 	/** Resolved jolli origin (key-derived or `getJolliUrl()`); maps to `env`. */
 	readonly origin?: string;
 	/** Telemetry-related config fields, for the consent gate. */
@@ -62,6 +72,8 @@ interface TelemetryContext {
 	readonly surface: string;
 	readonly surfaceVersion: string;
 	readonly env: TelemetryEnv;
+	/** Resolved agent, or absent when this process's host is not known. */
+	readonly agent?: TelemetryAgent;
 }
 
 let context: TelemetryContext | null = null;
@@ -77,6 +89,7 @@ export function initTelemetry(init: TelemetryInit): void {
 		platformDisabled: init.platformDisabled,
 	});
 	const { surface, surfaceVersion } = parseSurface();
+	const agent = resolveTelemetryAgent(init.agent);
 	context = {
 		enabled: consent.enabled,
 		cwd: init.cwd,
@@ -85,6 +98,41 @@ export function initTelemetry(init: TelemetryInit): void {
 		surface,
 		surfaceVersion,
 		env: resolveTelemetryEnv(init.origin, init.env),
+		...(agent ? { agent } : {}),
+	};
+}
+
+/**
+ * Record the AI host this process is working in, for a caller that learns it
+ * AFTER `initTelemetry` — a plugin bootstrap that resolved its host from an
+ * install source tag, or a pass that has narrowed down which session it is
+ * walking. Every later `track()` stamps it.
+ *
+ * Passing an unrecognised value — or `undefined` — CLEARS the dimension rather
+ * than leaving the previous one in place. Clearing is the safe direction: a
+ * stale agent is a wrong positive claim about the user's host, while an absent
+ * one correctly reads as unknown.
+ *
+ * No-op when uninitialized, so an un-wired surface stays silent instead of
+ * throwing. Deliberately process-wide and NOT async-scoped: the two callers
+ * either know their host for the whole process, or set it around a sequential
+ * pass. A caller that emits from concurrent work under two different hosts
+ * would need a scoped variant, and should add one rather than interleaving
+ * calls to this.
+ */
+export function setTelemetryAgent(agent: string | undefined): void {
+	if (!context) return;
+	const resolved = resolveTelemetryAgent(agent);
+	const { cwd, enabled, env, installId, sessionId, surface, surfaceVersion } = context;
+	context = {
+		enabled,
+		cwd,
+		installId,
+		sessionId,
+		surface,
+		surfaceVersion,
+		env,
+		...(resolved ? { agent: resolved } : {}),
 	};
 }
 
@@ -140,6 +188,45 @@ function emit(
 	if (!ctx || !ctx.enabled) return;
 	if (!isTelemetryEventName(eventName)) return;
 	try {
+		// `agent` is a NAMED dimension inside the properties bag, so it is stamped
+		// here rather than trusted from the caller's object: an explicit
+		// `properties.agent` is re-resolved against the closed vocabulary (a
+		// caller that knows its host beats the ambient one), and anything the gate
+		// rejects is DELETED rather than left to flow through the scrubber, which
+		// preserves an unrecognised string verbatim. So the wire value is always a
+		// known token or nothing at all.
+		//
+		// It rides in `properties` and not in the envelope on purpose: the ingest
+		// handler builds its stored record from named envelope fields only, so an
+		// unrecognised top-level field is accepted with a 204 and then silently
+		// dropped, whereas `properties` is scrubbed against a DENY-list that
+		// `agent` is not on — which is what makes this a client-only change.
+		// Promoting it to a first-class column later is a server-side schema
+		// change, not a reason to hold the data back now.
+		//
+		// `surfaceOverride` also suppresses the AMBIENT agent, and that follows from
+		// what the override MEANS: a caller reaches for `trackAs` precisely because
+		// the event did not originate in this process (today, a click in the local
+		// dashboard's web view). This process's host is then not the event's host
+		// either, so inheriting it would attribute a browser click to whatever
+		// shell happened to launch `jolli dashboard`. An explicitly passed agent
+		// still wins, since that caller is claiming to know the event's own host.
+		//
+		// A supplied `properties.agent` is AUTHORITATIVE, not merely preferred: if
+		// the gate rejects it the property is omitted, and the ambient value does
+		// NOT stand in. Falling back looks harmless and is the one shape that can
+		// manufacture a wrong value — a call site that named a host this build's
+		// vocabulary does not carry yet (a fourteenth host, an older dist) would
+		// have its event relabelled as the PROCESS's host, silently contradicting
+		// what the caller said it knew. Absent is recoverable; that is not. This
+		// also keeps `emit` consistent with `initTelemetry`, where an unrecognised
+		// explicit agent likewise suppresses rather than degrades.
+		const bag = scrubProperties(properties);
+		delete bag.agent;
+		const claimed = properties.agent !== undefined;
+		const ambient = surfaceOverride === undefined ? ctx.agent : undefined;
+		const agent = claimed ? resolveTelemetryAgent(properties.agent) : ambient;
+		if (agent) bag.agent = agent;
 		const envelope: TelemetryEnvelope = {
 			schemaVersion: SCHEMA_VERSION,
 			// Idempotency key minted once here, at buffer time. Written to disk and
@@ -159,7 +246,7 @@ function emit(
 			// Always null from the client; the backend attributes account_id
 			// from the Bearer key at ingest time (JOLLI-1785 as-built).
 			accountId: null,
-			properties: scrubProperties(properties),
+			properties: bag,
 		};
 		appendTelemetryEvent(ctx.cwd, envelope);
 	} catch {
@@ -236,6 +323,35 @@ export function resolveTelemetryEnv(origin?: string, env: NodeJS.ProcessEnv = pr
 	if (matches("jolli.ai")) return "prod";
 	return "unknown";
 }
+
+/**
+ * Every `surface` value the product emits, and therefore the complete list
+ * `TELEMETRY.md` discloses.
+ *
+ * Not derivable from this process: `surface` comes from a build-time `define`, so
+ * a running bundle can only ever name its OWN value — which is exactly how the
+ * doc's hand-written prose went stale (it was missing `cursor-plugin`,
+ * `web-local` and `web`). Enumerating it once here at least gives the staleness
+ * somewhere to be caught: `Telemetry.test.ts` runs every `PLUGIN_BUNDLE_KINDS`
+ * entry plus `cli` and `vscode-plugin` through `parseSurface` and asserts the
+ * result is a member, so adding a bundle without adding its surface fails.
+ *
+ * The remaining three cannot be derived that way and are asserted by name:
+ * `intellij` comes from the plugin's independent Kotlin stack and `web` from the
+ * hosted app, so no bundle here produces either, while `web-local` IS emitted
+ * here but only via `trackAs` from the local dashboard beacon. They are listed
+ * anyway because the doc describes the product, not one artifact.
+ */
+export const TELEMETRY_SURFACES: ReadonlyArray<string> = [
+	"cli",
+	"vscode",
+	"intellij",
+	"claude-plugin",
+	"codex-plugin",
+	"cursor-plugin",
+	"web-local",
+	"web",
+];
 
 /** Split `JOLLI_CLIENT_HEADER` ("cli/1.2.0", "vscode-plugin/0.99.4") into surface + version. */
 export function parseSurface(header: string = JOLLI_CLIENT_HEADER): {

--- a/cli/src/core/TelemetryAgent.test.ts
+++ b/cli/src/core/TelemetryAgent.test.ts
@@ -8,6 +8,7 @@ import type { PluginBootstrapHost } from "./localagent/PluginDefaults.js";
 import { SESSION_SOURCES } from "./sessions/SessionSources.js";
 import {
 	AGENT_DIMENSION_SINCE_VERSION,
+	AGENT_ENV_FAMILIES,
 	AGENT_ENV_MARKERS,
 	AMBIGUOUS_AGENT_ENV_KEYS,
 	detectAgentFromEnv,
@@ -124,12 +125,52 @@ describe("detectAgentFromEnv", () => {
 	});
 
 	it("refuses to guess from a marker that names a family rather than a host", () => {
-		// AI_AGENT is generic; CURSOR_TRACE_ID cannot separate `cursor` from
-		// `cursor-cli`. A partially-known case must not fall through to a value.
+		// AI_AGENT is generic; CURSOR_TRACE_ID was measured absent everywhere and is
+		// kept only as a guard. A partially-known case must not reach a value.
 		for (const key of AMBIGUOUS_AGENT_ENV_KEYS) {
 			expect(detectAgentFromEnv({ [key]: "abc" })).toBeUndefined();
 		}
 		expect(AMBIGUOUS_AGENT_ENV_KEYS).toContain("CURSOR_TRACE_ID");
+	});
+
+	it("splits the Cursor family into the IDE and the CLI (measured)", () => {
+		expect(detectAgentFromEnv({ CURSOR_AGENT: "1", CURSOR_WORKSPACE_LABEL: "snake-game" })).toBe("cursor");
+		expect(detectAgentFromEnv({ CURSOR_AGENT: "1", CURSOR_INVOKED_AS: "cursor-agent" })).toBe("cursor-cli");
+	});
+
+	it("does not treat a human in Cursor's own terminal as an agent", () => {
+		// The measurement this whole mapping rests on: a person typing in Cursor's
+		// integrated terminal has NO CURSOR_* vars, so the family gate cannot fire.
+		// Labelling human work as an agent's would attack the field's whole meaning.
+		expect(detectAgentFromEnv({ CURSOR_RIPGREP_PATH: "/rg", CURSOR_LAYOUT: "x" })).toBeUndefined();
+	});
+
+	it("abandons the answer when the family gate resolves to no single variant", () => {
+		// Both sides present (a future build setting both) and neither side present
+		// (a future build renaming both) are the same class of thing: a Cursor agent
+		// is here and we cannot say which. Neither may degrade to a coin flip.
+		expect(detectAgentFromEnv({ CURSOR_AGENT: "1" })).toBeUndefined();
+		expect(
+			detectAgentFromEnv({ CURSOR_AGENT: "1", CURSOR_WORKSPACE_LABEL: "w", CURSOR_INVOKED_AS: "a" }),
+		).toBeUndefined();
+	});
+
+	it("does not let an unresolved family hand the answer to another host's marker", () => {
+		// The subtle one: if a present-but-unresolved family merely contributed
+		// nothing, a nested session would report a confident single host.
+		expect(detectAgentFromEnv({ CURSOR_AGENT: "1", CLAUDECODE: "1" })).toBeUndefined();
+		expect(detectAgentFromEnv({ CURSOR_AGENT: "1", CURSOR_INVOKED_AS: "a", CLAUDECODE: "1" })).toBeUndefined();
+	});
+
+	it("declares every family variant as a known agent, and the gate as agent-named", () => {
+		for (const family of AGENT_ENV_FAMILIES) {
+			expect(family.variants.length).toBeGreaterThan(1);
+			for (const [, agent] of family.variants) expect(TELEMETRY_AGENTS).toContain(agent);
+			// Distinct variants, or the split cannot discriminate anything.
+			expect(new Set(family.variants.map(([, a]) => a)).size).toBe(family.variants.length);
+			// The gate must not double as a single-host marker.
+			expect(AGENT_ENV_MARKERS.map(([k]) => k)).not.toContain(family.familyKey);
+		}
 	});
 
 	it("still answers when an ambiguous marker sits beside a decisive one", () => {

--- a/cli/src/core/TelemetryAgent.test.ts
+++ b/cli/src/core/TelemetryAgent.test.ts
@@ -3,6 +3,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { compareSemver } from "../install/SemverCompare.js";
+import { INSTALLED_SKILL_NAMES } from "../install/SkillInstaller.js";
 import { LOCAL_AGENT_CHILD_ENV } from "./AgentReentry.js";
 import type { PluginBootstrapHost } from "./localagent/PluginDefaults.js";
 import { SESSION_SOURCES } from "./sessions/SessionSources.js";
@@ -15,7 +16,9 @@ import {
 	detectAgentFromEnv,
 	resolveClientInfoAgent,
 	resolveCommitOrigin,
+	resolveInvokedVia,
 	resolveTelemetryAgent,
+	SKILL_VIA_NAMES,
 	TELEMETRY_AGENTS,
 	type TelemetryAgent,
 } from "./TelemetryAgent.js";
@@ -296,5 +299,38 @@ describe("resolveCommitOrigin (who set a commit in motion)", () => {
 		).toEqual({
 			trigger: "unknown",
 		});
+	});
+});
+
+describe("resolveInvokedVia (the `via` dimension)", () => {
+	it("accepts skill:<name> for every name in the vocabulary", () => {
+		for (const name of SKILL_VIA_NAMES) {
+			expect(resolveInvokedVia(`skill:${name}`)).toBe(`skill:${name}`);
+		}
+	});
+
+	it("stays in lockstep with the installed-skill registry", () => {
+		// SKILL_VIA_NAMES is a deliberate hand-kept copy (this module is a leaf;
+		// deriving live would drag the install stack into every telemetry
+		// consumer). This assertion is what makes the copy safe: bare names here
+		// must equal SkillInstaller's registry with the `jolli-` prefix stripped.
+		const derived = INSTALLED_SKILL_NAMES.map((n) => (n.startsWith("jolli-") ? n.slice("jolli-".length) : n));
+		expect([...SKILL_VIA_NAMES].sort()).toEqual([...derived].sort());
+	});
+
+	it("drops an unknown name, a wrong prefix, and free-form input whole", () => {
+		for (const bad of [
+			"skill:windsurf",
+			"skill:jolli-recall", // the prefixed spelling the Codex renderer would corrupt — never valid
+			"skill:",
+			"menu:jolli",
+			"recall",
+			"skill:recall; rm -rf /",
+			"skill:recall extra",
+			"",
+			undefined,
+		]) {
+			expect(resolveInvokedVia(bad)).toBeUndefined();
+		}
 	});
 });

--- a/cli/src/core/TelemetryAgent.test.ts
+++ b/cli/src/core/TelemetryAgent.test.ts
@@ -2,6 +2,8 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { CODEX_PLUGIN_SKILL_NAMES } from "../install/CodexPluginSkills.js";
+import { CURSOR_PLUGIN_SKILL_NAMES } from "../install/CursorPluginSkills.js";
 import { compareSemver } from "../install/SemverCompare.js";
 import { INSTALLED_SKILL_NAMES } from "../install/SkillInstaller.js";
 import { LOCAL_AGENT_CHILD_ENV } from "./AgentReentry.js";
@@ -309,12 +311,17 @@ describe("resolveInvokedVia (the `via` dimension)", () => {
 		}
 	});
 
-	it("stays in lockstep with the installed-skill registry", () => {
+	it("stays in lockstep with every skill registry Jolli ships", () => {
 		// SKILL_VIA_NAMES is a deliberate hand-kept copy (this module is a leaf;
 		// deriving live would drag the install stack into every telemetry
-		// consumer). This assertion is what makes the copy safe: bare names here
-		// must equal SkillInstaller's registry with the `jolli-` prefix stripped.
-		const derived = INSTALLED_SKILL_NAMES.map((n) => (n.startsWith("jolli-") ? n.slice("jolli-".length) : n));
+		// consumer). This assertion is what makes the copy safe: it must equal the
+		// bare-name union of the installed registry and both plugin bundles'
+		// skill lists, so adding or retiring a skill anywhere breaks the pin
+		// rather than the vocabulary.
+		const bare = (n: string): string => (n.startsWith("jolli-") ? n.slice("jolli-".length) : n);
+		const derived = new Set(
+			[...INSTALLED_SKILL_NAMES, ...CODEX_PLUGIN_SKILL_NAMES, ...CURSOR_PLUGIN_SKILL_NAMES].map(bare),
+		);
 		expect([...SKILL_VIA_NAMES].sort()).toEqual([...derived].sort());
 	});
 

--- a/cli/src/core/TelemetryAgent.test.ts
+++ b/cli/src/core/TelemetryAgent.test.ts
@@ -11,7 +11,9 @@ import {
 	AGENT_ENV_FAMILIES,
 	AGENT_ENV_MARKERS,
 	AMBIGUOUS_AGENT_ENV_KEYS,
+	CLIENTINFO_AGENTS,
 	detectAgentFromEnv,
+	resolveClientInfoAgent,
 	resolveTelemetryAgent,
 	TELEMETRY_AGENTS,
 	type TelemetryAgent,
@@ -195,5 +197,51 @@ describe("detectAgentFromEnv", () => {
 			const agent: TelemetryAgent | undefined = detectAgentFromEnv({ [key]: "1" });
 			expect(TELEMETRY_AGENTS).toContain(agent);
 		}
+	});
+});
+
+describe("resolveClientInfoAgent (MCP initialize handshake)", () => {
+	it("maps each measured clientInfo name to its host", () => {
+		// Both strings captured 2026-08-20 with a probe MCP server logging the raw
+		// initialize request — not taken from documentation or memory.
+		expect(resolveClientInfoAgent("claude-code")).toBe("claude");
+		expect(resolveClientInfoAgent("codex-mcp-client")).toBe("codex");
+	});
+
+	it("pins that the key space is the hosts' own spellings, not our vocabulary", () => {
+		// "codex" is the obvious guess for Codex's clientInfo name and is WRONG —
+		// the measured value is "codex-mcp-client". This test is what makes adding
+		// a guessed key a visible decision rather than a plausible-looking edit.
+		expect(resolveClientInfoAgent("codex")).toBeUndefined();
+		expect(resolveClientInfoAgent("claude")).toBeUndefined();
+	});
+
+	it("leaves cursor-agent's 'Cursor' unmapped until the IDE's own name is measured", () => {
+		// Measured: cursor-agent declares {"name":"Cursor","version":"1.0.0"} — a
+		// family name with a hardcoded version. If the IDE also says "Cursor",
+		// mapping it collapses cursor/cursor-cli, the split this vocabulary exists
+		// to keep. Same refusal as CURSOR_TRACE_ID. When the IDE's string is
+		// captured (the oninitialized log line), this decision gets revisited.
+		expect(resolveClientInfoAgent("Cursor")).toBeUndefined();
+	});
+
+	it("answers nothing for unknown or absent names, never a pass-through", () => {
+		expect(resolveClientInfoAgent(undefined)).toBeUndefined();
+		expect(resolveClientInfoAgent("")).toBeUndefined();
+		expect(resolveClientInfoAgent("some-future-host")).toBeUndefined();
+	});
+
+	it("only ever maps into the closed vocabulary", () => {
+		for (const agent of CLIENTINFO_AGENTS.values()) {
+			expect(TELEMETRY_AGENTS).toContain(agent);
+		}
+	});
+
+	it("is immune to prototype-shaped names", () => {
+		// The table is a plain object and the name is host-authored input; a lookup
+		// of "constructor"/"__proto__" must answer undefined, not a function.
+		expect(resolveClientInfoAgent("constructor")).toBeUndefined();
+		expect(resolveClientInfoAgent("__proto__")).toBeUndefined();
+		expect(resolveClientInfoAgent("hasOwnProperty")).toBeUndefined();
 	});
 });

--- a/cli/src/core/TelemetryAgent.test.ts
+++ b/cli/src/core/TelemetryAgent.test.ts
@@ -14,6 +14,7 @@ import {
 	CLIENTINFO_AGENTS,
 	detectAgentFromEnv,
 	resolveClientInfoAgent,
+	resolveCommitOrigin,
 	resolveTelemetryAgent,
 	TELEMETRY_AGENTS,
 	type TelemetryAgent,
@@ -243,5 +244,57 @@ describe("resolveClientInfoAgent (MCP initialize handshake)", () => {
 		expect(resolveClientInfoAgent("constructor")).toBeUndefined();
 		expect(resolveClientInfoAgent("__proto__")).toBeUndefined();
 		expect(resolveClientInfoAgent("hasOwnProperty")).toBeUndefined();
+	});
+});
+
+describe("resolveCommitOrigin (who set a commit in motion)", () => {
+	it("labels an IDE Commit-button commit `ui`, with no agent", () => {
+		expect(resolveCommitOrigin({ fromPluginUi: true, isTTY: false })).toEqual({ trigger: "ui" });
+	});
+
+	it("lets the button beat an inherited agent marker — the misattribution this exists to stop", () => {
+		// An extension host cold-started from inside a Claude session carries
+		// CLAUDECODE for the window's whole life; the marker was written by the
+		// click handler milliseconds before THIS commit and is the more specific
+		// signal. Without this precedence, every button commit in that window
+		// would be labelled as the agent's work.
+		expect(resolveCommitOrigin({ fromPluginUi: true, isTTY: false, env: { CLAUDECODE: "1" } })).toEqual({
+			trigger: "ui",
+		});
+	});
+
+	it("labels an agent-session commit with the host", () => {
+		expect(resolveCommitOrigin({ fromPluginUi: false, isTTY: false, env: { CODEX_THREAD_ID: "t" } })).toEqual({
+			trigger: "agent",
+			agent: "codex",
+		});
+	});
+
+	it("prefers the agent marker over a TTY when both are present", () => {
+		// An agent session never gives the hook a TTY, so a present marker already
+		// falsifies the TTY reading.
+		expect(resolveCommitOrigin({ fromPluginUi: false, isTTY: true, env: { CLAUDECODE: "1" } })).toEqual({
+			trigger: "agent",
+			agent: "claude",
+		});
+	});
+
+	it("labels a human in a terminal `terminal`", () => {
+		expect(resolveCommitOrigin({ fromPluginUi: false, isTTY: true, env: {} })).toEqual({ trigger: "terminal" });
+	});
+
+	it("labels everything else `unknown`, never `terminal` — absence reads as unknown", () => {
+		// GUI git clients, cron, CI: no marker, no TTY.
+		expect(resolveCommitOrigin({ fromPluginUi: false, isTTY: false, env: {} })).toEqual({ trigger: "unknown" });
+	});
+
+	it("answers `agent` with no host for an unresolvable agent signal", () => {
+		// Two hosts' markers at once: detectAgentFromEnv refuses to name one, so
+		// the commit falls through to unknown rather than to a coin flip.
+		expect(
+			resolveCommitOrigin({ fromPluginUi: false, isTTY: false, env: { CLAUDECODE: "1", CODEX_THREAD_ID: "t" } }),
+		).toEqual({
+			trigger: "unknown",
+		});
 	});
 });

--- a/cli/src/core/TelemetryAgent.test.ts
+++ b/cli/src/core/TelemetryAgent.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { LOCAL_AGENT_CHILD_ENV } from "./AgentReentry.js";
+import type { PluginBootstrapHost } from "./localagent/PluginDefaults.js";
+import { SESSION_SOURCES } from "./sessions/SessionSources.js";
+import {
+	AGENT_DIMENSION_SINCE_VERSION,
+	AGENT_ENV_MARKERS,
+	AMBIGUOUS_AGENT_ENV_KEYS,
+	detectAgentFromEnv,
+	resolveTelemetryAgent,
+	TELEMETRY_AGENTS,
+	type TelemetryAgent,
+} from "./TelemetryAgent.js";
+
+describe("TELEMETRY_AGENTS vocabulary", () => {
+	// The point of the whole module: a fourteenth host cannot ship with a stale
+	// list here. Asserted from BOTH directions, because each catches a different
+	// mistake — a hand-copied list going stale, and a host registered for
+	// discovery that the telemetry dimension cannot spell.
+	it("covers every registered session source", () => {
+		const missing = SESSION_SOURCES.map((s) => s.source).filter(
+			(source) => !(TELEMETRY_AGENTS as readonly string[]).includes(source),
+		);
+		expect(missing).toEqual([]);
+	});
+
+	it("includes gemini, which has no session discoverer (push-based AfterAgent hook)", () => {
+		expect(TELEMETRY_AGENTS).toContain("gemini");
+		expect(SESSION_SOURCES.map((s) => s.source)).not.toContain("gemini");
+	});
+
+	it("keeps the cursor IDE and cursor-agent as separate tokens", () => {
+		// `surface` can never draw this distinction, which is part of why the
+		// dimension is worth adding — collapsing them would spend that value.
+		expect(TELEMETRY_AGENTS).toContain("cursor");
+		expect(TELEMETRY_AGENTS).toContain("cursor-cli");
+	});
+
+	it("holds no duplicates and only lowercase kebab tokens (low-cardinality, never free-form)", () => {
+		expect(new Set(TELEMETRY_AGENTS).size).toBe(TELEMETRY_AGENTS.length);
+		for (const agent of TELEMETRY_AGENTS) expect(agent).toMatch(/^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/);
+	});
+
+	it("spells every plugin bootstrap host, so a structural claim is always expressible", () => {
+		// `pluginBootstrapAgent` returns a PluginBootstrapHost straight into the
+		// telemetry `agent` slot. TS accepts that only while the union is a subset;
+		// this asserts the runtime side of the same thing.
+		const hosts: ReadonlyArray<PluginBootstrapHost> = ["claude", "codex", "cursor"];
+		for (const host of hosts) expect(resolveTelemetryAgent(host)).toBe(host);
+	});
+
+	it("records the watershed as a concrete version", () => {
+		expect(AGENT_DIMENSION_SINCE_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+});
+
+describe("resolveTelemetryAgent", () => {
+	it("accepts every member of the vocabulary verbatim", () => {
+		for (const agent of TELEMETRY_AGENTS) expect(resolveTelemetryAgent(agent)).toBe(agent);
+	});
+
+	it("rejects an unknown host rather than passing it through", () => {
+		expect(resolveTelemetryAgent("windsurf")).toBeUndefined();
+		expect(resolveTelemetryAgent("Claude")).toBeUndefined();
+		expect(resolveTelemetryAgent("claude-code")).toBeUndefined();
+	});
+
+	it("rejects free-form and non-string input (the value can never become free-form)", () => {
+		for (const bad of [
+			"",
+			"   ",
+			"/Users/someone/secret/path",
+			"user@example.com",
+			"sk-live-abcdef",
+			"claude; rm -rf /",
+			undefined,
+			null,
+			42,
+			true,
+			{ agent: "claude" },
+			["claude"],
+		]) {
+			expect(resolveTelemetryAgent(bad)).toBeUndefined();
+		}
+	});
+});
+
+describe("detectAgentFromEnv", () => {
+	it("maps each unambiguous marker to its host", () => {
+		for (const [key, agent] of AGENT_ENV_MARKERS) {
+			expect(detectAgentFromEnv({ [key]: "1" })).toBe(agent);
+		}
+	});
+
+	it("answers nothing for an environment with no marker", () => {
+		expect(detectAgentFromEnv({})).toBeUndefined();
+		expect(detectAgentFromEnv({ PATH: "/usr/bin", TERM: "xterm" })).toBeUndefined();
+	});
+
+	it("applies the same truthiness rule as the commit-feedback gate", () => {
+		for (const falsey of ["", "0", "false", "FALSE"]) {
+			expect(detectAgentFromEnv({ CLAUDECODE: falsey })).toBeUndefined();
+		}
+		expect(detectAgentFromEnv({ CLAUDECODE: "true" })).toBe("claude");
+	});
+
+	it("refuses to guess from a marker that names a family rather than a host", () => {
+		// AI_AGENT is generic; CURSOR_TRACE_ID cannot separate `cursor` from
+		// `cursor-cli`. A partially-known case must not fall through to a value.
+		for (const key of AMBIGUOUS_AGENT_ENV_KEYS) {
+			expect(detectAgentFromEnv({ [key]: "abc" })).toBeUndefined();
+		}
+		expect(AMBIGUOUS_AGENT_ENV_KEYS).toContain("CURSOR_TRACE_ID");
+	});
+
+	it("still answers when an ambiguous marker sits beside a decisive one", () => {
+		// Claude Code sets AI_AGENT as well as CLAUDECODE; the generic marker adds
+		// nothing but must not veto the specific one.
+		expect(detectAgentFromEnv({ AI_AGENT: "1", CLAUDECODE: "1" })).toBe("claude");
+	});
+
+	it("answers nothing when two hosts' markers disagree (one agent shelled out to another)", () => {
+		expect(detectAgentFromEnv({ CLAUDECODE: "1", CODEX_THREAD_ID: "t-1" })).toBeUndefined();
+		expect(detectAgentFromEnv({ GEMINI_CLI: "1", OPENCODE: "1" })).toBeUndefined();
+	});
+
+	it("answers nothing inside a local-agent child, which is the outbound dimension", () => {
+		// A summarizer we spawned sets its own marker in every descendant. Counting
+		// it would conflate `agent` with `LocalAgentToolId`.
+		expect(detectAgentFromEnv({ CLAUDECODE: "1", [LOCAL_AGENT_CHILD_ENV]: "1" })).toBeUndefined();
+	});
+
+	it("only ever answers a member of the vocabulary", () => {
+		for (const [key] of AGENT_ENV_MARKERS) {
+			const agent: TelemetryAgent | undefined = detectAgentFromEnv({ [key]: "1" });
+			expect(TELEMETRY_AGENTS).toContain(agent);
+		}
+	});
+});

--- a/cli/src/core/TelemetryAgent.test.ts
+++ b/cli/src/core/TelemetryAgent.test.ts
@@ -1,4 +1,8 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { compareSemver } from "../install/SemverCompare.js";
 import { LOCAL_AGENT_CHILD_ENV } from "./AgentReentry.js";
 import type { PluginBootstrapHost } from "./localagent/PluginDefaults.js";
 import { SESSION_SOURCES } from "./sessions/SessionSources.js";
@@ -51,6 +55,21 @@ describe("TELEMETRY_AGENTS vocabulary", () => {
 
 	it("records the watershed as a concrete version", () => {
 		expect(AGENT_DIMENSION_SINCE_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+
+	it("does not let the watershed fall behind the version being built", () => {
+		// The watershed starts as a prediction — which release this lands in is not
+		// knowable while writing it — and a stale prediction fails silently, in a
+		// PUBLIC doc. This is the one half that can be checked: the dimension cannot
+		// ship in a release older than the constant, so the constant must never sit
+		// below `cli/package.json`. If main's version overtakes it while this is
+		// still unreleased, the guess was overtaken and someone has to look.
+		//
+		// Resolved from this file rather than `process.cwd()` so it does not depend
+		// on which directory vitest was invoked from.
+		const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "package.json");
+		const { version } = JSON.parse(readFileSync(pkgPath, "utf-8")) as { version: string };
+		expect(compareSemver(AGENT_DIMENSION_SINCE_VERSION, version)).toBeGreaterThanOrEqual(0);
 	});
 });
 

--- a/cli/src/core/TelemetryAgent.ts
+++ b/cli/src/core/TelemetryAgent.ts
@@ -79,8 +79,10 @@
  *
  * One of these has been probed and is CLOSED AS UNCLOSABLE by env: **kimi sets
  * no environment variable at all in the shells it spawns** (kimi-code 0.34.0,
- * macOS, 2026-08 — a real one-shot run dumped its shell child's full env: zero
- * `KIMI_*`, zero `MOONSHOT_*`). The only kimi-shaped strings in that env were
+ * macOS, 2026-08 — measured in BOTH modes: a one-shot `--prompt` run and an
+ * interactive TUI session each dumped their shell child's full env, and both
+ * held zero `KIMI_*` and zero `MOONSHOT_*`; the two-mode check matters because
+ * cline demonstrably varies its vars by mode, `CLINE_NO_INTERACTIVE`). The only kimi-shaped strings in that env were
  * the user's own PATH entry (`~/.kimi-code/bin`, equally present in a human
  * shell — a PATH sniff would label people as the agent) and the parent process
  * name `kimi-code` (rejected as a signal for the reasons under

--- a/cli/src/core/TelemetryAgent.ts
+++ b/cli/src/core/TelemetryAgent.ts
@@ -88,7 +88,7 @@
  * every registered `SESSION_SOURCES` entry is spellable here.
  */
 
-import { isTranscriptSource, TRANSCRIPT_SOURCES, type TranscriptSource } from "../Types.js";
+import { type CommitTrigger, isTranscriptSource, TRANSCRIPT_SOURCES, type TranscriptSource } from "../Types.js";
 import { isLocalAgentChild } from "./AgentReentry.js";
 
 /**
@@ -310,6 +310,52 @@ export const CLIENTINFO_AGENTS: ReadonlyMap<string, TelemetryAgent> = new Map([
  * contract (closed set in, absent out), different key space — clientInfo names
  * are the hosts' own spellings, not our vocabulary.
  */
+/** Who set a commit in motion, plus which host when the answer is an agent. */
+export interface CommitOrigin {
+	readonly trigger: CommitTrigger;
+	/** Present only when `trigger === "agent"` and the family/marker named one host. */
+	readonly agent?: TelemetryAgent;
+}
+
+/**
+ * Resolve who set a commit in motion, at ENQUEUE time — inside the post-commit
+ * hook, whose process env and stdio are the last place the truth exists. The
+ * worker that drains the entry cannot re-derive any of this: it may be a
+ * chain-spawned survivor of an earlier commit (so its env belongs to that
+ * commit), and it never has the committing terminal's TTY.
+ *
+ * Precedence, and why each step beats the next:
+ *
+ *  1. **The IDE's Commit button** (`fromPluginUi` — the `plugin-source` marker
+ *     both IDE bridges write immediately before running `git commit`). Beats
+ *     the env markers deliberately: an extension host cold-started from inside
+ *     an agent session inherits that agent's marker for the window's whole
+ *     life, so a button commit would otherwise be labelled as the agent's work.
+ *     The marker is written milliseconds before THIS commit by the click
+ *     handler itself — the most specific signal there is — and the hook deletes
+ *     it after reading, so it cannot leak onto a later terminal commit. `ui`
+ *     also deliberately carries NO agent.
+ *  2. **An agent's markers** ({@link detectAgentFromEnv}) — the hook is git's
+ *     child, git is the committer's child, so the env chain is short and
+ *     current. Beats the TTY check because an agent session never gives the
+ *     hook a TTY, while a human's always does — so when a marker is present,
+ *     the TTY answer is already known to be false.
+ *  3. **A TTY** — a human typing `git commit`.
+ *  4. **`unknown`** — GUI git clients, cron, CI. NOT "terminal": absence of a
+ *     TTY is an absence, and the whole dimension's rule is that absence reads
+ *     as unknown rather than as the nearest plausible value.
+ */
+export function resolveCommitOrigin(opts: {
+	readonly fromPluginUi: boolean;
+	readonly isTTY: boolean;
+	readonly env?: NodeJS.ProcessEnv;
+}): CommitOrigin {
+	if (opts.fromPluginUi) return { trigger: "ui" };
+	const agent = detectAgentFromEnv(opts.env ?? process.env);
+	if (agent) return { trigger: "agent", agent };
+	return { trigger: opts.isTTY ? "terminal" : "unknown" };
+}
+
 export function resolveClientInfoAgent(name: string | undefined): TelemetryAgent | undefined {
 	// A Map, not a plain object: the name is host-authored input, and a bare
 	// object index would answer `Object` for "constructor" — a truthy Function

--- a/cli/src/core/TelemetryAgent.ts
+++ b/cli/src/core/TelemetryAgent.ts
@@ -101,9 +101,24 @@ export type TelemetryAgent = TranscriptSource;
  * the instrument coming online reads as adoption exploding from zero.
  *
  * Stamped into `TELEMETRY.md` by `TelemetryDoc`, so the disclosure and this
- * constant cannot drift. Update it only if this dimension ships in a different
- * release than planned — never on an ordinary version bump, since the watershed
- * is a fact about history rather than about the current build.
+ * constant cannot drift, and `TELEMETRY.md` is the repo's public statement of
+ * what is collected — a wrong number here is a wrong public fact.
+ *
+ * **Deliberately hand-written, and deliberately NOT derived from
+ * `cli/package.json`.** It is a fact about history: once this dimension has
+ * shipped, the answer is frozen forever, so tracking the current build would
+ * rewrite it on every release and destroy the only thing it records. That also
+ * means it starts life as a PREDICTION — the release this lands in is not
+ * knowable while writing it — and a prediction that goes wrong fails silently:
+ * nothing in the build can tell a correct guess from a stale one.
+ *
+ * `TelemetryAgent.test.ts` narrows that hole as far as it can go, by asserting
+ * this is never BELOW `cli/package.json`'s version. The feature cannot ship in a
+ * release older than the constant, so if main's version overtakes it while this
+ * is still unreleased, the guess has been overtaken too and the test says so.
+ * The remaining gap is genuine: nothing can distinguish "ships next release, as
+ * predicted" from "will ship two releases later", so a release that moves this
+ * must update the constant AND re-run `npm run gen:telemetry-doc`.
  */
 export const AGENT_DIMENSION_SINCE_VERSION = "0.99.14";
 

--- a/cli/src/core/TelemetryAgent.ts
+++ b/cli/src/core/TelemetryAgent.ts
@@ -62,11 +62,13 @@
  *    than by a disk scan — can reach `ai_source_detected`.
  *
  * So the gap is a CLI command run from a host with no marker of its own: `kimi`,
- * `copilot`, `cline`, `devin`, `antigravity` and the two Cursor tokens are
- * attributed at commit time but not on `command_invoked`. Closing one means a
- * real capture of that host's environment, added to {@link AGENT_ENV_MARKERS} —
- * an unmeasured key would be the guessing this module exists to refuse, and a
- * wrong marker is worse than the omission it replaces.
+ * `copilot`, `cline`, `devin` and `antigravity` are attributed at commit time
+ * but not on `command_invoked`. Closing one means a real capture of that host's
+ * environment, added to {@link AGENT_ENV_MARKERS} — an unmeasured key would be
+ * the guessing this module exists to refuse, and a wrong marker is worse than
+ * the omission it replaces. Cursor was in this list until its environment was
+ * actually captured; {@link AGENT_ENV_FAMILIES} records what that took, and it
+ * is the worked example for closing another.
  *
  * ## The vocabulary is derived, not restated
  *
@@ -125,12 +127,21 @@ export const AGENT_DIMENSION_SINCE_VERSION = "0.99.14";
 /**
  * Env markers that name **exactly one** host, each set by that host itself.
  *
- * Taken from `CaptureProgress.AGENT_ENV_KEYS`, which the post-commit hook
- * already trusts to decide whether a human is watching stdout — the same
- * measured set, read for a different question. `CODEX_THREAD_ID` in particular
- * is the measured Codex entry (present across interactive TUI and `codex exec`,
- * sandboxed and full-access alike, and scoped to command execution so Codex's
- * own lifecycle hooks cannot mistake themselves for the agent's shell).
+ * Drawn from `CaptureProgress.AGENT_ENV_KEYS`, which the post-commit hook uses
+ * to decide whether a human is watching stdout — a different question off the
+ * same signal. Deliberately NOT imported from it, and the two must not be
+ * merged: that list only needs "is an agent driving this", so one entry per
+ * family is enough, while this one has to name WHICH host and therefore splits
+ * families (see {@link AGENT_ENV_FAMILIES}) and refuses ambiguous keys.
+ *
+ * Keeping them separate is not hypothetical tidiness — that list's Cursor entry
+ * (`CURSOR_TRACE_ID`) turns out not to exist; see
+ * {@link AMBIGUOUS_AGENT_ENV_KEYS}. So treat "it is in that list" as a lead, not
+ * as evidence: every entry here should be traceable to a capture. `CODEX_THREAD_ID`
+ * is (present across interactive TUI and `codex exec`, sandboxed and full-access
+ * alike, and scoped to command execution so Codex's own lifecycle hooks cannot
+ * mistake themselves for the agent's shell), and `CLAUDECODE` was confirmed on a
+ * live machine, including in an MCP server Claude Code had spawned.
  *
  * Order carries no meaning: {@link detectAgentFromEnv} requires the matches to
  * agree rather than taking the first, so a precedence here could only hide an
@@ -144,19 +155,91 @@ export const AGENT_ENV_MARKERS: ReadonlyArray<readonly [string, TelemetryAgent]>
 ];
 
 /**
- * Markers that mark an agent session but not **which** agent, so they are
- * deliberately unmapped:
+ * A host family whose presence marker cannot name the variant on its own, plus
+ * the markers that do.
  *
- *  - `AI_AGENT` is generic — Claude Code sets it, and it names no host at all.
- *  - `CURSOR_TRACE_ID` names the Cursor *family*, and we have no measurement
- *    separating the IDE (`cursor`) from `cursor-agent` (`cursor-cli`). That
- *    distinction is part of what makes this dimension worth adding — `surface`
- *    can never draw it — so collapsing the two would spend the value we are
- *    here to gain. Mapping it needs a real capture of both, not a guess.
+ * Cursor is the only one, and it is the reason this shape exists rather than a
+ * second flat entry: `cursor` (the IDE) and `cursor-cli` (`cursor-agent`) must
+ * stay separate tokens — `surface` can never draw that line, and drawing it is
+ * part of what makes this dimension worth having — so collapsing them to a
+ * single "cursor" would spend the value we are here to gain.
+ */
+export interface AgentEnvFamily {
+	/** Set in every one of this family's contexts, and in no other. */
+	readonly familyKey: string;
+	/** Evidence for one variant each. Must be mutually exclusive. */
+	readonly variants: ReadonlyArray<readonly [string, TelemetryAgent]>;
+}
+
+/**
+ * Measured on Cursor (macOS, 2026-08) by dumping `CURSOR_*` in the three
+ * contexts that matter, which is what makes the split safe. The parent process
+ * is recorded beside each because it is what proves the three samples really
+ * came from three different places, rather than three runs of one shell:
  *
- * They are listed rather than merely absent so the omission reads as a decision.
- * Cursor is therefore a **known gap** in env-based attribution; the Cursor
- * plugin's own bootstrap still attributes structurally.
+ *   IDE agent    parent `Cursor Helper (Plugin): extension-host`
+ *                CURSOR_AGENT, CURSOR_CONVERSATION_ID, CURSOR_LAYOUT,
+ *                CURSOR_RIPGREP_PATH, CURSOR_WORKSPACE_LABEL
+ *   cursor-agent parent `~/.local/bin/agent`
+ *                CURSOR_AGENT, CURSOR_ASKPASS_SECRET, CURSOR_ASKPASS_SOCKET,
+ *                CURSOR_CONVERSATION_ID, CURSOR_INVOKED_AS, CURSOR_RIPGREP_PATH
+ *   human shell  parent `Cursor Helper: terminal pty-host`
+ *                (nothing at all)
+ *
+ * Those parent names separate the three contexts more sharply than the env does,
+ * and were still rejected as the SIGNAL. Reading them costs a `ps` subprocess on
+ * macOS (no `/proc`, and Node exposes only `ppid`) on a path that runs ahead of
+ * every command dispatch and inside `<5ms` git hooks. They are display strings
+ * that vary by platform and version, and `agent` is a basename from one install
+ * layout. Decisively, the parent link is broken exactly where env inheritance is
+ * most useful: `QueueWorker` is a DETACHED spawn, so it is reparented away from
+ * whatever committed, while the env it was handed survives intact.
+ *
+ * `CURSOR_AGENT` is the family gate because the third row is what makes it
+ * usable: it is absent when a person types in Cursor's own integrated terminal,
+ * so mapping it cannot label human work as an agent's — a failure that would be
+ * worse than the gap it replaces, since it attacks the field's whole meaning.
+ *
+ * The variant keys are chosen for semantics, not just for having differed once:
+ * a CLI has no workspace label or editor layout, and `CURSOR_INVOKED_AS` names
+ * how the binary was started. `CURSOR_LAYOUT` (IDE) and the `CURSOR_ASKPASS_*`
+ * pair (CLI) discriminated identically and are held in reserve — one key per
+ * side keeps a future rename degrading to *unknown* rather than to a coin flip.
+ * `CURSOR_CONVERSATION_ID` and `CURSOR_RIPGREP_PATH` appear on both sides and so
+ * could serve as the gate, but neither says "agent" in its name.
+ *
+ * One Cursor context stays unattributed and is not covered by any of this: an
+ * MCP server Cursor spawned carries no `CURSOR_*` variable at all (measured on
+ * two live servers). That path is attributed only by the Cursor plugin's own
+ * bootstrap, which is structural.
+ */
+export const AGENT_ENV_FAMILIES: ReadonlyArray<AgentEnvFamily> = [
+	{
+		familyKey: "CURSOR_AGENT",
+		variants: [
+			["CURSOR_WORKSPACE_LABEL", "cursor"],
+			["CURSOR_INVOKED_AS", "cursor-cli"],
+		],
+	},
+];
+
+/**
+ * Markers that mark an agent session but not **which** agent, and that no
+ * variant marker rescues — so they are deliberately unmapped.
+ *
+ *  - `AI_AGENT` is generic. Claude Code sets it, and while its VALUE encodes a
+ *    host (`claude-code_2-1-234_agent` / `…_harness`, captured live), parsing a
+ *    value prefix is a guess until other hosts have been sampled — and for
+ *    Claude it is redundant with `CLAUDECODE` anyway.
+ *  - `CURSOR_TRACE_ID` was this list's original reason to exist, as the Cursor
+ *    family marker that could not name a variant. The capture above found it in
+ *    **none** of the three contexts, so it is kept here only as a guard: if some
+ *    other Cursor build does set it, it still cannot discriminate, and
+ *    `CURSOR_AGENT` is the marker that actually appears. Note
+ *    `CaptureProgress.AGENT_ENV_KEYS` still keys Cursor off it, which is a
+ *    separate, pre-existing bug in a different feature.
+ *
+ * Listed rather than merely absent so each omission reads as a decision.
  */
 export const AMBIGUOUS_AGENT_ENV_KEYS: ReadonlyArray<string> = ["AI_AGENT", "CURSOR_TRACE_ID"];
 
@@ -198,10 +281,27 @@ export function resolveTelemetryAgent(value: unknown): TelemetryAgent | undefine
 export function detectAgentFromEnv(env: NodeJS.ProcessEnv = process.env): TelemetryAgent | undefined {
 	if (isLocalAgentChild(env)) return undefined;
 	let found: TelemetryAgent | undefined;
+	const claim = (agent: TelemetryAgent): boolean => {
+		if (found !== undefined && found !== agent) return false;
+		found = agent;
+		return true;
+	};
 	for (const [key, agent] of AGENT_ENV_MARKERS) {
 		if (!isTruthyEnv(env[key])) continue;
-		if (found !== undefined && found !== agent) return undefined;
-		found = agent;
+		if (!claim(agent)) return undefined;
+	}
+	for (const family of AGENT_ENV_FAMILIES) {
+		if (!isTruthyEnv(env[family.familyKey])) continue;
+		// A present family gate that resolves to no single variant abandons the
+		// WHOLE answer rather than contributing nothing. Contributing nothing would
+		// let another host's marker win an environment this family is also present
+		// in — reporting a confident single host for a nested session — and it would
+		// equally let a future Cursor build that renamed both variant keys fall
+		// through to whatever else happened to be set.
+		const matched = new Set(family.variants.filter(([key]) => isTruthyEnv(env[key])).map(([, agent]) => agent));
+		const [only] = matched;
+		if (matched.size !== 1 || only === undefined) return undefined;
+		if (!claim(only)) return undefined;
 	}
 	return found;
 }

--- a/cli/src/core/TelemetryAgent.ts
+++ b/cli/src/core/TelemetryAgent.ts
@@ -67,14 +67,26 @@
  *    frozen at spawn from whichever proxy arrived first. It also beats env on
  *    the single-session path: a declaration outranks an inherited marker.
  *
- * So the gap is a CLI command run from a host with no marker of its own: `kimi`,
- * `copilot`, `cline`, `devin` and `antigravity` are attributed at commit time
- * but not on `command_invoked`. Closing one means a real capture of that host's
- * environment, added to {@link AGENT_ENV_MARKERS} — an unmeasured key would be
- * the guessing this module exists to refuse, and a wrong marker is worse than
- * the omission it replaces. Cursor was in this list until its environment was
- * actually captured; {@link AGENT_ENV_FAMILIES} records what that took, and it
- * is the worked example for closing another.
+ * So the gap is a CLI command run from a host with no marker of its own:
+ * `kimi`, `copilot`, `cline`, `devin` and `antigravity` are attributed at
+ * commit time but not on `command_invoked`. Closing one means a real capture of
+ * that host's environment, added to {@link AGENT_ENV_MARKERS} — an unmeasured
+ * key would be the guessing this module exists to refuse, and a wrong marker is
+ * worse than the omission it replaces. Cursor was in this list until its
+ * environment was actually captured; {@link AGENT_ENV_FAMILIES} records what
+ * that took, and it is the worked example for closing another.
+ *
+ * One of these has been probed and is CLOSED AS UNCLOSABLE by env: **kimi sets
+ * no environment variable at all in the shells it spawns** (kimi-code 0.34.0,
+ * macOS, 2026-08 — a real one-shot run dumped its shell child's full env: zero
+ * `KIMI_*`, zero `MOONSHOT_*`). The only kimi-shaped strings in that env were
+ * the user's own PATH entry (`~/.kimi-code/bin`, equally present in a human
+ * shell — a PATH sniff would label people as the agent) and the parent process
+ * name `kimi-code` (rejected as a signal for the reasons under
+ * {@link AGENT_ENV_FAMILIES}: a `ps` spawn on hook-hot paths, and detached
+ * workers are reparented away). Kimi therefore stays commit-time-attributed
+ * only — re-probe on a major kimi release rather than re-deriving this, and do
+ * not add a guessed key.
  *
  * ## The vocabulary is derived, not restated
  *

--- a/cli/src/core/TelemetryAgent.ts
+++ b/cli/src/core/TelemetryAgent.ts
@@ -60,6 +60,12 @@
  *    walking: the QueueWorker loop passes `session.source` explicitly, which is
  *    how all thirteen hosts — Gemini included, fed by its AfterAgent hook rather
  *    than by a disk scan — can reach `ai_source_detected`.
+ *  - **Per-connection**, for MCP: the `initialize` handshake's `clientInfo.name`
+ *    through {@link resolveClientInfoAgent}. The only channel that works in the
+ *    shared `mcp-serve` daemon, where several hosts' sessions reach ONE process
+ *    and env inference is disabled — the handshake is per-connection, the env is
+ *    frozen at spawn from whichever proxy arrived first. It also beats env on
+ *    the single-session path: a declaration outranks an inherited marker.
  *
  * So the gap is a CLI command run from a host with no marker of its own: `kimi`,
  * `copilot`, `cline`, `devin` and `antigravity` are attributed at commit time
@@ -258,6 +264,58 @@ export const AGENT_ENV_FAMILIES: ReadonlyArray<AgentEnvFamily> = [
  * Listed rather than merely absent so each omission reads as a decision.
  */
 export const AMBIGUOUS_AGENT_ENV_KEYS: ReadonlyArray<string> = ["AI_AGENT", "CURSOR_TRACE_ID"];
+
+/**
+ * MCP `initialize` handshake `clientInfo.name` → agent, per CONNECTION.
+ *
+ * This is what attributes MCP tool calls, and it is the only signal that can:
+ * the env markers are structurally unavailable there (measured — of the hosts
+ * checked, only Claude passes a marker to an MCP child, and the shared
+ * `mcp-serve` daemon may not read its env at all, since one daemon serves
+ * several hosts' sessions and its env is frozen at spawn). `clientInfo` is the
+ * host DECLARING itself, once per connection, which is exactly the granularity
+ * a shared daemon needs.
+ *
+ * Keys are exact strings, each traceable to a probe capture (a minimal MCP
+ * server that logs the raw `initialize` request — the probe recipe lives with
+ * the design note). Guessing a key is worse than omitting it: `codex` here
+ * would have been the obvious guess and is WRONG — the measured value is
+ * `codex-mcp-client`. An unmapped name degrades to an absent property (unknown),
+ * never to a pass-through — `clientInfo.name` is an arbitrary host-authored
+ * string, and forwarding it verbatim would break the never-free-form rule. The
+ * `oninitialized` log line in `createMcpServer` records unmapped names locally,
+ * which is how the next host's exact string gets captured organically.
+ *
+ * Captured 2026-08-20 on macOS:
+ *   claude-code       claude  2.1.212, `claude -p … --strict-mcp-config`
+ *   codex-mcp-client  codex   0.147.0, `codex exec -c mcp_servers.probe…`
+ *
+ * One captured name is deliberately NOT mapped: `cursor-agent` declares
+ * `{"name":"Cursor","version":"1.0.0"}` — a family name with a hardcoded
+ * version, and the Cursor IDE's own clientInfo is unmeasured (the IDE spawns
+ * MCP from a shared process; no one-shot command reaches it, and its logs
+ * record only the server's info). If the IDE also says "Cursor", mapping it
+ * would collapse `cursor`/`cursor-cli` — the split this vocabulary exists to
+ * keep — so it waits, exactly like `CURSOR_TRACE_ID` did. The oninitialized
+ * log line captures the IDE's string the first time this dist serves one.
+ */
+export const CLIENTINFO_AGENTS: ReadonlyMap<string, TelemetryAgent> = new Map([
+	["claude-code", "claude"],
+	["codex-mcp-client", "codex"],
+]);
+
+/**
+ * Coerce an MCP client's self-declared name to a known agent token, or
+ * `undefined`. The clientInfo counterpart of {@link resolveTelemetryAgent}: same
+ * contract (closed set in, absent out), different key space — clientInfo names
+ * are the hosts' own spellings, not our vocabulary.
+ */
+export function resolveClientInfoAgent(name: string | undefined): TelemetryAgent | undefined {
+	// A Map, not a plain object: the name is host-authored input, and a bare
+	// object index would answer `Object` for "constructor" — a truthy Function
+	// leaking through a lookup typed as a token. Map.get has no prototype chain.
+	return name === undefined ? undefined : CLIENTINFO_AGENTS.get(name);
+}
 
 /** Same truthiness rule `CaptureProgress` applies to these markers. */
 function isTruthyEnv(v: string | undefined): boolean {

--- a/cli/src/core/TelemetryAgent.ts
+++ b/cli/src/core/TelemetryAgent.ts
@@ -208,10 +208,26 @@ export interface AgentEnvFamily {
  * `CURSOR_CONVERSATION_ID` and `CURSOR_RIPGREP_PATH` appear on both sides and so
  * could serve as the gate, but neither says "agent" in its name.
  *
- * One Cursor context stays unattributed and is not covered by any of this: an
- * MCP server Cursor spawned carries no `CURSOR_*` variable at all (measured on
- * two live servers). That path is attributed only by the Cursor plugin's own
- * bootstrap, which is structural.
+ * One Cursor context is measured unattributed, and the scope of that claim
+ * matters: an MCP server the **Cursor IDE** spawned carries no `CURSOR_*`
+ * variable at all (two live servers, both from the IDE's plugin cache). The
+ * likely mechanism is that `CURSOR_AGENT` / `CURSOR_CONVERSATION_ID` are
+ * per-conversation, while the IDE spawns MCP servers from a shared process
+ * before any workspace is known — the `WARN No workspace folders found` that
+ * AGENTS.md records for the same launch — so there is no conversation yet to
+ * name. Inference, not measurement.
+ *
+ * An MCP server `cursor-agent` spawned is **NOT measured**, and the two halves
+ * should not be assumed alike: `cursor-agent`'s shell-command children DO carry
+ * both markers (row 2 above), so if it spawns MCP the same way, such a server
+ * resolves to `cursor-cli` with no code change — this function reads whatever
+ * env a process was handed and does not care which parent handed it over. Treat
+ * the unattributed case as "the IDE's MCP servers", not as "Cursor's".
+ *
+ * Neither is rescued by the Cursor plugin's bootstrap, and that is worth being
+ * exact about too: the bootstrap attributes the events IT emits
+ * (`onboarding_progressed`, `app_installed`) structurally. It is a different
+ * process from the MCP server and does not label the server's tool calls.
  */
 export const AGENT_ENV_FAMILIES: ReadonlyArray<AgentEnvFamily> = [
 	{

--- a/cli/src/core/TelemetryAgent.ts
+++ b/cli/src/core/TelemetryAgent.ts
@@ -416,6 +416,7 @@ export const SKILL_VIA_NAMES: ReadonlyArray<string> = [
 	"status",
 	"timeline",
 	"push",
+	"dashboard",
 ];
 
 const SKILL_VIA_SET: ReadonlySet<string> = new Set(SKILL_VIA_NAMES);

--- a/cli/src/core/TelemetryAgent.ts
+++ b/cli/src/core/TelemetryAgent.ts
@@ -68,8 +68,9 @@
  *    the single-session path: a declaration outranks an inherited marker.
  *
  * So the gap is a CLI command run from a host with no marker of its own:
- * `kimi`, `copilot`, `cline`, `devin` and `antigravity` are attributed at
- * commit time but not on `command_invoked`. Closing one means a real capture of
+ * `kimi` (measured: none exists — see below), `copilot-chat`, `cline` (the
+ * VS Code extension) and `devin` (probe blocked) are attributed at commit time
+ * but not on `command_invoked`. Closing one means a real capture of
  * that host's environment, added to {@link AGENT_ENV_MARKERS} — an unmeasured
  * key would be the guessing this module exists to refuse, and a wrong marker is
  * worse than the omission it replaces. Cursor was in this list until its
@@ -170,7 +171,50 @@ export const AGENT_ENV_MARKERS: ReadonlyArray<readonly [string, TelemetryAgent]>
 	["CODEX_THREAD_ID", "codex"],
 	["GEMINI_CLI", "gemini"],
 	["OPENCODE", "opencode"],
+	// Probed 2026-08-20 (one-shot agent runs dumping their shell child's full
+	// env; the human-shell control held none of these — see the sweep notes
+	// below for each host's complete inventory and the caveats):
+	["ANTIGRAVITY_AGENT", "antigravity"],
+	["COPILOT_CLI", "copilot"],
+	["CLINE_WRAPPER_PATH", "cline-cli"],
+	["CLINE_CONNECTOR_CLI_LAUNCH", "cline-cli"],
 ];
+
+/**
+ * Provenance for the 2026-08-20 marker sweep (macOS; same probe as kimi's —
+ * the agent writes `env` to a file, so nothing depends on output formatting).
+ *
+ * **antigravity** (`agy` cli-1.1.16, Antigravity's headless CLI): nine
+ * `ANTIGRAVITY_*` vars — AGENT=1 (the gate), CONVERSATION_ID, TRAJECTORY_ID,
+ * PROJECT_ID, CSRF_TOKEN, LS_ADDRESS, LS_VERSION, AGENTAPI_EXE,
+ * SOURCE_METADATA. Two things make this the clean case: the vocabulary has ONE
+ * antigravity token (no CLI/IDE variant to confuse — if the IDE's agent sets
+ * the same var the answer is identical, and if it does not, IDE work is merely
+ * unattributed), and the dump held **no `GEMINI_*` var at all**, so Google's
+ * own CLI marker cannot be tripped by Antigravity — a collision that would have
+ * mislabelled antigravity work as gemini's, checked for explicitly.
+ *
+ * **copilot** (GitHub Copilot CLI 1.0.80): COPILOT_CLI=1 (the mapped key,
+ * self-naming the CLI variant), COPILOT_AGENT_SESSION_ID,
+ * COPILOT_CLI_BINARY_VERSION. Caveat: the sibling source `copilot-chat`
+ * (VS Code) is UNMEASURED — the mapping rests on `COPILOT_CLI` naming the CLI
+ * itself. Falsifier: a Copilot Chat terminal command observed carrying
+ * COPILOT_CLI would demote this to a family key; until then the worst case is
+ * family-internal (cli vs chat), never human-vs-agent.
+ *
+ * **cline-cli** (standalone `cline`): CLINE_WRAPPER_PATH (the CLI's own bin
+ * wrapper — set by the launcher, so present in every mode) and
+ * CLINE_CONNECTOR_CLI_LAUNCH (launcher JSON) are mapped; CLINE_BUILD_ENV and
+ * CLINE_NO_INTERACTIVE were also present but are NOT mapped — BUILD_ENV says
+ * nothing about which variant, and NO_INTERACTIVE varies by mode. Same caveat
+ * shape as copilot: the `cline` VS Code extension is unmeasured, and the
+ * mapped keys are launcher artifacts the extension has no reason to set.
+ *
+ * **devin**: probe blocked — two consecutive runs died on a server-side
+ * retryable API error (`cognition.ai/retryable: true`) before any command ran.
+ * Not a measurement of absence; re-run the probe when the service cooperates
+ * (`devin --respect-workspace-trust false -p "<probe>"`).
+ */
 
 /**
  * A host family whose presence marker cannot name the variant on its own, plus

--- a/cli/src/core/TelemetryAgent.ts
+++ b/cli/src/core/TelemetryAgent.ts
@@ -388,19 +388,35 @@ export const JOLLI_INVOKED_VIA_ENV = "JOLLI_INVOKED_VIA";
  * that bundle. Bare names also make the value host-neutral — all three plugin
  * bundles and the installed copies emit the same token.
  *
- * A hand-kept copy of the installed-skill registry, kept deliberately: this
+ * A hand-kept copy of the union of every skill name Jolli ships — the
+ * installed registry plus both plugin bundles' own skills — kept deliberately: this
  * module is a leaf that `Telemetry`, `TelemetryStartup` and the hooks all
  * import, and deriving the list live would drag `install/SkillInstaller` (the
  * whole install stack) into every one of them. The same trade
  * `ClientHeader.PLUGIN_BUNDLE_KINDS` makes, policed the same way:
- * `TelemetryAgent.test.ts` asserts it equals the names derived from
- * `SkillInstaller.INSTALLED_SKILL_NAMES`, so the copy cannot drift silently.
+ * `TelemetryAgent.test.ts` asserts it equals the bare-name union of
+ * `SkillInstaller.INSTALLED_SKILL_NAMES`, `CODEX_PLUGIN_SKILL_NAMES` and
+ * `CURSOR_PLUGIN_SKILL_NAMES`, so the copy cannot drift silently when a skill
+ * is added or retired in ANY of the three.
  *
- * Includes names whose recipes do not carry the prefix yet (`jolli`, the menu)
- * — the set answers "what could a legitimate via name be", so a recipe adopting
- * it later is a skill-template change only, never a core change.
+ * Every shipped run-cli recipe now carries its prefix (pinned per builder and
+ * per committed bundle file), so the set also includes names whose skills are
+ * currently MCP-only (`timeline`, `push`) — they emit nothing today, and being
+ * in the set means a future recipe there is a skill-template change only.
  */
-export const SKILL_VIA_NAMES: ReadonlyArray<string> = ["recall", "search", "local-run", "remote-run", "jolli"];
+export const SKILL_VIA_NAMES: ReadonlyArray<string> = [
+	"recall",
+	"search",
+	"local-run",
+	"remote-run",
+	"jolli",
+	"init",
+	"login",
+	"logout",
+	"status",
+	"timeline",
+	"push",
+];
 
 const SKILL_VIA_SET: ReadonlySet<string> = new Set(SKILL_VIA_NAMES);
 

--- a/cli/src/core/TelemetryAgent.ts
+++ b/cli/src/core/TelemetryAgent.ts
@@ -1,0 +1,192 @@
+/**
+ * TelemetryAgent — the `agent` telemetry dimension: **which AI host the user was
+ * actually working in**, as distinct from which of our build artifacts sent the
+ * event.
+ *
+ * ## Why `surface` cannot answer this
+ *
+ * `surface` comes from `__JOLLI_CLIENT_KIND__`, a compile-time constant each
+ * bundler `define`s, so the complete set of values a running process can emit
+ * equals the set of build configurations that exist — six. This product supports
+ * thirteen hosts ({@link TRANSCRIPT_SOURCES}), only three of which ship a plugin
+ * bundle; everything else is *observed* by whichever artifact happens to be
+ * running, so ten of thirteen report the surface of the observer.
+ *
+ * Worse than invisible, they are misattributed. Repo hooks are installed as
+ * source-neutral `run-hook` calls and resolved at trigger time by
+ * `pickBestDistPath` — highest core version wins, with plugin tags deliberately
+ * absent from the tie-break order — so a **Gemini** session's hook can be
+ * executed by the claude-plugin bundle and arrive tagged
+ * `surface: "claude-plugin"` on a session Claude was never in.
+ *
+ * `surface` answers "which of our artifacts ran, at which version", which is
+ * what min-version upgrade gating needs. This module adds the second dimension
+ * rather than widening the first.
+ *
+ * ## Three rules this module exists to enforce
+ *
+ * **Never defaulted.** An absent `agent` reads as *unknown*. Defaulting it to
+ * `cli` (or anything) would disguise "not measured" as a positive claim about
+ * the user's host, which silently corrupts every future comparison — and unlike
+ * a wrong value, an omission is recoverable later.
+ *
+ * **Never free-form.** {@link resolveTelemetryAgent} is the only way a value
+ * reaches the wire, and it answers from the closed {@link TELEMETRY_AGENTS} set.
+ * An unrecognised host is omitted, never passed through. That is what keeps the
+ * dimension inside the content-free contract: a fixed, low-cardinality
+ * enumeration of tool names is not identity, content, a path, or user input.
+ *
+ * **Never guessed.** A partially-known case must not fall through to a wrong
+ * value — see {@link AMBIGUOUS_AGENT_ENV_KEYS} for the two markers that name a
+ * family rather than a host, and {@link detectAgentFromEnv} for why two distinct
+ * markers at once yields nothing.
+ *
+ * ## What is attributed today, and what is not
+ *
+ * Three channels reach the wire, and they cover different events:
+ *
+ *  - **Structural**, strongest: a plugin's SessionStart bootstrap only ever runs
+ *    inside its own host, so `claude-plugin` / `codex-plugin` / `cursor-plugin`
+ *    are known outright (`pluginBootstrapAgent`). This is what attributes
+ *    `onboarding_progressed` and `app_installed`.
+ *  - **Env markers**, via {@link detectAgentFromEnv} at `bootstrapTelemetry`:
+ *    attributes everything a short-lived CLI process emits, `command_invoked`
+ *    included, since the bootstrap runs ahead of command dispatch. Four hosts
+ *    today. This channel is **opt-in** (`inferAgentFromEnv`) because a marker is
+ *    inherited by every descendant and never expires, so it only names the
+ *    current host in a process the host itself just launched — see that flag for
+ *    the long-lived cases it is off for.
+ *  - **Per-session**, for a pass that has narrowed which transcript it is
+ *    walking: the QueueWorker loop passes `session.source` explicitly, which is
+ *    how all thirteen hosts — Gemini included, fed by its AfterAgent hook rather
+ *    than by a disk scan — can reach `ai_source_detected`.
+ *
+ * So the gap is a CLI command run from a host with no marker of its own: `kimi`,
+ * `copilot`, `cline`, `devin`, `antigravity` and the two Cursor tokens are
+ * attributed at commit time but not on `command_invoked`. Closing one means a
+ * real capture of that host's environment, added to {@link AGENT_ENV_MARKERS} —
+ * an unmeasured key would be the guessing this module exists to refuse, and a
+ * wrong marker is worse than the omission it replaces.
+ *
+ * ## The vocabulary is derived, not restated
+ *
+ * {@link TELEMETRY_AGENTS} *is* `TRANSCRIPT_SOURCES`, the closed enumeration the
+ * discoverers, readers and session registry already share
+ * (`SessionSourceDefinition.source` is typed `TranscriptSource`, so a fourteenth
+ * host must be added there before it can be registered at all). A hand-written
+ * copy of this list is a known rot pattern in this repo — the Codex plugin's
+ * copy of a similar list went stale exactly that way when `kimi` shipped — and
+ * `TelemetryAgent.test.ts` additionally asserts from the other direction that
+ * every registered `SESSION_SOURCES` entry is spellable here.
+ */
+
+import { isTranscriptSource, TRANSCRIPT_SOURCES, type TranscriptSource } from "../Types.js";
+import { isLocalAgentChild } from "./AgentReentry.js";
+
+/**
+ * The closed agent vocabulary. Identical to {@link TRANSCRIPT_SOURCES} by
+ * construction — aliased rather than copied so a fourteenth host cannot ship
+ * with a silently stale list here.
+ */
+export const TELEMETRY_AGENTS = TRANSCRIPT_SOURCES;
+
+/** One AI host the work can have happened in. */
+export type TelemetryAgent = TranscriptSource;
+
+/**
+ * The first client version that emits `agent` — the **watershed**. Rows before
+ * it are not missing the field; the fact was never measured, and nothing can
+ * recover it (`surface: "cli"` cannot be resolved into "kimi" versus "someone
+ * typed `jolli push` by hand"). Every `agent`-sliced chart must start here, or
+ * the instrument coming online reads as adoption exploding from zero.
+ *
+ * Stamped into `TELEMETRY.md` by `TelemetryDoc`, so the disclosure and this
+ * constant cannot drift. Update it only if this dimension ships in a different
+ * release than planned — never on an ordinary version bump, since the watershed
+ * is a fact about history rather than about the current build.
+ */
+export const AGENT_DIMENSION_SINCE_VERSION = "0.99.14";
+
+/**
+ * Env markers that name **exactly one** host, each set by that host itself.
+ *
+ * Taken from `CaptureProgress.AGENT_ENV_KEYS`, which the post-commit hook
+ * already trusts to decide whether a human is watching stdout — the same
+ * measured set, read for a different question. `CODEX_THREAD_ID` in particular
+ * is the measured Codex entry (present across interactive TUI and `codex exec`,
+ * sandboxed and full-access alike, and scoped to command execution so Codex's
+ * own lifecycle hooks cannot mistake themselves for the agent's shell).
+ *
+ * Order carries no meaning: {@link detectAgentFromEnv} requires the matches to
+ * agree rather than taking the first, so a precedence here could only hide an
+ * ambiguity.
+ */
+export const AGENT_ENV_MARKERS: ReadonlyArray<readonly [string, TelemetryAgent]> = [
+	["CLAUDECODE", "claude"],
+	["CODEX_THREAD_ID", "codex"],
+	["GEMINI_CLI", "gemini"],
+	["OPENCODE", "opencode"],
+];
+
+/**
+ * Markers that mark an agent session but not **which** agent, so they are
+ * deliberately unmapped:
+ *
+ *  - `AI_AGENT` is generic — Claude Code sets it, and it names no host at all.
+ *  - `CURSOR_TRACE_ID` names the Cursor *family*, and we have no measurement
+ *    separating the IDE (`cursor`) from `cursor-agent` (`cursor-cli`). That
+ *    distinction is part of what makes this dimension worth adding — `surface`
+ *    can never draw it — so collapsing the two would spend the value we are
+ *    here to gain. Mapping it needs a real capture of both, not a guess.
+ *
+ * They are listed rather than merely absent so the omission reads as a decision.
+ * Cursor is therefore a **known gap** in env-based attribution; the Cursor
+ * plugin's own bootstrap still attributes structurally.
+ */
+export const AMBIGUOUS_AGENT_ENV_KEYS: ReadonlyArray<string> = ["AI_AGENT", "CURSOR_TRACE_ID"];
+
+/** Same truthiness rule `CaptureProgress` applies to these markers. */
+function isTruthyEnv(v: string | undefined): boolean {
+	return v !== undefined && v !== "" && v !== "0" && v.toLowerCase() !== "false";
+}
+
+/**
+ * Coerce an arbitrary value to a known agent token, or `undefined`.
+ *
+ * The single gate every value passes through on its way to the wire. Anything
+ * that is not a member of {@link TELEMETRY_AGENTS} — a non-string, a host we do
+ * not know, a typo, free-form user input — answers `undefined`, which callers
+ * turn into an omitted property rather than a default.
+ */
+export function resolveTelemetryAgent(value: unknown): TelemetryAgent | undefined {
+	return isTranscriptSource(value) ? value : undefined;
+}
+
+/**
+ * The host driving this process, read from its environment, or `undefined`.
+ *
+ * Two refusals are as load-bearing as the mapping:
+ *
+ * **Disagreement is unknown.** Distinct markers from two hosts mean one agent
+ * shelled out to another, and "which host is the user working in" genuinely has
+ * no single answer there — so it answers none. (Repeated markers for the *same*
+ * host are not a disagreement.)
+ *
+ * **A local-agent child is not the user's host.** When we spawn `claude` or
+ * `codex` outbound to generate a summary, that CLI sets its own marker in every
+ * descendant, including a `jolli` we invoke from inside it. Attributing those to
+ * the user's host would conflate this dimension with the outbound one it must
+ * stay distinct from (`LocalAgentToolId` — if the outbound direction ever needs a
+ * name, call it `summarizer`, never `agent`). Env-only, matching the documented
+ * pattern for hooks and other direct children of an agent CLI.
+ */
+export function detectAgentFromEnv(env: NodeJS.ProcessEnv = process.env): TelemetryAgent | undefined {
+	if (isLocalAgentChild(env)) return undefined;
+	let found: TelemetryAgent | undefined;
+	for (const [key, agent] of AGENT_ENV_MARKERS) {
+		if (!isTruthyEnv(env[key])) continue;
+		if (found !== undefined && found !== agent) return undefined;
+		found = agent;
+	}
+	return found;
+}

--- a/cli/src/core/TelemetryAgent.ts
+++ b/cli/src/core/TelemetryAgent.ts
@@ -310,6 +310,55 @@ export const CLIENTINFO_AGENTS: ReadonlyMap<string, TelemetryAgent> = new Map([
  * contract (closed set in, absent out), different key space — clientInfo names
  * are the hosts' own spellings, not our vocabulary.
  */
+/**
+ * Env var a skill's run-cli recipe sets on the ONE command it invokes:
+ * `JOLLI_INVOKED_VIA=skill:<bare-name>`. The `via` telemetry dimension — how a
+ * command was reached (a skill, vs typed directly), as distinct from which host
+ * ran it (`agent`). `TelemetryCommandHook` consumes it: read once, validated
+ * against {@link SKILL_VIA_NAMES}, then DELETED from the process env so a child
+ * the command spawns (a detached daemon, a chained worker) cannot inherit a
+ * claim that was only ever about this invocation.
+ */
+export const JOLLI_INVOKED_VIA_ENV = "JOLLI_INVOKED_VIA";
+
+/**
+ * The bare skill names that may appear in a `skill:<name>` via value.
+ *
+ * BARE names (`recall`, not `jolli-recall`) for a renderer reason: the Codex
+ * plugin generator rewrites `jolli-<name>` substrings to `jolli:<name>` across
+ * every shared skill body, so the prefixed spelling would ship corrupted in
+ * that bundle. Bare names also make the value host-neutral — all three plugin
+ * bundles and the installed copies emit the same token.
+ *
+ * A hand-kept copy of the installed-skill registry, kept deliberately: this
+ * module is a leaf that `Telemetry`, `TelemetryStartup` and the hooks all
+ * import, and deriving the list live would drag `install/SkillInstaller` (the
+ * whole install stack) into every one of them. The same trade
+ * `ClientHeader.PLUGIN_BUNDLE_KINDS` makes, policed the same way:
+ * `TelemetryAgent.test.ts` asserts it equals the names derived from
+ * `SkillInstaller.INSTALLED_SKILL_NAMES`, so the copy cannot drift silently.
+ *
+ * Includes names whose recipes do not carry the prefix yet (`jolli`, the menu)
+ * — the set answers "what could a legitimate via name be", so a recipe adopting
+ * it later is a skill-template change only, never a core change.
+ */
+export const SKILL_VIA_NAMES: ReadonlyArray<string> = ["recall", "search", "local-run", "remote-run", "jolli"];
+
+const SKILL_VIA_SET: ReadonlySet<string> = new Set(SKILL_VIA_NAMES);
+
+/**
+ * Validate a raw `JOLLI_INVOKED_VIA` value to a wire-safe `via` token, or
+ * `undefined`. Same contract as every other gate in this module: closed set in,
+ * absent out, never a pass-through — the env var is settable by anything, so an
+ * unrecognised value (wrong prefix, unknown name, free text) is dropped whole
+ * rather than partially honoured.
+ */
+export function resolveInvokedVia(value: string | undefined): string | undefined {
+	if (value === undefined || !value.startsWith("skill:")) return undefined;
+	const name = value.slice("skill:".length);
+	return SKILL_VIA_SET.has(name) ? value : undefined;
+}
+
 /** Who set a commit in motion, plus which host when the answer is an agent. */
 export interface CommitOrigin {
 	readonly trigger: CommitTrigger;

--- a/cli/src/core/TelemetryAgentMatrix.test.ts
+++ b/cli/src/core/TelemetryAgentMatrix.test.ts
@@ -132,11 +132,31 @@ const SHORT_LIVED: ReadonlyArray<Row> = [
 		because: "a family present but unresolved abandons the answer rather than picking a side",
 	},
 	{
-		scenario: "Kimi / Copilot / Cline / Devin / Antigravity runs a command",
+		scenario: "Antigravity's agent (agy CLI) runs a command",
+		inferAgentFromEnv: true,
+		env: { ANTIGRAVITY_AGENT: "1", ANTIGRAVITY_CONVERSATION_ID: "c1" },
+		expected: "antigravity",
+		because: "measured 2026-08-20; the same dump held no GEMINI_* var, so it cannot trip Google's own marker",
+	},
+	{
+		scenario: "GitHub Copilot CLI runs a command",
+		inferAgentFromEnv: true,
+		env: { COPILOT_CLI: "1", COPILOT_AGENT_SESSION_ID: "s1" },
+		expected: "copilot",
+	},
+	{
+		scenario: "standalone cline CLI runs a command",
+		inferAgentFromEnv: true,
+		env: { CLINE_WRAPPER_PATH: "/x/bin/.cline", CLINE_BUILD_ENV: "production" },
+		expected: "cline-cli",
+	},
+	{
+		scenario: "Kimi / Devin / Copilot Chat / cline (VS Code ext) runs a command",
 		inferAgentFromEnv: true,
 		env: {},
 		expected: undefined,
-		because: "these hosts set no marker we have measured; they are attributed at commit time instead",
+		because:
+			"kimi measured as setting nothing; devin's probe was service-blocked; the two IDE-side variants are unmeasured — all attributed at commit time instead",
 	},
 	{
 		scenario: "Claude Code shells out to Codex, which runs a command",

--- a/cli/src/core/TelemetryAgentMatrix.test.ts
+++ b/cli/src/core/TelemetryAgentMatrix.test.ts
@@ -105,12 +105,31 @@ const SHORT_LIVED: ReadonlyArray<Row> = [
 	},
 	{ scenario: "OpenCode runs a command", inferAgentFromEnv: true, env: { OPENCODE: "1" }, expected: "opencode" },
 	{
-		scenario: "Cursor runs a command",
+		scenario: "Cursor IDE's agent runs a command",
 		inferAgentFromEnv: true,
-		env: { CURSOR_TRACE_ID: "abc" },
+		env: { CURSOR_AGENT: "1", CURSOR_CONVERSATION_ID: "c1", CURSOR_WORKSPACE_LABEL: "snake-game" },
+		expected: "cursor",
+	},
+	{
+		scenario: "cursor-agent CLI runs a command",
+		inferAgentFromEnv: true,
+		env: { CURSOR_AGENT: "1", CURSOR_CONVERSATION_ID: "c1", CURSOR_INVOKED_AS: "cursor-agent" },
+		expected: "cursor-cli",
+		because: "the IDE/CLI split `surface` can never draw, and the reason the family shape exists",
+	},
+	{
+		scenario: "human types in Cursor's own integrated terminal",
+		inferAgentFromEnv: true,
+		env: {},
 		expected: undefined,
-		because:
-			"the marker names the Cursor family and cannot separate `cursor` from `cursor-cli` — a known gap, not a default",
+		because: "measured: no CURSOR_* var reaches a human shell, so no agent is claimed for a person's own command",
+	},
+	{
+		scenario: "a Cursor build that renamed both variant markers",
+		inferAgentFromEnv: true,
+		env: { CURSOR_AGENT: "1" },
+		expected: undefined,
+		because: "a family present but unresolved abandons the answer rather than picking a side",
 	},
 	{
 		scenario: "Kimi / Copilot / Cline / Devin / Antigravity runs a command",
@@ -140,7 +159,7 @@ const SHORT_LIVED: ReadonlyArray<Row> = [
 		expected: "claude",
 	},
 	{
-		scenario: "MCP server Cursor spawned (measured: no marker at all)",
+		scenario: "MCP server Cursor spawned (measured: not even a CURSOR_* var)",
 		inferAgentFromEnv: true,
 		env: {},
 		expected: undefined,
@@ -199,7 +218,8 @@ const STRUCTURAL: ReadonlyArray<Row> = [
 		inferAgentFromEnv: true,
 		env: {},
 		expected: "cursor",
-		because: "the one place Cursor IS attributed, since env cannot do it",
+		because:
+			"still the only thing that attributes a Cursor MCP session — those servers carry no CURSOR_* var at all (measured)",
 	},
 	{
 		scenario: "hand-run `jolli enable --repo-hooks-only` (no source tag) inside Claude Code",

--- a/cli/src/core/TelemetryAgentMatrix.test.ts
+++ b/cli/src/core/TelemetryAgentMatrix.test.ts
@@ -165,12 +165,15 @@ const SHORT_LIVED: ReadonlyArray<Row> = [
 		expected: undefined,
 	},
 	{
-		scenario: "QueueWorker from the VS Code bundle, commit made inside Claude Code",
+		scenario: "post-commit hook resolving a commit's origin, running from the VS Code bundle's dist",
 		inferAgentFromEnv: true,
 		env: { CLAUDECODE: "1" },
 		expected: "claude",
 		because:
-			"reports `surface: vscode` yet MUST trust its env — this is why nothing may gate env-trust on the surface",
+			"reports `surface: vscode` yet MUST trust its env — this is why nothing may gate env-trust on the surface. " +
+			"(The QueueWorker used to hold this row and no longer infers at all: it chain-drains entries OTHER commits " +
+			"enqueued, so its env belongs to whichever commit spawned the chain — each entry now carries its own stamp, " +
+			"resolved by this hook at enqueue time.)",
 	},
 ];
 

--- a/cli/src/core/TelemetryAgentMatrix.test.ts
+++ b/cli/src/core/TelemetryAgentMatrix.test.ts
@@ -1,0 +1,332 @@
+/**
+ * The `agent` × `surface` truth table, as one data-driven suite.
+ *
+ * Every row is a real way someone can reach Jolli, and the two dimensions only
+ * mean something together: `surface` says which of our builds sent the event,
+ * `agent` says which AI host the work happened in. Several rows share an
+ * expected `agent` and are told apart purely by `surface` (a human typing in a
+ * terminal and a human clicking in VS Code both have NO agent), and one pair is
+ * the reverse — same `surface`, different `agent` — which is why nothing may
+ * decide env-trust by looking at the surface.
+ *
+ * Kept as a table rather than prose because the interesting rows are the ones
+ * that answer "nothing": ambiguity, conflict, a long-lived host, an outbound
+ * summarizer. Those are decisions, and a decision with no test is a comment.
+ *
+ * `surface` cannot be varied from inside a unit test — it comes from a build-time
+ * `define` that vitest pins to `cli` — so the surface half is asserted through
+ * `parseSurface` on each bundle's real client header, and the agent half through
+ * envelopes actually written to a buffer.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { LOCAL_AGENT_CHILD_ENV } from "./AgentReentry.js";
+import {
+	getTelemetryContext,
+	initTelemetry,
+	parseSurface,
+	shutdownTelemetry,
+	TELEMETRY_SURFACES,
+	track,
+	trackAs,
+} from "./Telemetry.js";
+import { TELEMETRY_AGENTS } from "./TelemetryAgent.js";
+import { readTelemetryEvents } from "./TelemetryBuffer.js";
+import { bootstrapTelemetry } from "./TelemetryStartup.js";
+
+let cwd: string;
+
+beforeEach(async () => {
+	cwd = await mkdtemp(join(tmpdir(), "telemetry-matrix-"));
+});
+afterEach(async () => {
+	shutdownTelemetry();
+	await rm(cwd, { recursive: true, force: true });
+});
+
+const deps = {
+	loadConfig: async () => ({}),
+	getOrCreateInstallId: async () => ({ installId: "11111111-1111-4111-8111-111111111111", created: false }),
+	getJolliUrl: () => "https://acme.jolli.ai",
+};
+
+/** Bring telemetry up the way a given process would, then report the resolved agent. */
+async function agentFor(opts: {
+	readonly env?: NodeJS.ProcessEnv;
+	readonly agent?: string;
+	readonly inferAgentFromEnv?: boolean;
+}): Promise<string | undefined> {
+	await bootstrapTelemetry({ cwd, env: opts.env ?? {}, ...opts, deps });
+	return getTelemetryContext()?.agent;
+}
+
+// ─────────────────── the agent half, per emitting process ───────────────────
+
+interface Row {
+	/** What the user actually did. */
+	readonly scenario: string;
+	/** Does this process trust its env markers? Short-lived yes, long-lived no. */
+	readonly inferAgentFromEnv?: boolean;
+	/** A host the caller knows structurally. */
+	readonly agent?: string;
+	readonly env?: NodeJS.ProcessEnv;
+	readonly expected: string | undefined;
+	/** Why the expectation is what it is, when that is not obvious. */
+	readonly because?: string;
+}
+
+const SHORT_LIVED: ReadonlyArray<Row> = [
+	{
+		scenario: "human types `jolli recall` in their own terminal",
+		inferAgentFromEnv: true,
+		env: {},
+		expected: undefined,
+		because: "no agent was involved; `surface: cli` already says where it came from",
+	},
+	{
+		scenario: "Claude Code runs `jolli recall`",
+		inferAgentFromEnv: true,
+		env: { CLAUDECODE: "1", AI_AGENT: "claude-code_2-1-234_agent" },
+		expected: "claude",
+	},
+	{
+		scenario: "Codex runs a command",
+		inferAgentFromEnv: true,
+		env: { CODEX_THREAD_ID: "t-1" },
+		expected: "codex",
+	},
+	{
+		scenario: "Gemini's AfterAgent hook fires",
+		inferAgentFromEnv: true,
+		env: { GEMINI_CLI: "1" },
+		expected: "gemini",
+	},
+	{ scenario: "OpenCode runs a command", inferAgentFromEnv: true, env: { OPENCODE: "1" }, expected: "opencode" },
+	{
+		scenario: "Cursor runs a command",
+		inferAgentFromEnv: true,
+		env: { CURSOR_TRACE_ID: "abc" },
+		expected: undefined,
+		because:
+			"the marker names the Cursor family and cannot separate `cursor` from `cursor-cli` — a known gap, not a default",
+	},
+	{
+		scenario: "Kimi / Copilot / Cline / Devin / Antigravity runs a command",
+		inferAgentFromEnv: true,
+		env: {},
+		expected: undefined,
+		because: "these hosts set no marker we have measured; they are attributed at commit time instead",
+	},
+	{
+		scenario: "Claude Code shells out to Codex, which runs a command",
+		inferAgentFromEnv: true,
+		env: { CLAUDECODE: "1", CODEX_THREAD_ID: "t-1" },
+		expected: undefined,
+		because: '"which host is the user working in" genuinely has no single answer here',
+	},
+	{
+		scenario: "a summarizer WE spawned runs jolli internally",
+		inferAgentFromEnv: true,
+		env: { CLAUDECODE: "1", [LOCAL_AGENT_CHILD_ENV]: "1" },
+		expected: undefined,
+		because: "that is the outbound dimension (LocalAgentToolId), not the user's host",
+	},
+	{
+		scenario: "MCP server Claude Code spawned (measured: it does inherit CLAUDECODE)",
+		inferAgentFromEnv: true,
+		env: { CLAUDECODE: "1" },
+		expected: "claude",
+	},
+	{
+		scenario: "MCP server Cursor spawned (measured: no marker at all)",
+		inferAgentFromEnv: true,
+		env: {},
+		expected: undefined,
+	},
+	{
+		scenario: "QueueWorker from the VS Code bundle, commit made inside Claude Code",
+		inferAgentFromEnv: true,
+		env: { CLAUDECODE: "1" },
+		expected: "claude",
+		because:
+			"reports `surface: vscode` yet MUST trust its env — this is why nothing may gate env-trust on the surface",
+	},
+];
+
+const LONG_LIVED: ReadonlyArray<Row> = [
+	{
+		scenario: "VS Code extension host, cold-started with `code .` from inside a Claude session",
+		env: { CLAUDECODE: "1", AI_AGENT: "claude-code_2-1-234_agent" },
+		expected: undefined,
+		because:
+			"the regression this flag exists for — the window would otherwise claim `claude` for days of button clicks",
+	},
+	{
+		scenario: "VS Code extension host, launched normally",
+		env: {},
+		expected: undefined,
+	},
+	{
+		scenario: "ide-bridge server forwarding a JVM-host UI event",
+		env: { CLAUDECODE: "1" },
+		expected: undefined,
+		because: "long-lived, and the event describes the IDE's own UI",
+	},
+];
+
+const STRUCTURAL: ReadonlyArray<Row> = [
+	{
+		scenario: "Claude plugin SessionStart bootstrap",
+		agent: "claude",
+		inferAgentFromEnv: true,
+		env: {},
+		expected: "claude",
+		because: "structural — the manifest hook only ever runs inside its own host",
+	},
+	{
+		scenario: "Codex plugin bootstrap, running under a stale CLAUDECODE",
+		agent: "codex",
+		inferAgentFromEnv: true,
+		env: { CLAUDECODE: "1" },
+		expected: "codex",
+		because: "the structural claim beats any marker",
+	},
+	{
+		scenario: "Cursor plugin bootstrap",
+		agent: "cursor",
+		inferAgentFromEnv: true,
+		env: {},
+		expected: "cursor",
+		because: "the one place Cursor IS attributed, since env cannot do it",
+	},
+	{
+		scenario: "hand-run `jolli enable --repo-hooks-only` (no source tag) inside Claude Code",
+		agent: undefined,
+		inferAgentFromEnv: true,
+		env: { CLAUDECODE: "1" },
+		expected: "claude",
+		because:
+			"no structural host, but still a short-lived CLI process — env is valid, and must survive the re-bootstrap",
+	},
+	{
+		scenario: "a caller passes a host we do not know",
+		agent: "windsurf",
+		inferAgentFromEnv: true,
+		env: { CLAUDECODE: "1" },
+		expected: undefined,
+		because:
+			"an unrecognised explicit value is rejected AND suppresses the fallback — the caller claimed to know, and was wrong",
+	},
+];
+
+describe.each([
+	["short-lived processes (env markers trusted)", SHORT_LIVED],
+	["long-lived hosts (env markers NOT trusted)", LONG_LIVED],
+	["structural attribution", STRUCTURAL],
+])("%s", (_group, rows) => {
+	it.each(
+		rows.map((r) => [r.because ? `${r.scenario} → ${r.expected ?? "no agent"} (${r.because})` : r.scenario, r]),
+	)("%s", async (_label, row) => {
+		const resolved = await agentFor(row);
+		expect(resolved).toBe(row.expected);
+		// Whatever came out, it can only ever be a known token.
+		if (resolved !== undefined) expect(TELEMETRY_AGENTS).toContain(resolved);
+	});
+});
+
+// ─────────────── the two dimensions read together ───────────────
+
+describe("surface × agent read together", () => {
+	it("distinguishes a human in a terminal from a human clicking in an IDE", async () => {
+		// Both have NO agent. `surface` is the only thing that separates them, which
+		// is why the dimension must not be defaulted into something surface-like.
+		const terminal = await agentFor({ inferAgentFromEnv: true, env: {} });
+		const ide = await agentFor({ env: { CLAUDECODE: "1" } });
+		expect(terminal).toBeUndefined();
+		expect(ide).toBeUndefined();
+		expect(parseSurface("cli/0.99.14").surface).toBe("cli");
+		expect(parseSurface("vscode-plugin/0.99.14").surface).toBe("vscode");
+	});
+
+	it("exposes the misattribution the dimension exists for", async () => {
+		// Measured on a real machine: Claude Code was serving MCP out of the CODEX
+		// plugin's dist, because dist arbitration picks the highest core version and
+		// plugin tags are absent from the tie-break order. `surface` names the wrong
+		// host; `agent` names the right one, and only both together are readable.
+		const agent = await agentFor({ inferAgentFromEnv: true, env: { CLAUDECODE: "1" } });
+		expect(parseSurface("codex-plugin/1.0.2").surface).toBe("codex-plugin");
+		expect(agent).toBe("claude");
+	});
+
+	it("covers every surface the doc discloses with a known emitter or a documented reason", () => {
+		// Guards against a surface being added to the disclosure with nothing behind it.
+		const emitted = new Set(["cli", "vscode", "claude-plugin", "codex-plugin", "cursor-plugin", "web-local"]);
+		const notFromThisRepo = new Set(["intellij", "web"]);
+		for (const surface of TELEMETRY_SURFACES) {
+			expect(emitted.has(surface) || notFromThisRepo.has(surface)).toBe(true);
+		}
+		expect(emitted.size + notFromThisRepo.size).toBe(TELEMETRY_SURFACES.length);
+	});
+});
+
+// ─────────────── per-event overrides, on real envelopes ───────────────
+
+describe("per-event attribution on real envelopes", () => {
+	const init = (agent?: string) =>
+		initTelemetry({
+			cwd,
+			installId: "install-1",
+			origin: "https://acme.jolli.ai",
+			config: {},
+			...(agent ? { agent } : {}),
+		});
+
+	it("attributes each walked transcript to its own source, not the worker's env", async () => {
+		// The post-commit case: one worker, several sessions, thirteen possible hosts.
+		init("claude");
+		for (const source of ["gemini", "kimi", "cline-cli", "antigravity"]) {
+			track("ai_source_detected", { source, agent: source });
+		}
+		const events = await readTelemetryEvents(cwd);
+		expect(events.map((e) => e.properties.agent)).toEqual(["gemini", "kimi", "cline-cli", "antigravity"]);
+	});
+
+	it("drops a per-event value that is not a known host, and does not fall back", async () => {
+		init("claude");
+		for (const bad of ["windsurf", "../../etc/passwd", "", "Claude"]) {
+			track("ai_source_detected", { source: "claude", agent: bad });
+		}
+		const events = await readTelemetryEvents(cwd);
+		for (const e of events) expect(e.properties).not.toHaveProperty("agent");
+	});
+
+	it("does not attribute a dashboard browser click to the shell that launched the server", async () => {
+		// `jolli dashboard` was started from inside a Claude session, so the process
+		// really is `agent: claude` — but a click in the web view is not.
+		init("claude");
+		track("command_invoked", { command: "dashboard", ok: true });
+		trackAs("web-local", "dashboard_opened", { first_run: true });
+		trackAs("web-local", "range_changed", { range: "30d" });
+		const [invoked, opened, ranged] = await readTelemetryEvents(cwd);
+		expect(invoked).toMatchObject({ surface: "cli", properties: { agent: "claude" } });
+		expect(opened.surface).toBe("web-local");
+		expect(opened.properties).not.toHaveProperty("agent");
+		expect(ranged.properties).not.toHaveProperty("agent");
+	});
+
+	it("still lets a trackAs caller state the event's own host explicitly", async () => {
+		init("claude");
+		trackAs("web-local", "dashboard_opened", { agent: "codex" });
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.properties.agent).toBe("codex");
+	});
+
+	it("never puts agent in the envelope, on either path", async () => {
+		init("claude");
+		track("recall_performed");
+		trackAs("web-local", "dashboard_opened");
+		for (const e of await readTelemetryEvents(cwd)) expect(e).not.toHaveProperty("agent");
+	});
+});

--- a/cli/src/core/TelemetryCommandHook.test.ts
+++ b/cli/src/core/TelemetryCommandHook.test.ts
@@ -112,6 +112,53 @@ describe("installCommandTelemetryHooks", () => {
 	});
 });
 
+describe("via (JOLLI_INVOKED_VIA consumption)", () => {
+	afterEach(() => {
+		delete process.env.JOLLI_INVOKED_VIA;
+	});
+
+	it("attaches a valid skill via to the success event, and CONSUMES the env var", async () => {
+		process.env.JOLLI_INVOKED_VIA = "skill:recall";
+		const program = programWith(() => {});
+		await program.parseAsync(["node", "jolli", "recall"]);
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.properties).toMatchObject({ command: "recall", ok: true, via: "skill:recall" });
+		// Deleted, not merely read: a child this command spawns (a detached daemon,
+		// a nested jolli) must not inherit a claim about THIS invocation.
+		expect(process.env.JOLLI_INVOKED_VIA).toBeUndefined();
+	});
+
+	it("attaches it to the failure event too", async () => {
+		process.env.JOLLI_INVOKED_VIA = "skill:search";
+		const program = programWith(() => {
+			throw new Error("boom");
+		});
+		await expect(program.parseAsync(["node", "jolli", "recall"])).rejects.toThrow("boom");
+		trackCommandFailureIfPending();
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.properties).toMatchObject({ command: "recall", ok: false, via: "skill:search" });
+	});
+
+	it("drops an unrecognised value whole — and still consumes it", async () => {
+		// The env var is settable by anything; an unknown name must neither reach
+		// the wire nor survive into children.
+		process.env.JOLLI_INVOKED_VIA = "skill:not-a-skill";
+		const program = programWith(() => {});
+		await program.parseAsync(["node", "jolli", "recall"]);
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.properties).not.toHaveProperty("via");
+		expect(JSON.stringify(e.properties)).not.toContain("not-a-skill");
+		expect(process.env.JOLLI_INVOKED_VIA).toBeUndefined();
+	});
+
+	it("omits via for a directly-typed command", async () => {
+		const program = programWith(() => {});
+		await program.parseAsync(["node", "jolli", "recall"]);
+		const [e] = await readTelemetryEvents(cwd);
+		expect(e.properties).not.toHaveProperty("via");
+	});
+});
+
 describe("shouldSkipExitFlush", () => {
 	// Mirrors the real CLI shape: a `telemetry` group with a default subcommand,
 	// plus a global option registered on the root before parsing.

--- a/cli/src/core/TelemetryCommandHook.ts
+++ b/cli/src/core/TelemetryCommandHook.ts
@@ -21,6 +21,7 @@
  */
 import type { Command } from "commander";
 import { track } from "./Telemetry.js";
+import { JOLLI_INVOKED_VIA_ENV, resolveInvokedVia } from "./TelemetryAgent.js";
 
 /**
  * Space-joined command path excluding the root program, e.g. `recall` or
@@ -44,7 +45,7 @@ export function commandPath(cmd: Command): string {
  * command FAILED — `trackCommandFailureIfPending()` records that. A CLI runs one
  * command per process, so a single slot suffices.
  */
-let pending: { readonly command: string; readonly start: number } | null = null;
+let pending: { readonly command: string; readonly start: number; readonly via?: string } | null = null;
 
 /**
  * Root-level name of the command commander actually resolved this run (e.g.
@@ -99,11 +100,21 @@ export function getInvokedRootCommand(): string | null {
 export function installCommandTelemetryHooks(program: Command): void {
 	program.hook("preAction", (_thisCommand, actionCommand) => {
 		const command = commandPath(actionCommand);
-		pending = { command, start: Date.now() };
+		// `via` — how this invocation was reached (a skill's run-cli recipe sets
+		// `JOLLI_INVOKED_VIA=skill:<name>` on the one command it runs). CONSUMED,
+		// not merely read: the var is deleted before the action executes, so a
+		// child this command spawns — a detached daemon, a chained worker, a
+		// nested `jolli` — cannot inherit a claim that described only this
+		// invocation. Validated against the closed skill-name set; an
+		// unrecognised value is dropped whole (see resolveInvokedVia).
+		const via = resolveInvokedVia(process.env[JOLLI_INVOKED_VIA_ENV]);
+		delete process.env[JOLLI_INVOKED_VIA_ENV];
+		pending = { command, start: Date.now(), via };
 		invokedRootCommand = command.split(" ")[0] ?? null;
 	});
 	program.hook("postAction", (_thisCommand, actionCommand) => {
 		const start = pending?.start;
+		const via = pending?.via;
 		pending = null; // success — recorded below (or intentionally skipped for mcp)
 		// `mcp` is emitted per tool call by the MCP server's CallTool handler
 		// (JOLLI-1959, tagged with `tool`). The generic session-level event here
@@ -114,6 +125,7 @@ export function installCommandTelemetryHooks(program: Command): void {
 			command: commandPath(actionCommand),
 			duration_ms: start === undefined ? undefined : Date.now() - start,
 			ok: true,
+			...(via ? { via } : {}),
 		});
 	});
 }
@@ -131,5 +143,10 @@ export function trackCommandFailureIfPending(): void {
 	const p = pending;
 	pending = null;
 	if (!p || p.command === "mcp") return;
-	track("command_invoked", { command: p.command, duration_ms: Date.now() - p.start, ok: false });
+	track("command_invoked", {
+		command: p.command,
+		duration_ms: Date.now() - p.start,
+		ok: false,
+		...(p.via ? { via: p.via } : {}),
+	});
 }

--- a/cli/src/core/TelemetryDoc.ts
+++ b/cli/src/core/TelemetryDoc.ts
@@ -9,8 +9,41 @@
  * adding an event without regenerating the doc fails CI.
  *
  * Regenerate with: `npm run gen:telemetry-doc`.
+ *
+ * The surface and agent vocabularies are now generated too. They used to be
+ * hand-written prose in this file's template, which the drift-guard test cannot
+ * see — the staleness was in the generator's own string — and the surface list
+ * had already gone stale by three entries. Derive, never restate.
  */
+import { TELEMETRY_SURFACES } from "./Telemetry.js";
+import { AGENT_DIMENSION_SINCE_VERSION, TELEMETRY_AGENTS } from "./TelemetryAgent.js";
 import { TELEMETRY_EVENTS } from "./TelemetryEvents.js";
+
+/**
+ * Render a vocabulary as a code-quoted, comma-separated list, hard-wrapped to
+ * the prose width with a two-space continuation indent.
+ *
+ * Wrapped because these lists grow: unwrapped, one thirteen-entry vocabulary is
+ * a 200-column line in a file people read as a privacy contract, and every
+ * addition rewrites that whole line in the diff.
+ */
+function codeList(values: ReadonlyArray<string>, width = 74): string {
+	const lines: string[] = [];
+	let line = "";
+	for (const [i, value] of values.entries()) {
+		const token = `\`${value}\`${i === values.length - 1 ? "" : ","}`;
+		if (line === "") {
+			line = token;
+		} else if (`${line} ${token}`.length <= width) {
+			line = `${line} ${token}`;
+		} else {
+			lines.push(line);
+			line = token;
+		}
+	}
+	if (line !== "") lines.push(line);
+	return lines.join("\n  ");
+}
 
 /** The full Markdown body of `TELEMETRY.md`. Deterministic — registry order. */
 export function generateTelemetryMarkdown(): string {
@@ -19,7 +52,8 @@ export function generateTelemetryMarkdown(): string {
 		.join("\n");
 
 	return `<!-- GENERATED FILE — do not edit by hand.
-     Regenerate with \`npm run gen:telemetry-doc\` (source: cli/src/core/TelemetryEvents.ts). -->
+     Regenerate with \`npm run gen:telemetry-doc\` (sources: cli/src/core/TelemetryEvents.ts,
+     cli/src/core/TelemetryAgent.ts, cli/src/core/Telemetry.ts). -->
 
 # Jolli Memory telemetry
 
@@ -30,12 +64,32 @@ collected — generated from the event registry the code actually uses.
 
 ## What we collect
 
-- A random per-machine identifier (\`installId\`) and the surface (\`cli\`,
-  \`vscode\`, \`intellij\`, \`claude-plugin\`, or \`codex-plugin\`) + version.
+- A random per-machine identifier (\`installId\`) and the surface — which Jolli
+  build sent the event — plus its version. The surfaces are:
+  ${codeList(TELEMETRY_SURFACES)}.
+- The \`agent\` property: which AI coding tool the work happened in, when that
+  is known. It is a fixed, low-cardinality list of tool names, never free-form:
+  ${codeList(TELEMETRY_AGENTS)}. See below for when it is omitted.
 - Coarse environment facts: OS, architecture, runtime version, and which Jolli
   environment your client is pointed at (\`local\` / \`dev\` / \`preview\` / \`prod\`).
 - The events listed below, each with a small bag of **bucketed or boolean**
   properties (e.g. a result count as \`"1-5"\`, not the actual number).
+
+### About the \`agent\` property
+
+\`agent\` records the AI host — Claude Code, Codex, Cursor, Gemini, and so on —
+because the surface above only identifies which of our own builds ran, which is
+often not the tool you were using. It is a tool name and nothing else: not
+identity, not content, not a path, and not anything you typed.
+
+It is **omitted whenever the host is not actually known**, rather than defaulted
+to a guess. An absent \`agent\` means "not measured", never "the CLI". A host we
+do not recognise is omitted too — the value can only ever be one of the tokens
+listed above.
+
+Events recorded by earlier client versions carry no \`agent\` at all, and nothing
+reconstructs it retroactively. The first version to emit it is
+\`${AGENT_DIMENSION_SINCE_VERSION}\`.
 
 ## What we never collect
 
@@ -75,7 +129,9 @@ disk **before** they are sent.
 ${eventRows}
 
 ---
-*Generated from \`cli/src/core/TelemetryEvents.ts\`. The IntelliJ plugin is an
-independent implementation that sends the same event names and envelope.*
+*Generated from \`cli/src/core/TelemetryEvents.ts\` (events),
+\`cli/src/core/TelemetryAgent.ts\` (agents) and \`cli/src/core/Telemetry.ts\`
+(surfaces). The IntelliJ plugin is an independent implementation that sends the
+same event names and envelope.*
 `;
 }

--- a/cli/src/core/TelemetryEvents.ts
+++ b/cli/src/core/TelemetryEvents.ts
@@ -42,7 +42,7 @@ export const TELEMETRY_EVENTS = {
 		"Per-install onboarding-funnel snapshot, emitted from a repo context and deduped by state tuple (+ daily heartbeat). Content-free — answers 'after install, where do people stall'. Props: in_git_repo, repo_enabled, capture_configured, capture_method (discriminator: local-agent/anthropic/jolli/none), memories_generated, memories_bucket.",
 	// ── feature usage / adoption ──
 	command_invoked:
-		'Any CLI command ran (auto-emitted). Props: command (discriminator), ok, duration_ms. MCP tool calls carry a `tool` property and are emitted per call (not per session); the session-level `command:"mcp"` event is suppressed.',
+		'Any CLI command ran (auto-emitted). Props: command (discriminator), ok, duration_ms; via (discriminator: skill:<name> from a closed skill-name set — present only when a Jolli skill\'s recipe invoked the command, omitted for a directly-typed one). MCP tool calls carry a `tool` property and are emitted per call (not per session); the session-level `command:"mcp"` event is suppressed.',
 	recall_performed: "A recall was run. Props: hit, result_count_bucket.",
 	search_performed: "A search was run. Props: query_len_bucket, result_count_bucket.",
 	memory_pushed: "Memories pushed to a Space. Props: kind, created, plans_bucket.",

--- a/cli/src/core/TelemetryEvents.ts
+++ b/cli/src/core/TelemetryEvents.ts
@@ -42,7 +42,7 @@ export const TELEMETRY_EVENTS = {
 		"Per-install onboarding-funnel snapshot, emitted from a repo context and deduped by state tuple (+ daily heartbeat). Content-free — answers 'after install, where do people stall'. Props: in_git_repo, repo_enabled, capture_configured, capture_method (discriminator: local-agent/anthropic/jolli/none), memories_generated, memories_bucket.",
 	// ── feature usage / adoption ──
 	command_invoked:
-		'Any CLI command ran (auto-emitted). Props: command (discriminator), ok, duration_ms; via (discriminator: skill:<name> from a closed skill-name set — present only when a Jolli skill\'s recipe invoked the command, omitted for a directly-typed one). MCP tool calls carry a `tool` property and are emitted per call (not per session); the session-level `command:"mcp"` event is suppressed.',
+		'Any CLI command ran (auto-emitted). Props: command (discriminator), ok, duration_ms; via (discriminator: skill:<name> from a closed skill-name set — present when a Jolli skill\'s recipe invoked the command; absent means directly typed OR a pre-upgrade skill copy that predates the stamp, so absence is not proof of direct use). MCP tool calls carry a `tool` property and are emitted per call (not per session); the session-level `command:"mcp"` event is suppressed.',
 	recall_performed: "A recall was run. Props: hit, result_count_bucket.",
 	search_performed: "A search was run. Props: query_len_bucket, result_count_bucket.",
 	memory_pushed: "Memories pushed to a Space. Props: kind, created, plans_bucket.",

--- a/cli/src/core/TelemetryEvents.ts
+++ b/cli/src/core/TelemetryEvents.ts
@@ -55,7 +55,8 @@ export const TELEMETRY_EVENTS = {
 		"A drainIngest run finished. Props: outcome, ingested, idle (no-op when ingested=0), batches, route_calls, reconcile_calls, touched_slugs, topic_failures, duration_ms. Filter idle=true out for real-ingest latency/health metrics.",
 	error_occurred:
 		"A structured error was raised. Content-free schema: { where (stage/subsystem), code (enumerated), source? , retryable? }. Emitted via trackError(); never carries a message/stack/path.",
-	queue_drained: "QueueWorker finished a drain. Props: ops, duration_ms.",
+	queue_drained:
+		"QueueWorker finished a drain. Props: ops, duration_ms; trigger (discriminator: agent/ui/terminal/unknown — who set the drained commits in motion) and agent (which AI host, when trigger=agent) are present only when every drained entry agrees, and omitted for mixed or unstamped drains.",
 	sync_completed: "A memory-bank sync round finished. Props: outcome (discriminator), duration_ms.",
 	// ── IDE tool-window UI / engagement (IntelliJ, VS Code) ──
 	toolwindow_opened: "The memory tool window was opened. Props: view.",

--- a/cli/src/core/TelemetryStartup.test.ts
+++ b/cli/src/core/TelemetryStartup.test.ts
@@ -64,6 +64,69 @@ describe("bootstrapTelemetry", () => {
 		getJolliUrl: () => "https://jolli.ai",
 	});
 
+	it("does NOT read the env markers unless the caller opts in", async () => {
+		// The default protects long-lived hosts: env vars are inherited by every
+		// descendant and never expire, so a VS Code window cold-started from inside
+		// a Claude session would otherwise claim `claude` for its whole lifetime.
+		await bootstrapTelemetry({
+			cwd,
+			env: { CODEX_THREAD_ID: "t-1", CLAUDECODE: "1" },
+			deps: deps({ jolliUrl: "https://acme.jolli.ai" }, false),
+		});
+		expect(getTelemetryContext()?.agent).toBeUndefined();
+	});
+
+	it("derives the agent from the host's own env marker once opted in", async () => {
+		await bootstrapTelemetry({
+			cwd,
+			inferAgentFromEnv: true,
+			env: { CODEX_THREAD_ID: "t-1" },
+			deps: deps({ jolliUrl: "https://acme.jolli.ai" }, false),
+		});
+		expect(getTelemetryContext()?.agent).toBe("codex");
+	});
+
+	it("prefers an explicitly passed agent over the env markers (a structural claim wins)", async () => {
+		// A plugin bootstrap only ever runs inside its own host, which is stronger
+		// than a marker a child could have inherited.
+		await bootstrapTelemetry({
+			cwd,
+			agent: "cursor",
+			inferAgentFromEnv: true,
+			env: { CLAUDECODE: "1" },
+			deps: deps({ jolliUrl: "https://acme.jolli.ai" }, false),
+		});
+		expect(getTelemetryContext()?.agent).toBe("cursor");
+	});
+
+	it("clears an agent an earlier bootstrap inferred when a re-bootstrap does not opt in", async () => {
+		// The trap behind PluginBootstrapTelemetry passing inferAgentFromEnv: a
+		// second bootstrap REPLACES the context rather than merging into it.
+		const env = { CLAUDECODE: "1" };
+		await bootstrapTelemetry({ cwd, inferAgentFromEnv: true, env, deps: deps({}, false) });
+		expect(getTelemetryContext()?.agent).toBe("claude");
+		await bootstrapTelemetry({ cwd, env, deps: deps({}, false) });
+		expect(getTelemetryContext()?.agent).toBeUndefined();
+	});
+
+	it("leaves the agent absent when nothing knows the host", async () => {
+		await bootstrapTelemetry({ cwd, env: {}, deps: deps({ jolliUrl: "https://acme.jolli.ai" }, false) });
+		const ctx = getTelemetryContext();
+		expect(ctx?.enabled).toBe(true);
+		expect(ctx?.agent).toBeUndefined();
+	});
+
+	it("leaves the agent absent for an unrecognised explicit value", async () => {
+		await bootstrapTelemetry({
+			cwd,
+			agent: "windsurf",
+			inferAgentFromEnv: true,
+			env: { CLAUDECODE: "1" },
+			deps: deps({ jolliUrl: "https://acme.jolli.ai" }, false),
+		});
+		expect(getTelemetryContext()?.agent).toBeUndefined();
+	});
+
 	it("initializes context and fires app_installed on first run (created=true)", async () => {
 		await bootstrapTelemetry({ cwd, deps: deps({ jolliUrl: "https://acme.jolli.ai" }, true) });
 		const ctx = getTelemetryContext();

--- a/cli/src/core/TelemetryStartup.ts
+++ b/cli/src/core/TelemetryStartup.ts
@@ -28,6 +28,7 @@ import {
 	saveConfig as defaultSaveConfig,
 } from "./SessionTracker.js";
 import { initTelemetry, track } from "./Telemetry.js";
+import { detectAgentFromEnv } from "./TelemetryAgent.js";
 import { clearTelemetryBuffer } from "./TelemetryBuffer.js";
 import { isTelemetryEnabled, shouldShowTelemetryNotice } from "./TelemetryConsent.js";
 import { flushTelemetry } from "./TelemetryFlusher.js";
@@ -37,6 +38,38 @@ export interface BootstrapTelemetryOptions {
 	readonly cwd: string;
 	/** Current AI/editor session id, when known. */
 	readonly sessionId?: string;
+	/**
+	 * The AI host this process is working in, for a caller that knows it
+	 * STRUCTURALLY — a plugin bootstrap only ever runs inside its own host, which
+	 * is a stronger claim than any marker. Beats {@link inferAgentFromEnv} when
+	 * both are given. An unrecognised value leaves the dimension absent rather
+	 * than defaulted — see `TelemetryAgent`.
+	 */
+	readonly agent?: string;
+	/**
+	 * Whether this process may infer its host from the env markers
+	 * (`TelemetryAgent.detectAgentFromEnv`). **Defaults to false — opt in.**
+	 *
+	 * The markers are only trustworthy under one condition: *this process is the
+	 * one the AI host just launched*. Env vars are inherited by every descendant
+	 * and never expire, so the condition holds for a short-lived CLI invocation or
+	 * a git hook, and fails for anything long-lived that has outlived the shell
+	 * that started it — a GUI extension host, the `ide-bridge` server. Cold-start
+	 * VS Code with `code .` from inside a Claude session and its extension host
+	 * carries `CLAUDECODE` for days, so every button click in that window would
+	 * report `agent: "claude"` while the user is clicking, not prompting.
+	 *
+	 * Off by default because the two mistakes are not symmetric, which is the same
+	 * asymmetry the whole dimension rests on: forgetting to opt a short-lived path
+	 * IN costs one channel's data, and data can be backfilled from the day someone
+	 * notices. Forgetting to opt a long-lived host OUT produces confident wrong
+	 * values that no later fix can separate from the true ones.
+	 *
+	 * Note it must be ON for anything that re-bootstraps mid-process — a second
+	 * bootstrap REPLACES the context, so leaving it off would clear an agent an
+	 * earlier bootstrap had correctly inferred.
+	 */
+	readonly inferAgentFromEnv?: boolean;
 	/** Host-platform opt-out (VS Code passes `!vscode.env.isTelemetryEnabled`). */
 	readonly platformDisabled?: boolean;
 	/** Env for the `DO_NOT_TRACK` check. Defaults to `process.env`. */
@@ -79,6 +112,7 @@ export async function bootstrapTelemetry(opts: BootstrapTelemetryOptions): Promi
 			cwd: opts.cwd,
 			installId,
 			sessionId: opts.sessionId,
+			agent: opts.agent ?? (opts.inferAgentFromEnv ? detectAgentFromEnv(opts.env) : undefined),
 			origin,
 			config,
 			platformDisabled: opts.platformDisabled,

--- a/cli/src/core/localagent/PluginDefaults.test.ts
+++ b/cli/src/core/localagent/PluginDefaults.test.ts
@@ -3,6 +3,7 @@ import type { JolliMemoryConfig } from "../../Types.js";
 import { updateConfigTransactional } from "../SessionTracker.js";
 import {
 	applyPluginInitLocalAgentTool,
+	pluginBootstrapAgent,
 	pluginBootstrapHost,
 	pluginDefaultLocalAgentTool,
 	pluginSkillInvocation,
@@ -70,6 +71,27 @@ describe("pluginBootstrapHost", () => {
 			expect(pluginBootstrapHost(tag)).toBe("claude");
 		}
 		expect(pluginBootstrapHost(undefined)).toBe("claude");
+	});
+});
+
+describe("pluginBootstrapAgent", () => {
+	it("resolves each plugin tag to the same host token", () => {
+		expect(pluginBootstrapAgent("claude-plugin")).toBe("claude");
+		expect(pluginBootstrapAgent("codex-plugin")).toBe("codex");
+		expect(pluginBootstrapAgent("cursor-plugin")).toBe("cursor");
+	});
+
+	// The one difference from pluginBootstrapHost, and the reason both exist. There
+	// the claude fallback is right — a hand-run --repo-hooks-only must still get
+	// Claude's assets. Here it would be a lie: that run proves nothing about which
+	// host the user is typing into, and telemetry omits an unknown host rather than
+	// guessing one. Reusing pluginBootstrapHost would tag every bare run as claude.
+	it("answers undefined for an unmapped or missing tag instead of falling back to claude", () => {
+		for (const tag of ["cli", "vscode", "intellij", ""]) {
+			expect(pluginBootstrapAgent(tag)).toBeUndefined();
+			expect(pluginBootstrapHost(tag)).toBe("claude");
+		}
+		expect(pluginBootstrapAgent(undefined)).toBeUndefined();
 	});
 });
 

--- a/cli/src/core/localagent/PluginDefaults.ts
+++ b/cli/src/core/localagent/PluginDefaults.ts
@@ -112,6 +112,29 @@ export function pluginBootstrapHost(sourceTag: string | undefined): PluginBootst
 	return (sourceTag === undefined ? undefined : PLUGIN_HOSTS[sourceTag]?.host) ?? "claude";
 }
 
+/**
+ * The `agent` telemetry token for a plugin bootstrap, or undefined when
+ * `sourceTag` names no plugin host.
+ *
+ * The `PluginBootstrapHost` values are themselves valid `TranscriptSource`
+ * tokens, so this is `PLUGIN_HOSTS[tag].host` — but WITHOUT
+ * {@link pluginBootstrapHost}'s `"claude"` fallback, and that difference is the
+ * whole point of a second function. There the fallback is right: an unmapped tag
+ * means a hand-run `jolli enable --repo-hooks-only`, which installed the Claude
+ * assets before the host split and must keep doing so. Here it would be a lie —
+ * a hand-run enable proves nothing about which host the user is typing into, and
+ * telemetry's rule is that an unknown host is OMITTED, never guessed. Reusing
+ * `pluginBootstrapHost` for this would tag every bare `--repo-hooks-only` run as
+ * a Claude session.
+ *
+ * This is a STRUCTURAL claim and so beats the env markers: a plugin's
+ * SessionStart bootstrap only ever runs inside its own host, whereas a marker
+ * can be inherited by a child or missing under a host's env policy.
+ */
+export function pluginBootstrapAgent(sourceTag: string | undefined): PluginBootstrapHost | undefined {
+	return sourceTag === undefined ? undefined : PLUGIN_HOSTS[sourceTag]?.host;
+}
+
 /** Outcome of {@link applyPluginInitLocalAgentTool}, for the caller's report line. */
 export interface PluginInitToolResult {
 	/** The tool this host would drive — written only when nothing was configured. */

--- a/cli/src/hooks/CodexPluginBootstrapHook.ts
+++ b/cli/src/hooks/CodexPluginBootstrapHook.ts
@@ -144,7 +144,7 @@ export async function runCodexPluginBootstrap(projectDir: string): Promise<Codex
 		// Snapshot on the failure branch too — a setup that installs but never
 		// reaches a working state is precisely the drop-off the funnel observes.
 		// Nothing to overlap here, so await inline.
-		await capturePluginOnboardingSnapshot(worktreeRoot).done;
+		await capturePluginOnboardingSnapshot(worktreeRoot, undefined, "codex").done;
 		return null;
 	}
 
@@ -175,7 +175,7 @@ export async function runCodexPluginBootstrap(projectDir: string): Promise<Codex
 				// with the Claude path precisely so the two hosts cannot seed different
 				// values for the same machine-global config.
 				await ensurePluginDefaultProvider(SOURCE_TAG, config);
-				funnel = capturePluginOnboardingSnapshot(worktreeRoot);
+				funnel = capturePluginOnboardingSnapshot(worktreeRoot, undefined, "codex");
 				// Always include the briefing: unlike the Claude path there is no
 				// repo-installed SessionStart hook that would also produce one, so
 				// skipping it here would mean no briefing at all.
@@ -188,7 +188,7 @@ export async function runCodexPluginBootstrap(projectDir: string): Promise<Codex
 		);
 		contextDeferred = !contextPhase.acquired;
 	} finally {
-		funnel ??= capturePluginOnboardingSnapshot(worktreeRoot);
+		funnel ??= capturePluginOnboardingSnapshot(worktreeRoot, undefined, "codex");
 		await funnel.done;
 	}
 	if (contextDeferred) {

--- a/cli/src/hooks/PluginBootstrapHook.ts
+++ b/cli/src/hooks/PluginBootstrapHook.ts
@@ -161,7 +161,7 @@ export async function runPluginBootstrap(
 		// Snapshot on the failure branch too — a setup that installs but never
 		// reaches a working state is precisely the drop-off the funnel observes.
 		// Nothing to overlap here, so await inline.
-		await capturePluginOnboardingSnapshot(worktreeRoot, session?.sessionId).done;
+		await capturePluginOnboardingSnapshot(worktreeRoot, session?.sessionId, "claude").done;
 		return buildPluginBootstrapOutput(reloadSkills, null);
 	}
 
@@ -186,7 +186,7 @@ export async function runPluginBootstrap(
 				const config = await loadConfig();
 				if (config.claudeEnabled === false) return;
 				await ensurePluginDefaultProvider(SOURCE_TAG, config);
-				funnel = capturePluginOnboardingSnapshot(worktreeRoot, session?.sessionId);
+				funnel = capturePluginOnboardingSnapshot(worktreeRoot, session?.sessionId, "claude");
 				const hooksWereComplete = hookHealthAtEntry.stop && hookHealthAtEntry.sessionStart;
 				context = await buildSessionStartContext(worktreeRoot, SOURCE_TAG, {
 					includeBriefing: !hooksWereComplete,
@@ -197,7 +197,7 @@ export async function runPluginBootstrap(
 		);
 		contextDeferred = !contextPhase.acquired;
 	} finally {
-		funnel ??= capturePluginOnboardingSnapshot(worktreeRoot, session?.sessionId);
+		funnel ??= capturePluginOnboardingSnapshot(worktreeRoot, session?.sessionId, "claude");
 		await funnel.done;
 	}
 	if (contextDeferred) {

--- a/cli/src/hooks/PluginBootstrapTelemetry.test.ts
+++ b/cli/src/hooks/PluginBootstrapTelemetry.test.ts
@@ -49,6 +49,19 @@ describe("capturePluginOnboardingSnapshot", () => {
 		await expect(flushDeps.loadConfig()).resolves.toBe(config);
 	});
 
+	it("forwards the structural agent to the telemetry bootstrap", async () => {
+		await capturePluginOnboardingSnapshot("/repo", "s1", "codex").done;
+		expect(mocks.bootstrapTelemetry.mock.calls[0][0]).toMatchObject({ agent: "codex" });
+	});
+
+	it("passes no agent when the caller does not know the host", async () => {
+		// A hand-run `enable --repo-hooks-only` with no source tag: the bootstrap
+		// then falls back to env markers, and if those say nothing the dimension
+		// stays absent rather than being defaulted.
+		await capturePluginOnboardingSnapshot("/repo").done;
+		expect(mocks.bootstrapTelemetry.mock.calls[0][0].agent).toBeUndefined();
+	});
+
 	it("returns synchronously with the whole chain deferred, so the caller can overlap it", async () => {
 		let releaseConfig: (config: object) => void = () => {};
 		mocks.loadConfig.mockImplementation(

--- a/cli/src/hooks/PluginBootstrapTelemetry.ts
+++ b/cli/src/hooks/PluginBootstrapTelemetry.ts
@@ -62,13 +62,38 @@ export interface PluginFunnelSnapshot {
  * `ensurePluginDefaultProvider` (see the module doc). Fire on the success AND
  * failure paths: a setup that installs but never reaches a working state is
  * precisely the drop-off the funnel exists to observe.
+ *
+ * `agent` is the `agent` telemetry dimension — the AI host the user is actually
+ * working in, which a plugin bootstrap knows STRUCTURALLY (its manifest hook
+ * only ever runs inside its own host). That is a stronger claim than the env
+ * markers `bootstrapTelemetry` falls back to, so it is passed explicitly rather
+ * than inferred. Omit it where the host genuinely is not known — a hand-run
+ * `enable --repo-hooks-only` with no source tag — and the dimension stays
+ * ABSENT, which reads as unknown; see `TelemetryAgent` for why that must never
+ * be defaulted instead.
  */
-export function capturePluginOnboardingSnapshot(worktreeRoot: string, sessionId?: string): PluginFunnelSnapshot {
+export function capturePluginOnboardingSnapshot(
+	worktreeRoot: string,
+	sessionId?: string,
+	agent?: string,
+): PluginFunnelSnapshot {
 	const done = (async (): Promise<void> => {
 		try {
 			const config = await loadConfig();
 			const loadOnce = async (): Promise<typeof config> => config;
-			await bootstrapTelemetry({ cwd: worktreeRoot, sessionId, deps: { loadConfig: loadOnce } });
+			// `inferAgentFromEnv` even though `agent` is usually explicit: this call
+			// REPLACES the context an earlier bootstrap primed, so leaving it off
+			// would clear a correctly-inferred agent on the one path that reaches
+			// here without a structural one — a hand-run `enable --repo-hooks-only`
+			// with no source tag, which is still a short-lived CLI process. An
+			// explicit `agent` takes precedence, so the plugin hooks are unaffected.
+			await bootstrapTelemetry({
+				cwd: worktreeRoot,
+				sessionId,
+				agent,
+				inferAgentFromEnv: true,
+				deps: { loadConfig: loadOnce },
+			});
 			await maybeEmitOnboardingProgress({ cwd: worktreeRoot, config });
 			await flushTelemetryNow(worktreeRoot, {
 				loadConfig: loadOnce,

--- a/cli/src/hooks/PostCommitHook.test.ts
+++ b/cli/src/hooks/PostCommitHook.test.ts
@@ -178,6 +178,16 @@ vi.mock("../core/SummaryStore.js", async (importOriginal) => {
 	};
 });
 
+// The worker's telemetry surface: `track` for queue_drained assertions,
+// `setTelemetryAgent` for the per-entry attribution scope, and a null context
+// so the ai_source_detected consent gate stays closed (matching what the real
+// module does in these tests, where telemetry is never initialized).
+vi.mock("../core/Telemetry.js", () => ({
+	track: vi.fn(),
+	getTelemetryContext: vi.fn(() => null),
+	setTelemetryAgent: vi.fn(),
+}));
+
 vi.mock("node:fs", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("node:fs")>();
 	return {
@@ -448,6 +458,7 @@ import {
 import type { SummaryResult } from "../core/Summarizer.js";
 import { generateSummary } from "../core/Summarizer.js";
 import { getSummary, mergeManyToOne, migrateOneToOne, storeSummary } from "../core/SummaryStore.js";
+import { setTelemetryAgent, track } from "../core/Telemetry.js";
 import { buildMultiSessionContext, readTranscript } from "../core/TranscriptReader.js";
 import type { CommitSummary } from "../Types.js";
 import { runPostCommitHook, runWorker } from "./PostCommitHook.js";
@@ -2618,5 +2629,113 @@ describe("queue-driven Worker", () => {
 				expect.anything(),
 			);
 		});
+	});
+});
+
+describe("queue_drained attribution (entry-stamped, uniform-only)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.useFakeTimers();
+		vi.mocked(acquireWorkerLock).mockResolvedValue(true);
+		vi.mocked(releaseWorkerLock).mockResolvedValue();
+	});
+
+	const entry = (
+		hash: string,
+		stamp?: { trigger: "agent" | "ui" | "terminal" | "unknown"; agent?: "claude" | "codex" },
+	) => ({
+		op: {
+			type: "commit" as const,
+			commitHash: hash,
+			commitSource: "cli" as const,
+			createdAt: "2026-02-19T00:00:00.000Z",
+			...(stamp ?? {}),
+		},
+		filePath: `/test/project/.jolli/jollimemory/git-op-queue/1-${hash}.json`,
+	});
+
+	const drained = () =>
+		vi.mocked(track).mock.calls.find(([name]) => name === "queue_drained")?.[1] as Record<string, unknown>;
+
+	it("carries trigger and agent when every drained entry agrees, scoping each entry's agent while it runs", async () => {
+		setupFullPipeline();
+		vi.mocked(dequeueAllGitOperations)
+			.mockReset()
+			.mockResolvedValueOnce([
+				entry("aaa111", { trigger: "agent", agent: "claude" }),
+				entry("bbb222", { trigger: "agent", agent: "claude" }),
+			])
+			.mockResolvedValue([]);
+
+		await runWorker("/test/project");
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(drained()).toMatchObject({ ops: 2, trigger: "agent", agent: "claude" });
+		// Each entry's stamped agent was scoped over its processing, and the scope
+		// was CLEARED before the drain-level event — the last call must be the
+		// clear, so no entry's agent can leak past its own entry.
+		const calls = vi.mocked(setTelemetryAgent).mock.calls.map(([a]) => a);
+		expect(calls.slice(0, 2)).toEqual(["claude", "claude"]);
+		expect(calls[calls.length - 1]).toBeUndefined();
+	});
+
+	it("omits both for a drain whose entries came from different origins", async () => {
+		// A terminal commit drained by the same run as an agent's has no single
+		// honest answer — omission over aggregation, like everywhere else.
+		setupFullPipeline();
+		vi.mocked(dequeueAllGitOperations)
+			.mockReset()
+			.mockResolvedValueOnce([
+				entry("aaa111", { trigger: "agent", agent: "claude" }),
+				entry("bbb222", { trigger: "terminal" }),
+			])
+			.mockResolvedValue([]);
+
+		await runWorker("/test/project");
+		await vi.advanceTimersByTimeAsync(0);
+
+		const props = drained();
+		expect(props.ops).toBe(2);
+		expect(props).not.toHaveProperty("trigger");
+		expect(props).not.toHaveProperty("agent");
+	});
+
+	it("treats an unstamped legacy entry as mixing the batch, and clears the scope for it", async () => {
+		// Entries written by an older enqueuer carry no stamp; their origin is
+		// unknown, so the batch cannot claim uniformity — and while such an entry
+		// runs, the ambient agent must be CLEARED, not inherited from the previous
+		// entry in the loop.
+		setupFullPipeline();
+		vi.mocked(dequeueAllGitOperations)
+			.mockReset()
+			.mockResolvedValueOnce([entry("aaa111", { trigger: "agent", agent: "codex" }), entry("bbb222")])
+			.mockResolvedValue([]);
+
+		await runWorker("/test/project");
+		await vi.advanceTimersByTimeAsync(0);
+
+		const props = drained();
+		expect(props).not.toHaveProperty("trigger");
+		expect(props).not.toHaveProperty("agent");
+		expect(
+			vi
+				.mocked(setTelemetryAgent)
+				.mock.calls.map(([a]) => a)
+				.slice(0, 2),
+		).toEqual(["codex", undefined]);
+	});
+
+	it("reports a uniform trigger without an agent for an all-terminal drain", async () => {
+		setupFullPipeline();
+		vi.mocked(dequeueAllGitOperations)
+			.mockReset()
+			.mockResolvedValueOnce([entry("aaa111", { trigger: "terminal" })])
+			.mockResolvedValue([]);
+
+		await runWorker("/test/project");
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(drained()).toMatchObject({ ops: 1, trigger: "terminal" });
+		expect(drained()).not.toHaveProperty("agent");
 	});
 });

--- a/cli/src/hooks/PostCommitHook.ts
+++ b/cli/src/hooks/PostCommitHook.ts
@@ -15,6 +15,7 @@ import { basename, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { currentAgentSessionId } from "../core/AgentSessionEnv.js";
 import { readManualDisableFlag } from "../core/RepoProfile.js";
+import { resolveCommitOrigin } from "../core/TelemetryAgent.js";
 import { getCurrentTraceId, runWithTrace, traceIdFromEnv } from "../core/TraceContext.js";
 import { createLogger } from "../Logger.js";
 import type { CommitSource, GitOperation } from "../Types.js";
@@ -68,9 +69,14 @@ export function postCommitEntry(cwd: string): { commitHash: string } | null {
 	}
 
 	// Detect commit source (plugin vs CLI)
-	const commitSource: CommitSource = existsSync(join(cwd, ".jolli", "jollimemory", "plugin-source"))
-		? "plugin"
-		: "cli";
+	const fromPluginUi = existsSync(join(cwd, ".jolli", "jollimemory", "plugin-source"));
+	const commitSource: CommitSource = fromPluginUi ? "plugin" : "cli";
+	// Who set this commit in motion, resolved HERE because only this process
+	// still holds the truth: the worker that drains the entry may be a
+	// chain-spawned survivor of an earlier commit, carrying that commit's env,
+	// and it never has the committing terminal's TTY. Stamped on the entry so
+	// the worker attributes this commit's telemetry per entry.
+	const origin = resolveCommitOrigin({ fromPluginUi, isTTY: process.stdout.isTTY === true });
 
 	// Read squash-pending.json if detectCommitOperation found it
 	let opType: GitOperation["type"] = detected.type;
@@ -123,6 +129,8 @@ export function postCommitEntry(cwd: string): { commitHash: string } | null {
 		...(branch && { branch }),
 		...(sourceHashes && { sourceHashes }),
 		commitSource,
+		trigger: origin.trigger,
+		...(origin.agent && { agent: origin.agent }),
 		createdAt: new Date().toISOString(),
 		...(traceId && { traceId }),
 		...(executingSessionId && { executingSessionId }),

--- a/cli/src/hooks/PostRewriteHook.test.ts
+++ b/cli/src/hooks/PostRewriteHook.test.ts
@@ -25,6 +25,16 @@ vi.mock("../core/GitOps.js", () => ({
 	getCurrentBranch: vi.fn().mockResolvedValue(""),
 }));
 
+// Deterministic origin: the real resolver reads process.env / stdout.isTTY,
+// which differ between a dev machine (this suite may itself run inside an
+// agent session carrying CLAUDECODE) and CI. The resolver's own logic is unit
+// tested in TelemetryAgent.test.ts; what THESE tests pin is the threading —
+// that both enqueue paths stamp whatever the resolver answered.
+vi.mock("../core/TelemetryAgent.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../core/TelemetryAgent.js")>()),
+	resolveCommitOrigin: vi.fn(() => ({ trigger: "agent" as const, agent: "codex" as const })),
+}));
+
 vi.mock("../core/SessionTracker.js", () => ({
 	enqueueGitOperation: vi.fn(),
 }));
@@ -408,5 +418,49 @@ describe("PostRewriteHook", () => {
 			);
 			expect(launchWorker).toHaveBeenCalledWith("/test/project");
 		});
+	});
+});
+
+describe("commit-origin stamping (amend and rebase entries)", () => {
+	beforeEach(() => {
+		vi.mocked(enqueueGitOperation).mockResolvedValue(true);
+	});
+
+	it("stamps the resolved origin on an amend entry", async () => {
+		// Amend entries are built HERE, not in PostCommitHook — post-rewrite is the
+		// hook that receives the old→new mapping — so without this stamp every
+		// amend would drain as unattributed.
+		setStdinLines(["aaaa1111 bbbb2222"]);
+		await handlePostRewriteHook("amend", "/test/project");
+		expect(enqueueGitOperation).toHaveBeenCalledWith(
+			expect.objectContaining({ type: "amend", trigger: "agent", agent: "codex" }),
+			"/test/project",
+		);
+	});
+
+	it("stamps every rebase entry — pick and squash alike — with the one resolved origin", async () => {
+		// A rebase is one logical operation by one actor; the origin is resolved
+		// once at the hook entry and every group gets the same stamp.
+		setStdinLines(["aaaa1111 cccc3333", "bbbb2222 cccc3333", "dddd4444 eeee5555"]);
+		await handlePostRewriteHook("rebase", "/test/project");
+		const stamped = vi
+			.mocked(enqueueGitOperation)
+			.mock.calls.map(([op]) => op as { type: string; trigger?: string; agent?: string });
+		expect(stamped.length).toBeGreaterThanOrEqual(2);
+		for (const op of stamped) {
+			expect(["rebase-pick", "rebase-squash"]).toContain(op.type);
+			expect(op.trigger).toBe("agent");
+			expect(op.agent).toBe("codex");
+		}
+	});
+
+	it("threads the plugin marker into the resolver as fromPluginUi", async () => {
+		const { resolveCommitOrigin } = await import("../core/TelemetryAgent.js");
+		setStdinLines(["aaaa1111 bbbb2222"]);
+		await handlePostRewriteHook("amend", "/test/project");
+		// detectCommitSource found no marker in this harness, so the resolver must
+		// be asked with fromPluginUi:false — the marker consumed by commitSource
+		// and the one fed to origin resolution are the same read.
+		expect(vi.mocked(resolveCommitOrigin)).toHaveBeenCalledWith(expect.objectContaining({ fromPluginUi: false }));
 	});
 });

--- a/cli/src/hooks/PostRewriteHook.ts
+++ b/cli/src/hooks/PostRewriteHook.ts
@@ -29,6 +29,7 @@ import { getCurrentBranch } from "../core/GitOps.js";
 import { isWorkerLockHeld } from "../core/Locks.js";
 import { readManualDisableFlag } from "../core/RepoProfile.js";
 import { enqueueGitOperation } from "../core/SessionTracker.js";
+import { type CommitOrigin, resolveCommitOrigin } from "../core/TelemetryAgent.js";
 import { getCurrentTraceId, runWithTrace, traceIdFromEnv } from "../core/TraceContext.js";
 import { createLogger, getJolliMemoryDir, setLogDir } from "../Logger.js";
 import type { CommitSource, GitOperation } from "../Types.js";
@@ -65,6 +66,17 @@ export async function handlePostRewriteHook(command: string, cwd: string): Promi
 
 	// Detect commit source (plugin vs CLI)
 	const commitSource: CommitSource = detectCommitSource(cwd);
+	// Who set this rewrite in motion — same resolution, same reasons, and the
+	// same process-holds-the-truth argument as PostCommitHook's: amends and
+	// rebases are the entries the worker CANNOT re-derive an origin for, since
+	// post-commit never fires for a rebase pick and the drain may run in a
+	// chain-spawned worker carrying another commit's env. `fromPluginUi` reuses
+	// the plugin-source marker detectCommitSource just consumed (IntelliJ's
+	// Squash action writes it before driving a rewrite, same as Commit).
+	const origin = resolveCommitOrigin({
+		fromPluginUi: commitSource === "plugin",
+		isTTY: process.stdout.isTTY === true,
+	});
 
 	// Capture branch once for both subhandlers so the worker's tail cleanup
 	// can target the right `<branch>/` directory even if the user checks
@@ -79,9 +91,9 @@ export async function handlePostRewriteHook(command: string, cwd: string): Promi
 	}
 
 	if (command === "amend") {
-		await handleAmend(mappings, commitSource, cwd, branch);
+		await handleAmend(mappings, commitSource, origin, cwd, branch);
 	} else if (command === "rebase") {
-		await handleRebase(mappings, commitSource, cwd, branch);
+		await handleRebase(mappings, commitSource, origin, cwd, branch);
 	} else {
 		log.info("Unknown command '%s', skipping", command);
 	}
@@ -107,6 +119,7 @@ export async function handlePostRewriteHook(command: string, cwd: string): Promi
 async function handleAmend(
 	mappings: ReadonlyArray<HashMapping>,
 	commitSource: CommitSource,
+	origin: CommitOrigin,
 	cwd: string,
 	branch: string,
 ): Promise<void> {
@@ -120,6 +133,8 @@ async function handleAmend(
 		...(branch && { branch }),
 		sourceHashes: [oldHash],
 		commitSource,
+		trigger: origin.trigger,
+		...(origin.agent && { agent: origin.agent }),
 		createdAt: new Date().toISOString(),
 		...(traceId && { traceId }),
 	};
@@ -134,6 +149,7 @@ async function handleAmend(
 async function handleRebase(
 	mappings: ReadonlyArray<HashMapping>,
 	commitSource: CommitSource,
+	origin: CommitOrigin,
 	cwd: string,
 	branch: string,
 ): Promise<void> {
@@ -159,6 +175,8 @@ async function handleRebase(
 			...(branch && { branch }),
 			sourceHashes: oldHashes,
 			commitSource,
+			trigger: origin.trigger,
+			...(origin.agent && { agent: origin.agent }),
 			createdAt: new Date().toISOString(),
 			...(traceId && { traceId }),
 		};

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -148,7 +148,7 @@ import {
 import { resolveTranscriptIdsFiltered } from "../core/SummaryTree.js";
 import { associateSkillsWithCommit } from "../core/skills/SkillArchive.js";
 import { mergeSkillRefs } from "../core/skills/SkillDelta.js";
-import { getTelemetryContext, track } from "../core/Telemetry.js";
+import { getTelemetryContext, setTelemetryAgent, track } from "../core/Telemetry.js";
 import { bootstrapTelemetry, flushTelemetryNow } from "../core/TelemetryStartup.js";
 import { getCurrentTraceId, runWithTrace, TRACE_ID_ENV, traceIdFromEnv } from "../core/TraceContext.js";
 import { generateTranscriptId } from "../core/TranscriptId.js";
@@ -177,6 +177,7 @@ import {
 	type CommitInfo,
 	type CommitSource,
 	type CommitSummary,
+	type CommitTrigger,
 	type CommitType,
 	type ContextRelevanceRef,
 	type ConversationTokenBreakdown,
@@ -648,6 +649,10 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 		try {
 			// Drain the queue: process all entries, then check for new ones (added during processing)
 			let processedCount = 0;
+			// One record per drained summary entry, stamped at enqueue time (or
+			// undefined for entries an older enqueuer wrote) — folded into
+			// queue_drained below only when the whole drain agrees.
+			const drainOrigins: Array<{ trigger?: CommitTrigger; agent?: TranscriptSource }> = [];
 			// Tracks whether any commit-typed op was processed this run, so we can
 			// debounce-trigger a repo-wide topic-KB ingest after the drain (SP3).
 			// Ingest ops do NOT set it — that would self-perpetuate the trigger.
@@ -765,6 +770,15 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 					// stop inside the inner loop so the outer while condition can re-check and
 					// exit cleanly. The subsequent chain-spawn (line below) picks up leftovers.
 					if (processedCount >= MAX_ENTRIES_PER_RUN) break;
+					// Scope this entry's stamped agent over everything its processing
+					// emits (error_occurred, ai_source_detected's fallback, …). The
+					// worker's own env is NOT consulted (see the bootstrap above): a
+					// chain-spawned worker's env belongs to whichever commit started
+					// the chain, while the stamp was resolved by that entry's own
+					// hook. An unstamped entry (older enqueuer) CLEARS the ambient
+					// value — absent reads as unknown, never as the previous entry's.
+					setTelemetryAgent(op.agent);
+					drainOrigins.push({ trigger: op.trigger, agent: op.agent });
 					try {
 						// Adopt the trace id stamped on the entry at enqueue time so this
 						// commit's summarize/consolidate logs + outbound LLM/push calls
@@ -802,9 +816,27 @@ export async function runWorker(cwd: string, force = false): Promise<void> {
 				}
 			}
 
+			// The drain is over; no entry's agent may leak onto drain-level events.
+			setTelemetryAgent(undefined);
 			if (processedCount > 0) {
 				log.info("Processed %d queue entries", processedCount);
-				track("queue_drained", { ops: processedCount, duration_ms: Date.now() - drainStart });
+				// `trigger` / `agent` are per-COMMIT facts on a per-DRAIN event, so they
+				// are reported only when every drained entry agrees (the dominant case —
+				// one commit per drain) and omitted otherwise: a drain that mixed a
+				// terminal commit into an agent's batch has no single honest answer, and
+				// an entry an older enqueuer left unstamped makes the batch mixed by
+				// definition. Omission over aggregation — same rule as everywhere else
+				// in this dimension.
+				const uniform = <T>(values: ReadonlyArray<T>): T | undefined =>
+					values.length === processedCount && values.every((v) => v === values[0]) ? values[0] : undefined;
+				const trigger = uniform(drainOrigins.map((o) => o.trigger).filter((t) => t !== undefined));
+				const agent = uniform(drainOrigins.map((o) => o.agent));
+				track("queue_drained", {
+					ops: processedCount,
+					duration_ms: Date.now() - drainStart,
+					...(trigger ? { trigger } : {}),
+					...(agent ? { agent } : {}),
+				});
 			}
 
 			// SP3 — a commit just landed, so debounce-trigger a repo-wide topic-KB
@@ -4974,11 +5006,17 @@ if (isMainScript()) {
 		// short-lived CLI / hook invocations only buffered. All best-effort;
 		// never blocks exit on a telemetry error.
 		runWithTrace(traceIdFromEnv(), () =>
-			// `inferAgentFromEnv`: this worker is a detached spawn of `post-commit`,
-			// which inherits the committing process's env — so a commit made from
-			// inside an agent session is attributed to it. Per-transcript events
-			// override this with the session's own source, which is more specific.
-			bootstrapTelemetry({ cwd, inferAgentFromEnv: true })
+			// No `inferAgentFromEnv` — this used to be opted in ("the worker inherits
+			// the committing process's env"), and that reasoning holds only for the
+			// FIRST commit: the worker chain-spawns successors and drains entries
+			// other commits enqueued while it ran, all under the env of whichever
+			// commit spawned the chain. A terminal commit drained by an agent-spawned
+			// chain would inherit `agent: "claude"` — a wrong value, not a missing
+			// one. The truth is stamped per ENTRY at enqueue time instead
+			// (CommitGitOperation.trigger/agent, resolved by the post-commit hook,
+			// the one process that still holds it), and the drain loop scopes it via
+			// setTelemetryAgent around each entry.
+			bootstrapTelemetry({ cwd })
 				.then(() => runWorker(cwd))
 				.then(() => flushTelemetryNow(cwd))
 				.catch((_error: unknown) => {

--- a/cli/src/hooks/QueueWorker.ts
+++ b/cli/src/hooks/QueueWorker.ts
@@ -4504,8 +4504,19 @@ async function readAllTranscripts(
 		// so it never re-fires on later runs and can't skew the AI-source-mix view).
 		// Gated on telemetry being enabled so an opted-out/uninitialized run never
 		// writes the seen-sources ledger (also keeps it out of unit tests).
+		//
+		// `agent` is stamped from the SESSION rather than left to the worker's
+		// ambient value, and this loop is the one place that difference matters:
+		// the worker is a detached spawn whose env-derived agent describes the
+		// process that committed, which is not necessarily the host that produced
+		// the transcript being walked (and for the ten hosts with no hook of their
+		// own, is usually nothing at all). It is also how Gemini — the one
+		// push-based host, fed here by its AfterAgent hook rather than by a disk
+		// scan — gets attributed: it arrives as `source === "gemini"` like any
+		// other, so the push path needs no separate branch. `source` is a
+		// TranscriptSource, so it is already a member of the closed vocabulary.
 		if (getTelemetryContext()?.enabled && (await markAiSourceSeen(source))) {
-			track("ai_source_detected", { source });
+			track("ai_source_detected", { source, agent: source });
 		}
 
 		// Gemini, OpenCode, Cursor, Copilot, and Cline use dedicated readers (not JSONL line-based parsing).
@@ -4963,7 +4974,11 @@ if (isMainScript()) {
 		// short-lived CLI / hook invocations only buffered. All best-effort;
 		// never blocks exit on a telemetry error.
 		runWithTrace(traceIdFromEnv(), () =>
-			bootstrapTelemetry({ cwd })
+			// `inferAgentFromEnv`: this worker is a detached spawn of `post-commit`,
+			// which inherits the committing process's env — so a commit made from
+			// inside an agent session is attributed to it. Per-transcript events
+			// override this with the session's own source, which is more specific.
+			bootstrapTelemetry({ cwd, inferAgentFromEnv: true })
 				.then(() => runWorker(cwd))
 				.then(() => flushTelemetryNow(cwd))
 				.catch((_error: unknown) => {

--- a/cli/src/install/CodexPluginSkills.ts
+++ b/cli/src/install/CodexPluginSkills.ts
@@ -132,7 +132,7 @@ read:
 **Fallback (CLI):** if the \`status\` tool is unavailable, read the same facts from
 
 \`\`\`bash
-${RUN_CLI} status
+JOLLI_INVOKED_VIA=skill:jolli ${RUN_CLI} status
 \`\`\`
 
 If neither can be reached, skip the state-based guidance and go straight to
@@ -282,7 +282,7 @@ ${SHELL_PREREQUISITE_BLOCK}
 
 ## 1. Inspect state
 
-Call the Jolli Memory \`status\` tool. If unavailable, run \`${RUN_CLI} status\`.
+Call the Jolli Memory \`status\` tool. If unavailable, run \`JOLLI_INVOKED_VIA=skill:init ${RUN_CLI} status\`.
 If the dispatcher is missing, ask the user to start a new Codex session, open
 \`/hooks\`, trust the Jolli SessionStart hook, and retry.
 
@@ -291,7 +291,7 @@ If the dispatcher is missing, ask the user to start a new Codex session, open
 Run:
 
 \`\`\`bash
-${RUN_CLI} enable --repo-hooks-only --source-tag codex-plugin
+JOLLI_INVOKED_VIA=skill:init ${RUN_CLI} enable --repo-hooks-only --source-tag codex-plugin
 \`\`\`
 
 This explicit setup records \`codex\` as the local-agent tool only when none is
@@ -311,7 +311,7 @@ If the user only wants local memory, skip to Step 5. Otherwise, when status show
 neither a Jolli sign-in nor a Jolli API key, run and wait for:
 
 \`\`\`bash
-${RUN_CLI} auth login
+JOLLI_INVOKED_VIA=skill:init ${RUN_CLI} auth login
 \`\`\`
 
 The command opens the browser and waits for a loopback callback. Never ask for a
@@ -324,14 +324,14 @@ Otherwise present the available Spaces and ask them to choose, offering the defa
 first when one exists. Call \`bind_space\` with the selected value. Treat
 \`already_bound\` as success.
 
-If the Space tools are unavailable, run \`${RUN_CLI} spaces --format json\`,
+If the Space tools are unavailable, run \`JOLLI_INVOKED_VIA=skill:init ${RUN_CLI} spaces --format json\`,
 present only the returned Spaces, then bind the selected id or slug with
-\`${RUN_CLI} bind --space <id-or-slug> --format json\`. Never put free-typed
+\`JOLLI_INVOKED_VIA=skill:init ${RUN_CLI} bind --space <id-or-slug> --format json\`. Never put free-typed
 user text directly into this command.
 
 ## 5. Verify and report
 
-Call \`status\` again (or \`${RUN_CLI} status\` when the tool is not registered yet).
+Call \`status\` again (or \`JOLLI_INVOKED_VIA=skill:init ${RUN_CLI} status\` when the tool is not registered yet).
 Report:
 
 - memory generation enabled or the exact remaining problem;
@@ -357,7 +357,7 @@ ${SHELL_PREREQUISITE_BLOCK}
 Run and wait for the interactive browser flow:
 
 \`\`\`bash
-${RUN_CLI} auth login
+JOLLI_INVOKED_VIA=skill:login ${RUN_CLI} auth login
 \`\`\`
 
 Never ask the user for passwords, API keys, callback URLs, or browser tokens.
@@ -385,7 +385,7 @@ ${SHELL_PREREQUISITE_BLOCK}
 Run:
 
 \`\`\`bash
-${RUN_CLI} auth logout
+JOLLI_INVOKED_VIA=skill:logout ${RUN_CLI} auth logout
 \`\`\`
 
 Report the command output, then call the Jolli Memory \`status\` tool when
@@ -424,7 +424,7 @@ description: Diagnose Jolli Memory installation, provider, account, hooks, queue
    - \`anthropic\`: requires an Anthropic API key.
    - unset: requires a usable provider credential.
 
-If \`status\` is unavailable, run \`${RUN_CLI} status\` and summarize it. Do not
+If \`status\` is unavailable, run \`JOLLI_INVOKED_VIA=skill:status ${RUN_CLI} status\` and summarize it. Do not
 list branch memories; route those requests to \`jolli:recall\` or \`jolli:search\`.
 
 ${SHELL_PREREQUISITE_BLOCK}

--- a/cli/src/install/CursorPluginSkills.ts
+++ b/cli/src/install/CursorPluginSkills.ts
@@ -226,7 +226,7 @@ read:
 **Fallback (CLI):** if the \`status\` tool is unavailable, read the same facts from
 
 \`\`\`bash
-${RUN_CLI} status
+JOLLI_INVOKED_VIA=skill:jolli ${RUN_CLI} status
 \`\`\`
 
 If neither can be reached, skip the state-based guidance and go straight to
@@ -387,7 +387,7 @@ ${SHELL_PREREQUISITE_BLOCK}
 
 ## 1. Inspect state
 
-Call the Jolli Memory \`status\` tool. If unavailable, run \`${RUN_CLI} status\`.
+Call the Jolli Memory \`status\` tool. If unavailable, run \`JOLLI_INVOKED_VIA=skill:init ${RUN_CLI} status\`.
 
 ${CURSOR_DISPATCHER_MISSING_BLOCK}
 
@@ -396,7 +396,7 @@ ${CURSOR_DISPATCHER_MISSING_BLOCK}
 Run:
 
 \`\`\`bash
-${RUN_CLI} enable --repo-hooks-only --source-tag cursor-plugin
+JOLLI_INVOKED_VIA=skill:init ${RUN_CLI} enable --repo-hooks-only --source-tag cursor-plugin
 \`\`\`
 
 This explicit setup records \`cursor-agent\` as the local-agent tool only when none
@@ -422,7 +422,7 @@ If the user only wants local memory, skip to Step 5. Otherwise, when status show
 neither a Jolli sign-in nor a Jolli API key, run and wait for:
 
 \`\`\`bash
-${RUN_CLI} auth login
+JOLLI_INVOKED_VIA=skill:init ${RUN_CLI} auth login
 \`\`\`
 
 The command opens the browser and waits for a loopback callback. Never ask for a
@@ -435,14 +435,14 @@ Otherwise present the available Spaces and ask them to choose, offering the defa
 first when one exists. Call \`bind_space\` with the selected value. Treat
 \`already_bound\` as success.
 
-If the Space tools are unavailable, run \`${RUN_CLI} spaces --format json\`,
+If the Space tools are unavailable, run \`JOLLI_INVOKED_VIA=skill:init ${RUN_CLI} spaces --format json\`,
 present only the returned Spaces, then bind the selected id or slug with
-\`${RUN_CLI} bind --space <id-or-slug> --format json\`. Never put free-typed
+\`JOLLI_INVOKED_VIA=skill:init ${RUN_CLI} bind --space <id-or-slug> --format json\`. Never put free-typed
 user text directly into this command.
 
 ## 5. Verify and report
 
-Call \`status\` again (or \`${RUN_CLI} status\` when the tool is not registered yet).
+Call \`status\` again (or \`JOLLI_INVOKED_VIA=skill:init ${RUN_CLI} status\` when the tool is not registered yet).
 Report:
 
 - memory generation enabled or the exact remaining problem;
@@ -469,7 +469,7 @@ ${SHELL_PREREQUISITE_BLOCK}
 Run and wait for the interactive browser flow:
 
 \`\`\`bash
-${RUN_CLI} auth login
+JOLLI_INVOKED_VIA=skill:login ${RUN_CLI} auth login
 \`\`\`
 
 Never ask the user for passwords, API keys, callback URLs, or browser tokens.
@@ -497,7 +497,7 @@ ${SHELL_PREREQUISITE_BLOCK}
 Run:
 
 \`\`\`bash
-${RUN_CLI} auth logout
+JOLLI_INVOKED_VIA=skill:logout ${RUN_CLI} auth logout
 \`\`\`
 
 Report the command output, then call the Jolli Memory \`status\` tool when
@@ -535,7 +535,7 @@ description: Diagnose Jolli Memory installation, provider, account, hooks, queue
    - \`anthropic\`: requires an Anthropic API key.
    - unset: requires a usable provider credential.
 
-If \`status\` is unavailable, run \`${RUN_CLI} status\` and summarize it. Do not
+If \`status\` is unavailable, run \`JOLLI_INVOKED_VIA=skill:status ${RUN_CLI} status\` and summarize it. Do not
 list branch memories; route those requests to \`/jolli-recall\` or \`/jolli-search\`.
 
 ${SHELL_PREREQUISITE_BLOCK}

--- a/cli/src/install/PluginSkillText.ts
+++ b/cli/src/install/PluginSkillText.ts
@@ -225,7 +225,7 @@ server prints once it is listening:
 \`\`\`bash
 LOG=$(mktemp "\${TMPDIR:-/tmp}/jolli-dashboard.XXXXXX")
 echo "LOG $LOG"
-nohup "$HOME/.jolli/jollimemory/run-cli" dashboard >"$LOG" 2>&1 &
+JOLLI_INVOKED_VIA=skill:dashboard nohup "$HOME/.jolli/jollimemory/run-cli" dashboard >"$LOG" 2>&1 &
 echo "PID $!"
 for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
 	URL=$(grep -o 'http://127\\.0\\.0\\.1:[0-9]*/dashboard' "$LOG" | head -1)

--- a/cli/src/install/SkillInstaller.test.ts
+++ b/cli/src/install/SkillInstaller.test.ts
@@ -1476,8 +1476,13 @@ describe("skill revision is kept in lockstep with the body", () => {
 		search: { build: buildSearchSkillTemplate, revision: 3, fingerprint: "602cea610684" },
 		localRun: { build: buildLocalRunSkillTemplate, revision: 6, fingerprint: "d04d02ba2c73" },
 		remoteRun: { build: buildRemoteRunSkillTemplate, revision: 5, fingerprint: "e3e5572715a3" },
-		menu: { build: buildJolliMenuSkillTemplate, revision: 8, fingerprint: "5662a77934fb" },
-		pluginMenu: { build: buildPluginJolliMenuSkillTemplate, revision: 9, fingerprint: "5f05bec43ad1" },
+		// 9/10 rather than 8/9: main and this branch each changed the menu bodies
+		// under 8/9 independently (dashboard routing there, via prefixes here), so
+		// the merged bodies differ from BOTH already-dogfooded 8/9s under the same
+		// numbers — and an equal revision never overwrites (the lockstep contract),
+		// so without this bump no existing install would ever receive the merge.
+		menu: { build: buildJolliMenuSkillTemplate, revision: 9, fingerprint: "29b528112102" },
+		pluginMenu: { build: buildPluginJolliMenuSkillTemplate, revision: 10, fingerprint: "be1e140af79a" },
 	} as const;
 
 	for (const [name, want] of Object.entries(EXPECTED)) {
@@ -1507,7 +1512,9 @@ describe("skill revision is kept in lockstep with the body", () => {
 	// already prefixed) — deliberately narrower than "any line mentioning
 	// run-cli": the Step-0 `test -f …run-cli` presence checks never run a jolli
 	// command, so no command_invoked exists for them to annotate.
-	const INVOCATION = /^[ \t]*(?:JOLLI_INVOKED_VIA=\S+ )?"\$HOME\/\.jolli\/jollimemory\/run-cli" .*$/gm;
+	// `nohup` is a legal shape between the prefix and the command (the dashboard
+	// skill backgrounds its server); the env assignment must still come FIRST.
+	const INVOCATION = /^[ \t]*(?:JOLLI_INVOKED_VIA=\S+ )?(?:nohup )?"\$HOME\/\.jolli\/jollimemory\/run-cli" .*$/gm;
 	for (const { name, build } of VIA_SKILLS) {
 		it(`${name}: every run-cli invocation carries via skill:${name} (${build.name})`, () => {
 			const body = build();
@@ -1524,7 +1531,7 @@ describe("skill revision is kept in lockstep with the body", () => {
 	// generator, so nothing regenerates them when the shared builders move —
 	// which is exactly how they shipped without the via prefix once. Pin the
 	// prefix on the files themselves.
-	for (const name of ["recall", "search"] as const) {
+	for (const name of ["recall", "search", "dashboard"] as const) {
 		it(`claude bundle ${name}: its committed run-cli invocation carries via skill:${name}`, () => {
 			const file = join(
 				dirname(fileURLToPath(import.meta.url)),

--- a/cli/src/install/SkillInstaller.test.ts
+++ b/cli/src/install/SkillInstaller.test.ts
@@ -18,7 +18,8 @@
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
@@ -1475,8 +1476,8 @@ describe("skill revision is kept in lockstep with the body", () => {
 		search: { build: buildSearchSkillTemplate, revision: 3, fingerprint: "602cea610684" },
 		localRun: { build: buildLocalRunSkillTemplate, revision: 6, fingerprint: "d04d02ba2c73" },
 		remoteRun: { build: buildRemoteRunSkillTemplate, revision: 5, fingerprint: "e3e5572715a3" },
-		menu: { build: buildJolliMenuSkillTemplate, revision: 8, fingerprint: "8db133d89c3b" },
-		pluginMenu: { build: buildPluginJolliMenuSkillTemplate, revision: 9, fingerprint: "37225c630e7d" },
+		menu: { build: buildJolliMenuSkillTemplate, revision: 8, fingerprint: "5662a77934fb" },
+		pluginMenu: { build: buildPluginJolliMenuSkillTemplate, revision: 9, fingerprint: "5f05bec43ad1" },
 	} as const;
 
 	for (const [name, want] of Object.entries(EXPECTED)) {
@@ -1499,16 +1500,50 @@ describe("skill revision is kept in lockstep with the body", () => {
 		{ name: "search", build: buildSearchSkillTemplate },
 		{ name: "local-run", build: buildLocalRunSkillTemplate },
 		{ name: "remote-run", build: buildRemoteRunSkillTemplate },
+		{ name: "jolli", build: buildJolliMenuSkillTemplate },
+		{ name: "jolli", build: buildPluginJolliMenuSkillTemplate },
 	] as const;
+	// An INVOCATION is a fenced command line starting with run-cli (optionally
+	// already prefixed) — deliberately narrower than "any line mentioning
+	// run-cli": the Step-0 `test -f …run-cli` presence checks never run a jolli
+	// command, so no command_invoked exists for them to annotate.
+	const INVOCATION = /^[ \t]*(?:JOLLI_INVOKED_VIA=\S+ )?"\$HOME\/\.jolli\/jollimemory\/run-cli" .*$/gm;
 	for (const { name, build } of VIA_SKILLS) {
-		it(`${name}: every run-cli invocation carries via skill:${name}`, () => {
+		it(`${name}: every run-cli invocation carries via skill:${name} (${build.name})`, () => {
 			const body = build();
-			const invocations = body.match(/^.*\/run-cli" .*$/gm) ?? [];
+			const invocations = body.match(INVOCATION) ?? [];
 			expect(invocations.length).toBeGreaterThan(0);
 			for (const line of invocations) {
 				expect(line.trimStart().startsWith(`JOLLI_INVOKED_VIA=skill:${name} `)).toBe(true);
 			}
 			expect(body).not.toContain("skill:jolli-");
+		});
+	}
+
+	// The Claude plugin's bundled recall/search are COMMITTED copies with no
+	// generator, so nothing regenerates them when the shared builders move —
+	// which is exactly how they shipped without the via prefix once. Pin the
+	// prefix on the files themselves.
+	for (const name of ["recall", "search"] as const) {
+		it(`claude bundle ${name}: its committed run-cli invocation carries via skill:${name}`, () => {
+			const file = join(
+				dirname(fileURLToPath(import.meta.url)),
+				"..",
+				"..",
+				"..",
+				"claude-plugin",
+				"plugins",
+				"jolli",
+				"skills",
+				name,
+				"SKILL.md",
+			);
+			const body = readFileSync(file, "utf-8");
+			const invocations = body.match(INVOCATION) ?? [];
+			expect(invocations.length).toBeGreaterThan(0);
+			for (const line of invocations) {
+				expect(line.trimStart().startsWith(`JOLLI_INVOKED_VIA=skill:${name} `)).toBe(true);
+			}
 		});
 	}
 

--- a/cli/src/install/SkillInstaller.test.ts
+++ b/cli/src/install/SkillInstaller.test.ts
@@ -1471,10 +1471,10 @@ describe("skill revision is kept in lockstep with the body", () => {
 	// When a body legitimately changes: bump `revision`, then update `fingerprint`
 	// here. Both, in the same change.
 	const EXPECTED = {
-		recall: { build: buildRecallSkillTemplate, revision: 2, fingerprint: "5baf6ab3b7ce" },
-		search: { build: buildSearchSkillTemplate, revision: 2, fingerprint: "2fa504d6745f" },
-		localRun: { build: buildLocalRunSkillTemplate, revision: 5, fingerprint: "81db78096bb6" },
-		remoteRun: { build: buildRemoteRunSkillTemplate, revision: 4, fingerprint: "9fd34e36c20e" },
+		recall: { build: buildRecallSkillTemplate, revision: 3, fingerprint: "07580a0b4ad3" },
+		search: { build: buildSearchSkillTemplate, revision: 3, fingerprint: "602cea610684" },
+		localRun: { build: buildLocalRunSkillTemplate, revision: 6, fingerprint: "d04d02ba2c73" },
+		remoteRun: { build: buildRemoteRunSkillTemplate, revision: 5, fingerprint: "e3e5572715a3" },
 		menu: { build: buildJolliMenuSkillTemplate, revision: 8, fingerprint: "8db133d89c3b" },
 		pluginMenu: { build: buildPluginJolliMenuSkillTemplate, revision: 9, fingerprint: "37225c630e7d" },
 	} as const;
@@ -1484,6 +1484,31 @@ describe("skill revision is kept in lockstep with the body", () => {
 			const body = want.build();
 			expect(body.match(/revision:\s*(\d+)/)?.[1]).toBe(String(want.revision));
 			expect(stableFingerprint(body)).toBe(want.fingerprint);
+		});
+	}
+
+	// Every run-cli invocation a skill body ships must carry its own
+	// `JOLLI_INVOKED_VIA=skill:<bare-name>` prefix — that is the whole `via`
+	// telemetry dimension for the CLI path, and a bare invocation added later
+	// would silently emit as "typed directly". Derived from the body rather than
+	// a per-skill count so a recipe gaining or losing a call stays covered.
+	// BARE names only: `skill:jolli-<x>` would be corrupted to `skill:jolli:<x>`
+	// by the Codex renderer's substring rewrite.
+	const VIA_SKILLS = [
+		{ name: "recall", build: buildRecallSkillTemplate },
+		{ name: "search", build: buildSearchSkillTemplate },
+		{ name: "local-run", build: buildLocalRunSkillTemplate },
+		{ name: "remote-run", build: buildRemoteRunSkillTemplate },
+	] as const;
+	for (const { name, build } of VIA_SKILLS) {
+		it(`${name}: every run-cli invocation carries via skill:${name}`, () => {
+			const body = build();
+			const invocations = body.match(/^.*\/run-cli" .*$/gm) ?? [];
+			expect(invocations.length).toBeGreaterThan(0);
+			for (const line of invocations) {
+				expect(line.trimStart().startsWith(`JOLLI_INVOKED_VIA=skill:${name} `)).toBe(true);
+			}
+			expect(body).not.toContain("skill:jolli-");
 		});
 	}
 

--- a/cli/src/install/SkillInstaller.ts
+++ b/cli/src/install/SkillInstaller.ts
@@ -1517,7 +1517,7 @@ name: jolli
 description: The Jolli action menu — a single front door that lists the Jolli skills available in this session (recall, search, run a workflow local or remote, workflow history, plus any setup and account skills a Jolli plugin adds) and the Jolli MCP tools, then routes your choice to the right one. Use when the user types /jolli or asks for the Jolli menu.
 metadata:
   version: "${SKILL_VERSION}"
-  revision: 8
+  revision: 9
   vendor: "jolli.ai"
 ---
 
@@ -1699,7 +1699,7 @@ name: jolli
 description: The Jolli front door — checks how Jolli is set up in this repo, guides first-time setup through /jolli:init when something's missing, reminds you to sign in when memories can't sync yet, and otherwise shows a status snapshot and routes you to the right Jolli skill or MCP tool. Use when the user types /jolli or asks for Jolli / the Jolli menu.
 metadata:
   version: "${SKILL_VERSION}"
-  revision: 9
+  revision: 10
   vendor: "jolli.ai"
 ---
 

--- a/cli/src/install/SkillInstaller.ts
+++ b/cli/src/install/SkillInstaller.ts
@@ -1577,7 +1577,7 @@ has no such action.
   id), then shell:
 
   \`\`\`bash
-  "$HOME/.jolli/jollimemory/run-cli" workflow runs <workflowId>
+  JOLLI_INVOKED_VIA=skill:jolli "$HOME/.jolli/jollimemory/run-cli" workflow runs <workflowId>
   \`\`\`
 
   It prints \`{ "type": "runs", "runs": [ ... ] }\` — one entry per run with its
@@ -1589,7 +1589,7 @@ has no such action.
   and stop. Offer to open any listed URL via the \`open-url\` helper:
 
   \`\`\`bash
-  "$HOME/.jolli/jollimemory/run-cli" open-url <url>
+  JOLLI_INVOKED_VIA=skill:jolli "$HOME/.jolli/jollimemory/run-cli" open-url <url>
   \`\`\`
 
   (\`{ "opened": true|false, "url": "..." }\`; \`opened: false\` on a headless host
@@ -1784,7 +1784,7 @@ run the bundled CLI through its stable dispatch script and read the same facts
 from its printed output:
 
 \`\`\`bash
-"$HOME/.jolli/jollimemory/run-cli" status
+JOLLI_INVOKED_VIA=skill:jolli "$HOME/.jolli/jollimemory/run-cli" status
 \`\`\`
 
 If neither the tool nor the CLI can be reached at all, skip the state-based

--- a/cli/src/install/SkillInstaller.ts
+++ b/cli/src/install/SkillInstaller.ts
@@ -140,6 +140,15 @@ const SKILLS: ReadonlyArray<SkillRegistration> = [
 ];
 
 /**
+ * Every installed skill's directory name, exported for the lockstep pin in
+ * `TelemetryAgent.test.ts`: `SKILL_VIA_NAMES` (the `via` telemetry vocabulary)
+ * is a hand-kept bare-name copy of this list — kept separate so the telemetry
+ * leaf never imports the install stack — and the test derives one from the
+ * other so the copy cannot drift when a skill is added or retired here.
+ */
+export const INSTALLED_SKILL_NAMES: ReadonlyArray<string> = SKILLS.map((skill) => skill.name);
+
+/**
  * Skill directory names Jolli USED to ship but no longer does. On every
  * `jolli enable` these are removed from the write targets so an upgrade doesn't
  * strand a dead skill in the user's repo. Removal is guarded by the Jolli
@@ -671,6 +680,16 @@ async function upsertSkill(skillsDir: string, name: string, content: string): Pr
  * The literal `<DELIM>` placeholder is intentional: the LLM is the one that
  * generates the random value each invocation, which is what makes pre-computed
  * prompt-injection payloads useless.
+ *
+ * The `JOLLI_INVOKED_VIA=skill:<name>` env prefix is the `via` telemetry
+ * dimension — how this command was reached, as distinct from which host ran it
+ * (`agent`). `TelemetryCommandHook` consumes and validates it against the
+ * closed skill-name set and DELETES it from the process env, so a child the
+ * command spawns cannot inherit the claim. A static assignment with no
+ * interpolation, so it adds nothing to the injection surface this recipe
+ * exists to close. The value uses the BARE name (`skill:recall`, never
+ * `skill:jolli-recall`): the Codex renderer rewrites `jolli-<name>` substrings
+ * to `jolli:<name>` and would corrupt the prefixed form.
  */
 function heredocInvocation(subcommand: "recall" | "search", flagSuffix: string): string {
 	return `${SHELL_PREREQUISITE_BLOCK}
@@ -686,7 +705,7 @@ Then run this Bash, replacing the two \`<DELIM>\` occurrences with your
 delimiter token and replacing \`<user-arg>\` with the user's input verbatim:
 
 \`\`\`bash
-"$HOME/.jolli/jollimemory/run-cli" ${subcommand} --arg-stdin${flagSuffix} <<'JOLLI_ARG_<DELIM>_END'
+JOLLI_INVOKED_VIA=skill:${subcommand} "$HOME/.jolli/jollimemory/run-cli" ${subcommand} --arg-stdin${flagSuffix} <<'JOLLI_ARG_<DELIM>_END'
 <user-arg>
 JOLLI_ARG_<DELIM>_END
 \`\`\`
@@ -710,7 +729,7 @@ name: jolli-recall
 description: Recall prior development context from Jolli for the current branch. Use when the user wants to recall, remember, or resume prior work on a branch.
 metadata:
   version: "${SKILL_VERSION}"
-  revision: 2
+  revision: 3
   vendor: "jolli.ai"
 ---
 
@@ -940,7 +959,7 @@ name: jolli-search
 description: Search structured commit memories across all branches — decisions, topics, files. Use when the user wants to find prior decisions, related commits, or how a topic was handled before.
 metadata:
   version: "${SKILL_VERSION}"
-  revision: 2
+  revision: 3
   vendor: "jolli.ai"
 ---
 
@@ -1085,7 +1104,7 @@ name: jolli-local-run
 description: Run a Jolli workflow locally — your own agent executes the workflow's recipe (no Jolli LLM budget) and its file writes land in a git-backed Jolli Space via a branch and pull request that space-cli opens on this machine. Use when the user wants to run a Jolli workflow locally.
 metadata:
   version: "${SKILL_VERSION}"
-  revision: 5
+  revision: 6
   vendor: "jolli.ai"
 ---
 
@@ -1112,7 +1131,7 @@ ${SHELL_PREREQUISITE_BLOCK}
 Run the eligibility helper and read its JSON:
 
 \`\`\`bash
-"$HOME/.jolli/jollimemory/run-cli" workflow local-run
+JOLLI_INVOKED_VIA=skill:local-run "$HOME/.jolli/jollimemory/run-cli" workflow local-run
 \`\`\`
 
 - \`{ "type": "workflows", "workflows": [ { "id": 7, "name": "Impact Analysis", "autoMerges": true|false }, ... ] }\`
@@ -1167,7 +1186,7 @@ Capture from its result:
 Pull the destination clone onto the server-derived work branch:
 
 \`\`\`bash
-"$HOME/.jolli/jollimemory/run-cli" docs pull --branch <writeTarget.workBranch>
+JOLLI_INVOKED_VIA=skill:local-run "$HOME/.jolli/jollimemory/run-cli" docs pull --branch <writeTarget.workBranch>
 \`\`\`
 
 **Always \`--branch\`. NEVER \`--agent\`.** The \`--agent\` mode runs a destructive
@@ -1202,7 +1221,7 @@ fresh across the wait.
 1. Publish the branch as a pull request and capture the machine-readable result:
 
    \`\`\`bash
-   "$HOME/.jolli/jollimemory/run-cli" docs publish --json
+   JOLLI_INVOKED_VIA=skill:local-run "$HOME/.jolli/jollimemory/run-cli" docs publish --json
    \`\`\`
 
    \`--json\` prints exactly one JSON object on stdout (all human-readable progress
@@ -1214,7 +1233,7 @@ fresh across the wait.
    deterministically** — do not eyeball it yourself:
 
    \`\`\`bash
-   "$HOME/.jolli/jollimemory/run-cli" space verify-publish-branch <writeTarget.workBranch> <headBranch>
+   JOLLI_INVOKED_VIA=skill:local-run "$HOME/.jolli/jollimemory/run-cli" space verify-publish-branch <writeTarget.workBranch> <headBranch>
    \`\`\`
 
    It prints \`{ "match": true|false, "expected": "...", "actual": "..." }\` and exits
@@ -1270,7 +1289,7 @@ fresh across the wait.
    chooses, shell:
 
    \`\`\`bash
-   "$HOME/.jolli/jollimemory/run-cli" open-url <url>
+   JOLLI_INVOKED_VIA=skill:local-run "$HOME/.jolli/jollimemory/run-cli" open-url <url>
    \`\`\`
 
    It prints one JSON line \`{ "opened": true|false, "url": "..." }\`. When \`opened\` is
@@ -1316,7 +1335,7 @@ name: jolli-remote-run
 description: Run a Jolli workflow remotely — the Jolli backend executes the workflow server-side; this recipe triggers the run, monitors it to completion, reports the outcome (failed / cancelled / succeeded) with its article, PR, and workflow links, and offers to open any in your browser. Use when the user wants to run a Jolli workflow remotely (on the Jolli backend).
 metadata:
   version: "${SKILL_VERSION}"
-  revision: 4
+  revision: 5
   vendor: "jolli.ai"
 ---
 
@@ -1364,7 +1383,7 @@ its outcome).
 Run the plugin's eligibility helper purely as a presence probe and read its JSON:
 
 \`\`\`bash
-"$HOME/.jolli/jollimemory/run-cli" workflow local-run
+JOLLI_INVOKED_VIA=skill:remote-run "$HOME/.jolli/jollimemory/run-cli" workflow local-run
 \`\`\`
 
 - \`{ "type": "workflow_cli_required", "installHint": "..." }\` — the workflow-cli
@@ -1393,7 +1412,7 @@ that handle drives the monitor in Step 4.
 Shell the deterministic monitor with the captured \`runId\`:
 
 \`\`\`bash
-"$HOME/.jolli/jollimemory/run-cli" workflow run-status <runId>
+JOLLI_INVOKED_VIA=skill:remote-run "$HOME/.jolli/jollimemory/run-cli" workflow run-status <runId>
 \`\`\`
 
 It polls the run to a terminal state (with backoff, so you do not drive the poll
@@ -1446,7 +1465,7 @@ Offer to open any URL from the report in the user's default browser. For each UR
 the user chooses, shell:
 
 \`\`\`bash
-"$HOME/.jolli/jollimemory/run-cli" open-url <url>
+JOLLI_INVOKED_VIA=skill:remote-run "$HOME/.jolli/jollimemory/run-cli" open-url <url>
 \`\`\`
 
 It prints one JSON line \`{ "opened": true|false, "url": "..." }\`. When \`opened\` is

--- a/cli/src/mcp/McpServer.test.ts
+++ b/cli/src/mcp/McpServer.test.ts
@@ -46,6 +46,10 @@ const connectMock = vi.fn().mockResolvedValue(undefined);
 // Capture the Server constructor's args so the test can assert name/version + capabilities.
 let serverInfo: { name: string; version: string } | undefined;
 let serverCapabilities: { tools?: unknown; prompts?: unknown } | undefined;
+// The per-connection clientInfo the SDK exposes after `initialize`; tests set
+// this to simulate what a host declared on this connection. Reset per test.
+let mockClientInfo: { name: string; version: string } | undefined;
+const capturedServers: Array<{ oninitialized?: () => void }> = [];
 
 // Find the handler registered for a given schema marker kind (e.g. "listPrompts").
 function handlerForKind(kind: string): RequestHandler | undefined {
@@ -55,9 +59,14 @@ function handlerForKind(kind: string): RequestHandler | undefined {
 
 vi.mock("@modelcontextprotocol/sdk/server/index.js", () => ({
 	Server: class {
+		oninitialized?: () => void;
+		getClientVersion() {
+			return mockClientInfo;
+		}
 		constructor(info: { name: string; version: string }, options?: { capabilities?: typeof serverCapabilities }) {
 			serverInfo = info;
 			serverCapabilities = options?.capabilities;
+			capturedServers.push(this);
 		}
 		setRequestHandler(schema: { kind: string }, handler: RequestHandler) {
 			capturedSchemas.push(schema);
@@ -221,6 +230,8 @@ describe("startMcpServer", () => {
 	beforeEach(() => {
 		capturedHandlers.length = 0;
 		capturedSchemas.length = 0;
+		capturedServers.length = 0;
+		mockClientInfo = undefined;
 		serverCapabilities = undefined;
 		connectMock.mockClear();
 		probeWorktreeMock.mockReset().mockResolvedValue("inside");
@@ -454,6 +465,64 @@ describe("startMcpServer", () => {
 		);
 		const props = vi.mocked(track).mock.calls[0][1] as Record<string, unknown>;
 		expect(JSON.stringify(props)).not.toContain("acme-secret-exfil-tool");
+	});
+
+	it("attributes a tool call to the connection's self-declared client (clientInfo → agent)", async () => {
+		// The only signal that survives the shared mcp-serve daemon, where several
+		// hosts' sessions reach ONE process and env inference is off: the
+		// initialize handshake is per-connection. `claude-code` is a measured
+		// clientInfo string (claude 2.1.212), not a guess.
+		mockClientInfo = { name: "claude-code", version: "2.1.212" };
+		await startMcpServer("/repo");
+		await capturedHandlers[1]({ params: { name: "search", arguments: { query: "x" } } });
+		expect(track).toHaveBeenCalledWith(
+			"command_invoked",
+			expect.objectContaining({ command: "mcp", tool: "search", ok: true, agent: "claude" }),
+		);
+	});
+
+	it("attributes the failure path too, with the same connection's agent", async () => {
+		mockClientInfo = { name: "codex-mcp-client", version: "0.147.0" };
+		vi.mocked(runSearch).mockRejectedValueOnce(new Error("boom"));
+		await startMcpServer("/repo");
+		await capturedHandlers[1]({ params: { name: "search", arguments: {} } });
+		expect(track).toHaveBeenCalledWith(
+			"command_invoked",
+			expect.objectContaining({ command: "mcp", tool: "search", ok: false, agent: "codex" }),
+		);
+	});
+
+	it("omits agent for an unmapped clientInfo name rather than passing it through", async () => {
+		// clientInfo.name is a host-authored arbitrary string; only measured,
+		// mapped names may reach the wire. "Cursor" is real (cursor-agent declares
+		// it) and deliberately unmapped — see CLIENTINFO_AGENTS.
+		mockClientInfo = { name: "Cursor", version: "1.0.0" };
+		await startMcpServer("/repo");
+		await capturedHandlers[1]({ params: { name: "search", arguments: {} } });
+		const props = vi.mocked(track).mock.calls[0][1] as Record<string, unknown>;
+		expect(props).not.toHaveProperty("agent");
+		expect(JSON.stringify(props)).not.toContain("Cursor");
+	});
+
+	it("omits agent when the client sent no clientInfo at all", async () => {
+		mockClientInfo = undefined;
+		await startMcpServer("/repo");
+		await capturedHandlers[1]({ params: { name: "search", arguments: {} } });
+		expect(vi.mocked(track).mock.calls[0][1]).not.toHaveProperty("agent");
+	});
+
+	it("logs each connection's clientInfo on initialize (the capture instrument)", async () => {
+		// The organic capture point for the NEXT host's exact string: hosts' own
+		// logs record only the server's info, never their own clientInfo, so this
+		// line is the only place an unmapped name surfaces. Must never throw —
+		// with or without clientInfo present.
+		await startMcpServer("/repo");
+		const server = capturedServers[0];
+		expect(server.oninitialized).toBeTypeOf("function");
+		mockClientInfo = { name: "some-future-host", version: "9.9.9" };
+		expect(() => server.oninitialized?.()).not.toThrow();
+		mockClientInfo = undefined;
+		expect(() => server.oninitialized?.()).not.toThrow();
 	});
 
 	it("CallTool handler does NOT flag a binding_required result as isError (it's a needs-input outcome)", async () => {

--- a/cli/src/mcp/McpServer.ts
+++ b/cli/src/mcp/McpServer.ts
@@ -39,6 +39,7 @@ import { loadConfig } from "../core/SessionTracker.js";
 import { createStorage } from "../core/StorageFactory.js";
 import { setActiveStorage } from "../core/SummaryStore.js";
 import { track } from "../core/Telemetry.js";
+import { resolveClientInfoAgent } from "../core/TelemetryAgent.js";
 import { createLogger, setLogDir } from "../Logger.js";
 import type { JolliMemoryConfig } from "../Types.js";
 import {
@@ -663,11 +664,39 @@ export function createMcpServer(runtime: McpRuntime): Server {
 		{ capabilities: promptsEnabled ? { tools: {}, prompts: {} } : { tools: {} } },
 	);
 
+	// P0 instrument for the `agent` dimension: one line per connection recording
+	// the client's self-declared identity. This is how the NEXT host's exact
+	// clientInfo string gets captured — the mapping table only takes measured
+	// entries (see CLIENTINFO_AGENTS for why guessing is worse than omitting),
+	// and the hosts' own logs record the SERVER's info, never their own, so this
+	// line is the only organic capture point. debug.log only; the raw name is a
+	// host-authored string and never reaches telemetry.
+	server.oninitialized = () => {
+		const ci = server.getClientVersion();
+		const mapped = resolveClientInfoAgent(ci?.name);
+		log.info(
+			"MCP client connected: %s/%s%s",
+			ci?.name ?? "<no clientInfo>",
+			ci?.version ?? "?",
+			mapped ? ` (agent: ${mapped})` : " (unmapped — candidate for CLIENTINFO_AGENTS)",
+		);
+	};
+
 	server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: toolDefinitions }));
 
 	server.setRequestHandler(CallToolRequestSchema, async (req) => {
 		const { name, arguments: args } = req.params;
 		const start = Date.now();
+		// The `agent` dimension, resolved PER CONNECTION from the initialize
+		// handshake — the only signal that survives the shared daemon, where env
+		// inference is off because one process serves several hosts (see the
+		// daemon note in Cli.ts main()). Read per call rather than cached at
+		// oninitialized: getClientVersion() is a field read, and caching would
+		// add a second copy of per-connection state for no cost saved. Absent
+		// when the name is unmapped — the per-event property then simply isn't
+		// set, and the ambient context (env-inferred on the single-session stdio
+		// path, absent in the daemon) is the documented fallback.
+		const agent = resolveClientInfoAgent(server.getClientVersion()?.name);
 		try {
 			// Backstop for a client working from a cached `tools/list` (or one that
 			// ignores it). Throwing names the reason; the alternative is `dispatchTool`
@@ -741,6 +770,7 @@ export function createMcpServer(runtime: McpRuntime): Server {
 				tool: telemetryToolName(name),
 				duration_ms: Date.now() - start,
 				ok: !isError,
+				...(agent ? { agent } : {}),
 			});
 			return { content: [{ type: "text", text: JSON.stringify(result) }], ...(isError ? { isError: true } : {}) };
 		} catch (err) {
@@ -749,6 +779,7 @@ export function createMcpServer(runtime: McpRuntime): Server {
 				tool: telemetryToolName(name),
 				duration_ms: Date.now() - start,
 				ok: false,
+				...(agent ? { agent } : {}),
 			});
 			const message = err instanceof Error ? err.message : String(err);
 			log.warn("Tool %s failed: %s", name, message);

--- a/codex-plugin/plugins/jolli/skills/dashboard/SKILL.md
+++ b/codex-plugin/plugins/jolli/skills/dashboard/SKILL.md
@@ -56,7 +56,7 @@ server prints once it is listening:
 ```bash
 LOG=$(mktemp "${TMPDIR:-/tmp}/jolli-dashboard.XXXXXX")
 echo "LOG $LOG"
-nohup "$HOME/.jolli/jollimemory/run-cli" dashboard >"$LOG" 2>&1 &
+JOLLI_INVOKED_VIA=skill:dashboard nohup "$HOME/.jolli/jollimemory/run-cli" dashboard >"$LOG" 2>&1 &
 echo "PID $!"
 for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
 	URL=$(grep -o 'http://127\.0\.0\.1:[0-9]*/dashboard' "$LOG" | head -1)

--- a/codex-plugin/plugins/jolli/skills/init/SKILL.md
+++ b/codex-plugin/plugins/jolli/skills/init/SKILL.md
@@ -25,7 +25,7 @@ security recipe and the dist resolver and will not produce valid output.
 
 ## 1. Inspect state
 
-Call the Jolli Memory `status` tool. If unavailable, run `"$HOME/.jolli/jollimemory/run-cli" status`.
+Call the Jolli Memory `status` tool. If unavailable, run `JOLLI_INVOKED_VIA=skill:init "$HOME/.jolli/jollimemory/run-cli" status`.
 If the dispatcher is missing, ask the user to start a new Codex session, open
 `/hooks`, trust the Jolli SessionStart hook, and retry.
 
@@ -34,7 +34,7 @@ If the dispatcher is missing, ask the user to start a new Codex session, open
 Run:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" enable --repo-hooks-only --source-tag codex-plugin
+JOLLI_INVOKED_VIA=skill:init "$HOME/.jolli/jollimemory/run-cli" enable --repo-hooks-only --source-tag codex-plugin
 ```
 
 This explicit setup records `codex` as the local-agent tool only when none is
@@ -54,7 +54,7 @@ If the user only wants local memory, skip to Step 5. Otherwise, when status show
 neither a Jolli sign-in nor a Jolli API key, run and wait for:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" auth login
+JOLLI_INVOKED_VIA=skill:init "$HOME/.jolli/jollimemory/run-cli" auth login
 ```
 
 The command opens the browser and waits for a loopback callback. Never ask for a
@@ -67,14 +67,14 @@ Otherwise present the available Spaces and ask them to choose, offering the defa
 first when one exists. Call `bind_space` with the selected value. Treat
 `already_bound` as success.
 
-If the Space tools are unavailable, run `"$HOME/.jolli/jollimemory/run-cli" spaces --format json`,
+If the Space tools are unavailable, run `JOLLI_INVOKED_VIA=skill:init "$HOME/.jolli/jollimemory/run-cli" spaces --format json`,
 present only the returned Spaces, then bind the selected id or slug with
-`"$HOME/.jolli/jollimemory/run-cli" bind --space <id-or-slug> --format json`. Never put free-typed
+`JOLLI_INVOKED_VIA=skill:init "$HOME/.jolli/jollimemory/run-cli" bind --space <id-or-slug> --format json`. Never put free-typed
 user text directly into this command.
 
 ## 5. Verify and report
 
-Call `status` again (or `"$HOME/.jolli/jollimemory/run-cli" status` when the tool is not registered yet).
+Call `status` again (or `JOLLI_INVOKED_VIA=skill:init "$HOME/.jolli/jollimemory/run-cli" status` when the tool is not registered yet).
 Report:
 
 - memory generation enabled or the exact remaining problem;

--- a/codex-plugin/plugins/jolli/skills/jolli/SKILL.md
+++ b/codex-plugin/plugins/jolli/skills/jolli/SKILL.md
@@ -83,7 +83,7 @@ read:
 **Fallback (CLI):** if the `status` tool is unavailable, read the same facts from
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" status
+JOLLI_INVOKED_VIA=skill:jolli "$HOME/.jolli/jollimemory/run-cli" status
 ```
 
 If neither can be reached, skip the state-based guidance and go straight to

--- a/codex-plugin/plugins/jolli/skills/local-run/SKILL.md
+++ b/codex-plugin/plugins/jolli/skills/local-run/SKILL.md
@@ -40,7 +40,7 @@ security recipe and the dist resolver and will not produce valid output.
 Run the eligibility helper and read its JSON:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" workflow local-run
+JOLLI_INVOKED_VIA=skill:local-run "$HOME/.jolli/jollimemory/run-cli" workflow local-run
 ```
 
 - `{ "type": "workflows", "workflows": [ { "id": 7, "name": "Impact Analysis", "autoMerges": true|false }, ... ] }`
@@ -95,7 +95,7 @@ Capture from its result:
 Pull the destination clone onto the server-derived work branch:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" docs pull --branch <writeTarget.workBranch>
+JOLLI_INVOKED_VIA=skill:local-run "$HOME/.jolli/jollimemory/run-cli" docs pull --branch <writeTarget.workBranch>
 ```
 
 **Always `--branch`. NEVER `--agent`.** The `--agent` mode runs a destructive
@@ -130,7 +130,7 @@ fresh across the wait.
 1. Publish the branch as a pull request and capture the machine-readable result:
 
    ```bash
-   "$HOME/.jolli/jollimemory/run-cli" docs publish --json
+   JOLLI_INVOKED_VIA=skill:local-run "$HOME/.jolli/jollimemory/run-cli" docs publish --json
    ```
 
    `--json` prints exactly one JSON object on stdout (all human-readable progress
@@ -142,7 +142,7 @@ fresh across the wait.
    deterministically** — do not eyeball it yourself:
 
    ```bash
-   "$HOME/.jolli/jollimemory/run-cli" space verify-publish-branch <writeTarget.workBranch> <headBranch>
+   JOLLI_INVOKED_VIA=skill:local-run "$HOME/.jolli/jollimemory/run-cli" space verify-publish-branch <writeTarget.workBranch> <headBranch>
    ```
 
    It prints `{ "match": true|false, "expected": "...", "actual": "..." }` and exits
@@ -198,7 +198,7 @@ fresh across the wait.
    chooses, shell:
 
    ```bash
-   "$HOME/.jolli/jollimemory/run-cli" open-url <url>
+   JOLLI_INVOKED_VIA=skill:local-run "$HOME/.jolli/jollimemory/run-cli" open-url <url>
    ```
 
    It prints one JSON line `{ "opened": true|false, "url": "..." }`. When `opened` is

--- a/codex-plugin/plugins/jolli/skills/login/SKILL.md
+++ b/codex-plugin/plugins/jolli/skills/login/SKILL.md
@@ -24,7 +24,7 @@ security recipe and the dist resolver and will not produce valid output.
 Run and wait for the interactive browser flow:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" auth login
+JOLLI_INVOKED_VIA=skill:login "$HOME/.jolli/jollimemory/run-cli" auth login
 ```
 
 Never ask the user for passwords, API keys, callback URLs, or browser tokens.

--- a/codex-plugin/plugins/jolli/skills/logout/SKILL.md
+++ b/codex-plugin/plugins/jolli/skills/logout/SKILL.md
@@ -24,7 +24,7 @@ security recipe and the dist resolver and will not produce valid output.
 Run:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" auth logout
+JOLLI_INVOKED_VIA=skill:logout "$HOME/.jolli/jollimemory/run-cli" auth logout
 ```
 
 Report the command output, then call the Jolli Memory `status` tool when

--- a/codex-plugin/plugins/jolli/skills/recall/SKILL.md
+++ b/codex-plugin/plugins/jolli/skills/recall/SKILL.md
@@ -60,7 +60,7 @@ Then run this Bash, replacing the two `<DELIM>` occurrences with your
 delimiter token and replacing `<user-arg>` with the user's input verbatim:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" recall --arg-stdin --format json <<'JOLLI_ARG_<DELIM>_END'
+JOLLI_INVOKED_VIA=skill:recall "$HOME/.jolli/jollimemory/run-cli" recall --arg-stdin --format json <<'JOLLI_ARG_<DELIM>_END'
 <user-arg>
 JOLLI_ARG_<DELIM>_END
 ```

--- a/codex-plugin/plugins/jolli/skills/remote-run/SKILL.md
+++ b/codex-plugin/plugins/jolli/skills/remote-run/SKILL.md
@@ -61,7 +61,7 @@ its outcome).
 Run the plugin's eligibility helper purely as a presence probe and read its JSON:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" workflow local-run
+JOLLI_INVOKED_VIA=skill:remote-run "$HOME/.jolli/jollimemory/run-cli" workflow local-run
 ```
 
 - `{ "type": "workflow_cli_required", "installHint": "..." }` — the workflow-cli
@@ -90,7 +90,7 @@ that handle drives the monitor in Step 4.
 Shell the deterministic monitor with the captured `runId`:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" workflow run-status <runId>
+JOLLI_INVOKED_VIA=skill:remote-run "$HOME/.jolli/jollimemory/run-cli" workflow run-status <runId>
 ```
 
 It polls the run to a terminal state (with backoff, so you do not drive the poll
@@ -143,7 +143,7 @@ Offer to open any URL from the report in the user's default browser. For each UR
 the user chooses, shell:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" open-url <url>
+JOLLI_INVOKED_VIA=skill:remote-run "$HOME/.jolli/jollimemory/run-cli" open-url <url>
 ```
 
 It prints one JSON line `{ "opened": true|false, "url": "..." }`. When `opened` is

--- a/codex-plugin/plugins/jolli/skills/search/SKILL.md
+++ b/codex-plugin/plugins/jolli/skills/search/SKILL.md
@@ -81,7 +81,7 @@ Then run this Bash, replacing the two `<DELIM>` occurrences with your
 delimiter token and replacing `<user-arg>` with the user's input verbatim:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" search --arg-stdin --format json <<'JOLLI_ARG_<DELIM>_END'
+JOLLI_INVOKED_VIA=skill:search "$HOME/.jolli/jollimemory/run-cli" search --arg-stdin --format json <<'JOLLI_ARG_<DELIM>_END'
 <user-arg>
 JOLLI_ARG_<DELIM>_END
 ```

--- a/codex-plugin/plugins/jolli/skills/status/SKILL.md
+++ b/codex-plugin/plugins/jolli/skills/status/SKILL.md
@@ -19,7 +19,7 @@ description: Diagnose Jolli Memory installation, provider, account, hooks, queue
    - `anthropic`: requires an Anthropic API key.
    - unset: requires a usable provider credential.
 
-If `status` is unavailable, run `"$HOME/.jolli/jollimemory/run-cli" status` and summarize it. Do not
+If `status` is unavailable, run `JOLLI_INVOKED_VIA=skill:status "$HOME/.jolli/jollimemory/run-cli" status` and summarize it. Do not
 list branch memories; route those requests to `jolli:recall` or `jolli:search`.
 
 ### Shell prerequisite

--- a/cursor-plugin/plugins/jolli/skills/jolli-dashboard/SKILL.md
+++ b/cursor-plugin/plugins/jolli/skills/jolli-dashboard/SKILL.md
@@ -56,7 +56,7 @@ server prints once it is listening:
 ```bash
 LOG=$(mktemp "${TMPDIR:-/tmp}/jolli-dashboard.XXXXXX")
 echo "LOG $LOG"
-nohup "$HOME/.jolli/jollimemory/run-cli" dashboard >"$LOG" 2>&1 &
+JOLLI_INVOKED_VIA=skill:dashboard nohup "$HOME/.jolli/jollimemory/run-cli" dashboard >"$LOG" 2>&1 &
 echo "PID $!"
 for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
 	URL=$(grep -o 'http://127\.0\.0\.1:[0-9]*/dashboard' "$LOG" | head -1)

--- a/cursor-plugin/plugins/jolli/skills/jolli-init/SKILL.md
+++ b/cursor-plugin/plugins/jolli/skills/jolli-init/SKILL.md
@@ -25,30 +25,26 @@ security recipe and the dist resolver and will not produce valid output.
 
 ## 1. Inspect state
 
-Call the Jolli Memory `status` tool. If unavailable, run `"$HOME/.jolli/jollimemory/run-cli" status`.
-
-If `$HOME/.jolli/jollimemory/run-cli` does not exist, the plugin's `sessionStart`
-hook has not run on this machine yet — that hook is what writes it. Ask the user to
-**quit Cursor completely (⌘Q) and reopen it, then start a new chat**, and retry. A
-freshly installed plugin's hooks are not registered until the app has been fully
-restarted, so **Developer: Reload Window** or another chat is not enough (measured).
+Call the Jolli Memory `status` tool. If unavailable, run `JOLLI_INVOKED_VIA=skill:init "$HOME/.jolli/jollimemory/run-cli" status`.
+If the dispatcher is missing, ask the user to run **Developer: Reload Window** and
+start a new chat so the Jolli `sessionStart` hook runs, then retry.
 
 ## 2. Enable local memory generation
 
 Run:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" enable --repo-hooks-only --source-tag cursor-plugin
+JOLLI_INVOKED_VIA=skill:init "$HOME/.jolli/jollimemory/run-cli" enable --repo-hooks-only --source-tag cursor-plugin
 ```
 
 This explicit setup records `cursor-agent` as the local-agent tool only when none
 is configured yet — an agent tool and a paid provider already on disk are both left
-exactly as they are. What it writes is this repository's git hooks and this
-workspace's `.cursor/mcp.json`. It writes **no skills**: every Jolli skill ships
-with the plugin, so there is nothing here to place or repair — do not report
-skill files as an outcome of this step.
-
-Cursor notices `.cursor/mcp.json` within a second — no reload needed —
+exactly as they are. It also writes this workspace's
+`.cursor/mcp.json`, and places `/jolli-recall`, `/jolli-search`,
+`/jolli-local-run` and `/jolli-remote-run` into this repository — those four are
+not bundled with the plugin, so that they appear once in the menu rather than twice
+in a repository that also ran a full `jolli enable`. If they were already present
+this step changes nothing. Cursor notices that file within a second — no reload needed —
 but registers the server **disconnected**, so tell the user to open **Customize** in
 the sidebar and enable `jollimemory` to get the MCP tools. Everything below works
 without them either way. If the command reports that the repository is manually
@@ -64,7 +60,7 @@ If the user only wants local memory, skip to Step 5. Otherwise, when status show
 neither a Jolli sign-in nor a Jolli API key, run and wait for:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" auth login
+JOLLI_INVOKED_VIA=skill:init "$HOME/.jolli/jollimemory/run-cli" auth login
 ```
 
 The command opens the browser and waits for a loopback callback. Never ask for a
@@ -77,14 +73,14 @@ Otherwise present the available Spaces and ask them to choose, offering the defa
 first when one exists. Call `bind_space` with the selected value. Treat
 `already_bound` as success.
 
-If the Space tools are unavailable, run `"$HOME/.jolli/jollimemory/run-cli" spaces --format json`,
+If the Space tools are unavailable, run `JOLLI_INVOKED_VIA=skill:init "$HOME/.jolli/jollimemory/run-cli" spaces --format json`,
 present only the returned Spaces, then bind the selected id or slug with
-`"$HOME/.jolli/jollimemory/run-cli" bind --space <id-or-slug> --format json`. Never put free-typed
+`JOLLI_INVOKED_VIA=skill:init "$HOME/.jolli/jollimemory/run-cli" bind --space <id-or-slug> --format json`. Never put free-typed
 user text directly into this command.
 
 ## 5. Verify and report
 
-Call `status` again (or `"$HOME/.jolli/jollimemory/run-cli" status` when the tool is not registered yet).
+Call `status` again (or `JOLLI_INVOKED_VIA=skill:init "$HOME/.jolli/jollimemory/run-cli" status` when the tool is not registered yet).
 Report:
 
 - memory generation enabled or the exact remaining problem;

--- a/cursor-plugin/plugins/jolli/skills/jolli-init/SKILL.md
+++ b/cursor-plugin/plugins/jolli/skills/jolli-init/SKILL.md
@@ -26,8 +26,12 @@ security recipe and the dist resolver and will not produce valid output.
 ## 1. Inspect state
 
 Call the Jolli Memory `status` tool. If unavailable, run `JOLLI_INVOKED_VIA=skill:init "$HOME/.jolli/jollimemory/run-cli" status`.
-If the dispatcher is missing, ask the user to run **Developer: Reload Window** and
-start a new chat so the Jolli `sessionStart` hook runs, then retry.
+
+If `$HOME/.jolli/jollimemory/run-cli` does not exist, the plugin's `sessionStart`
+hook has not run on this machine yet — that hook is what writes it. Ask the user to
+**quit Cursor completely (⌘Q) and reopen it, then start a new chat**, and retry. A
+freshly installed plugin's hooks are not registered until the app has been fully
+restarted, so **Developer: Reload Window** or another chat is not enough (measured).
 
 ## 2. Enable local memory generation
 
@@ -39,12 +43,12 @@ JOLLI_INVOKED_VIA=skill:init "$HOME/.jolli/jollimemory/run-cli" enable --repo-ho
 
 This explicit setup records `cursor-agent` as the local-agent tool only when none
 is configured yet — an agent tool and a paid provider already on disk are both left
-exactly as they are. It also writes this workspace's
-`.cursor/mcp.json`, and places `/jolli-recall`, `/jolli-search`,
-`/jolli-local-run` and `/jolli-remote-run` into this repository — those four are
-not bundled with the plugin, so that they appear once in the menu rather than twice
-in a repository that also ran a full `jolli enable`. If they were already present
-this step changes nothing. Cursor notices that file within a second — no reload needed —
+exactly as they are. What it writes is this repository's git hooks and this
+workspace's `.cursor/mcp.json`. It writes **no skills**: every Jolli skill ships
+with the plugin, so there is nothing here to place or repair — do not report
+skill files as an outcome of this step.
+
+Cursor notices `.cursor/mcp.json` within a second — no reload needed —
 but registers the server **disconnected**, so tell the user to open **Customize** in
 the sidebar and enable `jollimemory` to get the MCP tools. Everything below works
 without them either way. If the command reports that the repository is manually

--- a/cursor-plugin/plugins/jolli/skills/jolli-local-run/SKILL.md
+++ b/cursor-plugin/plugins/jolli/skills/jolli-local-run/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: jolli-local-run
 description: Run a Jolli workflow locally — your own agent executes the workflow's recipe (no Jolli LLM budget) and its file writes land in a git-backed Jolli Space via a branch and pull request that space-cli opens on this machine. Use when the user wants to run a Jolli workflow locally.
+metadata:
+  version: "dev"
+  revision: 6
+  vendor: "jolli.ai"
 ---
 
 # Jolli Local Run
@@ -40,7 +44,7 @@ security recipe and the dist resolver and will not produce valid output.
 Run the eligibility helper and read its JSON:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" workflow local-run
+JOLLI_INVOKED_VIA=skill:local-run "$HOME/.jolli/jollimemory/run-cli" workflow local-run
 ```
 
 - `{ "type": "workflows", "workflows": [ { "id": 7, "name": "Impact Analysis", "autoMerges": true|false }, ... ] }`
@@ -95,7 +99,7 @@ Capture from its result:
 Pull the destination clone onto the server-derived work branch:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" docs pull --branch <writeTarget.workBranch>
+JOLLI_INVOKED_VIA=skill:local-run "$HOME/.jolli/jollimemory/run-cli" docs pull --branch <writeTarget.workBranch>
 ```
 
 **Always `--branch`. NEVER `--agent`.** The `--agent` mode runs a destructive
@@ -130,7 +134,7 @@ fresh across the wait.
 1. Publish the branch as a pull request and capture the machine-readable result:
 
    ```bash
-   "$HOME/.jolli/jollimemory/run-cli" docs publish --json
+   JOLLI_INVOKED_VIA=skill:local-run "$HOME/.jolli/jollimemory/run-cli" docs publish --json
    ```
 
    `--json` prints exactly one JSON object on stdout (all human-readable progress
@@ -142,7 +146,7 @@ fresh across the wait.
    deterministically** — do not eyeball it yourself:
 
    ```bash
-   "$HOME/.jolli/jollimemory/run-cli" space verify-publish-branch <writeTarget.workBranch> <headBranch>
+   JOLLI_INVOKED_VIA=skill:local-run "$HOME/.jolli/jollimemory/run-cli" space verify-publish-branch <writeTarget.workBranch> <headBranch>
    ```
 
    It prints `{ "match": true|false, "expected": "...", "actual": "..." }` and exits
@@ -198,7 +202,7 @@ fresh across the wait.
    chooses, shell:
 
    ```bash
-   "$HOME/.jolli/jollimemory/run-cli" open-url <url>
+   JOLLI_INVOKED_VIA=skill:local-run "$HOME/.jolli/jollimemory/run-cli" open-url <url>
    ```
 
    It prints one JSON line `{ "opened": true|false, "url": "..." }`. When `opened` is
@@ -223,15 +227,3 @@ user to install it and stop:
 ```bash
 npm i -g @jolli.ai/cli @jolli.ai/space-cli
 ```
-
-## If the Jolli CLI dispatcher is missing (Cursor)
-
-`$HOME/.jolli/jollimemory/run-cli` is written by this plugin's `sessionStart` hook,
-and a freshly installed plugin's hooks are not registered until Cursor has been fully
-restarted — a window reload or another chat is not enough (measured). So when that file
-does not exist, the fix is to **quit Cursor completely (⌘Q) and reopen it, then start
-a new chat**, and retry.
-
-This REPLACES any instruction above to report Jolli as not installed, or to install
-`@jolli.ai/cli` globally or the Jolli VS Code extension. You are running inside the
-Jolli plugin, so Jolli IS installed, and neither of those is the fix on this host.

--- a/cursor-plugin/plugins/jolli/skills/jolli-local-run/SKILL.md
+++ b/cursor-plugin/plugins/jolli/skills/jolli-local-run/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: jolli-local-run
 description: Run a Jolli workflow locally — your own agent executes the workflow's recipe (no Jolli LLM budget) and its file writes land in a git-backed Jolli Space via a branch and pull request that space-cli opens on this machine. Use when the user wants to run a Jolli workflow locally.
-metadata:
-  version: "dev"
-  revision: 6
-  vendor: "jolli.ai"
 ---
 
 # Jolli Local Run
@@ -227,3 +223,15 @@ user to install it and stop:
 ```bash
 npm i -g @jolli.ai/cli @jolli.ai/space-cli
 ```
+
+## If the Jolli CLI dispatcher is missing (Cursor)
+
+`$HOME/.jolli/jollimemory/run-cli` is written by this plugin's `sessionStart` hook,
+and a freshly installed plugin's hooks are not registered until Cursor has been fully
+restarted — a window reload or another chat is not enough (measured). So when that file
+does not exist, the fix is to **quit Cursor completely (⌘Q) and reopen it, then start
+a new chat**, and retry.
+
+This REPLACES any instruction above to report Jolli as not installed, or to install
+`@jolli.ai/cli` globally or the Jolli VS Code extension. You are running inside the
+Jolli plugin, so Jolli IS installed, and neither of those is the fix on this host.

--- a/cursor-plugin/plugins/jolli/skills/jolli-login/SKILL.md
+++ b/cursor-plugin/plugins/jolli/skills/jolli-login/SKILL.md
@@ -24,7 +24,7 @@ security recipe and the dist resolver and will not produce valid output.
 Run and wait for the interactive browser flow:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" auth login
+JOLLI_INVOKED_VIA=skill:login "$HOME/.jolli/jollimemory/run-cli" auth login
 ```
 
 Never ask the user for passwords, API keys, callback URLs, or browser tokens.

--- a/cursor-plugin/plugins/jolli/skills/jolli-logout/SKILL.md
+++ b/cursor-plugin/plugins/jolli/skills/jolli-logout/SKILL.md
@@ -24,7 +24,7 @@ security recipe and the dist resolver and will not produce valid output.
 Run:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" auth logout
+JOLLI_INVOKED_VIA=skill:logout "$HOME/.jolli/jollimemory/run-cli" auth logout
 ```
 
 Report the command output, then call the Jolli Memory `status` tool when

--- a/cursor-plugin/plugins/jolli/skills/jolli-recall/SKILL.md
+++ b/cursor-plugin/plugins/jolli/skills/jolli-recall/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: jolli-recall
 description: Recall prior development context from Jolli for the current branch. Use when the user wants to recall, remember, or resume prior work on a branch.
-metadata:
-  version: "dev"
-  revision: 3
-  vendor: "jolli.ai"
 ---
 
 # Jolli Recall
@@ -251,3 +247,15 @@ Surface the message verbatim to the user (translated into their language if
 non-English). For "no records in this repo" specifically, suggest running
 `jolli enable` if they expected records. Do NOT retry or fabricate a recall
 payload from nothing.
+
+## If the Jolli CLI dispatcher is missing (Cursor)
+
+`$HOME/.jolli/jollimemory/run-cli` is written by this plugin's `sessionStart` hook,
+and a freshly installed plugin's hooks are not registered until Cursor has been fully
+restarted — a window reload or another chat is not enough (measured). So when that file
+does not exist, the fix is to **quit Cursor completely (⌘Q) and reopen it, then start
+a new chat**, and retry.
+
+This REPLACES any instruction above to report Jolli as not installed, or to install
+`@jolli.ai/cli` globally or the Jolli VS Code extension. You are running inside the
+Jolli plugin, so Jolli IS installed, and neither of those is the fix on this host.

--- a/cursor-plugin/plugins/jolli/skills/jolli-recall/SKILL.md
+++ b/cursor-plugin/plugins/jolli/skills/jolli-recall/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: jolli-recall
 description: Recall prior development context from Jolli for the current branch. Use when the user wants to recall, remember, or resume prior work on a branch.
+metadata:
+  version: "dev"
+  revision: 3
+  vendor: "jolli.ai"
 ---
 
 # Jolli Recall
@@ -60,7 +64,7 @@ Then run this Bash, replacing the two `<DELIM>` occurrences with your
 delimiter token and replacing `<user-arg>` with the user's input verbatim:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" recall --arg-stdin --format json <<'JOLLI_ARG_<DELIM>_END'
+JOLLI_INVOKED_VIA=skill:recall "$HOME/.jolli/jollimemory/run-cli" recall --arg-stdin --format json <<'JOLLI_ARG_<DELIM>_END'
 <user-arg>
 JOLLI_ARG_<DELIM>_END
 ```
@@ -247,15 +251,3 @@ Surface the message verbatim to the user (translated into their language if
 non-English). For "no records in this repo" specifically, suggest running
 `jolli enable` if they expected records. Do NOT retry or fabricate a recall
 payload from nothing.
-
-## If the Jolli CLI dispatcher is missing (Cursor)
-
-`$HOME/.jolli/jollimemory/run-cli` is written by this plugin's `sessionStart` hook,
-and a freshly installed plugin's hooks are not registered until Cursor has been fully
-restarted — a window reload or another chat is not enough (measured). So when that file
-does not exist, the fix is to **quit Cursor completely (⌘Q) and reopen it, then start
-a new chat**, and retry.
-
-This REPLACES any instruction above to report Jolli as not installed, or to install
-`@jolli.ai/cli` globally or the Jolli VS Code extension. You are running inside the
-Jolli plugin, so Jolli IS installed, and neither of those is the fix on this host.

--- a/cursor-plugin/plugins/jolli/skills/jolli-remote-run/SKILL.md
+++ b/cursor-plugin/plugins/jolli/skills/jolli-remote-run/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: jolli-remote-run
 description: Run a Jolli workflow remotely — the Jolli backend executes the workflow server-side; this recipe triggers the run, monitors it to completion, reports the outcome (failed / cancelled / succeeded) with its article, PR, and workflow links, and offers to open any in your browser. Use when the user wants to run a Jolli workflow remotely (on the Jolli backend).
+metadata:
+  version: "dev"
+  revision: 5
+  vendor: "jolli.ai"
 ---
 
 # Jolli Remote Run
@@ -61,7 +65,7 @@ its outcome).
 Run the plugin's eligibility helper purely as a presence probe and read its JSON:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" workflow local-run
+JOLLI_INVOKED_VIA=skill:remote-run "$HOME/.jolli/jollimemory/run-cli" workflow local-run
 ```
 
 - `{ "type": "workflow_cli_required", "installHint": "..." }` — the workflow-cli
@@ -90,7 +94,7 @@ that handle drives the monitor in Step 4.
 Shell the deterministic monitor with the captured `runId`:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" workflow run-status <runId>
+JOLLI_INVOKED_VIA=skill:remote-run "$HOME/.jolli/jollimemory/run-cli" workflow run-status <runId>
 ```
 
 It polls the run to a terminal state (with backoff, so you do not drive the poll
@@ -143,7 +147,7 @@ Offer to open any URL from the report in the user's default browser. For each UR
 the user chooses, shell:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" open-url <url>
+JOLLI_INVOKED_VIA=skill:remote-run "$HOME/.jolli/jollimemory/run-cli" open-url <url>
 ```
 
 It prints one JSON line `{ "opened": true|false, "url": "..." }`. When `opened` is
@@ -160,15 +164,3 @@ While a remote run is still in progress, the user can stop it: call
 `mcp__jollimemory__cancel_remote_workflow`) with the workflow's numeric id —
 `{ "id": <workflow id> }`. After cancelling, re-run `workflow run-status <runId>`
 to report the cancelled outcome (who/when + workflow URL).
-
-## If the Jolli CLI dispatcher is missing (Cursor)
-
-`$HOME/.jolli/jollimemory/run-cli` is written by this plugin's `sessionStart` hook,
-and a freshly installed plugin's hooks are not registered until Cursor has been fully
-restarted — a window reload or another chat is not enough (measured). So when that file
-does not exist, the fix is to **quit Cursor completely (⌘Q) and reopen it, then start
-a new chat**, and retry.
-
-This REPLACES any instruction above to report Jolli as not installed, or to install
-`@jolli.ai/cli` globally or the Jolli VS Code extension. You are running inside the
-Jolli plugin, so Jolli IS installed, and neither of those is the fix on this host.

--- a/cursor-plugin/plugins/jolli/skills/jolli-remote-run/SKILL.md
+++ b/cursor-plugin/plugins/jolli/skills/jolli-remote-run/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: jolli-remote-run
 description: Run a Jolli workflow remotely — the Jolli backend executes the workflow server-side; this recipe triggers the run, monitors it to completion, reports the outcome (failed / cancelled / succeeded) with its article, PR, and workflow links, and offers to open any in your browser. Use when the user wants to run a Jolli workflow remotely (on the Jolli backend).
-metadata:
-  version: "dev"
-  revision: 5
-  vendor: "jolli.ai"
 ---
 
 # Jolli Remote Run
@@ -164,3 +160,15 @@ While a remote run is still in progress, the user can stop it: call
 `mcp__jollimemory__cancel_remote_workflow`) with the workflow's numeric id —
 `{ "id": <workflow id> }`. After cancelling, re-run `workflow run-status <runId>`
 to report the cancelled outcome (who/when + workflow URL).
+
+## If the Jolli CLI dispatcher is missing (Cursor)
+
+`$HOME/.jolli/jollimemory/run-cli` is written by this plugin's `sessionStart` hook,
+and a freshly installed plugin's hooks are not registered until Cursor has been fully
+restarted — a window reload or another chat is not enough (measured). So when that file
+does not exist, the fix is to **quit Cursor completely (⌘Q) and reopen it, then start
+a new chat**, and retry.
+
+This REPLACES any instruction above to report Jolli as not installed, or to install
+`@jolli.ai/cli` globally or the Jolli VS Code extension. You are running inside the
+Jolli plugin, so Jolli IS installed, and neither of those is the fix on this host.

--- a/cursor-plugin/plugins/jolli/skills/jolli-search/SKILL.md
+++ b/cursor-plugin/plugins/jolli/skills/jolli-search/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: jolli-search
 description: Search structured commit memories across all branches — decisions, topics, files. Use when the user wants to find prior decisions, related commits, or how a topic was handled before.
+metadata:
+  version: "dev"
+  revision: 3
+  vendor: "jolli.ai"
 ---
 
 # Jolli Search
@@ -81,7 +85,7 @@ Then run this Bash, replacing the two `<DELIM>` occurrences with your
 delimiter token and replacing `<user-arg>` with the user's input verbatim:
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" search --arg-stdin --format json <<'JOLLI_ARG_<DELIM>_END'
+JOLLI_INVOKED_VIA=skill:search "$HOME/.jolli/jollimemory/run-cli" search --arg-stdin --format json <<'JOLLI_ARG_<DELIM>_END'
 <user-arg>
 JOLLI_ARG_<DELIM>_END
 ```
@@ -160,15 +164,3 @@ hit you have:
 
 **Empty hits** → tell the user nothing matched; suggest broader keywords or a
 different phrasing. Do NOT mention BM25 or index internals.
-
-## If the Jolli CLI dispatcher is missing (Cursor)
-
-`$HOME/.jolli/jollimemory/run-cli` is written by this plugin's `sessionStart` hook,
-and a freshly installed plugin's hooks are not registered until Cursor has been fully
-restarted — a window reload or another chat is not enough (measured). So when that file
-does not exist, the fix is to **quit Cursor completely (⌘Q) and reopen it, then start
-a new chat**, and retry.
-
-This REPLACES any instruction above to report Jolli as not installed, or to install
-`@jolli.ai/cli` globally or the Jolli VS Code extension. You are running inside the
-Jolli plugin, so Jolli IS installed, and neither of those is the fix on this host.

--- a/cursor-plugin/plugins/jolli/skills/jolli-search/SKILL.md
+++ b/cursor-plugin/plugins/jolli/skills/jolli-search/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: jolli-search
 description: Search structured commit memories across all branches — decisions, topics, files. Use when the user wants to find prior decisions, related commits, or how a topic was handled before.
-metadata:
-  version: "dev"
-  revision: 3
-  vendor: "jolli.ai"
 ---
 
 # Jolli Search
@@ -164,3 +160,15 @@ hit you have:
 
 **Empty hits** → tell the user nothing matched; suggest broader keywords or a
 different phrasing. Do NOT mention BM25 or index internals.
+
+## If the Jolli CLI dispatcher is missing (Cursor)
+
+`$HOME/.jolli/jollimemory/run-cli` is written by this plugin's `sessionStart` hook,
+and a freshly installed plugin's hooks are not registered until Cursor has been fully
+restarted — a window reload or another chat is not enough (measured). So when that file
+does not exist, the fix is to **quit Cursor completely (⌘Q) and reopen it, then start
+a new chat**, and retry.
+
+This REPLACES any instruction above to report Jolli as not installed, or to install
+`@jolli.ai/cli` globally or the Jolli VS Code extension. You are running inside the
+Jolli plugin, so Jolli IS installed, and neither of those is the fix on this host.

--- a/cursor-plugin/plugins/jolli/skills/jolli-status/SKILL.md
+++ b/cursor-plugin/plugins/jolli/skills/jolli-status/SKILL.md
@@ -19,7 +19,7 @@ description: Diagnose Jolli Memory installation, provider, account, hooks, queue
    - `anthropic`: requires an Anthropic API key.
    - unset: requires a usable provider credential.
 
-If `status` is unavailable, run `"$HOME/.jolli/jollimemory/run-cli" status` and summarize it. Do not
+If `status` is unavailable, run `JOLLI_INVOKED_VIA=skill:status "$HOME/.jolli/jollimemory/run-cli" status` and summarize it. Do not
 list branch memories; route those requests to `/jolli-recall` or `/jolli-search`.
 
 ### Shell prerequisite

--- a/cursor-plugin/plugins/jolli/skills/jolli/SKILL.md
+++ b/cursor-plugin/plugins/jolli/skills/jolli/SKILL.md
@@ -95,7 +95,7 @@ read:
 **Fallback (CLI):** if the `status` tool is unavailable, read the same facts from
 
 ```bash
-"$HOME/.jolli/jollimemory/run-cli" status
+JOLLI_INVOKED_VIA=skill:jolli "$HOME/.jolli/jollimemory/run-cli" status
 ```
 
 If neither can be reached, skip the state-based guidance and go straight to

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/Telemetry.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/Telemetry.kt
@@ -16,6 +16,41 @@ import java.util.UUID
  *     timestamp, scrubs, and appends one buffer line.
  *   - No-op until `init()` runs or when consent resolved to off.
  *   - `surface` is fixed to "intellij"; `surfaceVersion` is the plugin version.
+ *
+ * ## The `agent` dimension is deliberately absent here
+ *
+ * The CLI stamps an `agent` property — which AI host the work happened in, as
+ * opposed to which of our builds sent the event; see `core/TelemetryAgent.ts`.
+ * This port does not, and that is a decision rather than drift.
+ *
+ * The question arises at all because this stack is genuinely INDEPENDENT, not a
+ * thin shim over the CLI the way most of the plugin now is: ~20 `Telemetry.track`
+ * call sites across the tool window feed a Kotlin buffer that this module's
+ * `TelemetryFlusher` POSTs itself — which is precisely why that one file is the
+ * sole entry on `check-no-direct-llm-http.sh`'s allowlist. The `telemetry-track`
+ * and `telemetry-bootstrap` ide-bridge actions exist but have NO caller in
+ * `intellij/`; nothing here routes telemetry through the CLI today.
+ *
+ * Absent is nonetheless the correct value:
+ *
+ *  - The rule the dimension rests on is that an ABSENT `agent` reads as
+ *    *unknown* and is never defaulted. An IDE is not one of the AI hosts the
+ *    vocabulary enumerates — a person clicking Commit in the tool window is not
+ *    prompting an agent — and `surface: "intellij"` already says where the click
+ *    happened. The CLI reaches the same answer for VS Code's UI events.
+ *  - All three attribution channels are CLI-side (a plugin bootstrap's
+ *    structural host, the agent CLIs' own env markers, the QueueWorker's
+ *    per-session walk), and the plugin drives the bundled CLI for the work those
+ *    cover — so the events that CAN name a host already come from there.
+ *  - It rides inside `properties`, so nothing about the envelope contract this
+ *    port mirrors changes. `TelemetryEvents.kt` stays in lockstep as before.
+ *
+ * Do NOT "fix" this by inferring the host from the process environment. This is
+ * a long-lived IDE process, so an inherited marker names whatever launched the
+ * IDE, possibly days ago; `TelemetryStartup.inferAgentFromEnv` defaults to off
+ * on the TS side for exactly this shape. If a JVM call site ever genuinely knows
+ * its host, add the property through a closed enumeration mirroring
+ * `TELEMETRY_AGENTS` — never a pass-through string, and never a default.
  */
 object Telemetry {
     const val SCHEMA_VERSION = 1

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
@@ -35,7 +35,10 @@ object TelemetryEvents {
                 "in_git_repo, repo_enabled, capture_configured, capture_method (discriminator: " +
                 "local-agent/anthropic/jolli/none), memories_generated, memories_bucket.",
             // ── feature usage / adoption ──
-            "command_invoked" to "Any CLI command ran (auto-emitted). Props: command (discriminator), ok, duration_ms.",
+            "command_invoked" to
+                "Any CLI command ran (auto-emitted). Props: command (discriminator), ok, duration_ms; via " +
+                "(discriminator: skill:<name> from a closed skill-name set — present only when a Jolli skill's recipe " +
+                "invoked the command, omitted for a directly-typed one).",
             "recall_performed" to "A recall was run. Props: hit, result_count_bucket.",
             "search_performed" to "A search was run. Props: query_len_bucket, result_count_bucket.",
             "memory_pushed" to "Memories pushed to a Space. Props: kind, created, plans_bucket.",

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
@@ -49,7 +49,10 @@ object TelemetryEvents {
             "error_occurred" to
                 "A structured error was raised. Content-free schema: { where, code, source?, retryable? }. " +
                 "Emitted via Telemetry.trackError(); never carries a message/stack/path.",
-            "queue_drained" to "QueueWorker finished a drain. Props: ops, duration_ms.",
+            "queue_drained" to
+                "QueueWorker finished a drain. Props: ops, duration_ms; trigger (discriminator: agent/ui/terminal/unknown — " +
+                "who set the drained commits in motion) and agent (which AI host, when trigger=agent) are present only when " +
+                "every drained entry agrees, and omitted for mixed or unstamped drains.",
             "sync_completed" to "A memory-bank sync round finished. Props: outcome (discriminator), duration_ms.",
             // ── IDE tool-window UI / engagement (IntelliJ, VS Code) ──
             "toolwindow_opened" to "The memory tool window was opened. Props: view.",

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryEvents.kt
@@ -37,8 +37,9 @@ object TelemetryEvents {
             // ── feature usage / adoption ──
             "command_invoked" to
                 "Any CLI command ran (auto-emitted). Props: command (discriminator), ok, duration_ms; via " +
-                "(discriminator: skill:<name> from a closed skill-name set — present only when a Jolli skill's recipe " +
-                "invoked the command, omitted for a directly-typed one).",
+                "(discriminator: skill:<name> from a closed skill-name set — present when a Jolli skill's recipe " +
+                "invoked the command; absent means directly typed OR a pre-upgrade skill copy that predates the " +
+                "stamp, so absence is not proof of direct use).",
             "recall_performed" to "A recall was run. Props: hit, result_count_bucket.",
             "search_performed" to "A search was run. Props: query_len_bucket, result_count_bucket.",
             "memory_pushed" to "Memories pushed to a Space. Props: kind, created, plans_bucket.",

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/core/telemetry/TelemetryTest.kt
@@ -157,6 +157,34 @@ class TelemetryTest {
         e.accountId shouldBe null
     }
 
+    /**
+     * The `agent` dimension (CLI-side `core/TelemetryAgent.ts`) records which AI
+     * host the work happened in. This port deliberately never emits it: an IDE is
+     * not one of the hosts that vocabulary enumerates, and `surface: "intellij"`
+     * already says where a tool-window click happened.
+     *
+     * Pinned with a marker PRESENT in the env because that is the tempting wrong
+     * fix. This is a long-lived IDE process, so an inherited `CLAUDECODE` names
+     * whatever launched the IDE — possibly days ago — and would then label every
+     * button click for the rest of the window's life. The TS side defaults
+     * `inferAgentFromEnv` to off for exactly this shape.
+     */
+    @Test
+    fun `track never stamps an agent, even under an inherited host marker`() {
+        Telemetry.init(
+            cwd = cwd,
+            installId = "install-1",
+            surfaceVersion = "1.2.0",
+            origin = "https://acme.jolli.ai",
+            env = mapOf("CLAUDECODE" to "1", "AI_AGENT" to "claude-code_2-1-234_agent"),
+        )
+        // The tool window's Commit button; the busiest JVM-side event.
+        Telemetry.track("memory_committed", mapOf("files_bucket" to "1-5", "has_conversations" to true))
+        val e = TelemetryBuffer.read(cwd).single()
+        e.surface shouldBe "intellij"
+        e.properties.containsKey("agent") shouldBe false
+    }
+
     @Test
     fun `track does not emit when consent is off`() {
         Telemetry.init(cwd = cwd, installId = "i", surfaceVersion = "1", telemetryFlag = "off", env = emptyMap())

--- a/vscode/src/TelemetryActivation.ts
+++ b/vscode/src/TelemetryActivation.ts
@@ -37,6 +37,13 @@ export interface TelemetryActivationDeps {
 
 /** Bootstrap telemetry for the extension and show the first-run notice once. Never throws. */
 export async function activateExtensionTelemetry(cwd: string, deps: TelemetryActivationDeps): Promise<void> {
+	// No `inferAgentFromEnv` — the extension host is the case that flag defaults
+	// off for. Cold-start VS Code with `code .` from inside a Claude Code session
+	// and this process inherits CLAUDECODE for as long as the window lives, so
+	// every UI event below would claim `agent: "claude"` while the user is
+	// clicking buttons rather than prompting an agent. An editor is not one of the
+	// AI hosts the dimension enumerates, so absent is the correct answer here, and
+	// `surface: "vscode"` already says where the click happened.
 	await bootstrapTelemetry({ cwd, platformDisabled: deps.platformDisabled });
 	// JOLLI-1963: count new + upgrade installs. Fires once per extension activation
 	// (a real session), carrying `surface_version` in the envelope; the metric dedups
@@ -89,5 +96,9 @@ export function flushExtensionTelemetry(cwd: string, platformDisabled: boolean):
  * first-run notice (that was handled at activate). Never throws.
  */
 export async function reinitExtensionTelemetry(cwd: string, platformDisabled: boolean): Promise<void> {
+	// Same reasoning as `activateExtensionTelemetry`, and it must stay consistent
+	// with it: this re-bootstrap REPLACES the context, so opting in here alone
+	// would make a mid-session telemetry toggle silently start attributing the
+	// window to an inherited marker.
 	await bootstrapTelemetry({ cwd, platformDisabled });
 }


### PR DESCRIPTION
## What this adds

Telemetry recorded which of our own build artifacts sent an event (`surface`) and nothing about **which AI host the user was actually working in**. `surface` cannot answer that: it is a compile-time constant, so its value set equals the set of build configurations — six, against thirteen supported hosts. Ten of thirteen reported the surface of the observer, and the `run-hook` dist arbitration makes it actively misattributing (measured live during this work: Claude Code serving MCP out of the codex-plugin dist, and Codex out of the cursor-plugin dist).

This branch adds the second dimension — **`agent`**, inside the event `properties` bag (deny-listed server-side, so client-only by design) — plus two sibling closed-set properties, answering four questions:

| Question | Answer |
|---|---|
| Which host ran a CLI command | `agent` from env markers, opt-in per call site (9/13 hosts measured) |
| Which host made an MCP tool call | `agent` from the connection's own `initialize` clientInfo — the only signal that survives the shared per-worktree daemon |
| Who set a commit in motion | `trigger: agent/ui/terminal/unknown`, resolved at enqueue time in the post-commit hook and stamped on the queue entry |
| Was a command skill-driven | `via: skill:<name>`, consumed (read-then-deleted) from the env the skill recipe sets |

## Invariants, enforced not stated

- **Never defaulted** — absent reads as *unknown*; nothing maps to `cli` by omission.
- **Never free-form** — every value passes a closed-vocabulary gate (`TELEMETRY_AGENTS` aliases `TRANSCRIPT_SOURCES`, so a 14th host cannot ship a stale list); an unrecognised value is omitted, never passed through.
- **Never guessed** — two hosts' markers at once answer nothing; a family gate that cannot name its variant abandons the whole answer; an IDE Commit button beats an inherited marker; long-lived processes (extension host, `mcp-serve`, `ide-bridge`) never infer from env at all.

## Everything is measured, including the negatives

Every mapping row traces to a capture made during this work: env probes across nine hosts (agent-spawned shell dumps against a human-shell control), MCP `initialize` captures via a logging probe server (`claude-code`, `codex-mcp-client` — where "codex" would have been the obvious wrong guess), and a real-SDK end-to-end run of the built dist. The recorded negatives matter as much: `CURSOR_TRACE_ID` does not exist in any Cursor context (exposing a pre-existing dead entry in `CaptureProgress`, tracked separately), kimi sets no env var at all, Antigravity sets no `GEMINI_*` (a collision that would have relabelled its work as gemini's), and cursor-agent's clientInfo is a family name deliberately left unmapped until the IDE's own string is captured. devin's probe is quota-blocked and documented for a one-paste retry.

## Public disclosure

`TELEMETRY.md` discloses the new dimension in the same change, and its previously hand-written surface list — stale by three entries, invisible to the drift test because the staleness was in the generator's own string — is now generated and pinned. The watershed (`AGENT_DIMENSION_SINCE_VERSION = "0.99.14"`) is stamped into the doc and guarded by a test that fails if main's version overtakes it before release; **if this ships in a different release, update the constant and regenerate.**

## Explicitly out of scope

`surface` and its allowlist are untouched; no server change; no backfill (pre-watershed rows were never measured, and nothing reconstructs them); the outbound `LocalAgentToolId` dimension stays distinct; skill-attribution on the MCP path is designed and measured but deliberately deferred (the only carrier is model-relayed and can manufacture false positives — the design note records the per-connection-schema mechanism for when the data need is real).

## Verification

`npm run all` green at every commit (CLI 98.41/96.18/98.4/98.83 against the 97/96/97/97 floor; vscode 98.92/97.54/98.33/99.06 — never lowered). IntelliJ telemetry suite green (its Kotlin event-description mirror updated in lockstep; the port deliberately never emits `agent`, with the reasoning pinned by a Kotlin test under an inherited marker). End-to-end verified against the real MCP SDK with every env marker scrubbed — the buffered event carried `agent:"claude"` from the handshake alone.
