### PR TITLE
Turn the Daily Standup board into a paged weekly view

### DIFF
--- a/cli/src/dashboard/DashboardModel.ts
+++ b/cli/src/dashboard/DashboardModel.ts
@@ -1476,29 +1476,59 @@ export interface StandupInsight {
 	readonly committedAtMs: number;
 }
 
-/** The Standup page payload. */
+/** One day column on the Standup board — a local day and the commits that landed on it. */
+export interface StandupDay {
+	/** Local `YYYY-MM-DD`. */
+	readonly day: string;
+	/** Commits completed on {@link day}, oldest-first within the day. Empty for a quiet day. */
+	readonly commits: ReadonlyArray<StandupCommit>;
+}
+
+/**
+ * The Standup page payload — a seven-day window of commit activity.
+ *
+ * The board is a rolling 7-day window ending on an anchor day, paged a whole
+ * week at a time (the `offset` request param: 0 = window ending today). The
+ * columns are COMMITS ONLY (JOLLI-2200 / 2201): a column states what was
+ * COMPLETED that day, matching the rows the stats page's Memory Activity card
+ * lists for the same day, and a session or an uncommitted worktree is work in
+ * flight rather than a completed row.
+ */
 export interface StandupModel {
-	/** Local `YYYY-MM-DD` the board was built for. */
+	/** The real local `YYYY-MM-DD` today, for the "Today"/"Yesterday" column titles. */
 	readonly today: string;
 	readonly yesterday: string;
+	/** Oldest and newest local `YYYY-MM-DD` of the shown window (newest = the anchor). */
+	readonly windowFrom: string;
+	readonly windowTo: string;
 	/**
-	 * NOT RENDERED, and absence from the page is not an oversight. Both day columns
-	 * are commits only: Today states what was COMPLETED today (JOLLI-2201), and the
-	 * columns are required to list the same rows the stats page's Memory Activity
-	 * card lists for the same day — which is commits and nothing else. A session is
-	 * not a commit, and a live session or an uncommitted worktree is work in flight
-	 * besides.
-	 *
-	 * All three are still queried: they are the only local record of "in progress",
-	 * and the column that wants them has not been designed yet. But a renderer
-	 * putting any of them back into a day column re-opens the ticket.
+	 * The resolved whole-week paging offset this window is at (0 = ending today).
+	 * Echoed so the client can preserve it across a repo-scope change or a poll
+	 * without re-reading the URL — see `JD.query` in `shell.js`.
 	 */
-	readonly yesterdaySessions: ReadonlyArray<RecentSession>;
-	readonly yesterdayCommits: ReadonlyArray<StandupCommit>;
-	/** Not rendered — see {@link StandupModel.yesterdaySessions}. */
-	readonly todaySessions: ReadonlyArray<RecentSession>;
-	readonly todayCommits: ReadonlyArray<StandupCommit>;
-	/** Uncommitted work. Not rendered — see {@link StandupModel.yesterdaySessions}. */
+	readonly offset: number;
+	/**
+	 * The seven day columns, NEWEST FIRST — the anchor day leftmost, going back a
+	 * week. Every day in the window is present, including quiet ones (empty
+	 * `commits`), so the grid has a stable seven columns.
+	 */
+	readonly days: ReadonlyArray<StandupDay>;
+	/**
+	 * A newer window exists to page forward to (i.e. the anchor is before today).
+	 * Drives the `‹` arrow, which moves toward more recent days — see the standup
+	 * pager in `shell.js`. False on the current window: there is no future to show.
+	 */
+	readonly hasNewer: boolean;
+	/**
+	 * An author-filtered commit exists strictly before this window, so paging back
+	 * lands on data rather than empty weeks. Drives the `›` arrow (older days).
+	 */
+	readonly hasOlder: boolean;
+	/**
+	 * Uncommitted work across the registered repos. NOT RENDERED in a day column —
+	 * it is work in flight, not a completed row — but carried for a future
+	 * in-progress surface and because it is window-independent (current state).
+	 */
 	readonly workspaces: ReadonlyArray<StandupWorkspace>;
 	/**
 	 * The git identity the commit columns were filtered to (an email, or a name
@@ -1509,15 +1539,17 @@ export interface StandupModel {
 	 */
 	readonly authoredBy?: string;
 	/**
-	 * Risks/blockers/questions/TODOs mined from the window's commit memories.
-	 * Present (possibly empty) from the memory tier onwards.
+	 * The memory-tier flag, carried by PRESENCE alone: an EMPTY array from the
+	 * memory tier onwards, absent below it. `renderStandup` reads only
+	 * `!!standup.insights` — how many fields a commit row may show — never the
+	 * contents.
 	 *
-	 * NOT RENDERED either, and now for two reasons at once. `todo` is unrouted for
-	 * the reason above and `decision` belongs to the Decisions card; the other
-	 * three had a column of their own until it was removed, because nothing can
-	 * produce them (see {@link CommitInsightKind}). What the field still does is
-	 * carry the memory tier: its mere PRESENCE is what `renderStandup` reads to
-	 * decide how many fields a commit row may show.
+	 * It is typed as an insight array, and stays so, for one reason: the standup
+	 * board once rendered a Risks/Blockers/Questions column from it. That column was
+	 * removed (JOLLI-2200/2201 — nothing produces those kinds, see
+	 * {@link CommitInsightKind}), and with it the server stopped populating this: the
+	 * per-window query re-sent ~40 KB the client discarded on every 30 s poll. The
+	 * shape is kept so a real insight column can return here without a wire change.
 	 */
 	readonly insights?: ReadonlyArray<StandupInsight>;
 }

