### PR TITLE
Show agent in skill usage tables

### DIFF
--- a/cli/src/commands/IdeBridgeCommand.test.ts
+++ b/cli/src/commands/IdeBridgeCommand.test.ts
@@ -347,6 +347,7 @@ vi.mock("../core/PrDescription.js", () => ({
 
 vi.mock("../core/SummaryFormat.js", () => ({
 	buildReferencePushTitle: vi.fn().mockReturnValue("Ref Title"),
+	skillSourceLabel: vi.fn((source: string) => (source === "claude" ? "Claude Code" : source)),
 }));
 
 vi.mock("../core/references/ReferenceStore.js", () => ({
@@ -3638,7 +3639,7 @@ describe("runIdeBridgeAction — shared-store", () => {
 			operation: "skills-live-markdown",
 		})) as { markdown: string };
 		expect(markdown).toContain("# Skills used — uncommitted");
-		expect(markdown).toContain("| brainstorming | 2 | 1.0k |");
+		expect(markdown).toContain("| brainstorming | Claude Code | 2 | 1.0k |");
 	});
 
 	// null rather than an empty table: committing archives every skill, so an empty
@@ -3690,8 +3691,10 @@ describe("runIdeBridgeAction — shared-store", () => {
 		})) as { markdown: string };
 		expect(markdown).toContain("# Skills used — abcdef12");
 		expect(markdown).toContain("commitHash: abcdef1234567890");
-		// Unattributed rows dash all four cells rather than showing a zero.
-		expect(markdown).toContain("| a | 1 | — | — | — | — |");
+		// Unattributed rows dash all four token cells rather than showing a zero, and
+		// the Agent cell dashes too: this payload carries no `source`, which is exactly
+		// what an older IntelliJ sends through this untyped operation.
+		expect(markdown).toContain("| a | — | 1 | — | — | — | — |");
 	});
 
 	it("returns a null committed markdown when the summary archived no skills", async () => {

--- a/cli/src/core/SkillsAggregateMarkdown.test.ts
+++ b/cli/src/core/SkillsAggregateMarkdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { CommitSummary, SkillCommitRef } from "../Types.js";
+import type { CommitSummary, SkillCommitRef, SkillSource } from "../Types.js";
 import {
 	buildLiveSkillsMarkdown,
 	buildSkillsAggregateMarkdown,
@@ -11,6 +11,7 @@ import {
 
 const row = (over: Partial<SkillTableRow> = {}): SkillTableRow => ({
 	skill: "superpowers:brainstorming",
+	source: "claude",
 	invocationCount: 2,
 	usage: { input: 79, cached: 59796, output: 33944, confidence: "attributed" },
 	...over,
@@ -26,9 +27,9 @@ describe("buildSkillsTable", () => {
 	it("renders one row per skill with count, total, and the three-way split", () => {
 		// 79 + 59796 + 33944 = 93819
 		expect(buildSkillsTable([row()])).toEqual([
-			"| Skill | × | Tokens | Input | Output | Cached |",
-			"|---|---|---|---|---|---|",
-			"| superpowers:brainstorming | 2 | 93.8k | 79 | 33.9k | 59.8k |",
+			"| Skill | Agent | × | Tokens | Input | Output | Cached |",
+			"|---|---|---|---|---|---|---|",
+			"| superpowers:brainstorming | Claude Code | 2 | 93.8k | 79 | 33.9k | 59.8k |",
 		]);
 	});
 
@@ -38,9 +39,9 @@ describe("buildSkillsTable", () => {
 		// the row into extra columns and misaligns every remaining cell against its
 		// header, silently, with no malformed-file signal anywhere.
 		const lines = buildSkillsTable([row({ skill: "weird|name" })]);
-		expect(lines[2]).toBe("| weird\\|name | 2 | 93.8k | 79 | 33.9k | 59.8k |");
-		// Six cells, exactly as many as the header declares.
-		expect(lines[2].split(/(?<!\\)\|/).filter((c) => c !== "")).toHaveLength(6);
+		expect(lines[2]).toBe("| weird\\|name | Claude Code | 2 | 93.8k | 79 | 33.9k | 59.8k |");
+		// Seven cells, exactly as many as the header declares.
+		expect(lines[2].split(/(?<!\\)\|/).filter((c) => c !== "")).toHaveLength(7);
 	});
 
 	it("escapes the backslash BEFORE the pipe, so a `\\|` id cannot smuggle a live pipe", () => {
@@ -49,9 +50,9 @@ describe("buildSkillsTable", () => {
 		// escape produced the very cell split it was added to prevent. Backslash-first
 		// makes every pre-existing backslash inert before any pipe is escaped.
 		const lines = buildSkillsTable([row({ skill: "weird\\|name" })]);
-		expect(lines[2]).toBe("| weird\\\\\\|name | 2 | 93.8k | 79 | 33.9k | 59.8k |");
-		// Still six cells: no unescaped delimiter survived.
-		expect(lines[2].split(/(?<!\\)\|/).filter((c) => c !== "")).toHaveLength(6);
+		expect(lines[2]).toBe("| weird\\\\\\|name | Claude Code | 2 | 93.8k | 79 | 33.9k | 59.8k |");
+		// Still seven cells: no unescaped delimiter survived.
+		expect(lines[2].split(/(?<!\\)\|/).filter((c) => c !== "")).toHaveLength(7);
 	});
 
 	it("leaves a lone backslash inert rather than escaping the character after it", () => {
@@ -64,7 +65,7 @@ describe("buildSkillsTable", () => {
 		// row is parsed as body text instead of table content.
 		const lines = buildSkillsTable([row({ skill: "two\nlines" })]);
 		expect(lines).toHaveLength(3);
-		expect(lines[2]).toBe("| two lines | 2 | 93.8k | 79 | 33.9k | 59.8k |");
+		expect(lines[2]).toBe("| two lines | Claude Code | 2 | 93.8k | 79 | 33.9k | 59.8k |");
 	});
 
 	it("shows an em dash, never a zero, in EVERY token cell when nothing could be attributed", () => {
@@ -73,7 +74,7 @@ describe("buildSkillsTable", () => {
 		// that dashed only the total while zeroing the split would say exactly that
 		// about the three components.
 		const lines = buildSkillsTable([row({ usage: undefined })]);
-		expect(lines[2]).toBe("| superpowers:brainstorming | 2 | — | — | — | — |");
+		expect(lines[2]).toBe("| superpowers:brainstorming | Claude Code | 2 | — | — | — | — |");
 		expect(lines[2]).not.toContain("0");
 	});
 
@@ -81,7 +82,7 @@ describe("buildSkillsTable", () => {
 		// The marker qualifies how the number was arrived at, not its magnitude, so
 		// splitting the column must not leave three unqualified cells behind.
 		const lines = buildSkillsTable([row({ usage: { input: 10, cached: 0, output: 90, confidence: "estimated" } })]);
-		expect(lines[2]).toBe("| superpowers:brainstorming | 2 | ~100 | ~10 | ~90 | ~0 |");
+		expect(lines[2]).toBe("| superpowers:brainstorming | Claude Code | 2 | ~100 | ~10 | ~90 | ~0 |");
 	});
 
 	it("orders heaviest first by TOTAL, then by name on a tie", () => {
@@ -92,9 +93,9 @@ describe("buildSkillsTable", () => {
 			row({ skill: "a-light", usage: { input: 1, cached: 0, output: 1, confidence: "attributed" } }),
 		]);
 		expect(lines.slice(2)).toEqual([
-			"| heavy | 2 | 93.8k | 79 | 33.9k | 59.8k |",
-			"| a-light | 2 | 2 | 1 | 1 | 0 |",
-			"| b-light | 2 | 2 | 1 | 1 | 0 |",
+			"| heavy | Claude Code | 2 | 93.8k | 79 | 33.9k | 59.8k |",
+			"| a-light | Claude Code | 2 | 2 | 1 | 1 | 0 |",
+			"| b-light | Claude Code | 2 | 2 | 1 | 1 | 0 |",
 		]);
 	});
 
@@ -117,12 +118,15 @@ describe("buildSkillsTable", () => {
 			row({ skill: "same", invocationCount: 1, usage: undefined }),
 			row({ skill: "same", invocationCount: 7, usage: undefined }),
 		]);
-		expect(lines.slice(2)).toEqual(["| same | 1 | — | — | — | — |", "| same | 7 | — | — | — | — |"]);
+		expect(lines.slice(2)).toEqual([
+			"| same | Claude Code | 1 | — | — | — | — |",
+			"| same | Claude Code | 7 | — | — | — | — |",
+		]);
 	});
 
 	it("daggers an inferred row and spells the footnote out once", () => {
 		const lines = buildSkillsTable([row({ detection: "heuristic", usage: undefined }), row()]);
-		expect(lines).toContain("| superpowers:brainstorming † | 2 | — | — | — | — |");
+		expect(lines).toContain("| superpowers:brainstorming † | Claude Code | 2 | — | — | — | — |");
 		expect(lines.filter((l) => l.startsWith("†"))).toHaveLength(1);
 	});
 
@@ -130,10 +134,66 @@ describe("buildSkillsTable", () => {
 		expect(buildSkillsTable([row()]).some((l) => l.includes("†"))).toBe(false);
 	});
 
+	it("names each host by its display label rather than its wire id", () => {
+		// The column is read by a person, so it shows what `skillSourceLabel` shows
+		// everywhere else — "Claude Code", not the `claude` the registry keys on.
+		const lines = buildSkillsTable([
+			row({ skill: "a", source: "claude", usage: undefined }),
+			row({ skill: "b", source: "opencode", usage: undefined }),
+			row({ skill: "c", source: "codex", usage: undefined }),
+			row({ skill: "d", source: "cursor", usage: undefined }),
+			row({ skill: "e", source: "kimi", usage: undefined }),
+		]);
+		expect(lines.slice(2).map((l) => l.split(" | ")[1])).toEqual([
+			"Claude Code",
+			"OpenCode",
+			"Codex",
+			"Cursor",
+			"Kimi",
+		]);
+	});
+
+	it("shows an em dash, never the string `undefined`, for a row with no source", () => {
+		// Reachable from the untyped ide-bridge producer: `skillTableRows` casts the
+		// caller's JSON to SkillTableRow without checking fields, so an older IntelliJ
+		// sends rows with no source. Dashed for the same reason an unattributed token
+		// figure is — an absent field is honest, and inventing a host would credit one
+		// agent's work to another.
+		const lines = buildSkillsTable([row({ source: undefined, usage: undefined })]);
+		expect(lines[2]).toBe("| superpowers:brainstorming | — | 2 | — | — | — | — |");
+		expect(lines[2]).not.toContain("undefined");
+	});
+
+	it("escapes a pipe smuggled in through an unknown source's fallback label", () => {
+		// `skillSourceLabel` falls back to capitalising the RAW source string, which is
+		// host-supplied transcript text — so the Agent cell needs the same escaping the
+		// Skill cell has, or an unknown host can split the row.
+		// Cast because SkillSource cannot express it — which is the point: this stands
+		// for a host the union does not know, arriving through the untyped bridge.
+		const lines = buildSkillsTable([row({ source: "we|ird" as SkillSource, usage: undefined })]);
+		expect(lines[2]).toContain("| We\\|ird |");
+		expect(lines[2].split(/(?<!\\)\|/).filter((c) => c !== "")).toHaveLength(7);
+	});
+
+	it("distinguishes the same skill run by two different hosts", () => {
+		// The registry keys a row `<source>:<skill>`, so this is two legitimate rows,
+		// not a duplicate. The input is deliberately reverse source order: equal-token,
+		// equal-name rows must still render deterministically across callers that supply
+		// their refs in different orders.
+		const lines = buildSkillsTable([
+			row({ skill: "jolli", source: "codex", usage: undefined }),
+			row({ skill: "jolli", source: "claude", usage: undefined }),
+		]);
+		expect(lines.slice(2)).toEqual([
+			"| jolli | Claude Code | 2 | — | — | — | — |",
+			"| jolli | Codex | 2 | — | — | — | — |",
+		]);
+	});
+
 	it("renders a header-only table for an empty set", () => {
 		expect(buildSkillsTable([])).toEqual([
-			"| Skill | × | Tokens | Input | Output | Cached |",
-			"|---|---|---|---|---|---|",
+			"| Skill | Agent | × | Tokens | Input | Output | Cached |",
+			"|---|---|---|---|---|---|---|",
 		]);
 	});
 });
@@ -226,7 +286,7 @@ describe("buildLiveSkillsMarkdown", () => {
 
 	it("renders the rows it was given", () => {
 		expect(buildLiveSkillsMarkdown([row()])).toContain(
-			"| superpowers:brainstorming | 2 | 93.8k | 79 | 33.9k | 59.8k |",
+			"| superpowers:brainstorming | Claude Code | 2 | 93.8k | 79 | 33.9k | 59.8k |",
 		);
 	});
 });

--- a/cli/src/core/SkillsAggregateMarkdown.ts
+++ b/cli/src/core/SkillsAggregateMarkdown.ts
@@ -7,7 +7,8 @@
  * surface later without importing a storage class.
  */
 
-import type { CommitSummary, SkillCommitRef, SkillUsage } from "../Types.js";
+import type { CommitSummary, SkillCommitRef, SkillSource, SkillUsage } from "../Types.js";
+import { skillSourceLabel } from "./SummaryFormat.js";
 
 /**
  * `skills--<hash8>` — the per-commit skill aggregate's identity.
@@ -26,7 +27,7 @@ export function skillsAggregateFileName(hash8: string): string {
 }
 
 /**
- * The four fields the table needs, and nothing else.
+ * The five fields the table needs, and nothing else.
  *
  * Deliberately narrower than either concrete type so ONE renderer serves both
  * sides of the commit boundary: `SkillCommitRef` (the archived snapshot behind
@@ -38,6 +39,17 @@ export function skillsAggregateFileName(hash8: string): string {
  */
 export interface SkillTableRow {
 	readonly skill: string;
+	/**
+	 * The AI host that ran the skill — the `Agent` column.
+	 *
+	 * OPTIONAL even though all three concrete types (`SkillEntry`, `ActiveSkill`,
+	 * `SkillCommitRef`) declare it as required, because one table-producing boundary
+	 * is not typed: the `skills-committed-markdown` ide-bridge operation casts the
+	 * caller's summary JSON to `CommitSummary`. An older IntelliJ can therefore send
+	 * archived rows with no `source` at all, and declaring it required would render
+	 * the string `undefined` into a cell rather than fail anywhere a test could see.
+	 */
+	readonly source?: SkillSource;
 	readonly invocationCount: number;
 	readonly usage?: SkillUsage;
 	readonly detection?: "heuristic";
@@ -61,25 +73,42 @@ export interface SkillTableRow {
  * rows are ORDERED by that total and the sidebar's group row summarises by it, so
  * dropping the column would leave both the sort key and the summary figure with no
  * counterpart in the table a reader is looking at.
+ *
+ * `Agent` sits second — beside the skill id and ahead of every figure — because it
+ * is identity, not measurement: the row reads "this skill, run by that host, N
+ * times, for this much". It also disambiguates a genuine duplicate the table could
+ * not previously explain. The registry keys a row `<source>:<skill>`, so one skill
+ * entered from two hosts is legitimately TWO rows; without this column they render
+ * as the same skill listed twice.
  */
 export function buildSkillsTable(skills: ReadonlyArray<SkillTableRow>): string[] {
-	const lines: string[] = ["| Skill | × | Tokens | Input | Output | Cached |", "|---|---|---|---|---|---|"];
+	const lines: string[] = [
+		"| Skill | Agent | × | Tokens | Input | Output | Cached |",
+		"|---|---|---|---|---|---|---|",
+	];
 
-	// Heaviest first, then by name, so the table reads as "what dominated this work".
+	// Heaviest first, then by name and source, so the table reads as "what dominated
+	// this work" while still giving the same skill used by two hosts a total order.
 	// `localeCompare` is deliberately avoided: it takes the ambient locale, and this
 	// file is regenerated on every write — under a different locale the rows would
 	// reorder and show up as a spurious diff for a colleague.
 	const ordered = [...skills].sort((a, b) => {
 		const byTokens = totalOf(b) - totalOf(a);
 		if (byTokens !== 0) return byTokens;
-		return a.skill < b.skill ? -1 : a.skill > b.skill ? 1 : 0;
+		const bySkill = a.skill < b.skill ? -1 : a.skill > b.skill ? 1 : 0;
+		if (bySkill !== 0) return bySkill;
+		const aSource = a.source ?? "";
+		const bSource = b.source ?? "";
+		return aSource < bSource ? -1 : aSource > bSource ? 1 : 0;
 	});
 
 	let anyInferred = false;
 	for (const ref of ordered) {
 		const marker = ref.detection === "heuristic" ? " †" : "";
 		if (marker !== "") anyInferred = true;
-		lines.push(`| ${escapeCell(ref.skill)}${marker} | ${ref.invocationCount} | ${tokenCells(ref).join(" | ")} |`);
+		lines.push(
+			`| ${escapeCell(ref.skill)}${marker} | ${agentCell(ref)} | ${ref.invocationCount} | ${tokenCells(ref).join(" | ")} |`,
+		);
 	}
 	if (anyInferred) {
 		// Spelled out rather than left as a bare dagger. A host with no skill tool
@@ -200,6 +229,31 @@ function escapeCell(value: string): string {
 function totalOf(ref: SkillTableRow): number {
 	const u = ref.usage;
 	return u === undefined ? 0 : u.input + u.cached + u.output;
+}
+
+/**
+ * The `Agent` cell — the host's display label, or an em dash when the row carries
+ * no source.
+ *
+ * Dashed rather than left blank or filled with a guess, for the same reason
+ * {@link tokenCells} dashes an unattributed figure: an absent field is honest.
+ * The only rows that reach here without a source come through the untyped
+ * ide-bridge boundary (see {@link SkillTableRow.source}), and inventing a host would
+ * attribute one agent's work to another.
+ *
+ * Escaped despite {@link skillSourceLabel} normally returning one of five in-repo
+ * constants: its fallback branch capitalises the RAW source string, which is
+ * host-supplied text from another program's transcript — the same untrusted input
+ * {@link escapeCell} exists for.
+ */
+function agentCell(ref: SkillTableRow): string {
+	// Widened to `string` on purpose. `SkillSource` cannot express `""`, but the
+	// ide-bridge boundary forwards unvalidated JSON into this table, so an empty string
+	// is reachable at runtime — and `skillSourceLabel` takes a bare `string` for exactly
+	// the same reason.
+	const source: string | undefined = ref.source;
+	if (source === undefined || source === "") return "—";
+	return escapeCell(skillSourceLabel(source));
 }
 
 /**

--- a/cli/src/core/SummaryMarkdownBuilder.ts
+++ b/cli/src/core/SummaryMarkdownBuilder.ts
@@ -334,9 +334,9 @@ export function buildReferencePushMarkdown(ref: ReferenceCommitRef, description?
  * aggregate and the sidebar use, which owns the em-dash-not-zero rule, the `~`
  * estimate marker, the `†` inferred footnote and the heaviest-first ordering. That
  * is what keeps this body byte-identical to the table VS Code shows for the same
- * commit, and it is also why the per-skill identity (host / plugin / entry paths)
- * is appended BELOW the table as a detail list rather than folded into it: those
- * are not measurements and have no column.
+ * commit. Per-skill identity is split deliberately: host is promoted into the table
+ * to disambiguate equal skill ids, while plugin and entry paths stay BELOW it as a
+ * detail list.
  *
  * **Every figure is THIS COMMIT's increment, read off the refs alone.** That is
  * the whole contract of this function, and it is a deliberate reversal: the body
@@ -383,6 +383,10 @@ export function buildSkillsPushMarkdown(refs: ReadonlyArray<SkillCommitRef>): st
 		...buildSkillsTable(
 			refs.map((ref) => ({
 				skill: ref.skill,
+				// Projected explicitly, like every other field here: this map picks fields
+				// rather than spreading the ref, so a column added to the table renders as
+				// an em dash in the pushed article until it is named here too.
+				source: ref.source,
 				invocationCount: ref.invocationCount,
 				...(ref.usage !== undefined && { usage: ref.usage }),
 				...(ref.detection !== undefined && { detection: ref.detection }),
@@ -390,7 +394,7 @@ export function buildSkillsPushMarkdown(refs: ReadonlyArray<SkillCommitRef>): st
 		),
 	];
 
-	// Identity, not measurement — see the header for why it sits below the table.
+	// The identity fields that are not columns stay below the table.
 	// Ordered by skill id rather than by weight: this list is looked up by name, and
 	// a stable order keeps a re-push from producing a spurious diff.
 	const detailed = [...refs].sort((a, b) => (a.skill < b.skill ? -1 : a.skill > b.skill ? 1 : 0));

--- a/cli/src/core/push/kinds/skill.test.ts
+++ b/cli/src/core/push/kinds/skill.test.ts
@@ -190,7 +190,7 @@ describe("body", () => {
 			ref({ invocationCount: 1, usage: { input: 50, cached: 0, output: 24900, confidence: "attributed" } }),
 			{ cwd: CWD },
 		);
-		expect(body).toContain("| superpowers:brainstorming | 1 | 24.9k | 50 | 24.9k | 0 |");
+		expect(body).toContain("| superpowers:brainstorming | Claude Code | 1 | 24.9k | 50 | 24.9k | 0 |");
 	});
 
 	it("includes the host, plugin and entry paths", async () => {
@@ -205,9 +205,18 @@ describe("body", () => {
 			ref({ usage: { input: 12300, cached: 76500, output: 5000, confidence: "attributed" } }),
 			{ cwd: CWD },
 		);
-		expect(body).toContain("| Skill | × | Tokens | Input | Output | Cached |");
+		expect(body).toContain("| Skill | Agent | × | Tokens | Input | Output | Cached |");
 		// 12300 + 76500 + 5000 = 93.8k, formatted by buildSkillsTable.
 		expect(body).toContain("93.8k");
+	});
+
+	it("carries the host into the pushed table's Agent cell, not just the details list", async () => {
+		// `buildSkillsPushMarkdown` PICKS fields rather than spreading the ref, so a
+		// column added to the shared table renders as an em dash in the pushed article
+		// until it is named there too — silently, since the table still lines up.
+		const body = await skillKind.body(ref(), { cwd: CWD });
+		expect(body).toContain("| superpowers:brainstorming | Claude Code |");
+		expect(body).not.toContain("| superpowers:brainstorming | — |");
 	});
 
 	it("omits the three cumulative fields it used to carry", async () => {
@@ -261,10 +270,10 @@ describe("body", () => {
 		];
 		const [aggregated] = skillKind.aggregate?.(refs, summary()) ?? [];
 		const body = await skillKind.body(aggregated, { cwd: CWD });
-		expect(body).toContain("| a | 1 |");
-		expect(body).toContain("| b | 1 |");
-		// Identity sits below the table because it has no column there — and it is
-		// per-skill, so two hosts on one commit both survive.
+		expect(body).toContain("| a | Claude Code | 1 |");
+		expect(body).toContain("| b | Codex | 1 |");
+		// The detail list keeps the rest of each skill's identity after host became a
+		// table column; it is per-skill, so two hosts on one commit both survive.
 		expect(body).toContain("## Skill details");
 		expect(body).toContain("- **a** — Host: Claude Code");
 		expect(body).toContain("- **b** — Host: Codex");


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Context (2)

- Recall
- Skills used — 2 skills · 391.3k tokens · some inferred

## Quick recap

Skill usage tables across the archived commit summary, the live in-progress preview, and the pushed commit article now show which AI agent ran each skill, displayed as a new column right after the skill name. Previously, if two different agents ran the same skill, the two rows looked like unexplained duplicates; they are now clearly distinguished by agent. Rows with no recorded agent (which can happen with older integrations that don't send this information) show a dash rather than a broken value, matching how missing usage numbers are already handled elsewhere in the same tables.

A review of this change caught two problems before it could be merged: a broken test suite and a subtle ordering inconsistency. When a skill was run by two agents with identical usage totals, the table could display them in a different order depending on which surface was showing it. A tie-breaking rule now keeps that order consistent everywhere the table appears. The review also found and fixed several outdated test expectations, including one that had been silently hidden behind an unrelated test failure, and the fix was validated with a full build, lint, and test run across every affected part of the codebase before it was considered safe to merge.

---

## Topics (2)
<details>
<summary><strong>01 · Fix ordering bug and stale tests found while reviewing the new agent column</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A review of the branch that added an agent/host indicator to skill usage tables turned up a merge-blocking problem: the test suite was red, and a subtler issue was found where two agents running the identical skill with the same token totals could show up in a different order depending on which surface displayed the table.

**💡 Decisions Behind the Code**

- **Ran the full build/lint/test pipeline before considering the fix done**: rather than trusting the narrower "changed files" test run, the complete chain across the CLI, editor extension, and acceptance suites was run to rule out any regression elsewhere, in direct response to an explicit instruction not to introduce new problems while fixing this one.
- **Treated one hidden failure as a signal to re-scan, not a one-off**: once a masked test failure was found, the fix wasn't considered complete until every other place that renders or checks this table was checked for the same kind of stale assumption, since the earlier failure showed that a partial fix could look green while still hiding a second problem.

**✅ What Was Implemented**

- A review pass found that the changed test suite had 4 failing tests: a mocked formatting helper was missing the new function that turns a raw agent id into its display name, and three other test expectations still assumed the table's old shape before the agent column existed.
- Fixing the mock uncovered a second, previously hidden failure in the live preview surface that had been masked by the first failure; a full sweep of the codebase was then run to make sure no other stale expectations were hiding behind it.
- A tie-breaking rule was added to the table's sort order so that when a skill's total usage and name are identical across two agents, the row order is now decided by the agent as well, keeping the archived table, the live preview, and the pushed article visually identical for the same commit.

**📁 FILES**
- `cli/src/core/SkillsAggregateMarkdown.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Add an agent/host column to skill usage tables</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

When the same skill was run by more than one AI agent, the skill usage tables showed what looked like duplicate rows with no way to tell which agent actually ran each one, and there was no way to see who was responsible for a given skill's usage at a glance.

**💡 Decisions Behind the Code**

- **Placed the agent column second, right after the skill name, ahead of all the numeric columns**: it was treated as an identity label rather than a measurement, so the row reads as "this skill, run by this agent, this many times, for this much usage," and none of the existing numeric formatting rules needed to change.
- **Chose to dash unattributed hosts instead of guessing**: rows that arrive without host information (from the untyped legacy intake path) show a dash rather than any inferred value, consistent with how the table already handles usage numbers that can't be attributed to a specific run.
- **Deferred two other hand-built skill tables in the editor extension (a tree-view tooltip and a hover card) rather than expanding scope**: those render their own markup instead of using the shared table logic, so extending them would have been a separate, larger change; this was flagged for the user to decide on rather than done unilaterally.

**✅ What Was Implemented**

- Added an "Agent" column to the shared table-building logic used by the archived skill summary, the live in-progress preview, and the editor bridge, showing each row's host (for example "Claude Code" or "Codex") right after the skill name.
- Made the underlying host field optional in the shared row data even though the concrete data sources always provide it, because one intake path accepts unvalidated data from older IntelliJ clients that may not send it; those rows now show a dash instead of a broken-looking value.
- Extended the pushed commit article's table builder to carry the host field through as well, since it explicitly lists out fields rather than passing the whole record along, so the pushed version of the table now matches the archived and live versions instead of silently missing the new column.

**📋 Future Enhancements**

Decide whether to add the same agent column to the editor extension's tree-view tooltip (a small change) and its hover card (a larger one, since it needs a data-structure change too) — both currently render their own hand-built tables and were explicitly left untouched pending a decision.

**📁 FILES**
- `cli/src/core/SkillsAggregateMarkdown.ts`
- `cli/src/core/SummaryMarkdownBuilder.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 20, 2026 at 6:24 PM · via Local agent - Claude Code*
<!-- jollimemory-summary-end -->