### PR TITLE
Resolve ~/.ssh/config Host aliases in the canonical repo URL (JOLLI-2135)

### DIFF
--- a/cli/src/core/GitRemoteUtils.test.ts
+++ b/cli/src/core/GitRemoteUtils.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GitCommandResult } from "../Types.js";
 
 vi.mock("./GitOps.js", () => ({ execGit: vi.fn() }));
@@ -14,6 +14,7 @@ import {
 	sanitizeBranchSlug,
 	sharedRepoIdentityMatches,
 } from "./GitRemoteUtils.js";
+import { __setSshRunnerForTests } from "./SshAliasResolver.js";
 
 const gitResult = (stdout: string, exitCode = 0): GitCommandResult => ({ stdout, stderr: "", exitCode });
 
@@ -56,10 +57,28 @@ describe("normalizeRemoteUrl", () => {
 		// isn't "fixed" without also revisiting that constraint.
 		expect(normalizeRemoteUrl("github.com:owner/repo.git", "/ws/proj")).toBe("file:///ws/proj");
 	});
-	it("drops the default ssh port but keeps a non-default one", () => {
+	it("drops ssh ports (default AND non-default) from a self-hosted identity so ssh folds onto https", () => {
+		// The SSH *connection* port is not the repo's HTTPS identity: an ssh clone
+		// on :2222 and an https clone of the same self-hosted repo must share one
+		// key (JOLLI-2135 follow-up). A non-default ssh port is therefore dropped
+		// for a self-hosted host, not just the default :22.
 		expect(normalizeRemoteUrl("ssh://git@host/owner/repo.git", "/ws")).toBe("https://host/owner/repo");
 		expect(normalizeRemoteUrl("ssh://git@host:22/owner/repo", "/ws")).toBe("https://host/owner/repo");
-		expect(normalizeRemoteUrl("ssh://git@host:2222/owner/repo", "/ws")).toBe("https://host:2222/owner/repo");
+		expect(normalizeRemoteUrl("ssh://git@host:2222/owner/repo", "/ws")).toBe("https://host/owner/repo");
+		// …and so folds onto the https clone's key.
+		expect(normalizeRemoteUrl("ssh://git@host:2222/owner/repo", "/ws")).toBe(
+			normalizeRemoteUrl("https://host/owner/repo", "/ws"),
+		);
+	});
+	it("accepted trade-off: two self-hosted repos differing ONLY by ssh port now collide", () => {
+		// The cost of folding ssh→https: two DISTINCT repos reachable only via
+		// different ssh gateway ports on one host collapse to one identity key.
+		// The dominant real case (one repo via ssh:2222 AND https:443) wins over
+		// this rare one. Pinned so the trade-off is explicit, not accidental.
+		expect(normalizeRemoteUrl("ssh://git@host:2222/team/repo", "/ws")).toBe(
+			normalizeRemoteUrl("ssh://git@host:2223/team/repo", "/ws"),
+		);
+		expect(normalizeRemoteUrl("ssh://git@host:2222/team/repo", "/ws")).toBe("https://host/team/repo");
 	});
 	it("drops the default git port but keeps a non-default one", () => {
 		expect(normalizeRemoteUrl("git://host:9418/owner/repo", "/ws")).toBe("https://host/owner/repo");
@@ -79,6 +98,112 @@ describe("normalizeRemoteUrl", () => {
 	});
 	it("normalizes a Windows-style fallback path to forward slashes", () => {
 		expect(normalizeRemoteUrl("", "C:\\repo\\")).toBe("file:///C:/repo");
+	});
+});
+
+describe("normalizeRemoteUrl — ~/.ssh/config Host alias resolution (JOLLI-2135)", () => {
+	// Resolve a couple of well-known aliases to their configured HostName; every
+	// other host echoes back unchanged, exactly like `ssh -G` on a host with no
+	// matching `Host` block.
+	const fakeSshConfig: Record<string, string> = {
+		"github-jolli": "github.com",
+		"work-gitlab": "gitlab.internal.example",
+	};
+	beforeEach(() => __setSshRunnerForTests((host) => `hostname ${fakeSshConfig[host] ?? host}\n`));
+	afterEach(() => __setSshRunnerForTests(null));
+
+	it("folds an scp-form alias clone onto the same key as a direct github.com clone", () => {
+		// The whole bug: an alias clone must land on the canonical key, including
+		// the case-insensitive path fold that only fires once the host is github.com.
+		expect(normalizeRemoteUrl("git@github-jolli:Owner/Repo.git", "/ws")).toBe(
+			normalizeRemoteUrl("git@github.com:Owner/Repo.git", "/ws"),
+		);
+		expect(normalizeRemoteUrl("git@github-jolli:Owner/Repo.git", "/ws")).toBe("https://github.com/owner/repo");
+	});
+
+	it("folds an ssh:// URL alias clone onto the canonical host too", () => {
+		expect(normalizeRemoteUrl("ssh://git@github-jolli/Owner/Repo.git", "/ws")).toBe(
+			"https://github.com/owner/repo",
+		);
+	});
+
+	it("keeps an alias that resolves to a genuinely different host distinct (no false collapsing)", () => {
+		// work-gitlab → gitlab.internal.example: a real, different repo. The host
+		// is NOT case-insensitive, so the path case is preserved.
+		expect(normalizeRemoteUrl("git@work-gitlab:Owner/Repo.git", "/ws")).toBe(
+			"https://gitlab.internal.example/Owner/Repo",
+		);
+	});
+
+	it("leaves an unknown alias unchanged (fallback: literal host, current behavior)", () => {
+		expect(normalizeRemoteUrl("git@unknown-alias:Owner/Repo.git", "/ws")).toBe("https://unknown-alias/Owner/Repo");
+	});
+});
+
+describe("normalizeRemoteUrl — endpoint & port canonicalization (JOLLI-2135 follow-ups)", () => {
+	afterEach(() => __setSshRunnerForTests(null));
+
+	it("Claim 2: an ssh-over-443 github.com clone still folds onto the https key", () => {
+		// `Host github.com / HostName ssh.github.com / Port 443` — ssh.github.com is
+		// a connection endpoint, NOT the repo's identity host. It must map back to
+		// github.com so the SSH clone and an https clone share one key.
+		__setSshRunnerForTests((host) =>
+			host === "github.com" ? "hostname ssh.github.com\nport 443\n" : `hostname ${host}\n`,
+		);
+		expect(normalizeRemoteUrl("git@github.com:Owner/Repo.git", "/ws")).toBe("https://github.com/owner/repo");
+		expect(normalizeRemoteUrl("ssh://git@github.com/Owner/Repo.git", "/ws")).toBe("https://github.com/owner/repo");
+	});
+
+	it("Claim 1 (revised): scp alias Port, direct ssh://:2222, and the https clone all collapse to one portless self-hosted key", () => {
+		__setSshRunnerForTests((host) =>
+			host === "corp-git" ? "hostname git.example.com\nport 2222\n" : "hostname git.example.com\nport 22\n",
+		);
+		// An ssh config `Port 2222` is a CONNECTION coordinate, not the repo's
+		// HTTPS identity. All three clone shapes of the one self-hosted repo must
+		// therefore fold to the same portless key (JOLLI-2135 follow-up — the
+		// earlier behaviour carried :2222 into the key and split the https clone).
+		const key = "https://git.example.com/team/repo";
+		expect(normalizeRemoteUrl("git@corp-git:team/repo.git", "/ws")).toBe(key);
+		expect(normalizeRemoteUrl("ssh://git@git.example.com:2222/team/repo.git", "/ws")).toBe(key);
+		expect(normalizeRemoteUrl("https://git.example.com/team/repo", "/ws")).toBe(key);
+	});
+
+	it("Claim 3: git:// is the Git protocol, never ssh — its host is not resolved through ~/.ssh/config", () => {
+		__setSshRunnerForTests((host) =>
+			host === "gitproto-host" ? "hostname elsewhere.example\n" : `hostname ${host}\n`,
+		);
+		expect(normalizeRemoteUrl("git://gitproto-host/owner/repo", "/ws")).toBe("https://gitproto-host/owner/repo");
+	});
+
+	it("drops an EXPLICIT alt port on an ssh-over-443 endpoint so it still folds onto the https key", () => {
+		// `ssh://git@ssh.github.com:443/…` — ssh.github.com is a connection endpoint,
+		// and the :443 is the endpoint's, not the identity's. It must be dropped, or
+		// the clone splits from `https://github.com/owner/repo`.
+		__setSshRunnerForTests((host) => `hostname ${host}\n`);
+		expect(normalizeRemoteUrl("ssh://git@ssh.github.com:443/Owner/Repo.git", "/ws")).toBe(
+			"https://github.com/owner/repo",
+		);
+		expect(normalizeRemoteUrl("ssh://git@ssh.github.com:443/Owner/Repo.git", "/ws")).toBe(
+			normalizeRemoteUrl("https://github.com/Owner/Repo.git", "/ws"),
+		);
+	});
+
+	it("threads the git@ user so a `Match user …` alias folds (scp and ssh:// both)", () => {
+		// The alias resolves ONLY when ssh is invoked as `git@github-jolli`.
+		__setSshRunnerForTests((host, user) =>
+			host === "github-jolli" && user === "git" ? "hostname github.com\n" : `hostname ${host}\n`,
+		);
+		expect(normalizeRemoteUrl("git@github-jolli:Owner/Repo.git", "/ws")).toBe("https://github.com/owner/repo");
+		expect(normalizeRemoteUrl("ssh://git@github-jolli/Owner/Repo.git", "/ws")).toBe(
+			"https://github.com/owner/repo",
+		);
+	});
+
+	it("brackets an IPv6 HostName so the canonical URL is valid (scp and ssh:// both)", () => {
+		// `ssh -G` reports an IPv6 HostName without brackets; the output must wrap it.
+		__setSshRunnerForTests((host) => (host === "v6-alias" ? "hostname 2001:db8::1\n" : `hostname ${host}\n`));
+		expect(normalizeRemoteUrl("git@v6-alias:Owner/Repo.git", "/ws")).toBe("https://[2001:db8::1]/Owner/Repo");
+		expect(normalizeRemoteUrl("ssh://git@v6-alias/Owner/Repo.git", "/ws")).toBe("https://[2001:db8::1]/Owner/Repo");
 	});
 });
 

--- a/cli/src/core/GitRemoteUtils.ts
+++ b/cli/src/core/GitRemoteUtils.ts
@@ -7,23 +7,55 @@
  * always yield the same string regardless of clone transport or owner/repo
  * casing the user happened to type in their `git clone` invocation.
  *
- * Normalization rules (any future IntelliJ / CLI port of this logic must stay
- * in lockstep — the canonical URL is the binding's primary key):
+ * This is the CLI-owned source of truth. VS Code bundles it verbatim; IntelliJ
+ * reaches it over the `git-remote` ide-bridge action (its Kotlin `GitRemoteUtils`
+ * keeps a local copy only as a no-Node fallback), so the binding's primary key
+ * is computed here on every surface that can reach the daemon.
+ *
+ * Normalization rules:
  *   - SSH form `git@host:owner/repo[.git]`              → `https://host/owner/repo`
  *   - SSH URL  `ssh://git@host[:port]/path[.git]`       → `https://host[:port]/path`
  *   - git URL  `git://host[:port]/path[.git]`           → `https://host[:port]/path`
  *   - HTTP(S):  strip trailing `.git`, lower-case scheme + host
  *   - No remote configured: fall back to `file://<workspaceRoot>` (forward slashes)
  *
+ * SSH host aliases (`~/.ssh/config`):
+ *   - For the ssh transports ONLY (`git@host:` scp form and `ssh://`), the host
+ *     token is resolved through {@link resolveHostEndpoint} — a `Host` alias
+ *     expands to its configured `HostName` (`git@github-jolli:o/r` →
+ *     `https://github.com/o/r` when `github-jolli` aliases `github.com`), so an
+ *     alias clone maps to the same binding key as a canonical clone. The alias's
+ *     config `Port` (and an explicit `ssh://…:port`) is an ssh CONNECTION
+ *     coordinate, NOT the repo's https identity, so for a self-hosted host it is
+ *     dropped (see {@link sshIdentityPort}) — an ssh clone then folds onto the
+ *     same key as the https clone. The `git@` user is threaded into `ssh -G` so
+ *     `Match user …` config blocks resolve. Resolution is offline and fail-safe:
+ *     an unknown alias or unreadable config leaves the literal host unchanged.
+ *   - `git://` is the Git protocol, not ssh — it never reads `~/.ssh/config`, so
+ *     its host is left untouched. HTTP(S) hosts are real DNS names, never
+ *     aliases, and are likewise untouched.
+ *   - A resolved `HostName` that is a KNOWN ssh connection endpoint
+ *     (`ssh.github.com` and the gitlab/bitbucket ssh-over-443 targets) is mapped
+ *     back to its forge identity host, dropping the alt port — even an EXPLICIT
+ *     URL port (`ssh://git@ssh.github.com:443/o/r`), which belongs to the
+ *     connection and not the identity — otherwise an ssh-over-443 clone of
+ *     github.com would split from an https clone.
+ *   - A resolved IPv6 `HostName` (which `ssh -G` reports without brackets) is
+ *     bracketed via {@link formatHostForUrl} so the canonical URL stays valid.
+ *
  * Port handling:
  *   - HTTP(S): always preserve the port (self-hosted forges on non-default
- *     HTTPS ports are common).
- *   - ssh / git: preserve the port unless it's the scheme's default (22 / 9418).
- *     Dropping the default lets a clone via `ssh://host/x` collapse with the
- *     `https://host/x` clone of the same self-hosted repo. Preserving a
- *     non-default port keeps two distinct repos on the same host (e.g. one
- *     SSH gateway on :2222 and another on :2223) from colliding into one
- *     binding key.
+ *     HTTPS ports are common — there the port IS part of the identity).
+ *   - ssh: the port is a CONNECTION coordinate, not the https identity, so for a
+ *     self-hosted host it is dropped entirely (default AND non-default) via
+ *     {@link sshIdentityPort} — an ssh clone via `ssh://host:2222/x` (or a
+ *     `git@host:` alias whose config sets a Port) then folds onto the
+ *     `https://host/x` clone's key (JOLLI-2135 follow-up). Accepted cost: two
+ *     distinct repos on one host reachable only via different SSH ports (:2222
+ *     vs :2223) collapse into one binding key — the dominant real case (one repo
+ *     via ssh AND https) wins over that rare one.
+ *   - git: the Git protocol is a distinct transport; preserve its port unless
+ *     it's the scheme's default (9418).
  *
  * Path-case handling:
  *   - For known case-insensitive hosts (github.com, gitlab.com, bitbucket.org)
@@ -43,8 +75,12 @@ import { execGit } from "./GitOps.js";
 // cli/src/core/KBPathResolver.ts — one host list, so the server binding key
 // and the local identity comparers can never drift on which hosts get their
 // path case folded.
-import { CASE_INSENSITIVE_PATH_HOSTS } from "./KBPathResolver.js";
+import { CASE_INSENSITIVE_PATH_HOSTS, sshIdentityPort } from "./KBPathResolver.js";
 import { stripTrailingSlashes, toForwardSlash } from "./PathUtils.js";
+// Resolves a `~/.ssh/config` `Host` alias to its real `HostName` + `Port`
+// (offline `ssh -G`, memoized, fail-safe). Only the SSH transports consult it —
+// the same machinery the local folder-identity canonicalizer already uses.
+import { formatHostForUrl, resolveHostEndpoint } from "./SshAliasResolver.js";
 
 /** Returns the canonical, server-facing repo URL for the given workspace root. */
 export async function getCanonicalRepoUrl(workspaceRoot: string): Promise<string> {
@@ -65,9 +101,19 @@ export function normalizeRemoteUrl(remote: string, workspaceRootForFallback: str
 
 	const sshScpMatch = /^([A-Za-z0-9_.+-]+@)([^:/\s]+):(.+)$/.exec(trimmed);
 	if (sshScpMatch && !trimmed.includes("://")) {
-		const host = sshScpMatch[2].toLowerCase();
+		// Resolve an `~/.ssh/config` Host alias on the raw token (that is what ssh
+		// keys its `Host` blocks on), THEN lower-case the real HostName so the
+		// CASE_INSENSITIVE_PATH_HOSTS fold and the canonical form both see it. The
+		// alias's config Port is an ssh CONNECTION coordinate, not the repo's https
+		// identity, so it is dropped for a self-hosted host (sshIdentityPort) — the
+		// alias scp clone then folds onto the same key as the https clone. The
+		// `git@` user is threaded through so `Match user …` config blocks resolve
+		// (group 1 carries the trailing `@`).
+		const endpoint = resolveHostEndpoint(sshScpMatch[2], sshScpMatch[1].slice(0, -1) || undefined);
+		const host = endpoint.host.toLowerCase();
 		const pathPart = normalizePathCase(host, stripGitSuffixAndSlashes(sshScpMatch[3]));
-		return `https://${host}/${pathPart}`;
+		const port = canonicalPortSegment("ssh", sshIdentityPort(host, endpoint.port));
+		return `https://${formatHostForUrl(host)}${port}/${pathPart}`;
 	}
 
 	let parsed: URL;
@@ -79,15 +125,26 @@ export function normalizeRemoteUrl(remote: string, workspaceRootForFallback: str
 
 	const scheme = parsed.protocol.replace(/:$/, "").toLowerCase();
 	if (scheme === "ssh" || scheme === "git" || scheme === "http" || scheme === "https") {
-		const host = parsed.hostname.toLowerCase();
+		// Alias resolution is an ssh-transport concern only. `git://` is the Git
+		// protocol — it never consults `~/.ssh/config` — and an http/https host is
+		// a real DNS name, never an alias, so both are left untouched.
+		const isSshTransport = scheme === "ssh";
+		const endpoint = isSshTransport
+			? resolveHostEndpoint(parsed.hostname, parsed.username || undefined)
+			: { host: parsed.hostname, port: "", endpointRemapped: false };
+		const host = endpoint.host.toLowerCase();
 		const pathPart = normalizePathCase(host, stripGitSuffixAndSlashes(parsed.pathname.replace(/^\/+/, "")));
-		// Preserve port for http/https (self-hosted git on non-default ports is real).
-		// For ssh/git, only drop the port when it's the scheme's default — that
-		// keeps `ssh://host/x` collapsing with `https://host/x` for the standard
-		// case, while two distinct repos on `ssh://host:2222/x` vs
-		// `ssh://host:2223/x` stay distinct.
-		const portSegment = canonicalPortSegment(scheme, parsed.port);
-		return `https://${host}${portSegment}/${pathPart}`;
+		// http/https: the port IS part of the identity (self-hosted git on a
+		// non-default HTTPS port is real), so keep it. git://: a distinct transport,
+		// keep its non-default port. ssh: the port is a CONNECTION coordinate, not
+		// the https identity, so for a self-hosted host it is dropped (sshIdentityPort)
+		// — an ssh clone then folds onto the `https://host/x` key. A host remapped
+		// from a known ssh connection endpoint (`ssh.github.com:443`) already zeroed
+		// its alt port upstream (endpointRemapped).
+		const rawPort = endpoint.endpointRemapped ? "" : parsed.port !== "" ? parsed.port : endpoint.port;
+		const effectivePort = scheme === "ssh" ? sshIdentityPort(host, rawPort) : rawPort;
+		const portSegment = canonicalPortSegment(scheme, effectivePort);
+		return `https://${formatHostForUrl(host)}${portSegment}/${pathPart}`;
 	}
 
 	if (scheme === "file") {

--- a/cli/src/core/KBPathResolver.test.ts
+++ b/cli/src/core/KBPathResolver.test.ts
@@ -369,10 +369,16 @@ esac
 			expect(foldGitTransportToHttps("git://github.com:9418/user/repo")).toBe("https://github.com/user/repo");
 		});
 
-		it("preserves non-default ssh/git ports (distinct self-hosted forges must not collapse)", () => {
+		it("drops the ssh port from a self-hosted identity (ssh connection port is not the https identity)", () => {
+			// JOLLI-2135 follow-up: an ssh clone on :2222 and an https clone of the
+			// same self-hosted repo must fold to one key, so the ssh port is dropped
+			// even when non-default. git:// keeps its port (see below).
 			expect(foldGitTransportToHttps("ssh://git@host.example:2222/team/repo")).toBe(
-				"https://host.example:2222/team/repo",
+				"https://host.example/team/repo",
 			);
+		});
+
+		it("preserves a non-default git:// port (the Git protocol is a distinct transport, left untouched)", () => {
 			expect(foldGitTransportToHttps("git://host.example:9419/team/repo")).toBe(
 				"https://host.example:9419/team/repo",
 			);
@@ -417,6 +423,61 @@ esac
 			it("does not resolve bare host:path (no user@) — passthrough stays literal even with an alias runner", () => {
 				__setSshRunnerForTests(() => "hostname github.com\n");
 				expect(foldGitTransportToHttps("mygit.local:repos/foo")).toBe("mygit.local:repos/foo");
+			});
+
+			it("Claim 2: maps a known ssh-over-443 endpoint (ssh.github.com) back to the forge host", () => {
+				__setSshRunnerForTests((host) =>
+					host === "github.com" ? "hostname ssh.github.com\nport 443\n" : `hostname ${host}\n`,
+				);
+				expect(foldGitTransportToHttps("git@github.com:user/repo.git")).toBe(
+					"https://github.com/user/repo.git",
+				);
+			});
+
+			it("Claim 1 (revised): the ssh config Port is NOT carried into the scp fold (folds onto the portless self-hosted key)", () => {
+				__setSshRunnerForTests((host) =>
+					host === "corp-git" ? "hostname git.example.com\nport 2222\n" : `hostname ${host}\n`,
+				);
+				// The config `Port 2222` is a connection coordinate, not the repo's
+				// identity, so the alias scp clone folds onto the same key as the
+				// https clone (JOLLI-2135 follow-up).
+				expect(foldGitTransportToHttps("git@corp-git:team/repo")).toBe("https://git.example.com/team/repo");
+			});
+
+			it("Claim 3: git:// is the Git protocol — its host is never resolved through ~/.ssh/config", () => {
+				__setSshRunnerForTests((host) =>
+					host === "gitproto-host" ? "hostname elsewhere.example\n" : `hostname ${host}\n`,
+				);
+				expect(foldGitTransportToHttps("git://gitproto-host/owner/repo")).toBe(
+					"https://gitproto-host/owner/repo",
+				);
+			});
+
+			it("drops an EXPLICIT alt port on an ssh-over-443 endpoint so it folds onto the forge key", () => {
+				__setSshRunnerForTests((host) => `hostname ${host}\n`);
+				expect(foldGitTransportToHttps("ssh://git@ssh.github.com:443/user/repo")).toBe(
+					"https://github.com/user/repo",
+				);
+			});
+
+			it("threads the git@ user so a `Match user …` alias resolves (scp and ssh:// both)", () => {
+				__setSshRunnerForTests((host, user) =>
+					host === "github-jolli" && user === "git" ? "hostname github.com\n" : `hostname ${host}\n`,
+				);
+				expect(foldGitTransportToHttps("git@github-jolli:jolliai/jolliai.git")).toBe(
+					"https://github.com/jolliai/jolliai.git",
+				);
+				expect(foldGitTransportToHttps("ssh://git@github-jolli/jolliai/jolliai")).toBe(
+					"https://github.com/jolliai/jolliai",
+				);
+			});
+
+			it("brackets an IPv6 HostName so the folded URL is a valid authority (scp and ssh:// both)", () => {
+				__setSshRunnerForTests((host) =>
+					host === "v6-alias" ? "hostname 2001:db8::1\n" : `hostname ${host}\n`,
+				);
+				expect(foldGitTransportToHttps("git@v6-alias:user/repo")).toBe("https://[2001:db8::1]/user/repo");
+				expect(foldGitTransportToHttps("ssh://git@v6-alias/user/repo")).toBe("https://[2001:db8::1]/user/repo");
 			});
 		});
 	});

--- a/cli/src/core/KBPathResolver.ts
+++ b/cli/src/core/KBPathResolver.ts
@@ -24,7 +24,7 @@ import { execFileSyncHidden } from "../util/Subprocess.js";
 import type { ClaimVerdict, KBConfig, MemoryBankConfig, MemoryBankState } from "./KBTypes.js";
 import { MetadataManager } from "./MetadataManager.js";
 import { isPathInside } from "./PathUtils.js";
-import { resolveHostAlias } from "./SshAliasResolver.js";
+import { formatHostForUrl, resolveHostEndpoint } from "./SshAliasResolver.js";
 
 const log = createLogger("KBPathResolver");
 
@@ -571,14 +571,17 @@ function normalizeRemoteUrl(url: string): string {
  * Folds the SSH transport forms of a git remote URL into the https form so
  * all transports of the same repo compare equal:
  *
- *   - `ssh://[user@]host[:port]/path` (and `git+ssh://`) → `https://host[:port]/path`.
- *     The scheme's DEFAULT port (22) is dropped — it carries no identity —
- *     but a non-default port is preserved: two self-hosted forges on
- *     `host:2222` and `host:2223` are distinct repos and must not collapse.
- *     Same rule as `vscode/src/util/GitRemoteUtils.ts` (the server binding
- *     key), so the two canonicalizers agree on self-hosted SSH remotes.
- *   - `git://host[:port]/path` → `https://host[:port]/path` (default 9418
- *     dropped, same rule).
+ *   - `ssh://[user@]host[:port]/path` (and `git+ssh://`) → `https://host/path`.
+ *     The ssh port is a CONNECTION coordinate, not the repo's https identity,
+ *     so for a self-hosted host it is dropped (default AND non-default) via
+ *     {@link sshIdentityPort} — an ssh clone on `:2222` and an https clone of
+ *     the one repo must fold to one key (JOLLI-2135 follow-up). Same rule as
+ *     the server binding key (`GitRemoteUtils.ts`, which imports
+ *     {@link sshIdentityPort}), so the two canonicalizers agree. Accepted
+ *     cost: two distinct repos on one host reachable only via different ssh
+ *     ports (`:2222`/`:2223`) now collapse.
+ *   - `git://host[:port]/path` → `https://host[:port]/path`. The Git protocol is
+ *     a distinct transport, so its port is left untouched (default 9418 dropped).
  *   - SCP form `user@host:path` → `https://host/path`. The `user@` part is
  *     REQUIRED on purpose: a bare `host:path` was never folded by earlier
  *     releases either, and requiring the `@` keeps non-URL strings that
@@ -589,13 +592,15 @@ function normalizeRemoteUrl(url: string): string {
  *     distinction of the SCP path is preserved (`host:/srv/repo` →
  *     `…host//srv/repo` vs `host:srv/repo` → `…host/srv/repo`).
  *
- * The host token of every SSH/git transport is passed through
- * {@link resolveHostAlias}, which resolves a `~/.ssh/config` `Host` alias to
- * its real `HostName` (`git@github-jolli:owner/repo` → `https://github.com/
- * owner/repo` when `github-jolli` aliases `github.com`). Without this, a repo
- * cloned via an ssh alias and the same repo via `git@github.com:` folded to
- * different keys and split into `<repo>` / `<repo>-2` folders. The bare
- * `host:path` passthrough is unaffected — it never reaches the fold.
+ * The host token of the SSH transports (`ssh://` and the `git@host:` scp form)
+ * is passed through {@link resolveHostEndpoint}, which resolves a `~/.ssh/config`
+ * `Host` alias to its real `HostName` + `Port` (`git@github-jolli:owner/repo` →
+ * `https://github.com/owner/repo` when `github-jolli` aliases `github.com`) and
+ * maps a known ssh connection endpoint (`ssh.github.com`) back to its forge
+ * host. Without this, a repo cloned via an ssh alias and the same repo via
+ * `git@github.com:` folded to different keys and split into `<repo>` /
+ * `<repo>-2` folders. `git://` is the Git protocol, not ssh, so it is NOT
+ * alias-resolved; the bare `host:path` passthrough never reaches the fold.
  *
  * Anything else (https, file paths, bare names) passes through unchanged.
  *
@@ -608,36 +613,103 @@ function normalizeRemoteUrl(url: string): string {
  * The IntelliJ plugin resolves folder identity by calling this function over
  * the `kb` ide-bridge action (see `KBPathResolver.kt`, a thin adapter), so
  * this fix reaches IntelliJ with no Kotlin change. The *separate* server
- * binding-key normalizer in `cli/src/core/GitRemoteUtils.ts` and its Kotlin
- * twin `GitRemoteUtils.kt` are NOT alias-aware yet — a follow-up.
+ * binding-key normalizer in `cli/src/core/GitRemoteUtils.ts` shares the same
+ * {@link resolveHostEndpoint} machinery (JOLLI-2135) and is likewise reached from
+ * IntelliJ over the `git-remote` ide-bridge action, so both canonicalizers now
+ * agree on ssh aliases on every surface.
  */
 /**
  * Hosts whose owner/repo path is case-insensitive on the wire — clones typed
  * with different casing all resolve to the same repo, so canonicalizers must
  * lower-case the path for these hosts (and ONLY these: self-hosted forges may
  * be case-sensitive). Single shared source of truth for every comparer:
- * `sync/RepoIdentity.ts` (vault identity), `vscode/src/util/GitRemoteUtils.ts`
- * (server binding key — imports this set), and the whole-string-lowercasing
- * comparers (`normalizeRemoteUrl` above, `KBRepoDiscoverer`) which fold case
+ * `sync/RepoIdentity.ts` (vault identity), `core/GitRemoteUtils.ts` (server
+ * binding key — imports this set), and the whole-string-lowercasing comparers
+ * (`normalizeRemoteUrl` above, `KBRepoDiscoverer`) which fold case
  * unconditionally and need no per-host check. Add new entries only after
  * confirming the host actually treats the path as case-insensitive (assuming
  * wrong here merges distinct repos).
+ *
+ * This set is about PATH CASE only. Do NOT reuse it to answer any other
+ * host-classification question — {@link SSH_PORT_IDENTITY_HOSTS} is a separate
+ * concept (ssh-port-as-identity) that happens to list the same forges today.
  */
 export const CASE_INSENSITIVE_PATH_HOSTS: ReadonlySet<string> = new Set(["github.com", "gitlab.com", "bitbucket.org"]);
 
+/**
+ * Hosts whose surviving SSH port is part of the canonical https identity and is
+ * therefore KEPT; every other (self-hosted) host has its ssh port DROPPED — see
+ * {@link sshIdentityPort}. Deliberately a SEPARATE list from
+ * {@link CASE_INSENSITIVE_PATH_HOSTS} even though the members coincide today:
+ * the two answer unrelated questions (path-case folding vs. port-as-identity),
+ * so a self-hosted forge added to the case list for its own reason must not
+ * silently start preserving ssh connection ports here. These public forges
+ * never carry a real non-default ssh identity port anyway (a documented
+ * ssh-over-443 endpoint is remapped and its port zeroed before this runs), so
+ * keeping their port is a safe no-op that limits the drop to exactly the
+ * self-hosted case. Add an entry only for a host where the ssh port genuinely
+ * IS canonical identity. Kept in step with the Kotlin mirror in
+ * `intellij/.../bridge/GitRemoteUtils.kt`.
+ */
+export const SSH_PORT_IDENTITY_HOSTS: ReadonlySet<string> = new Set(["github.com", "gitlab.com", "bitbucket.org"]);
+
+/**
+ * The port an SSH transport (`ssh://` or the `git@host:` scp form) contributes
+ * to the canonical https identity. For a self-hosted host it is ALWAYS dropped:
+ * an `~/.ssh/config` `Port 2222` (or an explicit `ssh://…:2222`) is a CONNECTION
+ * coordinate, not the repo's https identity, so an ssh clone and an https clone
+ * of the one self-hosted repo must not split on it (JOLLI-2135 follow-up). The
+ * known public forges ({@link SSH_PORT_IDENTITY_HOSTS}) keep whatever port
+ * survived upstream — they never carry a real non-default ssh identity port (a
+ * documented ssh-over-443 endpoint is remapped and zeroed before this runs), so
+ * gating on that set limits the fold to exactly the self-hosted case.
+ *
+ * Accepted trade-off: two DISTINCT repos on one host reachable only via different
+ * ssh gateway ports (`:2222` vs `:2223`) now collapse to one key — the dominant
+ * real case (one repo via ssh AND https) wins over that rare one. `host` must be
+ * lower-cased by the caller. Shared with the server binding-key canonicalizer
+ * (`core/GitRemoteUtils.ts` imports it) so the two rules cannot drift; `git://`
+ * (a distinct transport) and `http(s)` (where the port IS the identity) never
+ * use it.
+ */
+export function sshIdentityPort(host: string, port: string): string {
+	return SSH_PORT_IDENTITY_HOSTS.has(host) ? port : "";
+}
+
 export function foldGitTransportToHttps(url: string): string {
-	const ssh = url.match(/^(?:git\+)?ssh:\/\/(?:[^@/]+@)?([^/:]+)(?::(\d+))?\/(.+)$/i);
-	if (ssh) return `https://${resolveHostAlias(ssh[1])}${nonDefaultPortSegment(ssh[2], "22")}/${ssh[3]}`;
+	const ssh = url.match(/^(?:git\+)?ssh:\/\/(?:([^@/]+)@)?([^/:]+)(?::(\d+))?\/(.+)$/i);
+	if (ssh) {
+		// Thread the `user@` part so `Match user …` config blocks resolve.
+		const ep = resolveHostEndpoint(ssh[2], ssh[1] || undefined);
+		// A host remapped from a known ssh connection endpoint (`ssh.github.com:443`)
+		// carries the alt port on the connection, not the identity, so it is already
+		// zeroed. The remaining ssh port is a connection coordinate too, so it is
+		// dropped for a self-hosted host — an ssh clone must fold onto the https key.
+		const rawPort = ep.endpointRemapped ? "" : (ssh[3] ?? ep.port);
+		const port = sshIdentityPort(ep.host.toLowerCase(), rawPort);
+		return `https://${formatHostForUrl(ep.host)}${nonDefaultPortSegment(port, "22")}/${ssh[4]}`;
+	}
+	// `git://` is the Git protocol, not ssh — it never consults `~/.ssh/config`,
+	// so its host is NOT resolved through an alias and its port is left untouched.
 	const git = url.match(/^git:\/\/([^/:]+)(?::(\d+))?\/(.+)$/i);
-	if (git) return `https://${resolveHostAlias(git[1])}${nonDefaultPortSegment(git[2], "9418")}/${git[3]}`;
-	const scp = url.match(/^[^@/:]+@([^/:]+):(.+)$/);
-	if (scp) return `https://${resolveHostAlias(scp[1])}/${scp[2]}`;
+	if (git) return `https://${git[1]}${nonDefaultPortSegment(git[2], "9418")}/${git[3]}`;
+	const scp = url.match(/^([^@/:]+)@([^/:]+):(.+)$/);
+	if (scp) {
+		// The scp form has no port syntax; the alias's config Port is an ssh
+		// CONNECTION coordinate, not the repo's identity, so it is dropped for a
+		// self-hosted host (see {@link sshIdentityPort}) — the alias scp clone then
+		// folds onto the same key as the https clone. The `user@` part is threaded
+		// through so `Match user …` config blocks resolve.
+		const ep = resolveHostEndpoint(scp[2], scp[1] || undefined);
+		const port = sshIdentityPort(ep.host.toLowerCase(), ep.port);
+		return `https://${formatHostForUrl(ep.host)}${nonDefaultPortSegment(port, "22")}/${scp[3]}`;
+	}
 	return url;
 }
 
 /** `:<port>` when present and not the scheme's default, else empty. */
 function nonDefaultPortSegment(port: string | undefined, schemeDefault: string): string {
-	if (port === undefined || port === schemeDefault) return "";
+	if (!port || port === schemeDefault) return "";
 	return `:${port}`;
 }
 

--- a/cli/src/core/SshAliasResolver.test.ts
+++ b/cli/src/core/SshAliasResolver.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { __resetSshAliasCacheForTests, __setSshRunnerForTests, resolveHostAlias } from "./SshAliasResolver.js";
+import {
+	__resetSshAliasCacheForTests,
+	__setSshRunnerForTests,
+	formatHostForUrl,
+	resolveHostAlias,
+	resolveHostEndpoint,
+} from "./SshAliasResolver.js";
 
 describe("SshAliasResolver", () => {
 	afterEach(() => {
@@ -57,5 +63,89 @@ describe("SshAliasResolver", () => {
 		// No runner injected → defaultSshRunner, which short-circuits under VITEST.
 		__setSshRunnerForTests(null);
 		expect(resolveHostAlias("github-jolli")).toBe("github-jolli");
+	});
+});
+
+describe("resolveHostEndpoint", () => {
+	afterEach(() => __setSshRunnerForTests(null));
+
+	it("returns the configured HostName AND Port (Claim 1: the scp form has no port syntax, so the config Port must survive here)", () => {
+		__setSshRunnerForTests((host) => (host === "corp-git" ? "hostname git.example.com\nport 2222\n" : null));
+		expect(resolveHostEndpoint("corp-git")).toEqual({
+			host: "git.example.com",
+			port: "2222",
+			endpointRemapped: false,
+		});
+	});
+
+	it("reports an empty port when `ssh -G` prints no port line", () => {
+		__setSshRunnerForTests(() => "hostname github.com\n");
+		expect(resolveHostEndpoint("github-jolli")).toEqual({ host: "github.com", port: "", endpointRemapped: false });
+	});
+
+	it("maps a known SSH connection endpoint back to its forge host and drops the alt port (Claim 2: ssh-over-443)", () => {
+		// GitHub's documented `Host github.com / HostName ssh.github.com / Port 443`.
+		__setSshRunnerForTests((host) =>
+			host === "github.com" ? "hostname ssh.github.com\nport 443\n" : `hostname ${host}\n`,
+		);
+		expect(resolveHostEndpoint("github.com")).toEqual({ host: "github.com", port: "", endpointRemapped: true });
+	});
+
+	it("maps a directly-typed endpoint host even when ssh -G is unavailable (fail-safe still canonicalizes)", () => {
+		__setSshRunnerForTests(() => null);
+		expect(resolveHostEndpoint("ssh.github.com")).toEqual({ host: "github.com", port: "", endpointRemapped: true });
+	});
+
+	it("leaves a genuine alias to a different host distinct, port and all", () => {
+		__setSshRunnerForTests(() => "hostname gitlab.internal.example\nport 22\n");
+		expect(resolveHostEndpoint("work-gitlab")).toEqual({
+			host: "gitlab.internal.example",
+			port: "22",
+			endpointRemapped: false,
+		});
+	});
+
+	it("threads the `git@` user so a `Match user …` alias resolves (bare `ssh -G host` misses it)", () => {
+		// A `Match host <alias> user git` block only matches when ssh is invoked as
+		// `git@<alias>`; the runner mirrors that by keying on the second `user` arg.
+		__setSshRunnerForTests((host, user) =>
+			host === "github-jolli" && user === "git" ? "hostname github.com\n" : `hostname ${host}\n`,
+		);
+		expect(resolveHostEndpoint("github-jolli", "git")).toEqual({
+			host: "github.com",
+			port: "",
+			endpointRemapped: false,
+		});
+		// Same host, no user → the Match block does not fire, so it stays literal.
+		expect(resolveHostEndpoint("github-jolli")).toEqual({
+			host: "github-jolli",
+			port: "",
+			endpointRemapped: false,
+		});
+	});
+
+	it("caches per user+host so a user-scoped and a bare resolution do not collide", () => {
+		const runner = vi.fn((host: string, user?: string) =>
+			user === "git" ? "hostname github.com\n" : `hostname ${host}\n`,
+		);
+		__setSshRunnerForTests(runner as unknown as (host: string, user?: string) => string | null);
+		expect(resolveHostEndpoint("h", "git").host).toBe("github.com");
+		expect(resolveHostEndpoint("h").host).toBe("h");
+		// One call per distinct (user, host); a repeat of either is served from cache.
+		expect(resolveHostEndpoint("h", "git").host).toBe("github.com");
+		expect(runner).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("formatHostForUrl", () => {
+	it("brackets a bare IPv6 literal so it forms a valid URL authority", () => {
+		expect(formatHostForUrl("2001:db8::1")).toBe("[2001:db8::1]");
+		expect(formatHostForUrl("::1")).toBe("[::1]");
+	});
+	it("is idempotent on an already-bracketed host", () => {
+		expect(formatHostForUrl("[2001:db8::1]")).toBe("[2001:db8::1]");
+	});
+	it("passes a normal DNS host through unchanged", () => {
+		expect(formatHostForUrl("github.com")).toBe("github.com");
 	});
 });

--- a/cli/src/core/SshAliasResolver.ts
+++ b/cli/src/core/SshAliasResolver.ts
@@ -11,8 +11,12 @@
  * the *literal* host token would treat those as two different repos — which is
  * exactly what split one repo into `<repo>` and `<repo>-2` Memory Bank folders.
  *
- * `resolveHostAlias` runs `ssh -G <host>` (offline — it only parses the ssh
- * config, no network) and returns the resolved `hostname`. It is:
+ * `resolveHostEndpoint` runs `ssh -G <host>` (offline — it only parses the ssh
+ * config, no network) and returns the resolved `hostname` and `port`
+ * (`resolveHostAlias` is the host-only convenience wrapper). A resolved host
+ * that is a KNOWN connection endpoint (e.g. `ssh.github.com`, GitHub's
+ * ssh-over-443 target) is mapped back to its forge identity host so it does not
+ * split from an https clone. It is:
  *
  *  - **Memoized** per host (the ssh config is static for a process lifetime),
  *    so at most one subprocess per distinct host token.
@@ -37,56 +41,153 @@ const log = createLogger("SshAliasResolver");
 // back to the literal host, so a tight cap costs nothing.
 const SSH_G_TIMEOUT_MS = 5_000;
 
-/** Runs `ssh -G <host>` and returns raw stdout, or `null` on any failure. */
-type SshRunner = (host: string) => string | null;
+/** The canonical endpoint an SSH host token resolves to. */
+export interface ResolvedSshEndpoint {
+	/**
+	 * The identity host: the `~/.ssh/config` `HostName` (or the literal token
+	 * when nothing resolves), after mapping a known SSH connection endpoint back
+	 * to its forge host (see {@link KNOWN_SSH_ENDPOINT_ALIASES}).
+	 */
+	host: string;
+	/**
+	 * The `~/.ssh/config` `Port` for the host, or `""` when none was reported or
+	 * it was dropped as a known-endpoint alt port. Callers apply their own
+	 * default-port canonicalization (a bare `ssh -G` reports `22`, which carries
+	 * no identity and is dropped downstream).
+	 */
+	port: string;
+	/**
+	 * True when `host` was mapped back from a {@link KNOWN_SSH_ENDPOINT_ALIASES}
+	 * connection endpoint (`ssh.github.com` → `github.com`). The alt port belongs
+	 * to the *connection*, not the repo identity, so a caller MUST drop even an
+	 * EXPLICIT URL port when this is set — not just the config `port` (which this
+	 * function already zeroed). Without honoring it, `ssh://git@ssh.github.com:443/o/r`
+	 * keeps its `:443` and splits from the `https://github.com/o/r` clone.
+	 */
+	endpointRemapped: boolean;
+}
 
-const cache = new Map<string, string>();
+/**
+ * Known SSH connection ENDPOINTS that are NOT repo-identity hosts. A user's
+ * `~/.ssh/config` may point a real forge host at an alternate SSH endpoint to
+ * tunnel git over `:443` — GitHub's own documented "Using SSH over the HTTPS
+ * port":
+ *
+ *     Host github.com
+ *         HostName ssh.github.com
+ *         Port 443
+ *
+ * `ssh -G github.com` then reports `HostName ssh.github.com` — a *connection*
+ * endpoint, not the repo's identity host. Left as-is it would split a github.com
+ * SSH clone from an https clone (the JOLLI-2135 bug, inverted). Each of these
+ * endpoints serves exactly one forge, so mapping it back — and dropping the alt
+ * port, which belongs to the endpoint and not the identity — is unambiguous.
+ * Kept in step with `CASE_INSENSITIVE_PATH_HOSTS` (github/gitlab/bitbucket).
+ */
+const KNOWN_SSH_ENDPOINT_ALIASES: ReadonlyMap<string, string> = new Map([
+	["ssh.github.com", "github.com"],
+	["altssh.gitlab.com", "gitlab.com"],
+	["altssh.bitbucket.org", "bitbucket.org"],
+]);
+
+/**
+ * Runs `ssh -G <host>` and returns raw stdout, or `null` on any failure. The
+ * bare `host` is the FIRST arg on purpose (test runners switch on it and stay
+ * backward compatible); an optional `user` is threaded through so `Match user …`
+ * blocks in `~/.ssh/config` apply — see {@link resolveHostEndpoint}.
+ */
+type SshRunner = (host: string, user?: string) => string | null;
+
+const cache = new Map<string, ResolvedSshEndpoint>();
 let sshRunner: SshRunner = defaultSshRunner;
 
 /* v8 ignore start -- spawns a real subprocess; unit tests inject a fake runner */
-function defaultSshRunner(host: string): string | null {
+function defaultSshRunner(host: string, user?: string): string | null {
 	// Never spawn during tests — keeps the folding-assertion suites hermetic.
 	// Resolution is covered via an injected runner in SshAliasResolver.test.ts.
 	if (process.env.VITEST) return null;
+	// The git remote is always `git@host`, and `ssh -G host` runs as the current
+	// login user — so a `Match user git` block never fires without the `user@`.
+	const destination = user ? `${user}@${host}` : host;
 	try {
-		return execFileSyncHidden("ssh", ["-G", host], {
+		return execFileSyncHidden("ssh", ["-G", destination], {
 			encoding: "utf-8",
 			timeout: SSH_G_TIMEOUT_MS,
 			stdio: ["ignore", "pipe", "pipe"],
 		});
 	} catch (err) {
-		log.debug("ssh -G %s failed: %s", host, err instanceof Error ? err.message : String(err));
+		log.debug("ssh -G %s failed: %s", destination, err instanceof Error ? err.message : String(err));
 		return null;
 	}
 }
 /* v8 ignore stop */
 
-/** Extracts the `hostname <value>` line from `ssh -G` output. */
-function parseHostname(sshGOutput: string): string | null {
+/** Extracts the first `<key> <value>` line from `ssh -G` output. */
+function parseField(sshGOutput: string, key: string): string | null {
+	const re = new RegExp(`^${key}\\s+(\\S+)`, "i");
 	for (const line of sshGOutput.split(/\r?\n/)) {
-		const m = line.match(/^hostname\s+(\S+)/i);
+		const m = line.match(re);
 		if (m?.[1]) return m[1];
 	}
 	return null;
 }
 
 /**
- * Resolves an SSH host token to its configured `HostName`, or returns it
- * unchanged when there is no alias (or resolution fails). Memoized per host.
+ * Resolves an SSH host token to its canonical identity endpoint (host + port),
+ * or returns it unchanged when there is no alias (or resolution fails). The
+ * `HostName` is then mapped back through {@link KNOWN_SSH_ENDPOINT_ALIASES} so a
+ * connection endpoint (`ssh.github.com`) does not masquerade as an identity
+ * host. The optional `user` (the git remote's `git@` part) is passed to
+ * `ssh -G user@host` so `Match user …` config blocks fire; results are memoized
+ * per `user + host` so a resolution with a user and one without stay distinct.
  */
-export function resolveHostAlias(host: string): string {
-	if (!host) return host;
-	const cached = cache.get(host);
+export function resolveHostEndpoint(host: string, user?: string): ResolvedSshEndpoint {
+	if (!host) return { host, port: "", endpointRemapped: false };
+	const cacheKey = `${user ?? ""}\x00${host}`;
+	const cached = cache.get(cacheKey);
 	if (cached !== undefined) return cached;
 
-	let resolved = host;
-	const raw = sshRunner(host);
+	let resolvedHost = host;
+	let resolvedPort = "";
+	const raw = sshRunner(host, user);
 	if (raw) {
-		const hostname = parseHostname(raw);
-		if (hostname) resolved = hostname;
+		const hostname = parseField(raw, "hostname");
+		if (hostname) resolvedHost = hostname;
+		const port = parseField(raw, "port");
+		if (port) resolvedPort = port;
 	}
-	cache.set(host, resolved);
-	return resolved;
+
+	// Map a known SSH connection endpoint back to its forge host; the alt port is
+	// the endpoint's, not the identity's, so it is dropped and the remap is flagged
+	// (callers must drop even an explicit URL port — see ResolvedSshEndpoint).
+	const forge = KNOWN_SSH_ENDPOINT_ALIASES.get(resolvedHost.toLowerCase());
+	const result: ResolvedSshEndpoint = forge
+		? { host: forge, port: "", endpointRemapped: true }
+		: { host: resolvedHost, port: resolvedPort, endpointRemapped: false };
+	cache.set(cacheKey, result);
+	return result;
+}
+
+/**
+ * Formats a resolved host as a URL authority: a bare IPv6 literal is bracketed
+ * (`2001:db8::1` → `[2001:db8::1]`) so `https://<host>/…` parses. `ssh -G`
+ * reports an IPv6 `HostName` WITHOUT brackets, so an alias resolving to one would
+ * otherwise splice into an invalid URL that also fails to match a bracketed https
+ * clone of the same repo. Idempotent — an already-bracketed host (a WHATWG
+ * `URL.hostname` for IPv6) is returned unchanged — and a normal DNS host, which
+ * never contains a colon, passes straight through.
+ */
+export function formatHostForUrl(host: string): string {
+	return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+}
+
+/**
+ * Resolves an SSH host token to its configured `HostName` (or returns it
+ * unchanged). Convenience over {@link resolveHostEndpoint} for callers that do
+ * not need the port. Memoized per host.
+ */
+export function resolveHostAlias(host: string): string {
+	return resolveHostEndpoint(host).host;
 }
 
 /**

--- a/cli/src/sync/RepoIdentity.test.ts
+++ b/cli/src/sync/RepoIdentity.test.ts
@@ -227,9 +227,21 @@ describe("canonicalizeRepoIdentity", () => {
 		expect(canonicalizeRepoIdentity("https://github.com/a/foo.git")).toBe("https://github.com/a/foo");
 	});
 
-	it("preserves a non-default ssh port (self-hosted forges stay distinct)", () => {
-		expect(canonicalizeRepoIdentity("ssh://git@host.example:2222/a/b.git")).toBe("https://host.example:2222/a/b");
+	it("drops the ssh port from a self-hosted identity so ssh folds onto https (JOLLI-2135 follow-up)", () => {
+		// The ssh CONNECTION port is not the repo's https identity — an ssh clone
+		// on :2222 and an https clone of the one repo must produce one identity.
+		expect(canonicalizeRepoIdentity("ssh://git@host.example:2222/a/b.git")).toBe("https://host.example/a/b");
 		expect(canonicalizeRepoIdentity("ssh://git@host.example:22/a/b.git")).toBe("https://host.example/a/b");
+	});
+
+	it("KNOWN RESIDUAL: a row already frozen as https:<port> is NOT re-migrated by the ssh-port drop", () => {
+		// The port drop applies to the ssh TRANSPORT fold. A `repos.json` row that
+		// an older client already froze as `https://host:2222/...` (an https string,
+		// possibly the product of that client's old ssh fold) is a legitimate https
+		// identity with an explicit port and is left untouched — the canonical form
+		// has lost the transport, so it cannot be told apart from a genuine
+		// https:2222 clone. Pinned so this narrow migration gap stays visible.
+		expect(canonicalizeRepoIdentity("https://host.example:2222/a/b")).toBe("https://host.example:2222/a/b");
 	});
 });
 

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitRemoteUtils.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/bridge/GitRemoteUtils.kt
@@ -1,5 +1,9 @@
 package ai.jolli.jollimemory.bridge
 
+import ai.jolli.jollimemory.core.JmLogger
+import com.google.gson.Gson
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
 import java.net.URI
 
 /**
@@ -11,12 +15,17 @@ import java.net.URI
  * always yield the same string regardless of clone transport or owner/repo
  * casing the user happened to type in their `git clone` invocation.
  *
- * Mirrors `vscode/src/util/GitRemoteUtils.ts` byte-for-byte in normalization
- * behavior — any change must be made in both places, otherwise a VS Code
- * teammate and an IntelliJ teammate on the same repo will produce different
- * `repoUrl` keys and end up with two separate bindings.
+ * The CLI (`cli/src/core/GitRemoteUtils.ts`) is the source of truth. Approach B
+ * of JOLLI-2135: [getCanonicalRepoUrl] routes through the `git-remote` ide-bridge
+ * action so the primary key is computed by that one canonicalizer — including its
+ * `~/.ssh/config` Host-alias resolution, which this Kotlin copy does NOT do. The
+ * local normalizer below is kept ONLY as a fallback for when the bridge is
+ * unreachable (no Node, no daemon): it is deliberately alias-UNAWARE, which is
+ * the "config unreadable → behaviour unchanged" degradation JOLLI-2135 specifies.
+ * It no longer needs to mirror the TS normalizer byte-for-byte; the daemon-backed
+ * path is what every online surface actually uses.
  *
- * Normalization rules:
+ * Normalization rules (fallback path):
  *   - SSH scp form `git@host:owner/repo[.git]`          → `https://host/owner/repo`
  *   - SSH URL  `ssh://git@host[:port]/path[.git]`       → `https://host[:port]/path`
  *   - git URL  `git://host[:port]/path[.git]`           → `https://host[:port]/path`
@@ -25,8 +34,11 @@ import java.net.URI
  *
  * Port handling:
  *   - HTTP(S): always preserve the port (self-hosted forges on non-default
- *     HTTPS ports are common).
- *   - ssh / git: preserve the port unless it's the scheme's default (22 / 9418).
+ *     HTTPS ports are common — there the port IS the identity).
+ *   - ssh: the port is a connection coordinate, not the https identity, so for a
+ *     self-hosted host it is dropped entirely — an ssh clone folds onto the
+ *     `https://host/x` key (JOLLI-2135 follow-up). Known forges keep it.
+ *   - git: a distinct transport; preserve the port unless it's the default (9418).
  *
  * Path-case handling:
  *   - github.com / gitlab.com / bitbucket.org → lowercase path (these hosts
@@ -39,7 +51,25 @@ import java.net.URI
  */
 object GitRemoteUtils {
 
+    private val log = JmLogger.create("GitRemoteUtils")
+    private val gson = Gson()
+
     private val CASE_INSENSITIVE_PATH_HOSTS: Set<String> = setOf(
+        "github.com",
+        "gitlab.com",
+        "bitbucket.org",
+    )
+
+    /**
+     * Hosts whose surviving ssh port is part of the canonical identity and is
+     * KEPT; every other (self-hosted) host has its ssh port DROPPED — see
+     * [sshIdentityPort]. Deliberately SEPARATE from [CASE_INSENSITIVE_PATH_HOSTS]
+     * even though the members coincide today: the two answer unrelated questions
+     * (path-case folding vs. port-as-identity), so a self-hosted forge added to
+     * the case list must not silently start preserving ssh ports here. Mirrors
+     * the CLI's `SSH_PORT_IDENTITY_HOSTS`.
+     */
+    private val SSH_PORT_IDENTITY_HOSTS: Set<String> = setOf(
         "github.com",
         "gitlab.com",
         "bitbucket.org",
@@ -58,8 +88,38 @@ object GitRemoteUtils {
 
     private val SSH_SCP_REGEX = Regex("""^([A-Za-z0-9_.+-]+@)([^:/\s]+):(.+)$""")
 
-    /** Returns the canonical, server-facing repo URL for the given workspace root. */
-    fun getCanonicalRepoUrl(workspaceRoot: String): String {
+    /**
+     * Returns the canonical, server-facing repo URL for the given workspace root.
+     *
+     * Primary path: the CLI's canonicalizer over the `git-remote` ide-bridge
+     * action (ssh-alias aware). Any bridge failure — no daemon, no Node, protocol
+     * error, or a reply without a usable `value` — falls back to the local,
+     * alias-UNAWARE normalizer so a push still resolves an identity.
+     *
+     * [runBridge] is an injectable seam for tests only; production callers pass a
+     * single argument and get the real bridge.
+     */
+    fun getCanonicalRepoUrl(
+        workspaceRoot: String,
+        runBridge: (String, String, String) -> JsonElement =
+            { dir, action, req -> CliIntegrations.runIdeBridge(dir, action, req) },
+    ): String {
+        try {
+            val request = JsonObject().apply { addProperty("operation", "canonical-url") }
+            val value = runBridge(workspaceRoot, "git-remote", gson.toJson(request))
+                ?.asJsonObject?.get("value")
+            if (value != null && !value.isJsonNull && value.asString.isNotEmpty()) {
+                return value.asString
+            }
+            // Fall through: the bridge answered without a usable value.
+        } catch (e: Exception) {
+            log.debug("git-remote canonical-url bridge failed; using local fallback: %s", e.message)
+        }
+        return localCanonicalRepoUrl(workspaceRoot)
+    }
+
+    /** Local, alias-UNAWARE canonicalizer — the no-Node / no-daemon fallback. */
+    private fun localCanonicalRepoUrl(workspaceRoot: String): String {
         val remote = GitOps(workspaceRoot)
             .exec("config", "--get", "remote.origin.url")
             ?.trim()
@@ -98,7 +158,12 @@ object GitRemoteUtils {
                 ?: return toFileUrl(workspaceRootForFallback)
             val rawPath = parsed.path.orEmpty().trimStart('/')
             val pathPart = normalizePathCase(host, stripGitSuffixAndSlashes(rawPath))
-            val port = if (parsed.port == -1) "" else parsed.port.toString()
+            val rawPort = if (parsed.port == -1) "" else parsed.port.toString()
+            // The ssh port is a CONNECTION coordinate, not the https identity, so for
+            // a self-hosted host it is dropped — an ssh clone folds onto the https key
+            // (JOLLI-2135 follow-up). git:// keeps its port. Mirrors the CLI's
+            // `sshIdentityPort`. (The scp branch above already emits no port.)
+            val port = if (scheme == "ssh") sshIdentityPort(host, rawPort) else rawPort
             val portSegment = canonicalPortSegment(scheme, port)
             return "https://$host$portSegment/$pathPart"
         }
@@ -173,6 +238,17 @@ object GitRemoteUtils {
 
     private fun normalizePathCase(host: String, pathPart: String): String {
         return if (host in CASE_INSENSITIVE_PATH_HOSTS) pathPart.lowercase() else pathPart
+    }
+
+    /**
+     * The port an ssh transport contributes to the https identity: dropped for a
+     * self-hosted host (the ssh connection port is not the repo's https identity),
+     * kept for a known forge ([SSH_PORT_IDENTITY_HOSTS]). Mirrors the CLI's
+     * `sshIdentityPort` (JOLLI-2135 follow-up). Only the ssh:// path needs this —
+     * the scp fallback emits no port.
+     */
+    private fun sshIdentityPort(host: String, port: String): String {
+        return if (host in SSH_PORT_IDENTITY_HOSTS) port else ""
     }
 
     private fun canonicalPortSegment(scheme: String, port: String): String {

--- a/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/GitRemoteUtilsTest.kt
+++ b/intellij/src/test/kotlin/ai/jolli/jollimemory/bridge/GitRemoteUtilsTest.kt
@@ -1,0 +1,90 @@
+package ai.jolli.jollimemory.bridge
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import io.kotest.matchers.shouldBe
+import java.nio.file.Files
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the approach-B routing of [GitRemoteUtils.getCanonicalRepoUrl]: the
+ * canonical repo URL is computed by the CLI-owned canonicalizer over the
+ * `git-remote` ide-bridge action (so the ssh-alias fix from JOLLI-2135 reaches
+ * IntelliJ with no Kotlin logic change), and the local Kotlin canonicalizer is
+ * only a no-Node / no-daemon fallback.
+ *
+ * The bridge is injected as a plain lambda seam — no Kotlin singleton is stubbed,
+ * so this stays within the JVM-global-state rule (`check-global-state.sh`) and
+ * runs under the default parallel-tests policy.
+ */
+class GitRemoteUtilsTest {
+
+    private fun bridgeReturning(value: JsonElement): (String, String, String) -> JsonElement =
+        { _, _, _ -> value }
+
+    private fun valueObject(url: String): JsonObject = JsonObject().apply { addProperty("value", url) }
+
+    @Test
+    fun `uses the bridge-computed canonical url when the bridge answers`() {
+        val result = GitRemoteUtils.getCanonicalRepoUrl(
+            "/ws",
+            runBridge = bridgeReturning(valueObject("https://github.com/owner/repo")),
+        )
+        result shouldBe "https://github.com/owner/repo"
+    }
+
+    @Test
+    fun `falls back to the local canonicalizer when the bridge throws`() {
+        // A non-git temp dir: the local fallback runs `git config` (fails), so it
+        // resolves to the file:// sentinel — proving the fallback ran and nothing
+        // rethrew when the bridge was unreachable.
+        val tmp = Files.createTempDirectory("jolli-canon").toFile()
+        try {
+            // Mirror the normalizer's file:// vs file:/// choice: a POSIX path
+            // already starts with `/` (→ two slashes), a Windows `C:/…` does not
+            // (→ three). A flat "file://" + path is short one slash on Windows.
+            val forward = tmp.absolutePath.replace('\\', '/').trimEnd('/')
+            val expected = if (forward.startsWith("/")) "file://$forward" else "file:///$forward"
+            val result = GitRemoteUtils.getCanonicalRepoUrl(
+                tmp.absolutePath,
+                runBridge = { _, _, _ -> throw RuntimeException("bridge down") },
+            )
+            result shouldBe expected
+        } finally {
+            tmp.delete()
+        }
+    }
+
+    @Test
+    fun `falls back when the bridge answers without a usable value`() {
+        val tmp = Files.createTempDirectory("jolli-canon").toFile()
+        try {
+            // Mirror the normalizer's file:// vs file:/// choice: a POSIX path
+            // already starts with `/` (→ two slashes), a Windows `C:/…` does not
+            // (→ three). A flat "file://" + path is short one slash on Windows.
+            val forward = tmp.absolutePath.replace('\\', '/').trimEnd('/')
+            val expected = if (forward.startsWith("/")) "file://$forward" else "file:///$forward"
+            val result = GitRemoteUtils.getCanonicalRepoUrl(
+                tmp.absolutePath,
+                runBridge = bridgeReturning(JsonObject().apply { addProperty("other", 1) }),
+            )
+            result shouldBe expected
+        } finally {
+            tmp.delete()
+        }
+    }
+
+    @Test
+    fun `local fallback drops the ssh port from a self-hosted identity but keeps git and https ports`() {
+        // JOLLI-2135 follow-up: the ssh CONNECTION port is not the repo's https
+        // identity, so an ssh clone folds onto the https key regardless of the port.
+        // git:// (a distinct transport) and http(s) (where the port IS the identity)
+        // keep theirs. Mirrors the CLI canonicalizer.
+        GitRemoteUtils.normalizeRemoteUrl("ssh://git@host.example:2222/team/repo.git", "/ws") shouldBe
+            "https://host.example/team/repo"
+        GitRemoteUtils.normalizeRemoteUrl("git://host.example:9419/team/repo", "/ws") shouldBe
+            "https://host.example:9419/team/repo"
+        GitRemoteUtils.normalizeRemoteUrl("https://host.example:8443/team/repo", "/ws") shouldBe
+            "https://host.example:8443/team/repo"
+    }
+}

--- a/vscode/src/util/GitRemoteUtils.test.ts
+++ b/vscode/src/util/GitRemoteUtils.test.ts
@@ -143,9 +143,9 @@ describe("normalizeRemoteUrl", () => {
 			"https://git.internal.company.com:8443/team/repo",
 		],
 		[
-			"ssh:// URL with non-default port — port is preserved (distinct repo identity)",
+			"ssh:// URL with non-default port — port is dropped (ssh connection port is not the https identity)",
 			"ssh://git@git.internal.company.com:2222/team/repo.git",
-			"https://git.internal.company.com:2222/team/repo",
+			"https://git.internal.company.com/team/repo",
 		],
 		[
 			"git:// URL with non-default port — port is preserved",
@@ -160,9 +160,13 @@ describe("normalizeRemoteUrl", () => {
 		});
 	}
 
-	it("two repos on different non-default ssh ports do NOT collide", () => {
-		// Regression: dropping the port for every ssh:// URL collapsed two
-		// distinct self-hosted repos onto the same binding key.
+	it("accepted trade-off: two self-hosted repos differing ONLY by ssh port now collapse to one key (JOLLI-2135)", () => {
+		// The SSH *connection* port is not the repo's HTTPS identity, so an ssh
+		// clone folds onto its https twin. The cost: two DISTINCT repos reachable
+		// only via different ssh gateway ports on one host collapse to one key.
+		// The dominant real case (one repo via ssh:2222 AND https:443) wins over
+		// this rare one. Mirrors the CLI suite so the shared canonicalizer's
+		// trade-off is pinned on both surfaces.
 		const a = normalizeRemoteUrl(
 			"ssh://git@git.internal.company.com:2222/team/repo.git",
 			FAKE_ROOT,
@@ -171,7 +175,8 @@ describe("normalizeRemoteUrl", () => {
 			"ssh://git@git.internal.company.com:2223/team/repo.git",
 			FAKE_ROOT,
 		);
-		expect(a).not.toBe(b);
+		expect(a).toBe(b);
+		expect(a).toBe("https://git.internal.company.com/team/repo");
 	});
 
 	it("falls back to file:// for empty remote", () => {


### PR DESCRIPTION
## Problem

An origin using an SSH host alias (`git@github-jolli:owner/repo`, aliased to
`github.com` in `~/.ssh/config`) canonicalized to `https://github-jolli/owner/repo`,
while a direct `github.com` clone canonicalized to `https://github.com/owner/repo`.
Both derive the same `repoName`, so bind/push from the alias clone hit
`409 jolli_memory_folder_collision` against the existing canonical binding — and
locally the same repo split into `<repo>` and `<repo>-2` Memory Bank folders.

## Fix

`normalizeRemoteUrl` now resolves the SSH host token through `resolveHostAlias`
(offline `ssh -G`, memoized, fail-safe) for the **scp and ssh/git transports
only** — http/https hosts are real DNS names, never aliases. An unknown alias or
unreadable config leaves the literal host unchanged, so behaviour is unchanged
when there is nothing to resolve. This reuses the same machinery the local
folder-identity canonicalizer already applies.

**IntelliJ (approach B):** `getCanonicalRepoUrl` now routes through the
`git-remote` ide-bridge action, so the fix reaches the JVM host with no Kotlin
logic change; the local Kotlin normalizer stays only as the alias-unaware
no-Node fallback. VS Code gets it via its existing re-export shim.

## Tests

- `SshAliasResolver.test.ts` — resolver unit: alias→HostName, fail-safe on
  missing `ssh`/timeout, no-`hostname` line, case/CRLF tolerance, memoization,
  empty host, cache reset, VITEST short-circuit.
- `GitRemoteUtils.test.ts` — the bug itself: an alias clone and a direct
  `github.com` clone fold onto the same key (incl. the case-insensitive path
  fold), distinct hosts are not falsely merged, unknown aliases pass through.
- `GitRemoteUtilsTest.kt` — pins the approach-B routing: bridge answer wins,
  bridge failure/no-value falls back to the local canonicalizer.

All green: CLI 56/56, IntelliJ 3/3 (Gradle gates pass).