--- a/cli/src/dashboard/DashboardQuery.test.ts
+++ b/cli/src/dashboard/DashboardQuery.test.ts
@@ -17,6 +17,8 @@ import type {
 	DashboardScope,
 	McpServerRow,
 	SessionUpsertedEvent,
+	StandupCommit,
+	StandupModel,
 	StatsEventEnvelope,
 	StatsModel,
 	ToolUsageRow,
@@ -26,9 +28,30 @@ import { MEMORY_CARDS_LIMIT, TOOL_ROWS_LIMIT } from "./DashboardModel.js";
 /** UTC+8, no DST — the zone the day-boundary cases below contrast with UTC. */
 const SH = "Asia/Shanghai";
 
-import { buildDashboardModel, buildSkillDetail, buildToolUsagePage, type QueryOptions } from "./DashboardQuery.js";
+import {
+	buildDashboardModel,
+	buildSkillDetail,
+	buildToolUsagePage,
+	type QueryOptions,
+	STANDUP_MAX_OFFSET,
+} from "./DashboardQuery.js";
 import { volumeReachable } from "./RepoForget.js";
 import { applyStatsEvents } from "./StatsWriter.js";
+
+/** Every commit across a standup window's day columns, flattened newest-day-first. */
+function standupCommits(standup: StandupModel | undefined): ReadonlyArray<StandupCommit> {
+	return (standup?.days ?? []).flatMap((d) => d.commits);
+}
+
+/** The single commit with `hash` anywhere in the window, or undefined. */
+function commitByHash(standup: StandupModel | undefined, hash: string): StandupCommit | undefined {
+	return standupCommits(standup).find((c) => c.hash === hash);
+}
+
+/** The local day key of the column that holds `hash`, or undefined. */
+function commitDayKey(standup: StandupModel | undefined, hash: string): string | undefined {
+	return (standup?.days ?? []).find((d) => d.commits.some((c) => c.hash === hash))?.day;
+}
 
 /**
  * Seeds one memories row plus its `memory_topics` rows — the source the
@@ -605,41 +628,317 @@ describe("buildDashboardModel", () => {
 		if (!standup) throw new Error("standup missing");
 		expect(standup.today).toBe("2026-07-30");
 		expect(standup.yesterday).toBe("2026-07-29");
-		expect(standup.yesterdaySessions.map((s) => s.sessionId)).toEqual(["yesterday-1"]);
-		expect(standup.yesterdayCommits).toEqual([
+		expect(standup.windowFrom).toBe("2026-07-24");
+		expect(standup.windowTo).toBe("2026-07-30");
+		// abc1234 landed yesterday (Jul 29); it sits in that column, and today is empty.
+		expect(commitDayKey(standup, "abc1234")).toBe("2026-07-29");
+		expect(commitByHash(standup, "abc1234")).toEqual(
 			expect.objectContaining({
 				hash: "abc1234",
 				message: "feat: yesterday's commit",
 				branch: "main",
 				repoName: "jolli",
 			}),
-		]);
-		expect(standup.todaySessions.map((s) => s.sessionId)).toEqual(["today-1"]);
-		expect(standup.todayCommits).toEqual([]);
+		);
+		expect(standup.days.find((d) => d.day === "2026-07-30")?.commits ?? []).toEqual([]);
 		expect(standup.workspaces).toEqual([
 			{ repoName: "jolli", branch: "main", filesChanged: 6, insertions: 184, deletions: 22 },
 		]);
 	});
 
-	it("moves a 23:30 UTC session into the next local day under Asia/Shanghai", async () => {
+	/** A `commit.created` event on a given ISO instant, in `repo-1`. */
+	const commitAt = (iso: string, hash: string, message: string): StatsEventEnvelope => ({
+		producerKind: "cli",
+		event: {
+			type: "commit.created",
+			repoIdentity: "repo-1",
+			hash,
+			committedAtMs: Date.parse(iso),
+			message,
+			branch: "main",
+			branches: ["main"],
+			insertions: 1,
+			deletions: 0,
+		},
+	});
+
+	/** `repo.enabled` for `repo-1`, the prerequisite before any commit event. */
+	const repoEnabled: StatsEventEnvelope = {
+		producerKind: "cli",
+		event: { type: "repo.enabled", repoIdentity: "repo-1", repoName: "jolli", worktreeRoot: "/w", enabledAt: "t" },
+	};
+
+	it("windows the standup board to seven days, newest-first, ending today at offset 0", async () => {
 		await applySummaryEvents(
-			[session({ sessionId: "boundary", updatedAtMs: Date.parse("2026-07-29T23:30:00Z") })],
-			{
-				producerKind: "cli",
-				dbPath,
-			},
+			[
+				repoEnabled,
+				commitAt("2026-07-30T09:00:00Z", "c-today", "today commit"),
+				commitAt("2026-07-29T09:00:00Z", "c-yest", "yesterday commit"),
+				commitAt("2026-07-26T09:00:00Z", "c-sat", "saturday commit"),
+				commitAt("2026-07-24T09:00:00Z", "c-edge", "window edge commit"),
+				commitAt("2026-07-23T09:00:00Z", "c-older", "just before the window"),
+			],
+			{ producerKind: "cli", dbPath },
 		);
-		// In UTC that session is "yesterday"; in Shanghai it is "today".
+		const model = await withDashboardDb(
+			(db) =>
+				buildDashboardModel(db, {
+					view: "standup",
+					scope: { kind: "all" },
+					timeZone: "UTC",
+					nowMs,
+					standupOffset: 0,
+				}),
+			{ dbPath },
+		);
+		const standup = model.standup;
+		if (!standup) throw new Error("standup missing");
+		expect(standup.today).toBe("2026-07-30");
+		expect(standup.yesterday).toBe("2026-07-29");
+		expect(standup.windowFrom).toBe("2026-07-24");
+		expect(standup.windowTo).toBe("2026-07-30");
+		// Seven columns, newest first — the mockup's Today-on-the-left order.
+		expect(standup.days.map((d) => d.day)).toEqual([
+			"2026-07-30",
+			"2026-07-29",
+			"2026-07-28",
+			"2026-07-27",
+			"2026-07-26",
+			"2026-07-25",
+			"2026-07-24",
+		]);
+		const byDay = Object.fromEntries(standup.days.map((d) => [d.day, d.commits.map((c) => c.hash)]));
+		expect(byDay["2026-07-30"]).toEqual(["c-today"]);
+		expect(byDay["2026-07-29"]).toEqual(["c-yest"]);
+		expect(byDay["2026-07-26"]).toEqual(["c-sat"]);
+		expect(byDay["2026-07-24"]).toEqual(["c-edge"]);
+		expect(byDay["2026-07-25"]).toEqual([]);
+		// A commit the day before the window is excluded, not folded into the edge column.
+		const allHashes = standup.days.flatMap((d) => d.commits.map((c) => c.hash));
+		expect(allHashes).not.toContain("c-older");
+	});
+
+	it("reports no newer window and no older data when offset 0 holds the earliest commit", async () => {
+		await applySummaryEvents(
+			[
+				repoEnabled,
+				commitAt("2026-07-30T09:00:00Z", "c-today", "today commit"),
+				commitAt("2026-07-24T09:00:00Z", "c-edge", "window edge commit"),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		const model = await withDashboardDb(
+			(db) =>
+				buildDashboardModel(db, {
+					view: "standup",
+					scope: { kind: "all" },
+					timeZone: "UTC",
+					nowMs,
+					standupOffset: 0,
+				}),
+			{ dbPath },
+		);
+		expect(model.standup?.hasNewer).toBe(false);
+		expect(model.standup?.hasOlder).toBe(false);
+	});
+
+	it("pages back a whole week at offset 1 and reports a newer window", async () => {
+		await applySummaryEvents(
+			[
+				repoEnabled,
+				commitAt("2026-07-30T09:00:00Z", "c-today", "today commit"),
+				commitAt("2026-07-20T09:00:00Z", "c-lastweek", "last week commit"),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		const model = await withDashboardDb(
+			(db) =>
+				buildDashboardModel(db, {
+					view: "standup",
+					scope: { kind: "all" },
+					timeZone: "UTC",
+					nowMs,
+					standupOffset: 1,
+				}),
+			{ dbPath },
+		);
+		const standup = model.standup;
+		if (!standup) throw new Error("standup missing");
+		// The seven days ending Jul 23 — the week before the one ending today.
+		expect(standup.offset).toBe(1);
+		expect(standup.windowFrom).toBe("2026-07-17");
+		expect(standup.windowTo).toBe("2026-07-23");
+		expect(standup.days.map((d) => d.day)).toEqual([
+			"2026-07-23",
+			"2026-07-22",
+			"2026-07-21",
+			"2026-07-20",
+			"2026-07-19",
+			"2026-07-18",
+			"2026-07-17",
+		]);
+		const byDay = Object.fromEntries(standup.days.map((d) => [d.day, d.commits.map((c) => c.hash)]));
+		expect(byDay["2026-07-20"]).toEqual(["c-lastweek"]);
+		// Today's commit is newer than this window and must not leak into it.
+		expect(standup.days.flatMap((d) => d.commits.map((c) => c.hash))).not.toContain("c-today");
+		expect(standup.hasNewer).toBe(true);
+		expect(standup.hasOlder).toBe(false);
+	});
+
+	it("clamps a non-integer or negative offset to the window ending today", async () => {
+		await applySummaryEvents([repoEnabled, commitAt("2026-07-30T09:00:00Z", "c-today", "today commit")], {
+			producerKind: "cli",
+			dbPath,
+		});
+		for (const bad of [1.5, -3]) {
+			const model = await withDashboardDb(
+				(db) =>
+					buildDashboardModel(db, {
+						view: "standup",
+						scope: { kind: "all" },
+						timeZone: "UTC",
+						nowMs,
+						standupOffset: bad,
+					}),
+				{ dbPath },
+			);
+			expect(model.standup?.offset).toBe(0);
+			expect(model.standup?.windowTo).toBe("2026-07-30");
+			expect(model.standup?.hasNewer).toBe(false);
+		}
+	});
+
+	it("clamps an out-of-range offset to STANDUP_MAX_OFFSET rather than spinning addLocalDays", async () => {
+		// `offset` is deep-linkable, so a crafted magnitude must not reach addLocalDays'
+		// per-day loop unbounded. The clamp lands on the furthest window, one year back.
+		await applySummaryEvents([repoEnabled, commitAt("2026-07-30T09:00:00Z", "c-today", "today commit")], {
+			producerKind: "cli",
+			dbPath,
+		});
+		const model = await withDashboardDb(
+			(db) =>
+				buildDashboardModel(db, {
+					view: "standup",
+					scope: { kind: "all" },
+					timeZone: "UTC",
+					nowMs,
+					standupOffset: 99_999_999,
+				}),
+			{ dbPath },
+		);
+		expect(model.standup?.offset).toBe(STANDUP_MAX_OFFSET);
+		// The window is the seven days ending 52 weeks (364 days) before today.
+		expect(model.standup?.windowTo).toBe("2025-07-31");
+		expect(model.standup?.windowFrom).toBe("2025-07-25");
+	});
+
+	it("drops a rewritten-away commit from its day column and from hasOlder", async () => {
+		// A rebase/squash leaves the pre-rewrite commit's row in `commits` forever;
+		// standup is a first-person feed, so an unreachable hash is a false claim.
+		await applySummaryEvents(
+			[
+				repoEnabled,
+				commitAt("2026-07-29T09:00:00Z", "c-live", "reachable commit"),
+				commitAt("2026-07-28T09:00:00Z", "c-dead", "squashed-away commit"),
+				commitAt("2026-07-10T09:00:00Z", "c-old-dead", "older squashed-away commit"),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		const model = await withDashboardDb(
+			(db) =>
+				buildDashboardModel(db, {
+					view: "standup",
+					scope: { kind: "all" },
+					timeZone: "UTC",
+					nowMs,
+					standupOffset: 0,
+					// Only c-live remains reachable from a ref; the other two were rewritten away.
+					reachableCommits: new Map([["repo-1", new Set(["c-live"])]]),
+				}),
+			{ dbPath },
+		);
+		const standup = model.standup;
+		if (!standup) throw new Error("standup missing");
+		const allHashes = standup.days.flatMap((d) => d.commits.map((c) => c.hash));
+		expect(allHashes).toContain("c-live");
+		expect(allHashes).not.toContain("c-dead");
+		// The only older commit (c-old-dead) is unreachable, so `›` stays disabled.
+		expect(standup.hasOlder).toBe(false);
+	});
+
+	it("keeps hasOlder true when a reachable commit precedes the window", async () => {
+		await applySummaryEvents(
+			[
+				repoEnabled,
+				commitAt("2026-07-30T09:00:00Z", "c-today", "today commit"),
+				commitAt("2026-07-10T09:00:00Z", "c-old-live", "older reachable commit"),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		const model = await withDashboardDb(
+			(db) =>
+				buildDashboardModel(db, {
+					view: "standup",
+					scope: { kind: "all" },
+					timeZone: "UTC",
+					nowMs,
+					standupOffset: 0,
+					reachableCommits: new Map([["repo-1", new Set(["c-today", "c-old-live"])]]),
+				}),
+			{ dbPath },
+		);
+		expect(model.standup?.hasOlder).toBe(true);
+	});
+
+	it("disables `›` at STANDUP_MAX_OFFSET even when reachable older commits precede that window", async () => {
+		// The furthest window paging can reach ends 52 weeks back; a further click is
+		// clamped straight back onto it, so `›` there is a dead button. `hasOlder` must
+		// respect the ceiling even though older reachable commits DO exist before the
+		// window — the containment query alone would enable the arrow onto a window the
+		// clamp never lets you leave. Without the `safeOffset < STANDUP_MAX_OFFSET`
+		// guard this fixture reports `hasOlder: true`.
+		await applySummaryEvents(
+			[
+				repoEnabled,
+				commitAt("2026-07-30T09:00:00Z", "c-today", "today commit"),
+				commitAt("2025-07-28T09:00:00Z", "c-furthest", "inside the furthest window"),
+				commitAt("2025-07-01T09:00:00Z", "c-beyond", "older than the furthest window"),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		const model = await withDashboardDb(
+			(db) =>
+				buildDashboardModel(db, {
+					view: "standup",
+					scope: { kind: "all" },
+					timeZone: "UTC",
+					nowMs,
+					standupOffset: STANDUP_MAX_OFFSET,
+					// All reachable: the older commit is real, so only the ceiling can disable `›`.
+					reachableCommits: new Map([["repo-1", new Set(["c-today", "c-furthest", "c-beyond"])]]),
+				}),
+			{ dbPath },
+		);
+		expect(model.standup?.offset).toBe(STANDUP_MAX_OFFSET);
+		expect(model.standup?.hasOlder).toBe(false);
+	});
+
+	it("buckets a 23:30 UTC commit into the next local day column under Asia/Shanghai", async () => {
+		await applySummaryEvents([repoEnabled, commitAt("2026-07-29T23:30:00Z", "boundary", "edge commit")], {
+			producerKind: "cli",
+			dbPath,
+		});
+		// In UTC that commit is on Jul 29; in Shanghai (+08:00 → 07:30) it is Jul 30.
 		const utc = await withDashboardDb(
 			(db) => buildDashboardModel(db, { view: "standup", scope: { kind: "all" }, timeZone: "UTC", nowMs }),
 			{ dbPath },
 		);
-		expect(utc.standup?.yesterdaySessions.map((s) => s.sessionId)).toEqual(["boundary"]);
+		expect(commitDayKey(utc.standup, "boundary")).toBe("2026-07-29");
 		const shanghai = await withDashboardDb(
 			(db) => buildDashboardModel(db, { view: "standup", scope: { kind: "all" }, timeZone: SH, nowMs }),
 			{ dbPath },
 		);
-		expect(shanghai.standup?.todaySessions.map((s) => s.sessionId)).toEqual(["boundary"]);
+		expect(commitDayKey(shanghai.standup, "boundary")).toBe("2026-07-30");
 	});
 
 	/** A second and third repo, each with one session, alongside `seed()`'s. */
@@ -817,8 +1116,8 @@ describe("buildDashboardModel", () => {
 		);
 		const standup = model.standup;
 		if (!standup) throw new Error("standup missing");
-		expect(standup.todaySessions[0].title).toBe("claude session");
-		const commit = standup.todayCommits[0];
+		const commit = commitByHash(standup, "bare1");
+		if (!commit) throw new Error("bare1 commit missing");
 		expect(commit.message).toBe("");
 		expect(commit).not.toHaveProperty("branch");
 		expect(commit).not.toHaveProperty("insertions");
@@ -3374,22 +3673,17 @@ describe("buildDashboardModel — memory tier (phase 2)", () => {
 		expect(model.stats?.seriesKeys).toEqual(["codex"]);
 	});
 
-	it("surfaces standup insights ordered risks-first from the window's commits", async () => {
+	it("marks the memory tier with a present-but-empty insights flag, fetching no content", async () => {
+		// `insights` is a tier flag carried by PRESENCE, not a payload: the board
+		// renders no insight text (JOLLI-2200/2201), so it is an empty array at the
+		// memory tier and the server no longer runs a query to fill it. The seeded
+		// memories carry decisions/todo the old code would have surfaced here.
 		await seedMemory();
 		const model = await withDashboardDb(
 			(db) => buildDashboardModel(db, { view: "standup", scope: { kind: "all" }, timeZone: "UTC", nowMs }),
 			{ dbPath },
 		);
-		const insights = model.standup?.insights;
-		if (!insights) throw new Error("insights missing at memory tier");
-		// Derivation reality: summaries carry decisions/todo per topic, nothing
-		// else — todo ranks ahead of decision in the risk ordering.
-		expect(insights.map((i) => i.kind)).toEqual(["todo", "todo", "decision"]);
-		expect(insights[0]).toMatchObject({
-			text: "CI flaky",
-			commitHash: "mem1",
-			repoName: "jolli",
-		});
+		expect(model.standup?.insights).toEqual([]);
 	});
 
 	it("omits standup insights entirely below the memory tier", async () => {
@@ -3413,13 +3707,15 @@ describe("buildDashboardModel — memory tier (phase 2)", () => {
 		await seedMemory();
 		const standup = await standupOf();
 		// mem1 landed today and names a ticket; mem2 landed yesterday and does not.
-		expect(standup?.todayCommits[0]).toMatchObject({
+		expect(commitDayKey(standup, "mem1")).toBe(standup?.today);
+		expect(commitByHash(standup, "mem1")).toMatchObject({
 			hash: "mem1",
 			turns: 10,
 			estCostUsd: 3,
 			ticketId: "JOLLI-2069",
 		});
-		const yesterday = standup?.yesterdayCommits[0];
+		expect(commitDayKey(standup, "mem2")).toBe(standup?.yesterday);
+		const yesterday = commitByHash(standup, "mem2");
 		expect(yesterday).toMatchObject({ hash: "mem2", turns: 4, estCostUsd: 1 });
 		// Absent, not zero or empty: the row has to be able to omit what it does not
 		// know rather than render "$0.00 est" as if that were measured.
@@ -3456,7 +3752,7 @@ describe("buildDashboardModel — memory tier (phase 2)", () => {
 		);
 		// Mode: two feature topics outvote one ux topic.
 		await seedTopicRows(dbPath, "cat1", ["feature", "ux", "feature"]);
-		expect((await standupOf())?.todayCommits[0]).toMatchObject({ hash: "cat1", workCategory: "feature" });
+		expect(commitByHash(await standupOf(), "cat1")).toMatchObject({ hash: "cat1", workCategory: "feature" });
 	});
 
 	it("breaks label ties toward the first-appearing category — the stored copy's exact rule", async () => {
@@ -3492,7 +3788,7 @@ describe("buildDashboardModel — memory tier (phase 2)", () => {
 		);
 		// bugfix and ux both count 2; bugfix's first topic sits at pos 0.
 		await seedTopicRows(dbPath, "tie1", ["bugfix", "ux", "ux", "bugfix"]);
-		expect((await standupOf())?.todayCommits[0]).toMatchObject({ hash: "tie1", workCategory: "bugfix" });
+		expect(commitByHash(await standupOf(), "tie1")).toMatchObject({ hash: "tie1", workCategory: "bugfix" });
 	});
 
 	it("leaves the memory-tier columns off a commit only git reported", async () => {
@@ -3521,20 +3817,11 @@ describe("buildDashboardModel — memory tier (phase 2)", () => {
 			],
 			{ producerKind: "cli", dbPath },
 		);
-		const commit = (await standupOf())?.todayCommits[0];
+		const commit = commitByHash(await standupOf(), "raw1");
 		expect(commit).toMatchObject({ hash: "raw1" });
 		expect(commit).not.toHaveProperty("turns");
 		expect(commit).not.toHaveProperty("estCostUsd");
 		expect(commit).not.toHaveProperty("ticketId");
-	});
-
-	it("dates every standup insight by the commit that raised it", async () => {
-		await seedMemory();
-		const insights = (await standupOf())?.insights ?? [];
-		expect(insights.length).toBeGreaterThan(0);
-		expect(insights.every((insight) => typeof insight.committedAtMs === "number")).toBe(true);
-		// "CI flaky" came out of mem1, which landed three hours before now.
-		expect(insights.find((insight) => insight.text === "CI flaky")?.committedAtMs).toBe(nowMs - 3 * 3_600_000);
 	});
 });
 
@@ -4164,20 +4451,17 @@ describe("standup author filter", () => {
 	it("keeps only the local identity's commits, matching email case-insensitively or name", async () => {
 		await seedSharedBranch();
 		const standup = await standupOf(MINE);
-		expect(standup?.todayCommits.map((c) => c.hash).sort()).toEqual(["mine1", "mine2"]);
+		expect(
+			standupCommits(standup)
+				.map((c) => c.hash)
+				.sort(),
+		).toEqual(["mine1", "mine2"]);
 		expect(standup?.authoredBy).toBe("Me@Example.com");
 	});
 
-	it("drops a teammate's TODO out of the Risks column", async () => {
-		await seedSharedBranch();
-		const insights = (await standupOf(MINE))?.insights ?? [];
-		expect(insights.map((i) => i.text)).toEqual(["my own TODO"]);
-	});
-
-	it("leaves sessions and the dirty worktree unfiltered — they are this machine's own state", async () => {
+	it("leaves the dirty worktree unfiltered — it is this machine's own state", async () => {
 		await seedSharedBranch();
 		const standup = await standupOf(MINE);
-		expect(standup?.todaySessions.map((s) => s.sessionId)).toEqual(["s1"]);
 		expect(standup?.workspaces).toHaveLength(1);
 	});
 
@@ -4185,9 +4469,12 @@ describe("standup author filter", () => {
 		await seedSharedBranch();
 		for (const identity of [undefined, { emails: [], names: [] }, { emails: ["  "], names: [" "] }]) {
 			const standup = await standupOf(identity);
-			expect(standup?.todayCommits.map((c) => c.hash).sort()).toEqual(["mine1", "mine2", "theirs1"]);
+			expect(
+				standupCommits(standup)
+					.map((c) => c.hash)
+					.sort(),
+			).toEqual(["mine1", "mine2", "theirs1"]);
 			expect(standup).not.toHaveProperty("authoredBy");
-			expect((standup?.insights ?? []).length).toBe(2);
 		}
 	});
 
@@ -4195,7 +4482,11 @@ describe("standup author filter", () => {
 		await seedSharedBranch();
 		const standup = await standupOf({ emails: [], names: ["Me"] });
 		expect(standup?.authoredBy).toBe("Me");
-		expect(standup?.todayCommits.map((c) => c.hash).sort()).toEqual(["mine1", "mine2"]);
+		expect(
+			standupCommits(standup)
+				.map((c) => c.hash)
+				.sort(),
+		).toEqual(["mine1", "mine2"]);
 	});
 
 	it("never filters the stats page — repo activity is not a first-person question", async () => {

--- a/cli/src/dashboard/DashboardQuery.ts
+++ b/cli/src/dashboard/DashboardQuery.ts
@@ -27,7 +27,6 @@ import { ACTIVITY_BUCKET_MS } from "./ActivityBuckets.js";
 import type { DashboardDbHandle } from "./DashboardDb.js";
 import type {
 	AdoptionTier,
-	CommitInsightKind,
 	ConcurrencyModel,
 	CoverageNote,
 	DashboardMenus,
@@ -52,7 +51,7 @@ import type {
 	SkillDayPoint,
 	SkillDetail,
 	StandupCommit,
-	StandupInsight,
+	StandupDay,
 	StandupModel,
 	StandupWorkspace,
 	StatsModel,
@@ -267,6 +266,12 @@ export interface QueryOptions {
 	 * unfiltered; see {@link authorFilter} for why that fail-open matters.
 	 */
 	readonly authorIdentity?: AuthorIdentity;
+	/**
+	 * Standup view: whole-week paging offset. 0 (or absent) shows the window
+	 * ending today; each increment pages back another seven days. See
+	 * {@link StandupModel} for the window it selects.
+	 */
+	readonly standupOffset?: number;
 	/** Knowledge view: the async-read Memory Bank `_wiki` file lists. Absent renders an empty list. */
 	readonly knowledgeModel?: KnowledgeModel;
 	/** Graph view: the async-read Memory Bank repo list. Absent renders an empty list. */
@@ -777,10 +782,9 @@ function buildDecisionsCard(
 			   -- under the pre-rewrite hash, reachable only through the alias.
 			   JOIN topic_insights i ON i.repo_id = c.repo_id AND (i.commit_hash = c.hash OR i.commit_hash = al.target_hash)
 			  WHERE i.kind = 'decision' AND c.committed_at_ms >= ? AND c.committed_at_ms < ?${filter.sql}
-			  -- i.ord for the same reason buildStandupInsights carries it: one commit
-			  -- contributes several decision rows sharing its timestamp, so the date
-			  -- alone does not pick a first row — and rows[0] here IS the card (its
-			  -- one line and its one deep link).
+			  -- i.ord because one commit contributes several decision rows sharing its
+			  -- timestamp, so the date alone does not pick a first row — and rows[0]
+			  -- here IS the card (its one line and its one deep link).
 			  ORDER BY c.committed_at_ms DESC, i.ord`,
 		)
 		.all(fromMs, toMs, ...filter.params) as ReadonlyArray<{
@@ -1013,65 +1017,74 @@ function toRecentSession(s: SessionRow, nowMs: number): RecentSession {
 
 // ── Standup page ────────────────────────────────────────────────────────────
 
-/**
- * Render order for standup insights: risks first, notes last.
- *
- * The first three entries never match anything — {@link TOPIC_INSIGHTS_CTE} emits
- * only `decision` and `todo` — so today this sorts TODOs ahead of decisions and
- * nothing else. Kept whole rather than trimmed to the producible pair: the order
- * is the answer to "where would a risk go", which is a question the list should
- * still answer if the summarizer learns to record one. See `CommitInsightKind`.
- */
-const INSIGHT_ORDER: ReadonlyArray<CommitInsightKind> = ["blocker", "question", "gotcha", "todo", "decision"];
+/** Days in a single standup window, and the paging step between adjacent windows. */
+const STANDUP_WINDOW_DAYS = 7;
 
-/** Insights mined from the standup window's commit memories. */
-function buildStandupInsights(
+/**
+ * The furthest back `›` can page — one year of whole weeks. An upper bound is
+ * load-bearing, not cosmetic: `offset` is deep-linkable and reload-safe, so a
+ * crafted or mistyped `?offset=99999999` reaches `addLocalDays`, whose loop
+ * steps one local day at a time and would spin ~700M Intl-backed iterations,
+ * blocking the single-threaded dashboard for every tab. Clamped here (the query
+ * layer every caller passes through) and again at the URL parse boundary.
+ */
+export const STANDUP_MAX_OFFSET = 52;
+
+/**
+ * How many newest-first rows {@link hasCommitsBefore} pulls while looking for a
+ * reachable one. A generous ceiling, not a correctness knob: unreachable rows are
+ * only rebase/squash residue, so the first reachable commit is in practice the
+ * very newest older row, and a run of this many CONSECUTIVE residue rows sitting
+ * ahead of a real older commit does not occur. The bound is what keeps a
+ * per-render / per-30s-poll query off a full materialise-and-sort of `commits`,
+ * which is machine-global and grows without bound (DbBackfill imports whole
+ * histories) and has no single-column `committed_at_ms` index. Were the bound ever
+ * exceeded the only cost is `›` disabling one window early — never wrong data.
+ */
+const HAS_OLDER_SCAN_LIMIT = 256;
+
+/**
+ * Is there a REACHABLE, author-filtered commit strictly before `beforeMs` in
+ * scope? Drives `hasOlder`.
+ *
+ * Reachability is a JS-side set (git, not the DB — see {@link ReachableCommits}),
+ * so this cannot be a bare SQL `EXISTS`: a rebased or squashed-away commit keeps
+ * its `commits` row forever, and counting it would enable `›` onto a window whose
+ * only commits no longer exist in git. Rows are read newest-first, bounded to the
+ * first {@link HAS_OLDER_SCAN_LIMIT}; `.some` then returns at the first reachable
+ * one — in practice the very newest older commit, since unreachable rows are only
+ * rebase/squash residue. The `LIMIT` is load-bearing, not decorative: without it
+ * this materialises and sorts the whole `commits` table (no `committed_at_ms`
+ * index) on every render and poll, for a single boolean (see that constant for why
+ * the bound cannot lose a real answer). When `reachable` is absent (fail-open)
+ * `isReachable` accepts the first row, so this collapses back to the old existence
+ * check.
+ *
+ * This answers "is there ANY older commit", NOT "is the next window non-empty":
+ * paging steps a fixed seven-day calendar week, so a gap in history still lets
+ * the reader page through intermediate empty weeks before reaching older data —
+ * intended for a weekly board, where an empty week is truthful. What it guards is
+ * the TERMINAL case: `›` never runs off the end into a window with nothing beyond.
+ */
+function hasCommitsBefore(
 	db: DashboardDbHandle,
 	scope: DashboardScope,
-	fromMs: number,
-	toMs: number,
+	beforeMs: number,
 	identity: AuthorIdentity | undefined,
-): StandupInsight[] {
+	reachable: ReachableCommits | undefined,
+): boolean {
 	const filter = scopeFilter(scopeToRepoIds(db, scope), "c.repo_id");
-	// Same filter as the commit columns, and for a stronger reason: the Risks
-	// column is a list of things the reader is expected to answer for. A
-	// teammate's blocker rendered here is work silently reassigned to whoever
-	// reads the board.
 	const author = authorFilter(identity, "c");
 	const rows = db
 		.prepare(
-			`${TOPIC_INSIGHTS_CTE}
-			 SELECT i.kind, i.text, i.addressed_to, c.hash, c.committed_at_ms, r.repo_name
-			   FROM commits c
-			   JOIN repos r ON r.id = c.repo_id
-			   LEFT JOIN commit_aliases al ON al.repo_id = c.repo_id AND al.old_hash = c.hash
-			   -- See commitsInRange / buildDecisionsCard: a rewritten commit's insights
-			   -- are still filed under the pre-rewrite hash, reachable only through the
-			   -- alias. Without this join an amended commit's blockers and questions
-			   -- vanish from Standup while its decisions still render on the Decisions
-			   -- card, which reads the same table through the alias.
-			   JOIN topic_insights i ON i.repo_id = c.repo_id AND (i.commit_hash = c.hash OR i.commit_hash = al.target_hash)
-			  WHERE c.committed_at_ms >= ? AND c.committed_at_ms < ?${filter.sql}${author.sql}
-			  ORDER BY c.committed_at_ms DESC, i.ord`,
+			`SELECT c.hash, r.repo_identity
+			   FROM commits c JOIN repos r ON r.id = c.repo_id
+			  WHERE c.committed_at_ms < ?${filter.sql}${author.sql}
+			  ORDER BY c.committed_at_ms DESC
+			  LIMIT ${HAS_OLDER_SCAN_LIMIT}`,
 		)
-		.all(fromMs, toMs, ...filter.params, ...author.params) as ReadonlyArray<{
-		kind: string;
-		text: string;
-		addressed_to: string | null;
-		hash: string;
-		committed_at_ms: number;
-		repo_name: string;
-	}>;
-	return rows
-		.map((row) => ({
-			kind: row.kind as CommitInsightKind,
-			text: row.text,
-			commitHash: row.hash,
-			repoName: row.repo_name,
-			committedAtMs: row.committed_at_ms,
-			...(row.addressed_to ? { addressedTo: row.addressed_to } : {}),
-		}))
-		.sort((a, b) => INSIGHT_ORDER.indexOf(a.kind) - INSIGHT_ORDER.indexOf(b.kind));
+		.all(beforeMs, ...filter.params, ...author.params) as ReadonlyArray<{ hash: string; repo_identity: string }>;
+	return rows.some((row) => isReachable(reachable, row.repo_identity, row.hash));
 }
 
 function buildStandup(
@@ -1081,10 +1094,19 @@ function buildStandup(
 	nowMs: number,
 	tier: AdoptionTier,
 	identity: AuthorIdentity | undefined,
+	/** Whole-week paging offset: 0 = window ending today, 1 = the previous seven days, … */
+	offset: number,
+	/** Reachable commit sets, keyed by `repo_identity` — see {@link ReachableCommits}. */
+	reachable: ReachableCommits | undefined,
 ): StandupModel {
-	const todayStart = startOfLocalDay(nowMs, timeZone);
-	const tomorrowStart = addLocalDays(nowMs, 1, timeZone);
-	const yesterdayStart = addLocalDays(nowMs, -1, timeZone);
+	/* The anchor is the newest day shown. offset pages a whole week at a time, so
+	   the window is always the seven local days ending on the anchor. Clamped to
+	   [0, STANDUP_MAX_OFFSET]: negatives and non-integers fall to today's window,
+	   and an out-of-range magnitude is capped rather than left to spin addLocalDays. */
+	const safeOffset = Number.isInteger(offset) ? Math.min(Math.max(offset, 0), STANDUP_MAX_OFFSET) : 0;
+	const anchorStart = addLocalDays(nowMs, -STANDUP_WINDOW_DAYS * safeOffset, timeZone);
+	const windowStart = addLocalDays(anchorStart, -(STANDUP_WINDOW_DAYS - 1), timeZone);
+	const windowEnd = addLocalDays(anchorStart, 1, timeZone);
 
 	/* What the header states the board is filtered to. Derived from the SAME
 	   identity the queries were given (and by the same emptiness rule), so the
@@ -1145,21 +1167,64 @@ function buildStandup(
 		deletions: w.deletions ?? 0,
 	}));
 
+	/* One query over the whole window, then bucketed by local day. commitsInRange
+	   orders newest-first; a day column reads oldest-first (the mockup's order), so
+	   each bucket accumulates newest-first with push and is reversed ONCE when the
+	   day is emitted below — not `unshift`ed per row, which is O(n²) in a busy day's
+	   commit count. Rewritten-away commits are dropped, not shown: a rebase/squash
+	   leaves their `commits` row behind, and the board is a first-person "what I did"
+	   feed, so a commit that no longer exists in git is a false claim rather than
+	   noise — see ReachableCommits. */
+	const byDay = new Map<string, StandupCommit[]>();
+	for (const row of commitsInRange(db, scope, windowStart, windowEnd, identity)) {
+		if (!isReachable(reachable, row.repo_identity, row.hash)) continue;
+		const key = localDayKey(row.committed_at_ms, timeZone);
+		const bucket = byDay.get(key);
+		if (bucket) bucket.push(toStandupCommit(row));
+		else byDay.set(key, [toStandupCommit(row)]);
+	}
+
+	/* Seven columns, newest first — every day present so the grid is stable, quiet
+	   days rendered as an empty column. Each bucket was filled newest-first, so it is
+	   reversed here (in place, once) to the oldest-first order a column reads in. */
+	const days: StandupDay[] = [];
+	for (let d = 0; d < STANDUP_WINDOW_DAYS; d++) {
+		const key = localDayKey(addLocalDays(anchorStart, -d, timeZone), timeZone);
+		const bucket = byDay.get(key);
+		if (bucket) bucket.reverse();
+		days.push({ day: key, commits: bucket ?? [] });
+	}
+
 	return {
 		today: localDayKey(nowMs, timeZone),
-		yesterday: localDayKey(yesterdayStart, timeZone),
-		/* Sessions and workspaces carry no author filter, and need none: an agent
-		   session and an uncommitted diff are this machine's own working state, so
-		   they are already first-person. Only `commits` can hold a teammate's row. */
-		yesterdaySessions: sessionsInRange(db, scope, yesterdayStart, todayStart).map((s) => toRecentSession(s, nowMs)),
-		yesterdayCommits: commitsInRange(db, scope, yesterdayStart, todayStart, identity).map(toStandupCommit),
-		todaySessions: sessionsInRange(db, scope, todayStart, tomorrowStart).map((s) => toRecentSession(s, nowMs)),
-		todayCommits: commitsInRange(db, scope, todayStart, tomorrowStart, identity).map(toStandupCommit),
+		yesterday: localDayKey(addLocalDays(nowMs, -1, timeZone), timeZone),
+		windowFrom: localDayKey(windowStart, timeZone),
+		windowTo: localDayKey(anchorStart, timeZone),
+		offset: safeOffset,
+		days,
+		/* `‹` (newer) exists whenever the anchor is before today; `›` (older) whenever
+		   there is a REACHABLE, author-filtered commit anywhere before the window AND
+		   the window is not already the furthest one paging can reach. Paging steps a
+		   fixed calendar week, so on a history with gaps the reader can still land on
+		   intermediate empty weeks before reaching older data — that is intended for a
+		   weekly board. What `hasOlder` guarantees is the terminal case: `›` never
+		   enables a window with nothing beyond it — and the STANDUP_MAX_OFFSET ceiling
+		   is exactly such a nothing-beyond, because `safeOffset` clamps a further click
+		   straight back onto this same window, so an enabled `›` there is a dead button
+		   (the invariant the containment query was added to hold). The `&&` also skips
+		   that query at the ceiling, where its answer cannot change the result. */
+		hasNewer: safeOffset > 0,
+		hasOlder: safeOffset < STANDUP_MAX_OFFSET && hasCommitsBefore(db, scope, windowStart, identity, reachable),
 		workspaces,
 		...(authoredBy ? { authoredBy } : {}),
-		...(tier !== "installed"
-			? { insights: buildStandupInsights(db, scope, yesterdayStart, tomorrowStart, identity) }
-			: {}),
+		/* `insights` survives ONLY as the memory-tier flag its PRESENCE carries — the
+		   board renders no insight text (JOLLI-2200/2201: the column could never fill,
+		   and `renderStandup` reads only `!!standup.insights`). So it is an empty array
+		   at the tier and absent below it, and the content is deliberately not fetched:
+		   a per-window query whose every row the client discards was ~40 KB re-sent on
+		   each 30 s poll for a boolean. If a real insight column ever returns, this is
+		   where its query goes back. */
+		...(tier !== "installed" ? { insights: [] } : {}),
 	};
 }
 
@@ -2939,7 +3004,18 @@ export function buildDashboardModel(db: DashboardDbHandle, opts: QueryOptions): 
 					),
 				};
 			case "standup":
-				return { standup: buildStandup(db, options.scope, timeZone, nowMs, tier, options.authorIdentity) };
+				return {
+					standup: buildStandup(
+						db,
+						options.scope,
+						timeZone,
+						nowMs,
+						tier,
+						options.authorIdentity,
+						options.standupOffset ?? 0,
+						options.reachableCommits,
+					),
+				};
 			case "knowledge":
 				// Read off disk (Memory Bank `_wiki`), pre-built in the model builder
 				// like settings — there is no DB query for it here.

--- a/cli/src/dashboard/DashboardServer.test.ts
+++ b/cli/src/dashboard/DashboardServer.test.ts
@@ -92,6 +92,7 @@ import {
 	DASHBOARD_SCRIPT_FILES,
 	hasForeignOrigin,
 	isAllowedHost,
+	type ModelRequest,
 	resolveDashboardAssetsDir,
 	startDashboardServer,
 } from "./DashboardServer.js";
@@ -430,6 +431,26 @@ describe("routes", () => {
 		expect(res.status).toBe(200);
 		expect(((await res.json()) as DashboardModel).view).toBe("standup");
 		expect(scopes).toEqual([{ kind: "repo", repoIdentities: ["r1"] }]);
+	});
+
+	it("threads the standup whole-week paging offset from ?offset=, rejecting non-integer and negative", async () => {
+		const reqs: ModelRequest[] = [];
+		const port = await listen(
+			testServer({
+				buildModel: async (req) => {
+					reqs.push(req);
+					return model(req.view);
+				},
+			}),
+		);
+		await get(port, "/api/model?view=standup&offset=2");
+		await get(port, "/api/model?view=standup");
+		await get(port, "/api/model?view=standup&offset=-1");
+		await get(port, "/api/model?view=standup&offset=abc");
+		// Deep-linkable, so an out-of-range magnitude is clamped to the furthest page
+		// (STANDUP_MAX_OFFSET = 52) rather than dropped or forwarded to addLocalDays' loop.
+		await get(port, "/api/model?view=standup&offset=99999999");
+		expect(reqs.map((r) => r.standupOffset)).toEqual([2, undefined, undefined, undefined, 52]);
 	});
 
 	it("reads a multi-repo scope from REPEATED repo params", async () => {
@@ -1665,10 +1686,10 @@ describe("defaultModelBuilder (no injected buildModel)", () => {
 		expect(graph.graph?.repos[0]?.graphAvailable).toBe(true);
 	});
 
-	// Memories is the one view that reads git before querying: a rebase leaves
-	// rewritten commits in `memories` forever, so the list is filtered against
-	// what is still reachable. Only this view pays that cost, and only for
-	// repos that are still enabled.
+	// The Memories view reads git before querying: a rebase leaves rewritten
+	// commits in `memories` forever, so the list is filtered against what is still
+	// reachable. Stats and Standup pay the same cost (see REACHABILITY_VIEWS); the
+	// views outside that set skip it, and it is only paid for still-enabled repos.
 	it("reads reachable commits for the Memories view, and prunes rows that no branch reaches", async () => {
 		const dbPath = join(dir, "memories-reach.db");
 		const configDir = join(dir, "config");
@@ -2375,7 +2396,7 @@ describe("Decisions card gist (Stats view only)", () => {
 		expect(body.standup?.authoredBy).toBe("me@example.com");
 		// The seeded commit carries no author, so the filter excludes it — the proof
 		// the identity reached the query rather than being resolved and dropped.
-		expect(body.standup?.todayCommits).toEqual([]);
+		expect((body.standup?.days ?? []).flatMap((d) => d.commits)).toEqual([]);
 	});
 
 	it("never reads the git identity for views other than Standup", async () => {

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -128,6 +128,7 @@ import {
 	buildToolUsagePage,
 	clearWorktreeExistenceCache,
 	type QueryOptions,
+	STANDUP_MAX_OFFSET,
 } from "./DashboardQuery.js";
 import { projectRepoRegistryState } from "./DbBackfill.js";
 import { buildGraphViewerDocument } from "./GraphViewerDocument.js";
@@ -534,17 +535,23 @@ export type ModelRequest = Omit<QueryOptions, "timeZone" | "nowMs">;
 export type ModelBuilder = (request: ModelRequest) => Promise<DashboardModel>;
 
 /**
- * Views whose payload counts or renders per-MEMORY rows, and therefore pay for
- * one `git rev-list --branches` per repo. Deliberately not `standup`: its
- * commit lists — like the stats heatmap and KPI row — report activity, and a
- * commit that has since been squashed away still happened. Only the
- * memory-facing rows are filtered, because a rewritten commit's `memories` row
- * is a DUPLICATE of the surviving one, not a record of separate work.
+ * Views that filter rewritten-away commits, and therefore pay for one
+ * `git rev-list --branches` per repo.
+ *
+ * `stats` and `memories` join because their per-MEMORY rows are duplicates of the
+ * surviving one once a commit is rewritten, not a record of separate work.
+ * `standup` joins for a DIFFERENT reason: it is a FIRST-PERSON "what I did" feed
+ * whose columns the user pastes as their own standup, so a discrete line naming a
+ * commit hash that no longer exists in git is a false claim, and a squashed-away
+ * commit keeping `›` enabled onto an empty older window is the same defect one
+ * level up. This is the one place standup diverges from the stats heatmap and KPI
+ * row, which stay AGGREGATE activity counts — squashed work still happened, so it
+ * still counts there.
  *
  * `repositories` used to be here too, for its per-repo memory badge; it went
  * with that page.
  */
-const REACHABILITY_VIEWS: ReadonlySet<DashboardView> = new Set<DashboardView>(["stats", "memories"]);
+const REACHABILITY_VIEWS: ReadonlySet<DashboardView> = new Set<DashboardView>(["stats", "memories", "standup"]);
 
 /**
  * How long one worktree's git identity is trusted. Minutes, not hours: the value
@@ -1027,6 +1034,25 @@ function parseRange(url: URL): DashboardRange | undefined {
 }
 
 /**
+ * `offset=N` — the standup board's whole-week paging step. A non-negative
+ * integer, else absent (buildStandup then defaults to the window ending today).
+ * Validated here rather than forwarded verbatim like `from`/`to` because it
+ * reaches `addLocalDays`, which loops one local day at a time: a non-integer
+ * throws there, and an unbounded magnitude (this param is deep-linkable) would
+ * spin the single-threaded server for minutes. A too-large value is CLAMPED to
+ * the furthest page rather than dropped, so a stale deep link lands on the oldest
+ * window instead of silently snapping to today; `buildStandup` re-clamps for any
+ * caller that does not pass through here.
+ */
+function parseStandupOffset(url: URL): number | undefined {
+	const raw = url.searchParams.get("offset");
+	if (raw === null) return undefined;
+	const n = Number(raw);
+	if (!Number.isInteger(n) || n < 0) return undefined;
+	return Math.min(n, STANDUP_MAX_OFFSET);
+}
+
+/**
  * The query params that select a window and an axis.
  *
  * `from`/`to` are forwarded verbatim: validating them here as well as in
@@ -1052,6 +1078,7 @@ function parseWindow(url: URL): Omit<ModelRequest, "view" | "scope"> {
 	// parameters, and an unresolvable value means the detail falls back to the
 	// page scope rather than erroring.
 	const detailRepo = url.searchParams.get("detailRepo") ?? undefined;
+	const standupOffset = parseStandupOffset(url);
 	return {
 		...(dimension ? { dimension } : {}),
 		...(range ? { range } : {}),
@@ -1059,6 +1086,7 @@ function parseWindow(url: URL): Omit<ModelRequest, "view" | "scope"> {
 		...(customTo ? { customTo } : {}),
 		...(hash ? { hash } : {}),
 		...(detailRepo ? { detailRepoIdentity: detailRepo } : {}),
+		...(standupOffset !== undefined ? { standupOffset } : {}),
 	};
 }
 

--- a/cli/src/dashboard/ShellAsset.test.ts
+++ b/cli/src/dashboard/ShellAsset.test.ts
@@ -1150,3 +1150,124 @@ describe("JD.renderShell — optional nav rows", () => {
 		expect(navViews(h)).not.toContain("settings");
 	});
 });
+
+/**
+ * The standup week pager (topbar), which replaces the range control on the standup
+ * board. Two halves: `JD.query` carries the `offset` across a scope change or a
+ * reload and drops it on the way out, and `renderShell` wires the three controls'
+ * disabled state and destinations. The board itself had asset coverage before this;
+ * the pager did not, which is how a `›` left enabled at the furthest window (a dead
+ * button) could ship — see the STANDUP_MAX_OFFSET guard in DashboardQuery.ts.
+ */
+const standupModel = (standupOver: Record<string, unknown> = {}, modelOver: Record<string, unknown> = {}): unknown =>
+	model({
+		view: "standup",
+		// No ranged payload on standup — the board carries its own week window.
+		stats: undefined,
+		standup: {
+			windowFrom: "2026-07-24",
+			windowTo: "2026-07-30",
+			offset: 0,
+			hasNewer: false,
+			hasOlder: true,
+			days: [],
+			workspaces: [],
+			...standupOver,
+		},
+		...modelOver,
+	});
+
+describe("JD.query — standup offset", () => {
+	it("carries the offset from the model's own echo, so a reload preserves the window", () => {
+		const { JD } = loadJD();
+		expect(JD.query(standupModel({ offset: 3 }))).toBe("?offset=3");
+	});
+
+	it("keeps the offset when only the repo scope changes", () => {
+		const { JD } = loadJD();
+		const query = JD.query(standupModel({ offset: 2 }, { scope: scoped(JOLLIAI) }), { repo: [SITE] });
+		expect(query).toContain("offset=2");
+		expect(query).toContain("repo=site");
+	});
+
+	it("omits offset 0 — the current week is the bare URL", () => {
+		const { JD } = loadJD();
+		expect(JD.query(standupModel({ offset: 0 }))).toBe("");
+	});
+
+	it("drops the offset when it is explicitly cleared, as navigating away does", () => {
+		const { JD } = loadJD();
+		expect(JD.query(standupModel({ offset: 4 }), { offset: undefined })).toBe("");
+	});
+
+	it("never emits offset off the standup view, even with one in the model", () => {
+		const { JD } = loadJD();
+		// A stats model still carries stats, so this also proves the emit is gated on
+		// the view and not on the absence of a standup payload.
+		expect(JD.query(model(), { offset: 5 })).not.toContain("offset");
+	});
+});
+
+describe("the standup week pager", () => {
+	it("is hidden on a non-standup view", () => {
+		const h = loadJD();
+		h.JD.renderShell(model());
+		expect(h.element("standupPager").hidden).toBe(true);
+	});
+
+	it("shows the window range as its label", () => {
+		const h = loadJD();
+		h.JD.renderShell(standupModel({ windowFrom: "2026-07-24", windowTo: "2026-07-30" }));
+		expect(h.element("standupPager").hidden).toBe(false);
+		expect(h.element("standupPagerLabel").textContent).toBe("Jul 24 – 30");
+	});
+
+	it("on the current week disables ‹ and Today, and enables › when older data exists", () => {
+		const h = loadJD();
+		h.JD.renderShell(standupModel({ offset: 0, hasNewer: false, hasOlder: true }));
+		expect(h.element("standupNewer").disabled).toBe(true);
+		expect(h.element("standupToday").disabled).toBe(true);
+		expect(h.element("standupOlder").disabled).toBe(false);
+	});
+
+	it("at the furthest window disables › and enables ‹ / Today", () => {
+		// The server sets hasOlder:false at the STANDUP_MAX_OFFSET ceiling (a further
+		// click clamps back onto this window); the client must honour it. This is the
+		// asset-side half of the dead-button fix.
+		const h = loadJD();
+		h.JD.renderShell(standupModel({ offset: 52, hasNewer: true, hasOlder: false }));
+		expect(h.element("standupOlder").disabled).toBe(true);
+		expect(h.element("standupNewer").disabled).toBe(false);
+		expect(h.element("standupToday").disabled).toBe(false);
+	});
+
+	it("‹ pages one week newer, › one older, Today jumps to the current week", () => {
+		const h = loadJD();
+		h.JD.renderShell(standupModel({ offset: 3, hasNewer: true, hasOlder: true }));
+		h.element("standupNewer").onclick?.();
+		expect(h.href()).toBe("/dashboard/standup?offset=2");
+		h.element("standupOlder").onclick?.();
+		expect(h.href()).toBe("/dashboard/standup?offset=4");
+		h.element("standupToday").onclick?.();
+		// offset 0 is left out of the URL, so Today lands on the bare current-week path.
+		expect(h.href()).toBe("/dashboard/standup");
+	});
+
+	it("preserves the repo scope in a pager destination", () => {
+		const h = loadJD();
+		h.JD.renderShell(standupModel({ offset: 1, hasNewer: true, hasOlder: true }, { scope: scoped(JOLLIAI) }));
+		h.element("standupOlder").onclick?.();
+		expect(h.href()).toContain("/dashboard/standup?");
+		expect(h.href()).toContain("repo=jolliai");
+		expect(h.href()).toContain("offset=2");
+	});
+
+	it("a disabled control navigates nowhere", () => {
+		const h = loadJD();
+		h.JD.renderShell(standupModel({ offset: 0, hasNewer: false, hasOlder: false }));
+		h.element("standupNewer").onclick?.();
+		h.element("standupOlder").onclick?.();
+		h.element("standupToday").onclick?.();
+		expect(h.href()).toBe("");
+	});
+});

--- a/cli/src/dashboard/StandupAsset.test.ts
+++ b/cli/src/dashboard/StandupAsset.test.ts
@@ -21,6 +21,7 @@ import { describe, expect, it } from "vitest";
 
 interface JDNamespace {
 	renderStandup: (model: unknown) => void;
+	standupPagerLabel: (fromKey: string, toKey: string) => string;
 }
 
 interface FakeElement {
@@ -79,6 +80,26 @@ function loadJD(): { JD: JDNamespace; element: (id: string) => FakeElement } {
 
 const nowMs = Date.parse("2026-07-30T12:00:00Z");
 
+/** The seven local day keys of the default window, newest first (as the server emits them). */
+const WINDOW_DAYS = ["2026-07-30", "2026-07-29", "2026-07-28", "2026-07-27", "2026-07-26", "2026-07-25", "2026-07-24"];
+
+/** A full seven-day `days` array, with only the named days carrying commits. */
+function days(byDay: Record<string, unknown[]> = {}): unknown[] {
+	return WINDOW_DAYS.map((day) => ({ day, commits: byDay[day] ?? [] }));
+}
+
+/** One commit row, defaulted so a test names only the fields it cares about. */
+function commit(over: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		hash: "abc1234def",
+		message: "feat: my work",
+		committedAtMs: nowMs - 26 * 3_600_000,
+		repoName: "jolliai",
+		branch: "main",
+		...over,
+	};
+}
+
 function model(standupOver: Record<string, unknown> = {}): unknown {
 	return {
 		schemaVersion: 1,
@@ -92,24 +113,35 @@ function model(standupOver: Record<string, unknown> = {}): unknown {
 		standup: {
 			today: "2026-07-30",
 			yesterday: "2026-07-29",
-			yesterdaySessions: [],
-			yesterdayCommits: [
-				{
-					hash: "abc1234def",
-					message: "feat: my work",
-					committedAtMs: nowMs - 26 * 3_600_000,
-					repoName: "jolliai",
-					branch: "main",
-				},
-			],
-			todaySessions: [],
-			todayCommits: [],
+			windowFrom: "2026-07-24",
+			windowTo: "2026-07-30",
+			offset: 0,
+			days: days({ "2026-07-29": [commit()] }),
+			hasNewer: false,
+			hasOlder: false,
 			workspaces: [],
 			insights: [],
 			...standupOver,
 		},
 	};
 }
+
+describe("standup pager label", () => {
+	it("collapses a same-month window to a single month name", () => {
+		const { JD } = loadJD();
+		expect(JD.standupPagerLabel("2026-07-24", "2026-07-30")).toBe("Jul 24 – 30");
+	});
+
+	it("names both months across a month boundary", () => {
+		const { JD } = loadJD();
+		expect(JD.standupPagerLabel("2026-07-28", "2026-08-03")).toBe("Jul 28 – Aug 3");
+	});
+
+	it("includes the year on both ends across a year boundary", () => {
+		const { JD } = loadJD();
+		expect(JD.standupPagerLabel("2025-12-29", "2026-01-04")).toBe("Dec 29, 2025 – Jan 4, 2026");
+	});
+});
 
 describe("standup author disclosure", () => {
 	it("names the identity the board was filtered to", () => {
@@ -140,76 +172,66 @@ describe("standup column shape", () => {
 		expect(html).not.toContain("Copy as standup");
 	});
 
-	// JOLLI-2201. A TODO is work that has NOT happened; the column states what
-	// landed today, so an unfinished item in it is a claim the board cannot make.
-	it("keeps TODOs out of Today and counts today's commits instead", () => {
+	// One column per day in the window, in the server's newest-first order. The
+	// column's stable, locale-independent handle is `data-day` (an ISO date); the
+	// aria-label carries the HUMAN-READABLE title instead — a region landmark named
+	// by a bare ISO string reads badly to a screen reader. Today and Yesterday get
+	// their named titles.
+	it("renders one column per window day, newest first, with Today/Yesterday titles", () => {
 		const { JD, element } = loadJD();
-		JD.renderStandup(
-			model({
-				todayCommits: [
-					{
-						hash: "0f0f0f0abc",
-						message: "fix: today's landing",
-						committedAtMs: nowMs - 3_600_000,
-						repoName: "jolliai",
-						branch: "main",
-					},
-				],
-				insights: [
-					{
-						kind: "todo",
-						text: "wire the retry path",
-						commitHash: "abc1234def",
-						repoName: "jolliai",
-						committedAtMs: nowMs - 26 * 3_600_000,
-					},
-				],
-			}),
-		);
+		JD.renderStandup(model({ authoredBy: "me@example.com" }));
 		const html = element("app").innerHTML;
-		expect(html).toContain("fix: today&#39;s landing");
-		expect(html).not.toContain("wire the retry path");
-		expect(html).not.toContain("TODO");
+		for (const day of WINDOW_DAYS) expect(html).toContain(`data-day="${day}"`);
+		// The accessible name is the readable title, never the raw ISO date.
+		expect(html).toContain('aria-label="Today"');
+		expect(html).not.toContain('aria-label="Standup for');
+		// Newest first: Today's column markup precedes the oldest day's.
+		expect(html.indexOf('data-day="2026-07-30"')).toBeLessThan(html.indexOf('data-day="2026-07-24"'));
+		expect(html).toContain(">Today<");
+		expect(html).toContain(">Yesterday<");
+		// Dated columns read in English (en-US pinned), matching the Today/Yesterday titles.
+		expect(html).toContain("Jul 24");
 	});
 
-	// Yesterday is commits-only too, at BOTH tiers. Below the memory tier it used
-	// to carry the raw session trail; Memory Activity never lists a session, and
-	// the two are required to agree.
-	it("keeps session rows out of Yesterday at the raw tier", () => {
+	// A quiet day is still a column — the grid stays a stable seven wide rather
+	// than collapsing — and it says so rather than rendering blank.
+	it("renders a quiet day as an empty column", () => {
+		const { JD, element } = loadJD();
+		JD.renderStandup(model());
+		const html = element("app").innerHTML;
+		expect(html).toContain("No commits.");
+		// The day that does carry a commit shows it, and its count.
+		expect(html).toContain("feat: my work");
+		expect(html).toContain("· 1 commit");
+	});
+
+	// A commit lands in the column for its own day, not another.
+	it("buckets a commit into its own day column", () => {
 		const { JD, element } = loadJD();
 		JD.renderStandup(
 			model({
-				insights: undefined,
-				yesterdaySessions: [
-					{
-						title: "an agent run",
-						source: "claude",
-						messageCount: 40,
-						updatedAtMs: nowMs - 26 * 3_600_000,
-						repoName: "jolliai",
-						isLive: false,
-					},
-				],
+				days: days({
+					"2026-07-30": [commit({ hash: "todayc", message: "fix: today's landing" })],
+					"2026-07-26": [commit({ hash: "satc", message: "chore: saturday" })],
+				}),
 			}),
 		);
 		const html = element("app").innerHTML;
-		expect(html).toContain("feat: my work");
-		expect(html).not.toContain("an agent run");
-		expect(html).toContain("· 1 commit");
+		// Today's column (first) holds today's commit; it precedes Saturday's.
+		expect(html.indexOf("fix: today&#39;s landing")).toBeLessThan(html.indexOf("chore: saturday"));
 	});
 
 	// Memory Activity's grouping IS the day; here the day is already the column, so
 	// a second axis inside one makes two identical lists read as different ones.
-	it("renders both day columns flat, with no group headers", () => {
+	it("renders the day columns flat, with no group headers", () => {
 		const { JD, element } = loadJD();
 		JD.renderStandup(model({ authoredBy: "me@example.com" }));
 		expect(element("app").innerHTML).not.toContain("ghead");
 	});
 
 	// The heading and its count already say what the column holds. An EMPTY `.sub`
-	// is not the same as none — it carries a bottom margin, so it would hold the
-	// caption's gap open.
-	it("gives the day columns no caption, and no empty caption element", () => {
+	// is not the same as none — it carries a bottom margin, so it would hold a gap open.
+	it("gives the day columns no caption element", () => {
 		const { JD, element } = loadJD();
 		JD.renderStandup(model({ authoredBy: "me@example.com" }));
 		const html = element("app").innerHTML;
@@ -222,20 +244,11 @@ describe("standup column shape", () => {
 		const { JD, element } = loadJD();
 		JD.renderStandup(
 			model({
-				yesterdayCommits: [
-					{
-						hash: "abc1234def",
-						message: "feat: my work",
-						committedAtMs: nowMs - 26 * 3_600_000,
-						repoName: "jolliai",
-						branch: "main",
-						turns: 12,
-						workCategory: "bugfix",
-						estCostUsd: 2.29,
-						insertions: 58,
-						deletions: 11,
-					},
-				],
+				days: days({
+					"2026-07-29": [
+						commit({ turns: 12, workCategory: "bugfix", estCostUsd: 2.29, insertions: 58, deletions: 11 }),
+					],
+				}),
 			}),
 		);
 		const html = element("app").innerHTML;
@@ -251,32 +264,9 @@ describe("standup column shape", () => {
 		expect(html).not.toContain("+58");
 	});
 
-	// Same rule for the two other non-completed sources the column used to carry.
-	it("keeps live sessions and uncommitted work out of Today", () => {
-		const { JD, element } = loadJD();
-		JD.renderStandup(
-			model({
-				todaySessions: [
-					{
-						title: "still going",
-						source: "claude",
-						messageCount: 12,
-						updatedAtMs: nowMs - 60_000,
-						repoName: "jolliai",
-						isLive: true,
-					},
-				],
-				workspaces: [{ repoName: "jolliai", branch: "main", filesChanged: 3, insertions: 40, deletions: 2 }],
-			}),
-		);
-		const html = element("app").innerHTML;
-		expect(html).not.toContain("still going");
-		expect(html).not.toContain("Uncommitted on");
-		expect(html).toContain("Nothing yet.");
-	});
-
-	// JOLLI-2200. Titles only — the decision text belongs to the Decisions card.
-	it("renders Yesterday outcomes without their decision detail", () => {
+	// JOLLI-2200. Titles only — the decision text belongs to the Decisions card,
+	// and a TODO is not work that landed (JOLLI-2201). No insight kind reaches a column.
+	it("renders commit rows only, never an insight's text", () => {
 		const { JD, element } = loadJD();
 		JD.renderStandup(
 			model({
@@ -286,14 +276,15 @@ describe("standup column shape", () => {
 						text: "chose the lock-free path",
 						commitHash: "abc1234def",
 						repoName: "jolliai",
-						committedAtMs: nowMs - 26 * 3_600_000,
 					},
+					{ kind: "todo", text: "wire the retry path", commitHash: "abc1234def", repoName: "jolliai" },
 				],
 			}),
 		);
 		const html = element("app").innerHTML;
 		expect(html).toContain("feat: my work");
 		expect(html).not.toContain("chose the lock-free path");
+		expect(html).not.toContain("wire the retry path");
 		expect(html).not.toContain("<b>Decision:</b>");
 	});
 });
@@ -339,12 +330,11 @@ describe("standup columns", () => {
 		},
 	];
 
-	it("renders exactly Yesterday and Today", () => {
+	it("renders the seven day columns and no Risks/Blockers column", () => {
 		const { JD, element } = loadJD();
 		JD.renderStandup(model({ insights: everyKind }));
 		const html = element("app").innerHTML;
-		expect(html).toContain('aria-label="Yesterday"');
-		expect(html).toContain('aria-label="Today"');
+		for (const day of WINDOW_DAYS) expect(html).toContain(`data-day="${day}"`);
 		expect(html).not.toContain("Risks");
 		expect(html).not.toContain("Blockers");
 	});

--- a/cli/src/dashboard/assets/index.html
+++ b/cli/src/dashboard/assets/index.html
@@ -69,6 +69,20 @@
 				<button type="button" data-range="3m">90d</button>
 				<button type="button" data-range="custom" aria-expanded="false" aria-controls="rangeCustom">Custom</button>
 			</div>
+			<!-- Standup week pager. Shown only on the standup board (shell.js toggles
+			     it against the preset range control above): the board pages a whole
+			     seven-day window at a time rather than picking a preset. The label
+			     states the window; `‹` moves to more recent days, `›` to older — the
+			     direction of travel across the Today-on-the-left columns. `Today`
+			     jumps straight back to the current week (offset 0), so a reader many
+			     weeks back does not have to click `‹` repeatedly; disabled once the
+			     window already ends today. -->
+			<div class="standup-pager" id="standupPager" role="group" aria-label="Standup week" hidden>
+				<span class="standup-pager-label" id="standupPagerLabel"></span>
+				<button type="button" class="standup-pager-nav" id="standupNewer" aria-label="More recent days">‹</button>
+				<button type="button" class="standup-pager-nav" id="standupOlder" aria-label="Older days">›</button>
+				<button type="button" class="standup-pager-today" id="standupToday" aria-label="Jump to the current week">Today</button>
+			</div>
 			<!-- The form keeps Apply keyboard-submittable while the calendar provides
 			     an explicit, visible start-to-end selection. Future days are disabled
 			     from the model's own zone, rather than being silently clamped later. -->

--- a/cli/src/dashboard/assets/js/shell.js
+++ b/cli/src/dashboard/assets/js/shell.js
@@ -44,13 +44,38 @@ window.JD = window.JD || {};
 			parts.push("to=" + encodeURIComponent(to));
 		}
 		if (dimension) parts.push("dimension=" + encodeURIComponent(dimension));
+		/* Standup pages a whole week at a time via `offset`, preserved across a
+		   scope change or reload from the model's own echo. 0 is the default and is
+		   left out of the URL. Only the standup view carries it; navigating away
+		   passes `{ offset: undefined }` so it is dropped. */
+		var offset =
+			"offset" in o ? o.offset : model.view === "standup" && model.standup ? model.standup.offset : undefined;
+		if (model.view === "standup" && offset) parts.push("offset=" + encodeURIComponent(offset));
 		return parts.length > 0 ? "?" + parts.join("&") : "";
 	};
 
 	/* The view payload that carries a time window, whichever page this is. The
-	   standup board is a fixed yesterday/today pair and deliberately has none,
-	   which is what hides the range control there. */
+	   standup board carries its own whole-week window and pages it with the topbar
+	   pager (see renderShell), so the preset range control stays hidden there. */
 	JD.ranged = (model) => model.stats || null;
+
+	/* The standup pager's window label — a date range like "Jul 24 – 30". The keys
+	   are bare local YYYY-MM-DD, formatted in UTC so reading them back through the
+	   local zone cannot shift the calendar day. Locale is pinned to en-US to match
+	   the English day-column titles rather than a viewer's localized month names.
+	   The month name repeats only across a month boundary, and the year appears
+	   only when the window straddles one. */
+	JD.standupPagerLabel = (fromKey, toKey) => {
+		var from = new Date(fromKey + "T00:00:00Z");
+		var to = new Date(toKey + "T00:00:00Z");
+		var sameYear = from.getUTCFullYear() === to.getUTCFullYear();
+		var md = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
+		var mdy = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric", timeZone: "UTC" });
+		var dayOnly = new Intl.DateTimeFormat("en-US", { day: "numeric", timeZone: "UTC" });
+		if (!sameYear) return mdy.format(from) + " – " + mdy.format(to);
+		if (from.getUTCMonth() === to.getUTCMonth()) return md.format(from) + " – " + dayOnly.format(to);
+		return md.format(from) + " – " + md.format(to);
+	};
 
 	/* One page-level tooltip (#tip in index.html), positioned above-left of the
 	   pointer and clamped to the viewport — ported from the mockup's showTip so a
@@ -814,6 +839,48 @@ window.JD = window.JD || {};
 			if (calendarPending) renderCalendar();
 		}
 
+		/* Topbar — standup week pager. Replaces the preset range control on the
+		   standup board, which pages a whole seven-day window at a time. The label
+		   states the window; `‹` reveals more recent days (disabled on the window
+		   ending today) and `›` older days (disabled once no reachable author-filtered
+		   commit precedes the window), matching the Today-on-the-left column order.
+		   `Today` jumps back to the current week in one click. Each control is a real
+		   navigation, like the range control above. */
+		var pager = document.getElementById("standupPager");
+		if (pager) {
+			var standup = model.view === "standup" ? model.standup : null;
+			pager.hidden = !standup;
+			if (standup) {
+				document.getElementById("standupPagerLabel").textContent = JD.standupPagerLabel(
+					standup.windowFrom,
+					standup.windowTo,
+				);
+				var newer = document.getElementById("standupNewer");
+				var older = document.getElementById("standupOlder");
+				var today = document.getElementById("standupToday");
+				newer.disabled = !standup.hasNewer;
+				older.disabled = !standup.hasOlder;
+				/* `Today` shares its enabled condition with `‹`: both are meaningful only
+				   when the window is not already the one ending today (hasNewer ⟺ offset > 0). */
+				today.disabled = !standup.hasNewer;
+				newer.onclick = () => {
+					if (!standup.hasNewer) return;
+					window.location.href =
+						JD.viewPath("standup") + JD.query(model, { offset: Math.max(0, standup.offset - 1) });
+				};
+				older.onclick = () => {
+					if (!standup.hasOlder) return;
+					window.location.href = JD.viewPath("standup") + JD.query(model, { offset: standup.offset + 1 });
+				};
+				today.onclick = () => {
+					if (!standup.hasNewer) return;
+					/* offset 0 is left out of the URL by JD.query, so this lands on the
+					   current-week window with no `offset=` param. */
+					window.location.href = JD.viewPath("standup") + JD.query(model, { offset: 0 });
+				};
+			}
+		}
+
 		/* Navigation. Real links (not client-side swaps) so a view is deep-linkable
 		   and reload-safe; the server renders each page with its data inlined.
 
@@ -836,7 +903,9 @@ window.JD = window.JD || {};
 					return;
 				}
 				if (navView && navView !== model.view) JD.track("dashboard_view_switched", { view: navView });
-				window.location.href = path + JD.query(model, { range: undefined });
+				// Range and the standup pager offset are both per-page window state, dropped
+				// on the way out; the repo scope survives (see above).
+				window.location.href = path + JD.query(model, { range: undefined, offset: undefined });
 			};
 		});
 		document.getElementById("machinesChip").hidden = model.tier !== "space";
@@ -928,12 +997,12 @@ window.JD = window.JD || {};
 	   Down to one key, by one rule applied twice. `blocker`/`question`/`gotcha`
 	   went with the standup's Risks column — those insight kinds are never
 	   produced (see the note at the top of standup.js). `session`/`workspace`/
-	   `todo`/`decision` went with the rows that drew them: both day columns are
-	   commits only now (JOLLI-2200 / 2201), and nothing else ever asked for a
-	   mark. Sessions, workspaces and TODOs are all still QUERIED — see
-	   `StandupModel.yesterdaySessions` — so re-add a key here when the column
-	   that wants them is designed, rather than treating this list as the record
-	   of what the model carries. */
+	   `todo`/`decision` went with the rows that drew them: the standup board's day
+	   columns are commits only now (JOLLI-2200 / 2201), and nothing else ever asked
+	   for a mark. Uncommitted worktrees are still QUERIED — see
+	   `StandupModel.workspaces` — so re-add a key here when the column that wants
+	   them is designed, rather than treating this list as the record of what the
+	   model carries. */
 	JD.glyph = {
 		commit: '<span class="glyph commit">◆</span>',
 	};

--- a/cli/src/dashboard/assets/js/standup.js
+++ b/cli/src/dashboard/assets/js/standup.js
@@ -110,15 +110,17 @@ window.JD = window.JD || {};
 				"read from your commits</span>"
 			);
 		}
-		/* Prototype-less: ticket ids come from commit messages. */
+		/* Prototype-less: ticket ids come from commit messages, across the whole window. */
 		var counts = Object.create(null);
-		standup.yesterdayCommits.concat(standup.todayCommits).forEach((commit) => {
-			if (commit.ticketId) counts[commit.ticketId] = (counts[commit.ticketId] || 0) + 1;
+		(standup.days || []).forEach((entry) => {
+			(entry.commits || []).forEach((commit) => {
+				if (commit.ticketId) counts[commit.ticketId] = (counts[commit.ticketId] || 0) + 1;
+			});
 		});
 		var tickets = Object.keys(counts).sort((a, b) => counts[b] - counts[a] || a.localeCompare(b));
 		if (tickets.length === 0) {
 			return (
-				'<span class="schip" style="border-style:dashed">no ticket on the last two days of commits — ' +
+				'<span class="schip" style="border-style:dashed">no ticket in this window — ' +
 				"chips appear when a commit names one</span>"
 			);
 		}
@@ -152,75 +154,75 @@ window.JD = window.JD || {};
 
 	/* ---- columns ----------------------------------------------------------- */
 
-	/* `sub` is optional. The two day columns pass none — their heading and count
-	   already say what they hold, and the sentence under them was restating it. An
-	   empty string must not render an empty `.sub`: it carries a bottom margin, so
-	   the blank div would leave the gap the caption used to occupy. */
-	function column(title, count, sub, bodyHtml) {
+	var plural = (n, word) => n + " " + word + (n === 1 ? "" : "s");
+
+	/* Column title. Today and Yesterday keep their named titles; every other day is
+	   its own short weekday date. The key is a bare local `YYYY-MM-DD` the server
+	   already computed in the model's zone, so it is formatted in UTC — reading it
+	   back through the local zone could shift the calendar day. Locale is pinned to
+	   en-US so the whole board reads in one language (the Today/Yesterday titles are
+	   English), rather than mixing them with a viewer's localized month names. */
+	var dayTitleFormat = new Intl.DateTimeFormat("en-US", {
+		weekday: "short",
+		month: "short",
+		day: "numeric",
+		timeZone: "UTC",
+	});
+	function dayTitle(dayKey, standup) {
+		if (dayKey === standup.today) return "Today";
+		if (dayKey === standup.yesterday) return "Yesterday";
+		return dayTitleFormat.format(new Date(dayKey + "T00:00:00Z"));
+	}
+
+	/* One day's column. COMMITS ONLY, flat, and identical in shape to the stats
+	   page's Memory Activity rows for the same day — only how many FIELDS a row can
+	   show varies with tier, which is the row's own business (see commitRow). No
+	   `.sub` caption: the heading and count already say what the column holds, and
+	   an empty one would hold its bottom margin open. A quiet day is still a column,
+	   so the grid stays a stable seven wide.
+
+	   A named `<section>` is a region landmark, so its aria-label is what a screen
+	   reader announces and lists this column by — it must be the human-readable
+	   title ("Today", "Yesterday", "Wed, Jul 30"), not a bare ISO date. The ISO day
+	   rides on `data-day` instead: a stable, locale-independent handle for the asset
+	   test that never reaches the accessibility tree. The title format is en-US
+	   pinned (see dayTitle), so the aria-label stays locale-independent too. */
+	function dayCard(entry, standup, model, memory) {
+		var commits = entry.commits || [];
+		var body = commits.length ? dayColumn(commits, model, memory) : '<div class="empty-note">No commits.</div>';
 		return (
-			'<section class="card col" aria-label="' +
-			JD.esc(title) +
-			'"><h2>' +
-			JD.esc(title) +
-			'<span class="cnt">' +
-			JD.esc(count) +
+			'<section class="card col" data-day="' +
+			JD.esc(entry.day) +
+			'" aria-label="' +
+			JD.esc(dayTitle(entry.day, standup)) +
+			'"><h2><span class="day-title">' +
+			JD.esc(dayTitle(entry.day, standup)) +
+			'</span><span class="cnt">· ' +
+			JD.esc(plural(commits.length, "commit")) +
 			"</span></h2>" +
-			(sub ? '<div class="sub">' + JD.esc(sub) + "</div>" : "") +
 			'<div class="col-list">' +
-			bodyHtml +
+			body +
 			"</div></section>"
 		);
 	}
 
-	var plural = (n, word) => n + " " + word + (n === 1 ? "" : "s");
-
 	JD.renderStandup = (model) => {
-		var esc = JD.esc;
 		var standup = model.standup;
 		var memory = !!standup.insights;
 
-		/* Context strip: date and sprint chips. The Copy-as-standup button and its
-		   "posts nowhere" caption used to close this row (JOLLI-2198); the board is
-		   now read directly, so there is nothing to right-align against and the
-		   spacer went with them. */
+		/* Context strip: the author disclosure and sprint chips. The window's date
+		   range is stated by the pager in the topbar (see shell.js), not here. */
 		var html =
-			'<div class="ctx"><span class="date">' +
-			esc(JD.weekdayDate(model.generatedAtMs, model.timeZone)) +
-			'</span><span class="sprint-chips">' +
-			authorChip(standup) +
-			sprintChips(standup, model) +
-			"</span></div>";
+			'<div class="ctx"><span class="sprint-chips">' + authorChip(standup) + sprintChips(standup, model) + "</span></div>";
 
-		/* The two day columns. Both are COMMITS ONLY, flat, and identical in shape:
-		   what was completed that day, which is what Memory Activity lists for the
-		   same day on the stats page.
-
-		   Three things used to make them disagree with that card, all removed. Today
-		   carried open TODOs, live sessions and uncommitted worktree rows — work in
-		   flight under a heading everyone reads as "done" (JOLLI-2201). Yesterday
-		   carried session rows below the memory tier, which are not commits at all.
-		   And Yesterday grouped its rows under `TICKET · category` / `repo · branch`
-		   headers, which Memory Activity has no counterpart for: its grouping IS the
-		   day, and here the day is already the column. A group header inside one is a
-		   second axis the other page does not have, so two identical lists read as
-		   different ones.
-
-		   Neither column splits by tier any more. A commit is a commit without
-		   memory; only how many FIELDS a row can show varies, and that is the row's
-		   own business (see commitRow). */
-		var yBody = dayColumn(standup.yesterdayCommits, model, memory);
-		if (!yBody) yBody = '<div class="empty-note">Nothing recorded.</div>';
-		var yCount = "· " + plural(standup.yesterdayCommits.length, "commit");
-
-		var tBody = dayColumn(standup.todayCommits, model, memory);
-		if (!tBody) tBody = '<div class="empty-note">Nothing yet.</div>';
-		var tCount = "· " + plural(standup.todayCommits.length, "commit");
-
-		/* Two columns. The third — Risks · Blockers · Questions — is gone; see the
-		   note at the top of this file for why it could never fill. */
-		html += '<div class="cols">';
-		html += column("Yesterday", yCount, "", yBody);
-		html += column("Today", tCount, "", tBody);
+		/* One column per day, in the server's newest-first order — Today leftmost,
+		   the week trailing off to the right, horizontally scrollable. The third
+		   Risks · Blockers · Questions column is gone; see the note at the top of
+		   this file for why it could never fill. */
+		html += '<div class="cols standup-days">';
+		(standup.days || []).forEach((entry) => {
+			html += dayCard(entry, standup, model, memory);
+		});
 		html += "</div>";
 
 		document.getElementById("app").innerHTML = html;

--- a/cli/src/dashboard/assets/styles/main.css
+++ b/cli/src/dashboard/assets/styles/main.css
@@ -723,21 +723,57 @@ body {
 
   /* ---------- standup view ---------- */
   .ctx { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; margin-bottom: 16px; }
-  .ctx .date { font-size: 15px; font-weight: 650; }
   .sprint-chips { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
   .schip { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--ink-2); border: 1px solid var(--border); border-radius: 999px; padding: 4px 11px; }
   /* No `.st` status rule: the mockup's `● on track` chip needed plan-step
      progress, which does not exist locally, so `sprintChips` emits tickets only
      and nothing ever carried the class. */
   .cols { display: grid; grid-template-columns: 1fr; gap: 16px; }
-  /* Two columns — Yesterday and Today. The third (Risks · Blockers · Questions)
-     was removed because the insight kinds it filtered for are never produced; see
-     the note at the top of standup.js. */
   @media (min-width: 980px) { .cols { grid-template-columns: 1fr 1fr; } }
   .cols > .card { grid-column: auto; }
   .col h2 { display: flex; align-items: baseline; gap: 8px; }
   .col h2 .cnt { font-size: 11px; color: var(--muted); font-weight: 500; }
   .col-list { display: grid; gap: 8px; margin-top: 12px; }
+  .day-title { font-weight: 650; }
+
+  /* The standup board's seven day columns: one card per day, newest (Today)
+     leftmost, laid out as fixed-width columns that scroll horizontally rather
+     than wrapping — so the week reads as one strip and a quiet day is a visible
+     empty column rather than a gap. Overrides the two-column `.cols` grid above.
+     The third Risks · Blockers · Questions column stays gone — the insight kinds
+     it filtered for are never produced; see the note at the top of standup.js. */
+  .main:has(.standup-days) { overflow-x: hidden; }
+  .cols.standup-days {
+    grid-template-columns: none;
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(260px, 1fr);
+    align-items: start;
+    overflow-x: auto;
+    max-width: 100%;
+    padding-bottom: 8px;
+    scroll-snap-type: x proximity;
+  }
+  .cols.standup-days > .card { min-width: 0; scroll-snap-align: start; }
+  .standup-days .col h2 { min-width: 0; }
+  .standup-days .item .r1, .standup-days .item .t { min-width: 0; }
+  .standup-days .item .t { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .standup-days .empty-note { min-height: 28px; display: flex; align-items: center; margin-top: 12px; }
+  @media (max-width: 700px) { .cols.standup-days { grid-auto-columns: minmax(238px, 82vw); } }
+
+  /* The standup week pager, sitting where the preset range control sits on other
+     views. A pill matching `.seg`'s treatment: a static label flanked by two nav
+     arrows; a disabled arrow is the window's edge (today, or the earliest data). */
+  .standup-pager { display: inline-flex; align-items: center; gap: 2px; border: 1px solid var(--border); border-radius: 9px; padding: 2px; background: var(--surface); }
+  .standup-pager[hidden] { display: none; }
+  .standup-pager-label { font-size: 12px; font-weight: 600; color: var(--ink); padding: 5px 10px; white-space: nowrap; }
+  .standup-pager-nav { display: inline-flex; align-items: center; justify-content: center; width: 26px; height: 26px; border: 0; border-radius: 7px; background: transparent; color: var(--ink-2); font-size: 15px; line-height: 1; cursor: pointer; }
+  .standup-pager-nav:hover:not(:disabled) { color: var(--ink); background: var(--lock-bg); }
+  .standup-pager-nav:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+  .standup-pager-nav:disabled { opacity: .35; cursor: default; }
+  .standup-pager-today { display: inline-flex; align-items: center; height: 26px; margin-left: 2px; padding: 0 10px; border: 0; border-radius: 7px; background: transparent; color: var(--ink-2); font-size: 12px; font-weight: 600; line-height: 1; cursor: pointer; }
+  .standup-pager-today:hover:not(:disabled) { color: var(--ink); background: var(--lock-bg); }
+  .standup-pager-today:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+  .standup-pager-today:disabled { opacity: .35; cursor: default; }
 
   /* No `.ghead` group header: both day columns are flat. Memory Activity's
      grouping IS the day, and here the day is already the column, so a second


### PR DESCRIPTION
## Summary

Turns the Daily Standup board from a fixed yesterday/today pair into a rolling seven-day window of per-day columns (Today leftmost, scrolling horizontally), paged a whole week at a time by a topbar pager that replaces the preset range control.

## What changed

**Server**
- `StandupModel` reshaped from yesterday/today commit/session arrays into a `days[]` of per-day commit buckets plus `windowFrom`/`windowTo`, the resolved `offset`, and `hasNewer`/`hasOlder`. The unused session arrays are dropped.
- `buildStandup` queries `[today - 7*offset - 6, today - 7*offset]` grouped by local day.
- **Standup joins `REACHABILITY_VIEWS`.** It is a first-person "what I did" feed, so a rebased/squashed-away commit still sitting in `commits` is a false claim rather than aggregate activity: the window drops unreachable rows and `hasOlder` is answered by a *reachable*, author-filtered commit before the window.
- **`?offset=N` is clamped to one year of weeks (52).** The param is deep-linkable and reaches `addLocalDays`' per-day loop, so an unbounded magnitude would spin the single-threaded dashboard; both the URL parse boundary and `buildStandup` clamp.

**Client**
- `standup.js` renders the day columns (commits only; a quiet day is still a column so the grid stays seven wide).
- `shell.js` hides the range segment on standup and renders the pager `‹ › Today`: `‹` reveals more recent days (disabled on the window ending today), `›` older days (disabled once no reachable author-filtered commit precedes the window), and **`Today` jumps back to the current week in one click** — for a reader many weeks back.
- `offset` is preserved across a repo-scope change or reload and dropped when leaving the view.

## Notes on behavior

Paging steps a fixed calendar week, so a history with gaps can still show intermediate empty weeks — intended for a weekly board, where an empty week is truthful. `hasOlder` only guarantees the terminal case: `›` never enables a window with nothing beyond it.

## Testing

- `npm run typecheck` and `npm run lint` clean.
- Full `cli/src/dashboard` suite green (1753 tests), including new cases for the offset clamp, dropping unreachable commits from the window, and reachability-gated `hasOlder`.
- Full `npm run all` gate not run locally; CI runs the same chain.
