### PR TITLE
Preserve hand-maintained README.md in the graph-assets copier

### DIFF
--- a/scripts/copy-graph-assets.mjs
+++ b/scripts/copy-graph-assets.mjs
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, rmSync } from "node:fs";
+import { cpSync, existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -22,6 +22,10 @@ import { fileURLToPath } from "node:url";
 //
 // base = <first non-flag arg> || $JOLLI_WEB_BASE || "E:\jolli". If <base>/frontend
 // does not exist, the web copy is skipped (not an error).
+//
+// A hand-maintained README.md in a destination is PRESERVED across the rm+copy
+// (src ships none): the web repo keeps a jolli-only doc describing the vendored
+// tree + the postMessage protocol, and it must survive every re-vendor.
 //
 // ORDER: the CLI must be built before this runs. If cli/dist/graph-assets is missing,
 // build the CLI first.
@@ -57,8 +61,15 @@ if (!vscodeOnly) {
 
 try {
 	for (const dest of dests) {
+		// Preserve a hand-maintained README.md across the rm+copy. `src` carries no
+		// README, so a bare rm+copy would delete the web repo's jolli-only doc (which
+		// explains the vendored tree + the postMessage protocol) on every re-vendor.
+		// vscode/assets/graph has none, so this is a no-op there.
+		const readmePath = join(dest, "README.md");
+		const preservedReadme = existsSync(readmePath) ? readFileSync(readmePath, "utf8") : null;
 		rmSync(dest, { recursive: true, force: true });
 		cpSync(src, dest, { recursive: true });
+		if (preservedReadme !== null) writeFileSync(readmePath, preservedReadme, "utf8");
 		console.log(`[copy-graph-assets] copied ${src} → ${dest}`);
 	}
 } catch (err) {


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Context

- [JOLLI-2258 — Graph: de-inline wiki bodies from graph.json, fetch on demand](https://linear.app/jolliai/issue/JOLLI-2258/graph-de-inline-wiki-bodies-from-graphjson-fetch-on-demand)

## Quick recap

The developer completed a multi-part improvement to the graph-assets vendor workflow. The vendor script now preserves hand-maintained documentation across re-vendor cycles, allowing the web repo to maintain its own README describing the vendored assets and the postMessage protocol for on-demand wiki bodies. The README was expanded with explicit instructions for re-vendoring from jollimemory and documentation of the schema v5 wiki protocol contract. A separate issue was filed to track a data-loss bug in the VSCode sync feature where local graph.json files are being overwritten by older remote versions. The feature branch was rebased to the latest main (which already contained the merged schema v5 work) and the preservation fix was isolated on its own branch for independent review.

---

## Topics (4)
<details>
<summary><strong>01 · Preserve hand-maintained README in graph-assets vendor script</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The graph-assets vendor script (`copy-graph-assets.mjs`) performs a destructive rm+copy operation that was deleting the web repo's hand-maintained README.md on every re-vendor, even though that file documents jolli-only information (the vendored tree structure and the postMessage protocol for on-demand wiki bodies).

**💡 Decisions Behind the Code**

The preservation happens at the script level rather than in git (e.g., via `.gitignore` or a separate tracked copy) because the web repo's README is a living document that describes the current vendored assets and their protocol contract. Storing it outside the vendor destination would create a maintenance burden and risk of drift. By preserving it in-place during the copy, the README stays colocated with the assets it documents and survives every re-vendor automatically. This approach also keeps the source (`cli/dist/graph-assets`) clean and focused on CLI-only assets, avoiding the need to ship jolli-specific documentation in the CLI distribution.

**✅ What Was Implemented**

Modified `scripts/copy-graph-assets.mjs` to preserve any existing README.md in the destination before the rm+copy cycle and restore it afterward. The script now reads the destination README (if present), deletes the entire destination tree, copies fresh assets from source, and writes the preserved README back. This allows the web repo to maintain its own documentation without it being overwritten on each vendor cycle, while the vscode destination (which has no README) is unaffected.

**📁 FILES**
- `scripts/copy-graph-assets.mjs`

</blockquote>
</details>
<details>
<summary><strong>02 · Enhance graph-assets README with wiki protocol and vendor instructions</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The web repo's README.md for the vendored graph assets was missing documentation of the on-demand wiki-body postMessage protocol (part of schema v5) and lacked clear instructions for developers on how to re-vendor assets from the jollimemory repo.

**💡 Decisions Behind the Code**

The README documents the vendored tree and its protocol contract, so it belongs in the web repo rather than only in jollimemory source. By including explicit re-vendor instructions in the README itself, developers can discover the correct workflow without needing to search across repos or documentation. The protocol documentation ensures that future maintainers understand the postMessage contract without having to reverse-engineer it from minified JavaScript.

**✅ What Was Implemented**

Restored and expanded `frontend/public/graph/README.md` to include: (1) a new "On-demand wiki bodies (schema v5)" section documenting the `jolli-graph-wiki-request` and `jolli-graph-wiki-body` postMessage contract; (2) a "Updating" section with explicit commands for re-vendoring from jollimemory (including `npm run build:cli && npm run copy-graph-assets`, environment variable override, and manual `cp -rf` fallback); (3) a note clarifying that this README is jolli-only and will be preserved across re-vendor cycles.

**📁 FILES**
- `frontend/public/graph/README.md`

</blockquote>
</details>
<details>
<summary><strong>03 · Create issue for graph.json sync direction bug</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A user reported that after generating a new schema v5 graph.json locally and running "Sync to Personal Space" in the VSCode plugin, the local file was overwritten with the older schema v3 version from the web, indicating the sync direction was reversed.

**💡 Decisions Behind the Code**

Filing this as a separate issue rather than bundling it with the schema v5 feature work ensures the sync bug gets proper triage and visibility. The issue captures the exact repro sequence and version details needed for debugging, making it actionable for whoever investigates the sync logic.

**✅ What Was Implemented**

Created Linear issue JOLLI-2259 documenting the bug: local graph.json (schema v5, ~500 KB) was overwritten by remote version (schema v3, ~1.14 MB) after a successful "Sync to Personal Space" operation, with clear repro steps and risk assessment (data loss).

**📁 FILES**
- `(issue tracking only)`

</blockquote>
</details>
<details>
<summary><strong>04 · Rebase feature branch to latest main and create preservation fix branch</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The feature branch needed to be rebased to the latest main, and the README preservation fix for the vendor script needed to be isolated on a new branch for independent review and merge.

**💡 Decisions Behind the Code**

Isolating the vendor script fix on its own branch keeps the preservation logic separate from the main feature work, making it easier to review, test, and merge independently. This also clarifies that the preservation is a follow-up improvement to the re-vendor process rather than part of the core schema v5 feature.

**✅ What Was Implemented**

Rebased `feat/graph-wiki-deinline` to the latest `origin/main` (which already contained the merged schema v5 feature), resolving no conflicts. Created a new branch `fix/copy-graph-assets-preserve-readme` based on the updated main, carrying the vendor script preservation logic and README enhancements as a separate, focused change.

**📁 FILES**
- `scripts/copy-graph-assets.mjs`
- `frontend/public/graph/README.md`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 20, 2026 at 4:57 PM · via Anthropic*
<!-- jollimemory-summary-end -->