### PR TITLE
Fix spec-grounded defects surfaced by the PR 521 review

### DIFF
--- a/cli/src/commands/DoctorCommand.test.ts
+++ b/cli/src/commands/DoctorCommand.test.ts
@@ -1523,6 +1523,43 @@ describe("doctor --repair-transcripts", () => {
 		expect(out).toContain("No summaries need transcript repair");
 	});
 
+	it("does not re-archive turns an ALREADY-REPAIRED earlier sibling holds (cross-run dedup)", async () => {
+		// A is repaired in a PRIOR run (run 1 below) and archives the only turn (10:00)
+		// in its window [firstSeen..10:15]. B fails capture later and is a candidate in
+		// run 2. Folding what A PROVABLY archived into the per-session dedup floor bounds
+		// B's session at 10:00, so B has nothing left and is skipped. Without the fold,
+		// B's floor is undefined, it re-reads from firstSeenLine, and the 10:00 turn
+		// lands on TWO memories — the exact cross-run break this guards. A is repaired
+		// FOR REAL (readable stored transcript), so the floor rests on its proven
+		// per-session content, not the retired unreadable-fallback bound.
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[repo, EDGE]]) },
+			globalDir,
+		);
+		// Run 1: only A present, bounded at 10:15 so its window covers the 10:00 turn.
+		await storeSummary(
+			summary({ commitHash: "a".repeat(40), transcripts: [], generatedAt: "2026-08-17T10:15:00.000Z" }),
+			repo,
+		);
+		await captureLog(() => runRepairTranscripts(repo, true));
+		const aAfter = await getSummary("a".repeat(40), repo);
+		expect(aAfter?.transcriptsRepairedAt).toBeTruthy();
+		expect(aAfter?.transcripts).toHaveLength(1);
+
+		// Run 2: B fails capture and is now the only candidate; A is a repaired sibling.
+		await storeSummary(
+			summary({ commitHash: "b".repeat(40), transcripts: [], generatedAt: "2026-08-17T11:00:00.000Z" }),
+			repo,
+		);
+		const out = await captureLog(() => runRepairTranscripts(repo, true));
+
+		expect(out).toContain(`${"b".repeat(8)}  skipped — no-entries-in-window`);
+		expect(out).toContain("Repaired 0 of 1 summaries.");
+		expect((await getSummary("b".repeat(40), repo))?.transcripts ?? []).toHaveLength(0);
+		// A is untouched in run 2 — it was no longer a candidate.
+		expect((await getSummary("a".repeat(40), repo))?.transcripts).toEqual(aAfter?.transcripts);
+	});
+
 	it("continues past a candidate whose repair throws, and the totals still add up", async () => {
 		// Two candidates: the default HASH one (which the mock lets through to
 		// the real engine and succeeds) and a second at the sentinel `throwHash`
@@ -1611,6 +1648,81 @@ describe("doctor --repair-transcripts", () => {
 
 		const lines = await runDoctor(["--repair-transcripts", "--cwd", repo]);
 		const out = lines.join("\n");
+
+		expect(out).toContain("would repair");
+		expect((await getSummary(HASH, repo))?.transcripts ?? []).toHaveLength(0);
+	});
+
+	it("de-duplicates turns across candidates in one run, so no turn is archived to two memories", async () => {
+		// Two turns with distinct timestamps (a user then an assistant turn — the
+		// parser merges consecutive same-role turns).
+		await writeFile(
+			transcript,
+			`${JSON.stringify({ cwd: repo, timestamp: "2026-08-17T10:00:00.000Z", message: { role: "user", content: "first" } })}\n` +
+				`${JSON.stringify({ cwd: repo, timestamp: "2026-08-17T10:30:00.000Z", message: { role: "assistant", content: [{ type: "text", text: "reply" }] } })}\n`,
+			"utf-8",
+		);
+		// Two empty memories owned by the same session, with distinct upper bounds.
+		// Earlier-bounded A closes just after the first turn; later-bounded B spans both.
+		await storeSummary(summary({ commitHash: "a".repeat(40), generatedAt: "2026-08-17T10:15:00.000Z" }), repo);
+		await storeSummary(summary({ commitHash: "b".repeat(40), generatedAt: "2026-08-17T11:00:00.000Z" }), repo);
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[repo, EDGE]]) },
+			globalDir,
+		);
+
+		const out = await captureLog(() => runRepairTranscripts(repo, true));
+
+		// Each memory reports exactly one entry — A the first turn, B only the turn A
+		// did not take. Without dedup, B (spanning both) would report two, archiving
+		// the first turn twice.
+		const perCandidate = out.split("\n").filter((l) => l.includes("repaired —"));
+		expect(perCandidate).toHaveLength(2);
+		expect(perCandidate.every((l) => l.includes("1 entries"))).toBe(true);
+	});
+
+	it("orders candidates by NUMERIC upper bound, so a mixed-format bound is not mis-sequenced", async () => {
+		await writeFile(
+			transcript,
+			`${JSON.stringify({ cwd: repo, timestamp: "2026-08-17T10:00:00.000Z", message: { role: "user", content: "first" } })}\n` +
+				`${JSON.stringify({ cwd: repo, timestamp: "2026-08-17T10:30:00.000Z", message: { role: "assistant", content: [{ type: "text", text: "reply" }] } })}\n`,
+			"utf-8",
+		);
+		// A's bound (10:15 UTC) is EARLIER than B's (11:00 UTC), so A must be
+		// processed first and become B's dedup floor. But A's bound is written in
+		// offset form, whose STRING sorts AFTER B's Z-form bound — a lexicographic
+		// sort would run B first, give B both turns, then dedup A's only turn away
+		// and skip A with `no-entries-in-window`. Numeric ordering keeps A first.
+		await storeSummary(summary({ commitHash: "a".repeat(40), generatedAt: "2026-08-17T18:15:00.000+08:00" }), repo);
+		await storeSummary(summary({ commitHash: "b".repeat(40), generatedAt: "2026-08-17T11:00:00.000Z" }), repo);
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[repo, EDGE]]) },
+			globalDir,
+		);
+
+		const out = await captureLog(() => runRepairTranscripts(repo, true));
+
+		// Both repaired with exactly one entry each — A the 10:00 turn, B the 10:30
+		// turn. No `skipped — no-entries-in-window`, no candidate with two entries.
+		const perCandidate = out.split("\n").filter((l) => l.includes("repaired —"));
+		expect(perCandidate).toHaveLength(2);
+		expect(perCandidate.every((l) => l.includes("1 entries"))).toBe(true);
+		expect(out).not.toContain("no-entries-in-window");
+	});
+
+	it("honors --dry-run even alongside --fix, writing nothing", async () => {
+		// A repair rewrites a stored memory and stamps its own idempotency key in the
+		// same write, so applying one under --dry-run would both contradict the flag
+		// and make the write non-re-attemptable. --dry-run must force report-only.
+		await storeSummary(summary(), repo);
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[repo, EDGE]]) },
+			globalDir,
+		);
+		const st = await import("../core/SessionTracker.js");
+		vi.mocked(st.getGlobalConfigDir).mockReturnValue(globalDir);
+
+		const out = (await runDoctor(["--repair-transcripts", "--dry-run", "--fix", "--cwd", repo])).join("\n");
 
 		expect(out).toContain("would repair");
 		expect((await getSummary(HASH, repo))?.transcripts ?? []).toHaveLength(0);

--- a/cli/src/commands/DoctorCommand.ts
+++ b/cli/src/commands/DoctorCommand.ts
@@ -31,8 +31,13 @@ import {
 import { resolveSotBackend } from "../core/SotStorageResolver.js";
 import { createStorage } from "../core/StorageFactory.js";
 import { listSummaries, setActiveStorage } from "../core/SummaryStore.js";
-import { getTranscriptIds } from "../core/SummaryTree.js";
-import { repairSummaryTranscripts } from "../core/TranscriptRepair.js";
+import {
+	archivedSessionFloor,
+	isTranscriptRepairCandidate,
+	mergeSessionFloor,
+	orderTranscriptRepairCandidates,
+	repairSummaryTranscripts,
+} from "../core/TranscriptRepair.js";
 import { probeGlobalDaemon } from "../daemon/EnsureGlobalDaemon.js";
 import type { GlobalDaemonHello } from "../daemon/GlobalDaemonProtocol.js";
 import { backupHealthCheck } from "../dashboard/Backup.js";
@@ -1168,21 +1173,51 @@ export async function runSessionSyncNow(): Promise<void> {
  */
 export async function runRepairTranscripts(cwd: string, apply: boolean): Promise<void> {
 	const summaries = await listSummaries(Number.MAX_SAFE_INTEGER, cwd);
-	const candidates = summaries.filter(
-		(s) => s.transcriptsRepairedAt === undefined && getTranscriptIds(s).length === 0,
-	);
+	const candidates = summaries.filter(isTranscriptRepairCandidate);
 	if (candidates.length === 0) {
 		console.log("No summaries need transcript repair.");
 		return;
 	}
 
+	// Process oldest-upper-bound first and carry a PER-SESSION dedup floor forward:
+	// the per-owner lower bound is a constant (`firstSeenLine`), so without this
+	// every empty memory's window nests inside the next and the same turns are
+	// archived to all of them. Already-repaired siblings (from a PRIOR run) are
+	// folded into the same ordered walk — they archived their window from
+	// `firstSeenLine` too, so a candidate ordered after one must start past what
+	// that sibling actually archived, per session, or re-archive turns it already
+	// holds (the cross-run half of the dedup guarantee; a single run has no repaired
+	// siblings and so behaves exactly as before). The floor is per session, not one
+	// worktree-wide bound, precisely so a repaired sibling cannot suppress a session
+	// it never touched (P1). Only candidates are repaired; a repaired sibling just
+	// advances the floor. The ordering, the candidate predicate above, and the
+	// floor-advance helpers are the ONES shared with `transcriptRepairState`'s floor
+	// replay, so the UI's "repairable" wording cannot drift from what this run does.
+	const repairedSiblings = summaries.filter((s) => s.transcriptsRepairedAt !== undefined);
+	const ordered = orderTranscriptRepairCandidates([...candidates, ...repairedSiblings]);
+
 	let repaired = 0;
 	let errored = 0;
-	for (const candidate of candidates) {
-		const hash = candidate.commitHash.substring(0, 8);
+	// Per-session dedup floor carried forward. A repaired sibling whose stored
+	// transcript is unreadable contributes NOTHING (see `archivedSessionFloor`):
+	// an invisible copy is not a duplicate to guard a later memory's turns against.
+	const afterExclusiveBySession = new Map<string, number>();
+	for (const memory of ordered) {
+		// A prior-run repaired sibling only advances the floor — it is done. Fold in
+		// what it PROVABLY archived, per session; contribute nothing when its stored
+		// transcript is unreadable.
+		if (memory.transcriptsRepairedAt !== undefined) {
+			const archived = await archivedSessionFloor(memory, cwd);
+			if (archived.readable) mergeSessionFloor(afterExclusiveBySession, archived.bySession);
+			continue;
+		}
+		const hash = memory.commitHash.substring(0, 8);
 		let outcome: Awaited<ReturnType<typeof repairSummaryTranscripts>>;
 		try {
-			outcome = await repairSummaryTranscripts(candidate.commitHash, cwd, { apply });
+			outcome = await repairSummaryTranscripts(memory.commitHash, cwd, {
+				apply,
+				afterExclusiveBySession,
+			});
 		} catch (err) {
 			errored++;
 			console.log(`  ${hash}  error — ${errMsg(err)}`);
@@ -1190,6 +1225,11 @@ export async function runRepairTranscripts(cwd: string, apply: boolean): Promise
 		}
 		if (outcome.repaired) {
 			repaired++;
+			// Advance the dedup floor so the next (later-bounded) candidate keeps only
+			// turns past this one — per session, and only for the sessions this repair
+			// actually archived. Holds for dry runs too, so the reported "would repair
+			// — N entries" counts match what a real run would write.
+			if (outcome.archivedBySession) mergeSessionFloor(afterExclusiveBySession, outcome.archivedBySession);
 			console.log(`  ${hash}  ${apply ? "repaired" : "would repair"} — ${outcome.entries} entries`);
 		} else {
 			console.log(`  ${hash}  skipped — ${outcome.reason}`);
@@ -1337,7 +1377,12 @@ export function registerDoctorCommand(program: Command): void {
 					// the repair falls back to the frozen system-of-record and silently
 					// reads — or on --fix, tries to write — the wrong backend.
 					setActiveStorage(await createStorage(options.cwd, options.cwd));
-					await runRepairTranscripts(options.cwd, options.fix === true);
+					// `--dry-run` forces a report-only run even alongside `--fix`: a repair
+					// rewrites a stored memory and stamps its own idempotency key in the
+					// same write, so applying one under `--dry-run` would both contradict
+					// the flag and make the write non-re-attemptable. Every other doctor
+					// mode already treats `--dry-run` as "change nothing".
+					await runRepairTranscripts(options.cwd, options.fix === true && options.dryRun !== true);
 					return;
 				}
 				await runDoctor(

--- a/cli/src/commands/IdeBridgeCommand.test.ts
+++ b/cli/src/commands/IdeBridgeCommand.test.ts
@@ -361,6 +361,9 @@ vi.mock("../core/references/ReferenceStore.js", () => ({
 // `claude-owners.json` and stats every transcript path it names.
 vi.mock("../core/TranscriptRepair.js", () => ({
 	transcriptRepairState: vi.fn().mockResolvedValue("unrepairable"),
+	// The action filters `listSummaries` through this to build the sibling set it
+	// hands the predicate; a pass-through is enough (the list is stubbed empty).
+	isTranscriptRepairCandidate: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("../core/SummaryStore.js", () => ({
@@ -1446,18 +1449,30 @@ describe("runIdeBridgeAction — transcript-repair-state", () => {
 		vi.mocked(transcriptRepairState).mockResolvedValue("repairable");
 	});
 
-	it("answers the CLI predicate's state for a known commit", async () => {
+	it("answers the CLI predicate's state for a known commit, forwarding the repo's empty siblings", async () => {
 		// The action must FORWARD the predicate, not restate it: a Kotlin- or
 		// host-side restatement of "can this still be repaired?" is exactly the
 		// drift this bridge exists to prevent. Asserting the returned state comes
-		// from the predicate (and that the summary + cwd reach it) is what fails if
-		// someone hard-codes an answer here.
+		// from the predicate (and that the summary + cwd + sibling set reach it) is
+		// what fails if someone hard-codes an answer here. The siblings let the
+		// verdict reflect the batch dedup floor rather than the lone-repair window.
 		const { transcriptRepairState } = await import("../core/TranscriptRepair.js");
+		const { listSummaries } = await import("../core/SummaryStore.js");
+		vi.mocked(listSummaries).mockResolvedValueOnce([{ commitHash: "sib" }] as never);
 
 		const result = await runIdeBridgeAction("transcript-repair-state", "/repo", { commitHash: "abc" });
 
 		expect(result).toEqual({ state: "repairable" });
-		expect(transcriptRepairState).toHaveBeenCalledWith({ commitHash: "abc" }, "/repo");
+		expect(transcriptRepairState).toHaveBeenCalledWith({ commitHash: "abc" }, "/repo", expect.any(Object));
+		// `siblingSummaries` is a LAZY provider (so the enumeration is paid only for a
+		// real candidate). Assert it resolves to the repo's list rather than that an
+		// eager array was passed — the mocked predicate never invokes it, so calling it
+		// here is what consumes the `mockResolvedValueOnce` and proves the wiring.
+		const opts = vi.mocked(transcriptRepairState).mock.calls[0][2] as {
+			siblingSummaries: () => Promise<unknown>;
+		};
+		expect(typeof opts.siblingSummaries).toBe("function");
+		await expect(opts.siblingSummaries()).resolves.toEqual([{ commitHash: "sib" }]);
 	});
 
 	it("passes every state through unchanged", async () => {

--- a/cli/src/commands/IdeBridgeCommand.ts
+++ b/cli/src/commands/IdeBridgeCommand.ts
@@ -1922,11 +1922,25 @@ export async function runIdeBridgeAction(action: string, cwd: string, request: J
 			// direction to guess in: it invites the user to run a repair that has
 			// nothing to work from, and a memory nobody can look up is no evidence
 			// that local transcripts survive.
-			const { getSummary } = await import("../core/SummaryStore.js");
+			const { getSummary, listSummaries } = await import("../core/SummaryStore.js");
 			const summary = await getSummary(optionalString(request, "commitHash") ?? "", cwd);
 			if (!summary) return { state: "unrepairable" satisfies TranscriptRepairState };
 			const { transcriptRepairState } = await import("../core/TranscriptRepair.js");
-			return { state: await transcriptRepairState(summary, cwd) };
+			// Supply the repo's empty-or-repaired siblings so the verdict reflects the
+			// dedup floor a real `doctor --repair-transcripts` run would hand this memory
+			// — the only repair path a user can trigger — rather than the lone-repair
+			// window. Passed as a LAZY provider: `transcriptRepairState` short-circuits
+			// for the present/repaired majority before it needs siblings, so the
+			// `listSummaries(MAX)` enumeration (a read per memory) is paid only for an
+			// actual candidate, not on every state query. The engine owns the "which
+			// siblings count" filter (a repaired sibling still bounds the floor), so this
+			// passes the raw list. Safe here: this process reads local storage routed by
+			// `cwd`, the same way `getSummary` above does.
+			return {
+				state: await transcriptRepairState(summary, cwd, {
+					siblingSummaries: () => listSummaries(Number.MAX_SAFE_INTEGER, cwd),
+				}),
+			};
 		}
 		case "compile": {
 			const config = request.config as JolliMemoryConfig | undefined;

--- a/cli/src/core/AgentSessionEnv.test.ts
+++ b/cli/src/core/AgentSessionEnv.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { currentAgentSessionId } from "./AgentSessionEnv.js";
+import { currentAgentSessionId, isSafeSessionId } from "./AgentSessionEnv.js";
 
 const KEY = "CLAUDE_CODE_SESSION_ID";
 const original = process.env[KEY];
@@ -28,5 +28,26 @@ describe("currentAgentSessionId", () => {
 	it("is undefined for a blank value rather than returning an empty id", () => {
 		process.env[KEY] = "   ";
 		expect(currentAgentSessionId()).toBeUndefined();
+	});
+
+	it("treats a traversal / separator-bearing value as absent rather than carrying it forward", () => {
+		// A hostile or malformed value must never become a path segment downstream.
+		for (const hostile of ["../../etc/passwd", "a/b", "a\\b", "..", "."]) {
+			process.env[KEY] = hostile;
+			expect(currentAgentSessionId()).toBeUndefined();
+		}
+	});
+});
+
+describe("isSafeSessionId", () => {
+	it("accepts plain producer id tokens (uuid, hyphens, dots, underscores)", () => {
+		expect(isSafeSessionId("4ad551f5-35b5-4331-b807-987843d81113")).toBe(true);
+		expect(isSafeSessionId("sid_123.v2")).toBe(true);
+	});
+
+	it("rejects anything that could escape a directory or is not a plain segment", () => {
+		for (const bad of ["", ".", "..", "../x", "a/b", "a\\b", "/abs", "with space", "x y"]) {
+			expect(isSafeSessionId(bad)).toBe(false);
+		}
 	});
 });

--- a/cli/src/core/AgentSessionEnv.ts
+++ b/cli/src/core/AgentSessionEnv.ts
@@ -36,6 +36,21 @@
 export const SESSION_ID_ENV_VARS: ReadonlyArray<string> = ["CLAUDE_CODE_SESSION_ID"];
 
 /**
+ * True when `id` is safe to interpolate as a single path segment when locating a
+ * session's transcript (`<projectsDir>/<slug>/<id>.jsonl`). The id reaches that
+ * `join` from two attacker-influenceable sources — the process environment, and
+ * the executing-session field of a queue entry, which is an ordinary JSON file
+ * parsed with no schema — so an unvalidated value carrying `../` traversal
+ * escapes the producer's transcript directory (`join` normalises the traversal
+ * rather than rejecting it). A real producer session id is a plain token; this
+ * predicate admits exactly that and rejects any separator, traversal, or empty /
+ * dot-only name, which closes the escape at the point the id becomes a path.
+ */
+export function isSafeSessionId(id: string): boolean {
+	return /^[A-Za-z0-9._-]+$/.test(id) && id !== "." && id !== "..";
+}
+
+/**
  * The agent session this process is running inside, or `undefined` for a plain
  * terminal and for every host in the note above. A blank value is treated as
  * absent rather than returned as an empty id.
@@ -43,7 +58,10 @@ export const SESSION_ID_ENV_VARS: ReadonlyArray<string> = ["CLAUDE_CODE_SESSION_
 export function currentAgentSessionId(): string | undefined {
 	for (const name of SESSION_ID_ENV_VARS) {
 		const id = process.env[name]?.trim();
-		if (id) return id;
+		// A malformed value (traversal, separators) is treated as absent rather
+		// than carried forward: an invented/hostile id must never become a path
+		// segment downstream, and "no id" is the honest answer for one we refuse.
+		if (id && isSafeSessionId(id)) return id;
 	}
 	return undefined;
 }

--- a/cli/src/core/AtomicWrite.test.ts
+++ b/cli/src/core/AtomicWrite.test.ts
@@ -5,6 +5,9 @@ const h = vi.hoisted(() => ({
 	writeFile: vi.fn(),
 	rename: vi.fn(),
 	rm: vi.fn(),
+	writeFileSync: vi.fn(),
+	renameSync: vi.fn(),
+	rmSync: vi.fn(),
 }));
 
 vi.mock("node:crypto", () => ({
@@ -17,7 +20,13 @@ vi.mock("node:fs/promises", () => ({
 	rm: h.rm,
 }));
 
-import { atomicWriteFile } from "./AtomicWrite.js";
+vi.mock("node:fs", () => ({
+	writeFileSync: h.writeFileSync,
+	renameSync: h.renameSync,
+	rmSync: h.rmSync,
+}));
+
+import { atomicWriteFile, atomicWriteFileSync } from "./AtomicWrite.js";
 
 describe("atomicWriteFile", () => {
 	beforeEach(() => {
@@ -26,6 +35,9 @@ describe("atomicWriteFile", () => {
 		h.writeFile.mockResolvedValue(undefined);
 		h.rename.mockResolvedValue(undefined);
 		h.rm.mockResolvedValue(undefined);
+		h.writeFileSync.mockReturnValue(undefined);
+		h.renameSync.mockReturnValue(undefined);
+		h.rmSync.mockReturnValue(undefined);
 	});
 
 	it("writes through a unique tmp file and renames it into place", async () => {
@@ -66,6 +78,19 @@ describe("atomicWriteFile", () => {
  * so both arms are pinned here.
  */
 describe("atomicWriteFile — mode", () => {
+	// Reset between tests, exactly as the sibling blocks do: without it the mock
+	// CALL HISTORY accumulates across this block's cases, so the EPERM-fallback
+	// test's `toHaveBeenNthCalledWith(2, …)` matches the SECOND case's tmpfile
+	// write rather than its own fallback write, and fails whenever the whole block
+	// runs (green only when that one test is run in isolation).
+	beforeEach(() => {
+		for (const fn of Object.values(h)) fn.mockReset();
+		h.randomUUID.mockReturnValue("uuid");
+		h.writeFile.mockResolvedValue(undefined);
+		h.rename.mockResolvedValue(undefined);
+		h.rm.mockResolvedValue(undefined);
+	});
+
 	it("applies mode to the tmpfile, so the rename carries it to the target", async () => {
 		await atomicWriteFile("/repo/state.json", "next", 0o600);
 
@@ -91,5 +116,57 @@ describe("atomicWriteFile — mode", () => {
 			encoding: "utf-8",
 			mode: 0o600,
 		});
+	});
+});
+
+describe("atomicWriteFileSync", () => {
+	beforeEach(() => {
+		for (const fn of Object.values(h)) fn.mockReset();
+		h.randomUUID.mockReturnValue("uuid");
+		h.writeFileSync.mockReturnValue(undefined);
+		h.renameSync.mockReturnValue(undefined);
+		h.rmSync.mockReturnValue(undefined);
+	});
+
+	it("writes through a unique tmp file and renames it into place, applying mode", () => {
+		atomicWriteFileSync("/repo/state.json", '{"ok":true}', 0o600);
+
+		const tmpPath = `/repo/state.json.${process.pid}.uuid.tmp`;
+		expect(h.writeFileSync).toHaveBeenCalledWith(tmpPath, '{"ok":true}', { encoding: "utf-8", mode: 0o600 });
+		expect(h.renameSync).toHaveBeenCalledWith(tmpPath, "/repo/state.json");
+		expect(h.rmSync).not.toHaveBeenCalled();
+	});
+
+	it("omits the mode option entirely when no mode is given", () => {
+		atomicWriteFileSync("/repo/state.json", "next");
+
+		const tmpPath = `/repo/state.json.${process.pid}.uuid.tmp`;
+		expect(h.writeFileSync).toHaveBeenCalledWith(tmpPath, "next", "utf-8");
+	});
+
+	it.each(["EPERM", "EACCES"])("falls back to direct overwrite and removes tmp on %s", (code) => {
+		h.renameSync.mockImplementationOnce(() => {
+			throw Object.assign(new Error(code), { code });
+		});
+
+		atomicWriteFileSync("/repo/state.json", "next", 0o600);
+
+		const tmpPath = `/repo/state.json.${process.pid}.uuid.tmp`;
+		expect(h.writeFileSync).toHaveBeenNthCalledWith(1, tmpPath, "next", { encoding: "utf-8", mode: 0o600 });
+		expect(h.writeFileSync).toHaveBeenNthCalledWith(2, "/repo/state.json", "next", {
+			encoding: "utf-8",
+			mode: 0o600,
+		});
+		expect(h.rmSync).toHaveBeenCalledWith(tmpPath, { force: true });
+	});
+
+	it("rethrows non-recoverable rename failures", () => {
+		const err = Object.assign(new Error("nope"), { code: "EISDIR" });
+		h.renameSync.mockImplementationOnce(() => {
+			throw err;
+		});
+
+		expect(() => atomicWriteFileSync("/repo/state.json", "next")).toThrow(err);
+		expect(h.rmSync).not.toHaveBeenCalled();
 	});
 });

--- a/cli/src/core/AtomicWrite.ts
+++ b/cli/src/core/AtomicWrite.ts
@@ -6,6 +6,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { renameSync, rmSync, writeFileSync } from "node:fs";
 import { rename, rm, writeFile } from "node:fs/promises";
 
 /**
@@ -43,6 +44,34 @@ export async function atomicWriteFile(filePath: string, content: string, mode?: 
 			// already has are the ones its owner chose.
 			await writeFile(filePath, content, mode === undefined ? "utf-8" : { encoding: "utf-8", mode });
 			await rm(tmpPath, { force: true });
+		} else {
+			throw error;
+		}
+	}
+}
+
+/**
+ * Synchronous sibling of {@link atomicWriteFile}, for the sync-only state writers
+ * (e.g. the session-statistics channel's cursor file, written from hook and
+ * daemon paths that are not async). Same tmpfile + rename guarantee and the same
+ * Windows EPERM/EACCES fallback — a torn/partial write can never be observed even
+ * though this channel deliberately holds no lock and lets writers overlap, so the
+ * only residual is a last-writer-wins on the whole file, never a corrupt one.
+ */
+export function atomicWriteFileSync(filePath: string, content: string, mode?: number): void {
+	const tmpPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+	writeFileSync(tmpPath, content, mode === undefined ? "utf-8" : { encoding: "utf-8", mode });
+	try {
+		renameSync(tmpPath, filePath);
+	} catch (error: unknown) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "EPERM" || code === "EACCES") {
+			// Windows fallback (mirrors {@link atomicWriteFile}): a direct overwrite cannot
+			// carry `mode` onto an existing target (node ignores it there), which is
+			// acceptable — this branch exists because the target is held open by another
+			// process, and the permissions it already has are the ones its owner chose.
+			writeFileSync(filePath, content, mode === undefined ? "utf-8" : { encoding: "utf-8", mode });
+			rmSync(tmpPath, { force: true });
 		} else {
 			throw error;
 		}

--- a/cli/src/core/ClaudeOwnerScan.test.ts
+++ b/cli/src/core/ClaudeOwnerScan.test.ts
@@ -95,6 +95,17 @@ describe("scanOwnerEdges", () => {
 		expect(edges.size).toBe(0);
 	});
 
+	it("skips a RELATIVE cwd without even resolving it (it would anchor against the reader's own cwd)", () => {
+		const always = vi.fn(() => "/root");
+		const { edges } = scanOwnerEdges(
+			[line(".", "2026-08-17T10:00:00.000Z"), line("/abs", "2026-08-17T10:01:00.000Z")],
+			0,
+			always,
+		);
+		expect(always).not.toHaveBeenCalledWith(".");
+		expect([...edges.keys()]).toEqual(["/root"]);
+	});
+
 	it("falls back to a caller-supplied instant when a line carries no timestamp", () => {
 		const lines = [JSON.stringify({ cwd: "/repo/a" })];
 		const edge = scanOwnerEdges(lines, 0, roots, () => "2026-08-17T12:00:00.000Z").edges.get("/repo/a");
@@ -254,6 +265,23 @@ describe("resolveClaudeTranscriptPath", () => {
 
 	it("returns null when the projects directory does not exist", async () => {
 		expect(await resolveClaudeTranscriptPath("sid", join(tmpdir(), "jolli-no-such-dir-xyz"))).toBeNull();
+	});
+
+	it("rejects an unsafe (traversal) session id before it can become a path segment", async () => {
+		const projects = await mkdtemp(join(tmpdir(), "jolli-proj3-"));
+		const proj = join(projects, "-Users-me-repo");
+		await mkdir(proj);
+		// A traversal id would escape `projects`; must be refused outright.
+		expect(await resolveClaudeTranscriptPath("../../../etc/hosts", projects)).toBeNull();
+	});
+
+	it("returns null when the candidate exists but is not a regular file", async () => {
+		const projects = await mkdtemp(join(tmpdir(), "jolli-proj4-"));
+		const proj = join(projects, "-Users-me-repo");
+		await mkdir(proj);
+		// A directory (or fifo) named like the transcript must not be accepted and read.
+		await mkdir(join(proj, "sid-dir.jsonl"));
+		expect(await resolveClaudeTranscriptPath("sid-dir", projects)).toBeNull();
 	});
 });
 

--- a/cli/src/core/ClaudeOwnerScan.ts
+++ b/cli/src/core/ClaudeOwnerScan.ts
@@ -13,10 +13,11 @@
  * notions of "line N" cannot drift apart.
  */
 
-import { access, readdir, readFile } from "node:fs/promises";
+import { readdir, readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join } from "node:path";
 import { createLogger } from "../Logger.js";
+import { isSafeSessionId } from "./AgentSessionEnv.js";
 import { type ClaudeOwnerEdge, recordClaudeOwners } from "./ClaudeOwnership.js";
 import { resolveWorktreeRootOrNull } from "./GitOps.js";
 import { loadExtractorCursorLine, saveExtractorCursor } from "./SessionTracker.js";
@@ -123,6 +124,14 @@ export function scanOwnerEdges(
 		}
 		const cwd = typeof raw.cwd === "string" ? raw.cwd : "";
 		if (cwd.length === 0) continue;
+		// A RELATIVE cwd cannot identify a worktree root on its own — resolving it
+		// would anchor against THIS process's own working directory (the draining
+		// worker's = the committing worktree), so a transcript whose lines carry a
+		// relative cwd (e.g. `"."`) would mint an owner edge keyed to whatever
+		// checkout happens to be draining, regardless of what the transcript is
+		// about. Real producer transcripts always stamp an absolute cwd, so
+		// requiring one loses no genuine edge and closes that minting vector.
+		if (!isAbsolute(cwd)) continue;
 
 		const at = typeof raw.timestamp === "string" && raw.timestamp.length > 0 ? raw.timestamp : now();
 
@@ -200,6 +209,11 @@ export async function resolveClaudeTranscriptPath(
 	sessionId: string,
 	projectsDir: string = join(homedir(), ".claude", "projects"),
 ): Promise<string | null> {
+	// The id becomes a path segment below, and it arrives unvalidated from the
+	// environment or from a schema-less queue entry — so a traversal value would
+	// escape `projectsDir` here. Reject anything that is not a plain segment
+	// before it can reach `join` (see isSafeSessionId).
+	if (!isSafeSessionId(sessionId)) return null;
 	let slugs: string[];
 	try {
 		slugs = (await readdir(projectsDir, { withFileTypes: true })).filter((d) => d.isDirectory()).map((d) => d.name);
@@ -209,8 +223,10 @@ export async function resolveClaudeTranscriptPath(
 	for (const slug of slugs) {
 		const candidate = join(projectsDir, slug, `${sessionId}.jsonl`);
 		try {
-			await access(candidate);
-			return candidate;
+			// Require a REGULAR FILE, not merely "something exists": the whole file
+			// is read next, and `access` would happily accept a directory or a fifo
+			// (which a `readFile` could block on).
+			if ((await stat(candidate)).isFile()) return candidate;
 		} catch {
 			// not in this project dir — keep looking
 		}

--- a/cli/src/core/ClaudeOwnership.test.ts
+++ b/cli/src/core/ClaudeOwnership.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -273,6 +273,99 @@ describe("ClaudeOwnership", () => {
 		expect(mine).toEqual([
 			{ sessionId: "good", transcriptPath: "/t/good.jsonl", edge: expect.objectContaining({ firstSeenLine: 5 }) },
 		]);
+	});
+
+	it("quarantines a present-but-corrupt ledger instead of overwriting every other session with the new one", async () => {
+		const path = join(dir, "claude-owners.json");
+		// A prior ledger held two sessions, then the file was corrupted (torn write).
+		await writeFile(path, '{ "sessions": { "claude:old-1": {}, "claude:old-2": ', "utf-8");
+
+		const durable = await recordClaudeOwners(
+			{ sessionId: "new", transcriptPath: "/t/new.jsonl", edges: new Map([["/repo/a", edge()]]) },
+			dir,
+		);
+
+		// Non-durable: the caller must NOT advance its cursor mark over a
+		// recovered-from-corrupt write.
+		expect(durable).toBe(false);
+		// The corrupt bytes are preserved for recovery, not destroyed...
+		const { readdir } = await import("node:fs/promises");
+		const quarantined = (await readdir(dir)).filter((f) => f.startsWith("claude-owners.json.corrupt-"));
+		expect(quarantined).toHaveLength(1);
+		expect(await readFile(join(dir, quarantined[0]), "utf-8")).toContain("claude:old-1");
+		// ...and a fresh, valid ledger now holds the session being written.
+		expect(Object.keys((await loadClaudeOwners(dir)).sessions)).toEqual(["claude:new"]);
+	});
+
+	it("quarantines a ledger with a per-session-corrupt entry instead of silently dropping it on the next write", async () => {
+		const path = join(dir, "claude-owners.json");
+		// The whole file parses and its top-level shape is sound, but ONE session
+		// entry is malformed (its `owners` is null). The write path must treat this
+		// exactly like a top-level corruption — quarantine the file, preserving the
+		// torn entry for recovery — not silently filter it out and rewrite it away.
+		await writeFile(
+			path,
+			JSON.stringify({
+				version: 1,
+				sessions: {
+					"claude:good": {
+						sessionId: "good",
+						transcriptPath: "/t/good.jsonl",
+						source: "claude",
+						owners: { "/repo/a": edge() },
+					},
+					"claude:torn": {
+						sessionId: "torn",
+						transcriptPath: "/t/torn.jsonl",
+						source: "claude",
+						owners: null,
+					},
+				},
+			}),
+			"utf-8",
+		);
+
+		const durable = await recordClaudeOwners(
+			{ sessionId: "new", transcriptPath: "/t/new.jsonl", edges: new Map([["/repo/b", edge()]]) },
+			dir,
+		);
+
+		// Non-durable: a recovered-from-corrupt write started from an emptied base,
+		// so the caller must not advance its cursor mark over it.
+		expect(durable).toBe(false);
+		// The torn entry (and its well-formed sibling) are preserved for recovery,
+		// not silently deleted...
+		const { readdir } = await import("node:fs/promises");
+		const quarantined = (await readdir(dir)).filter((f) => f.startsWith("claude-owners.json.corrupt-"));
+		expect(quarantined).toHaveLength(1);
+		const preserved = await readFile(join(dir, quarantined[0]), "utf-8");
+		expect(preserved).toContain("claude:torn");
+		expect(preserved).toContain("claude:good");
+		// ...and a fresh, valid ledger now holds only the session being written.
+		expect(Object.keys((await loadClaudeOwners(dir)).sessions)).toEqual(["claude:new"]);
+	});
+
+	it("defers the write (never quarantines or overwrites) when the ledger cannot be READ at all", async () => {
+		// A non-ENOENT read failure (here EISDIR from a directory in the file's place;
+		// in production EACCES / EMFILE / EIO) read NO bytes, so it is no evidence the
+		// content is corrupt. Overwriting or quarantining it would destroy every other
+		// session's edges over a momentary I/O error, so the write must be deferred.
+		const { mkdir, readdir } = await import("node:fs/promises");
+		const path = join(dir, "claude-owners.json");
+		await mkdir(path); // readFile → EISDIR
+
+		const durable = await recordClaudeOwners(
+			{ sessionId: "new", transcriptPath: "/t/new.jsonl", edges: new Map([["/repo/a", edge()]]) },
+			dir,
+		);
+
+		// Non-durable: the caller keeps its cursor mark put and re-emits next pass.
+		expect(durable).toBe(false);
+		// The file is left ENTIRELY alone — not quarantined, and not overwritten with
+		// a fresh ledger holding only the new session.
+		expect((await readdir(dir)).filter((f) => f.startsWith("claude-owners.json.corrupt-"))).toHaveLength(0);
+		expect((await stat(path)).isDirectory()).toBe(true);
+		expect(Object.keys((await loadClaudeOwners(dir)).sessions)).toEqual([]);
 	});
 
 	it("resolves against the machine-global config dir when globalDir is omitted", async () => {

--- a/cli/src/core/ClaudeOwnership.ts
+++ b/cli/src/core/ClaudeOwnership.ts
@@ -14,8 +14,8 @@
  * is a later task's job.
  */
 
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { readFile, rename } from "node:fs/promises";
+import { basename, join } from "node:path";
 import { createLogger, errMsg } from "../Logger.js";
 import { atomicWriteFile } from "./AtomicWrite.js";
 import { withClaudeOwnersLock } from "./Locks.js";
@@ -129,7 +129,12 @@ function hasValidOwners(session: unknown): session is ClaudeOwnedSession {
 /**
  * Reads the ledger. A missing or unparseable file reads as empty: this is
  * consulted from the post-commit path, where throwing would take the whole
- * summary down over a state file that the next Stop hook rewrites anyway.
+ * summary down over a state file. Reading empty is safe for a LOOKUP (it returns
+ * no owners); it is emphatically NOT safe as the basis of a WRITE — a write that
+ * started from this empty snapshot would overwrite every other session's edges
+ * with the one it is recording. The write path therefore uses
+ * {@link readLedgerForWrite}, which distinguishes "absent" from "present but
+ * corrupt" and quarantines the latter rather than overwriting it.
  * The same never-throw posture extends to each individual session: one whose
  * `owners` field is missing or malformed is dropped rather than surfaced, so
  * every session `loadClaudeOwners` returns is safe for a caller to index into
@@ -148,6 +153,104 @@ export async function loadClaudeOwners(globalDir?: string): Promise<ClaudeOwners
 		log.debug("claude-owners.json unreadable (%s) — treating as empty", errMsg(err));
 		return EMPTY;
 	}
+}
+
+/**
+ * Reads the ledger for the WRITE path, distinguishing THREE outcomes a merge
+ * must treat differently:
+ *
+ *   - present & parseable — the base to merge into (`corrupt`/`unavailable` both
+ *     false).
+ *   - genuinely absent (ENOENT) — normal on a fresh machine; an empty base
+ *     (`corrupt`/`unavailable` both false, `ledger` = EMPTY).
+ *   - present but the CONTENT is bad — read succeeded, but parse failed, the
+ *     top-level shape is wrong, OR any single session entry is malformed:
+ *     `corrupt: true`, quarantine before overwriting. A torn per-session entry
+ *     counts here (unlike the lenient READ path) precisely because this base is
+ *     about to be rewritten — see the loop below.
+ *   - could not be READ at all — a transient I/O error (EACCES, EMFILE/ENFILE
+ *     under FD exhaustion, EIO): `unavailable: true`. The file was NEVER read,
+ *     so it is NOT evidence of corruption; treating it as corrupt would move a
+ *     healthy ledger aside and rewrite it from empty over a momentary error.
+ *
+ * The merge must never overwrite from an empty base for either of the last two:
+ * doing so replaces every session's edges with the single one being written,
+ * and because the per-transcript `owners` marks have already advanced past the
+ * lines those edges came from, the loss is unrecoverable. `corrupt` says
+ * "quarantine, then start fresh"; `unavailable` says "leave it entirely alone
+ * and retry next pass".
+ */
+async function readLedgerForWrite(
+	globalDir?: string,
+): Promise<{ ledger: ClaudeOwnersLedger; corrupt: boolean; unavailable: boolean }> {
+	let text: string;
+	try {
+		text = await readFile(claudeOwnersPath(globalDir), "utf-8");
+	} catch (err) {
+		if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+			return { ledger: EMPTY, corrupt: false, unavailable: false };
+		}
+		// A failed READ is not a failed PARSE: the bytes on disk are unknown, so
+		// they must not be classified corrupt (which would quarantine + rewrite).
+		log.debug("claude-owners.json could not be read (%s) — deferring the write", errMsg(err));
+		return { ledger: EMPTY, corrupt: false, unavailable: true };
+	}
+	try {
+		const raw = JSON.parse(text) as Partial<ClaudeOwnersLedger>;
+		if (!raw || typeof raw !== "object" || typeof raw.sessions !== "object" || raw.sessions === null) {
+			return { ledger: EMPTY, corrupt: true, unavailable: false };
+		}
+		const sessions: Record<string, ClaudeOwnedSession> = {};
+		for (const [key, session] of Object.entries(raw.sessions)) {
+			// A per-session entry whose `owners` is malformed is corruption too, not
+			// something to filter away. The READ path (`loadClaudeOwners`) drops it
+			// because a lookup has nothing to gain from a torn entry, but the WRITE
+			// path must NOT: merging from a silently-filtered base and rewriting the
+			// file permanently deletes that session on the next successful write.
+			// Treat it exactly like a top-level shape failure — quarantine the whole
+			// file (preserving the torn entry for recovery) rather than overwrite it.
+			// Same "present-but-corrupt" posture, applied consistently to both
+			// granularities.
+			if (!hasValidOwners(session)) {
+				return { ledger: EMPTY, corrupt: true, unavailable: false };
+			}
+			sessions[key] = session;
+		}
+		return { ledger: { version: 1, sessions }, corrupt: false, unavailable: false };
+	} catch {
+		return { ledger: EMPTY, corrupt: true, unavailable: false };
+	}
+}
+
+/**
+ * Moves a present-but-corrupt ledger aside so a fresh one can be written without
+ * destroying the sessions it held (they remain in the quarantine file for manual
+ * recovery). Returns `false` when the file could not be moved — in which case the
+ * caller MUST NOT overwrite it, since that would be the very data loss this
+ * guards against.
+ */
+async function quarantineCorruptLedger(globalDir?: string): Promise<boolean> {
+	const path = claudeOwnersPath(globalDir);
+	const dest = `${path}.corrupt-${Date.now()}`;
+	try {
+		await rename(path, dest);
+		log.warn(
+			"claude-owners.json was unparseable; quarantined to %s and starting fresh — prior sessions' edges are preserved there for recovery",
+			basename(dest),
+		);
+		return true;
+		/* v8 ignore start -- reached only when the rename itself fails (a read-only
+		 * parent, a vanished directory): fault-injection-only, and the behaviour it
+		 * guards — never overwrite a file we could not move aside — is asserted through
+		 * the caller's return value in the reachable corrupt-file test. */
+	} catch (err) {
+		log.warn(
+			"claude-owners.json is unparseable and could not be quarantined (%s); refusing to overwrite it",
+			errMsg(err),
+		);
+		return false;
+	}
+	/* v8 ignore stop */
 }
 
 /**
@@ -177,7 +280,23 @@ export async function recordClaudeOwners(
 		async (acquired) => {
 			// Read inside the lock: a snapshot taken before it would merge a peer's
 			// write away, which is the exact race the lock exists for.
-			const ledger = await loadClaudeOwners(globalDir);
+			const { ledger, corrupt, unavailable } = await readLedgerForWrite(globalDir);
+			if (unavailable) {
+				// A transient I/O error read no bytes, so it is no evidence the file is
+				// corrupt. Overwriting it (or quarantining it) would destroy every other
+				// session's edges over a momentary failure. Leave it untouched and report
+				// non-durable so the caller keeps its cursor mark put and re-emits these
+				// edges next pass, once the file is readable again.
+				return false;
+			}
+			if (corrupt) {
+				// A present-but-unparseable file must not be overwritten with just this
+				// session. Move it aside first; if that fails, abort the write entirely
+				// and leave the caller's cursor mark put so nothing is lost.
+				/* v8 ignore next -- the abort fires only when quarantine's rename failed
+				 * (fault-injection-only; see quarantineCorruptLedger). */
+				if (!(await quarantineCorruptLedger(globalDir))) return false;
+			}
 			const key = sessionKey(input.sessionId);
 			const existing = ledger.sessions[key];
 			const owners: Record<string, ClaudeOwnerEdge> = { ...(existing?.owners ?? {}) };
@@ -207,7 +326,11 @@ export async function recordClaudeOwners(
 				),
 			};
 			await atomicWriteFile(claudeOwnersPath(globalDir), JSON.stringify(next, null, "\t"));
-			return acquired;
+			// A recovered-from-corrupt write started from an emptied base, so it is
+			// NOT a durable merge of prior state: report non-durable so the caller
+			// leaves its cursor mark put and re-emits these edges next pass into the
+			// now-fresh (or peer-repopulated) ledger.
+			return corrupt ? false : acquired;
 		},
 		globalDir === undefined ? {} : { globalDir },
 	);

--- a/cli/src/core/GitOps.stateRoot.realgit.test.ts
+++ b/cli/src/core/GitOps.stateRoot.realgit.test.ts
@@ -59,4 +59,36 @@ describe("resolveStateRoot (real git)", () => {
 		const plain = makeTempDir();
 		expect(resolveStateRoot(plain)).toBe(plain);
 	});
+
+	// Regression for the ownership-ledger defect: a post-commit hook in a linked
+	// worktree runs with GIT_DIR exported, the detached worker inherits it, and the
+	// resolver's git fallback used to forward it — so `rev-parse` answered for the
+	// ambient repo instead of the asked-about directory, breaking the ledger's keys.
+	// With GIT_DIR set, the FS fast path declines (gitLocationIsOverridden), so this
+	// exercises exactly that fallback; the strip is what keeps it correct.
+	it("ignores an inherited GIT_DIR and resolves the asked-about directory's own repo", () => {
+		const repoA = makeTempDir();
+		execFileSync("git", ["init"], { cwd: repoA, stdio: ["ignore", "ignore", "ignore"] });
+		const repoB = makeTempDir();
+		execFileSync("git", ["init"], { cwd: repoB, stdio: ["ignore", "ignore", "ignore"] });
+		const deepB = join(repoB, "sub", "deeper");
+		mkdirSync(deepB, { recursive: true });
+		const expectedB = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+			cwd: repoB,
+			encoding: "utf-8",
+		}).trim();
+
+		const savedGitDir = process.env.GIT_DIR;
+		try {
+			process.env.GIT_DIR = join(repoA, ".git"); // as a hook running in repoA would export
+			resetStateRootCache();
+			// Without the strip, GIT_DIR=repoA would misdirect this to repoA (or to the
+			// cwd itself); with it, we get repoB's real toplevel.
+			expect(resolveStateRoot(deepB)).toBe(expectedB);
+		} finally {
+			if (savedGitDir === undefined) delete process.env.GIT_DIR;
+			else process.env.GIT_DIR = savedGitDir;
+			resetStateRootCache();
+		}
+	});
 });

--- a/cli/src/core/GitOps.ts
+++ b/cli/src/core/GitOps.ts
@@ -36,6 +36,38 @@ export function resetStateRootCache(): void {
 }
 
 /**
+ * The location env vars git exports to hook processes so every child `git`
+ * invocation targets the CURRENT repo. A detached process spawned from a hook
+ * (e.g. the queue worker) inherits them, and a child `git` that forwards
+ * `process.env` would then answer for the ambient (hook) repo for EVERY path
+ * regardless of its cwd — so they must be stripped whenever we ask which repo
+ * SOME OTHER directory belongs to. Measured on git 2.50.1 in a linked worktree:
+ * with `GIT_DIR` inherited, `git -C <dir> rev-parse --show-toplevel` resolves
+ * `<dir>` to itself (even a non-repo dir), instead of to its real worktree root.
+ */
+const GIT_LOCATION_ENV_VARS = [
+	"GIT_DIR",
+	"GIT_WORK_TREE",
+	"GIT_INDEX_FILE",
+	"GIT_COMMON_DIR",
+	"GIT_PREFIX",
+	"GIT_OBJECT_DIRECTORY",
+	"GIT_NAMESPACE",
+] as const;
+
+/**
+ * A copy of the process environment with the git-location vars above removed, so
+ * a `git` child spawned from inside a hook discovers the repo from its `cwd`
+ * rather than from the inherited redirect. Shared by every resolver that asks
+ * "which repo contains this directory".
+ */
+function gitEnvWithoutLocationVars(): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = { ...process.env, LC_ALL: "C" };
+	for (const v of GIT_LOCATION_ENV_VARS) delete env[v];
+	return env;
+}
+
+/**
  * Anchors a project working directory to its git worktree root via
  * `git rev-parse --show-toplevel`, memoized per input. Falls back to `cwd` on
  * any failure (not a git repo, git missing).
@@ -99,6 +131,12 @@ export function resolveWorktreeRootOrNull(cwd: string): string | null {
 		const out = execFileSyncHidden("git", ["rev-parse", "--show-toplevel"], {
 			cwd,
 			encoding: "utf-8",
+			// Strip the git-location redirect a hook exports, or in a LINKED worktree
+			// the inherited GIT_DIR makes `rev-parse` resolve `cwd` to itself (or to
+			// the hook's own repo) instead of to `cwd`'s real worktree root — which
+			// silently breaks the ownership ledger's keys and its cross-checkout
+			// backfill (see gitEnvWithoutLocationVars).
+			env: gitEnvWithoutLocationVars(),
 			// Capture git's stderr so a non-git cwd doesn't leak "fatal: not a git
 			// repository …" to the terminal; the throw is handled below.
 			stdio: ["ignore", "pipe", "pipe"],
@@ -1059,24 +1097,6 @@ export async function getGitCommonDir(cwd: string): Promise<string> {
 }
 
 /**
- * The location env vars git exports to hook processes so every child `git`
- * invocation targets the CURRENT repo. A detached process spawned from a hook
- * (e.g. the queue worker) inherits them, and `execGit` forwards `process.env` —
- * so they must be stripped when asking which repo ANOTHER directory belongs to,
- * or `rev-parse` reports the ambient (hook) repo for every path regardless of
- * its cwd.
- */
-const GIT_LOCATION_ENV_VARS = [
-	"GIT_DIR",
-	"GIT_WORK_TREE",
-	"GIT_INDEX_FILE",
-	"GIT_COMMON_DIR",
-	"GIT_PREFIX",
-	"GIT_OBJECT_DIRECTORY",
-	"GIT_NAMESPACE",
-] as const;
-
-/**
  * Resolves the absolute git-common-dir of the repository that CONTAINS `dir`,
  * using cwd-based discovery even when running inside a git hook. Unlike
  * {@link getGitCommonDir} it strips the ambient `GIT_DIR`/`GIT_WORK_TREE`/… that
@@ -1086,13 +1106,11 @@ const GIT_LOCATION_ENV_VARS = [
  * inside any git repository (or cannot be resolved).
  */
 export async function resolveContainingRepoCommonDir(dir: string): Promise<string | null> {
-	const env: NodeJS.ProcessEnv = { ...process.env, LC_ALL: "C" };
-	for (const v of GIT_LOCATION_ENV_VARS) delete env[v];
 	try {
 		const { stdout } = await execFileAsyncHidden("git", ["rev-parse", "--git-common-dir"], {
 			cwd: dir,
 			maxBuffer: MAX_GIT_BUFFER_BYTES,
-			env,
+			env: gitEnvWithoutLocationVars(),
 		});
 		return resolve(dir, stdout.trim());
 	} catch {

--- a/cli/src/core/JolliMemoryPushClient.test.ts
+++ b/cli/src/core/JolliMemoryPushClient.test.ts
@@ -1221,9 +1221,34 @@ describe("pushSessions", () => {
 		).rejects.toBeInstanceOf(SessionPreconditionFailedError);
 	});
 
-	it("accepts a valid but empty JSON body", async () => {
-		// `{}` is a real answer from a backend that ingested nothing and holds no
-		// cursor — not a parse failure, and must not be treated as one.
+	it("accepts a body that carries an accepted map but no cursor (ingested, no cursor opinion)", async () => {
+		// A conforming backend that stored the rows but holds no per-table cursor
+		// acknowledges via `accepted` (even empty). That is a real success; the runner
+		// then advances via its own high-water fallback, which is safe BECAUSE the
+		// server acknowledged.
+		const c = client(async () => jsonResponse(200, { accepted: {} }));
+		await expect(c.pushSessions(payload)).resolves.toEqual({ accepted: {}, cursor: {} });
+	});
+
+	it("rejects a 2xx that carries NEITHER an accepted map nor a cursor when rows WERE sent", async () => {
+		// `{}` is not a valid acknowledgement for a payload that carried rows: an
+		// ingesting endpoint always answers with at least one of the two. Treated as
+		// full success it defaulted both to `{}`, so every table fell to the batch's own
+		// high-water mark and the cursor advanced over rows the server never stored —
+		// the JSON-body twin of the non-JSON hole above. Same CLASS as a missing
+		// endpoint. Note the NON-EMPTY payload: the guard is gated on rows being sent.
+		const nonEmpty = { ...payload, tables: { sessions: [{ id: "s1" }] } };
+		const c = client(async () => jsonResponse(200, {}));
+		await expect(c.pushSessions(nonEmpty)).rejects.toBeInstanceOf(SessionEndpointMissingError);
+	});
+
+	it("does NOT reject a bare {} for an EMPTY reconcile ping (no rows to advance over)", async () => {
+		// The idle-machine steady state: `SessionSyncRunner.sync` sends one empty-tables
+		// request per throttle window purely to let a fresh backend answer 409/
+		// cursor-behind. That ping has no rows, so it cannot advance the cursor whatever
+		// the answer, and the empty-ack guard's rationale ("do not advance over unstored
+		// rows") does not apply. Gating the guard on rows-sent is what stops a backend
+		// that answers the ping with a bare `{}` from silencing the whole channel for 24h.
 		const c = client(async () => jsonResponse(200, {}));
 		await expect(c.pushSessions(payload)).resolves.toEqual({ accepted: {}, cursor: {} });
 	});

--- a/cli/src/core/JolliMemoryPushClient.ts
+++ b/cli/src/core/JolliMemoryPushClient.ts
@@ -753,6 +753,30 @@ export class JolliMemoryPushClient {
 					"the backend may not implement this endpoint",
 			);
 		}
+		if (Object.keys(payload.tables).length > 0 && json.accepted === undefined && json.cursor === undefined) {
+			// A well-formed JSON 2xx that carries NEITHER an accepted count nor a
+			// cursor is not a valid acknowledgement — an ingesting endpoint always
+			// answers with at least one. Left as "full success" it defaulted both to
+			// `{}`, so every table fell through to the batch's own high-water mark and
+			// the cursor advanced over rows the server never stored (the parse-failure
+			// case above is only the non-JSON shape of this same hole). Same CLASS as a
+			// missing endpoint: fail loudly, never advance. A conforming backend that
+			// genuinely has no per-table cursor opinion still returns an `accepted`
+			// map, so this rejects only the empty-ack shape.
+			//
+			// GATED on rows actually being SENT. This guard's whole rationale is "do not
+			// advance the cursor over unstored rows", and the empty-batch RECONCILE ping
+			// (`SessionSyncRunner.sync`'s one request per throttle window with `tables:
+			// {}`) has no rows to advance over — its `localMaxima` is empty, so it cannot
+			// move the cursor regardless of the answer, and its purpose is served entirely
+			// by the server's own 409/cursor-behind reply, not by this ack. Without the
+			// gate, a backend that answers that idle ping with a bare `{}` would silence
+			// the whole channel for 24h over the steady-state request of an idle machine.
+			throw new SessionEndpointMissingError(
+				`Response from /api/push/jollimemory/sessions (HTTP ${status}) carried neither an accepted count nor a ` +
+					"cursor — treating as an unimplemented endpoint rather than advancing the cursor over unstored rows",
+			);
+		}
 		return { accepted: json.accepted ?? {}, cursor: json.cursor ?? {} };
 	}
 

--- a/cli/src/core/SessionPushCursor.ts
+++ b/cli/src/core/SessionPushCursor.ts
@@ -19,9 +19,10 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { createLogger, errMsg, isEnoent } from "../Logger.js";
+import { atomicWriteFileSync } from "./AtomicWrite.js";
 import { getGlobalConfigDir } from "./SessionTracker.js";
 
 const log = createLogger("SessionPushCursor");
@@ -266,7 +267,14 @@ export function writeSessionPushChannel(state: SessionPushChannelState, configDi
 	const path = getSessionPushChannelPath(configDir);
 	try {
 		mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
-		writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+		// Atomic (tmpfile + rename), NOT a bare in-place write: this channel holds
+		// no lock and three producers (the daemon tick, the commit-drain tail, and
+		// `doctor --sync-sessions`) can overlap, so an in-place write let a reader —
+		// or the next producer — observe a half-written file. The rename makes every
+		// write all-or-nothing; the accepted residual is last-writer-wins on the
+		// whole file, which costs one duplicated delivery into an upsert, never a
+		// corrupt cursor map.
+		atomicWriteFileSync(path, `${JSON.stringify(state, null, 2)}\n`, 0o600);
 	} catch (err) {
 		log.debug("could not write session push channel state: %s", errMsg(err));
 	}

--- a/cli/src/core/TranscriptRepair.test.ts
+++ b/cli/src/core/TranscriptRepair.test.ts
@@ -104,7 +104,7 @@ afterEach(() => {
 
 describe("transcriptRepairState", () => {
 	it("is present when the summary already references a transcript", async () => {
-		expect(await transcriptRepairState(summary({ transcripts: ["t1"] }), repo, globalDir)).toBe("present");
+		expect(await transcriptRepairState(summary({ transcripts: ["t1"] }), repo, { globalDir })).toBe("present");
 	});
 
 	it("is repaired when the marker is set", async () => {
@@ -112,7 +112,7 @@ describe("transcriptRepairState", () => {
 			await transcriptRepairState(
 				summary({ transcripts: ["t1"], transcriptsRepairedAt: "2026-08-17T12:00:00.000Z" }),
 				repo,
-				globalDir,
+				{ globalDir },
 			),
 		).toBe("repaired");
 	});
@@ -122,11 +122,11 @@ describe("transcriptRepairState", () => {
 			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[resolveStateRoot(repo), EDGE]]) },
 			globalDir,
 		);
-		expect(await transcriptRepairState(summary({ transcripts: [] }), repo, globalDir)).toBe("repairable");
+		expect(await transcriptRepairState(summary({ transcripts: [] }), repo, { globalDir })).toBe("repairable");
 	});
 
 	it("is unrepairable when no owner edge proves this checkout", async () => {
-		expect(await transcriptRepairState(summary({ transcripts: [] }), repo, globalDir)).toBe("unrepairable");
+		expect(await transcriptRepairState(summary({ transcripts: [] }), repo, { globalDir })).toBe("unrepairable");
 	});
 
 	it("is unrepairable when the transcript file is gone", async () => {
@@ -138,7 +138,7 @@ describe("transcriptRepairState", () => {
 			},
 			globalDir,
 		);
-		expect(await transcriptRepairState(summary({ transcripts: [] }), repo, globalDir)).toBe("unrepairable");
+		expect(await transcriptRepairState(summary({ transcripts: [] }), repo, { globalDir })).toBe("unrepairable");
 	});
 
 	it("is unrepairable when the owner window holds no turns, despite the transcript existing", async () => {
@@ -154,7 +154,7 @@ describe("transcriptRepairState", () => {
 			},
 			globalDir,
 		);
-		expect(await transcriptRepairState(summary({ transcripts: [] }), repo, globalDir)).toBe("unrepairable");
+		expect(await transcriptRepairState(summary({ transcripts: [] }), repo, { globalDir })).toBe("unrepairable");
 	});
 
 	it("is unrepairable when the summary carries no upper bound, despite owner and transcript", async () => {
@@ -165,11 +165,9 @@ describe("transcriptRepairState", () => {
 			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[resolveStateRoot(repo), EDGE]]) },
 			globalDir,
 		);
-		const state = await transcriptRepairState(
-			summary({ transcripts: [], generatedAt: "", commitDate: "" }),
-			repo,
+		const state = await transcriptRepairState(summary({ transcripts: [], generatedAt: "", commitDate: "" }), repo, {
 			globalDir,
-		);
+		});
 		expect(state).toBe("unrepairable");
 	});
 
@@ -181,10 +179,155 @@ describe("transcriptRepairState", () => {
 			globalDir,
 		);
 
-		const state = await transcriptRepairState(summary({ transcripts: [] }), repo, globalDir);
+		const state = await transcriptRepairState(summary({ transcripts: [] }), repo, { globalDir });
 
 		expect(resolveStateRoot).toHaveBeenCalledWith(repo);
 		expect(state).toBe("repairable");
+	});
+
+	it("is unrepairable for a later memory whose only turns an earlier empty sibling claims in a batch run", async () => {
+		// The drift the sibling-aware path removes: memory B alone LOOKS repairable
+		// (its window holds the 10:00 turn), but the ONLY repair a user can run is
+		// the multi-memory batch, which archives that turn to the earlier-bounded A
+		// and dedups B to empty. The transcript holds nothing after A's bound, so B
+		// is genuinely unrepairable — and the UI must say so, not promise a repair
+		// the batch then refuses.
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[resolveStateRoot(repo), EDGE]]) },
+			globalDir,
+		);
+		const a = summary({ commitHash: "a".repeat(40), transcripts: [], generatedAt: "2026-08-17T10:15:00.000Z" });
+		const b = summary({ commitHash: "b".repeat(40), transcripts: [], generatedAt: "2026-08-17T11:00:00.000Z" });
+
+		// Alone (no siblings), B still over-promises — the single-memory verdict.
+		expect(await transcriptRepairState(b, repo, { globalDir })).toBe("repairable");
+
+		// With the repo's empty siblings, B reflects the batch's dedup floor (A's
+		// bound) and correctly reports unrepairable, while A itself stays repairable.
+		const siblings = () => Promise.resolve([a, b]);
+		expect(await transcriptRepairState(b, repo, { globalDir, siblingSummaries: siblings })).toBe("unrepairable");
+		expect(await transcriptRepairState(a, repo, { globalDir, siblingSummaries: siblings })).toBe("repairable");
+	});
+
+	it("is unrepairable when an ALREADY-REPAIRED earlier sibling claims its only turns (cross-run dedup)", async () => {
+		// The cross-run gap: A was repaired in an EARLIER `doctor --repair-transcripts`
+		// run (so it carries `transcriptsRepairedAt` and is no longer a candidate), and
+		// B fails capture and is repaired in a SECOND run. A's window [firstSeen..10:15]
+		// already archived the only turn (10:00); B's real floor is what A PROVABLY
+		// archived from that session, so B is genuinely unrepairable. Filtering siblings
+		// to candidates alone would drop the repaired A, hand B an undefined floor, and
+		// re-archive A's turn into B — so the UI must fold repaired siblings into the
+		// floor exactly as the batch run does. A is REPAIRED FOR REAL here (its
+		// transcript is stored and read back readable): the floor now rests on A's
+		// proven per-session content, not on the retired unreadable-fallback bound.
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[resolveStateRoot(repo), EDGE]]) },
+			globalDir,
+		);
+		// Distinct hashes (beforeEach seeds "a".repeat(40)); A bounded at 10:15 so it
+		// sorts before B and its stored slice covers the only turn (10:00).
+		const aHash = "e".repeat(40);
+		const bHash = "f".repeat(40);
+		await storeSummary(
+			summary({ commitHash: aHash, transcripts: [], generatedAt: "2026-08-17T10:15:00.000Z" }),
+			repo,
+		);
+		expect((await repairSummaryTranscripts(aHash, repo, { apply: true, globalDir })).repaired).toBe(true);
+		const a = (await getSummary(aHash, repo)) as CommitSummary;
+		const b = summary({ commitHash: bHash, transcripts: [], generatedAt: "2026-08-17T11:00:00.000Z" });
+
+		// Alone, B still over-promises (the single-memory verdict, no dedup).
+		expect(await transcriptRepairState(b, repo, { globalDir })).toBe("repairable");
+		// With the repaired sibling A folded into the floor, B is correctly unrepairable.
+		expect(
+			await transcriptRepairState(b, repo, { globalDir, siblingSummaries: () => Promise.resolve([a, b]) }),
+		).toBe("unrepairable");
+	});
+
+	it("keeps a later memory repairable when a repaired sibling never archived a newly-owned session (cross-run, per-session floor)", async () => {
+		// The P1 data-loss shape: the dedup floor must be PER SESSION, not one
+		// worktree-wide bound. In run 1 only session sX was owned, so repaired
+		// sibling A archived sX up to its 10:15 bound. AFTER that run a second
+		// session sY becomes owned by this worktree, and sY's only turn (10:05)
+		// predates A's bound — but A never saw sY, so that turn was archived
+		// NOWHERE. A single global floor of 10:15 would suppress it and report B
+		// empty; a per-session floor (derived from what A actually archived) leaves
+		// sY untouched, so B stays repairable.
+		const sX = join(globalDir, "sX.jsonl");
+		const sY = join(globalDir, "sY.jsonl");
+		await writeFile(
+			sX,
+			`${JSON.stringify({ cwd: repo, timestamp: "2026-08-17T10:00:00.000Z", message: { role: "user", content: "x" } })}\n`,
+			"utf-8",
+		);
+		await writeFile(
+			sY,
+			`${JSON.stringify({ cwd: repo, timestamp: "2026-08-17T10:05:00.000Z", message: { role: "user", content: "y" } })}\n`,
+			"utf-8",
+		);
+		// Distinct hashes: the beforeEach already seeds one at "a".repeat(40), and
+		// storeSummary is first-write-wins on generatedAt — colliding there would
+		// silently keep the default bound and mis-order the two siblings.
+		const aHash = "c".repeat(40);
+		const bHash = "d".repeat(40);
+		await storeSummary(
+			summary({ commitHash: aHash, transcripts: [], generatedAt: "2026-08-17T10:15:00.000Z" }),
+			repo,
+		);
+		await storeSummary(
+			summary({ commitHash: bHash, transcripts: [], generatedAt: "2026-08-17T11:00:00.000Z" }),
+			repo,
+		);
+
+		// Run 1: only sX owned. Actually repair A so it stores what it archived.
+		await recordClaudeOwners(
+			{ sessionId: "sX", transcriptPath: sX, edges: new Map([[resolveStateRoot(repo), EDGE]]) },
+			globalDir,
+		);
+		expect((await repairSummaryTranscripts(aHash, repo, { apply: true, globalDir })).repaired).toBe(true);
+
+		// Between runs: sY (an older, un-archived turn) becomes owned by this worktree.
+		await recordClaudeOwners(
+			{ sessionId: "sY", transcriptPath: sY, edges: new Map([[resolveStateRoot(repo), EDGE]]) },
+			globalDir,
+		);
+
+		const a = (await getSummary(aHash, repo)) as CommitSummary;
+		const b = (await getSummary(bHash, repo)) as CommitSummary;
+		expect(a.transcriptsRepairedAt).toBeTruthy();
+		// Guards the fixture: A must carry its 10:15 bound (so it sorts before B and
+		// its floor is a real threat to sY's 10:05 turn), not the default 11:00:05.
+		expect(a.generatedAt).toBe("2026-08-17T10:15:00.000Z");
+		expect(
+			await transcriptRepairState(b, repo, { globalDir, siblingSummaries: () => Promise.resolve([a, b]) }),
+		).toBe("repairable");
+	});
+
+	it("keeps a later memory repairable when an earlier repaired sibling's stored transcript is UNREADABLE", async () => {
+		// A repaired sibling whose stored transcript cannot be read contributes
+		// NOTHING to the floor. Its archived copy is invisible to the user, so using
+		// its bound as a worktree-wide floor would suppress a later memory's turns and
+		// hide them from BOTH places — the P1 shape one step along. Sibling A is
+		// repaired (carries `transcriptsRepairedAt`) and names transcript "t-a", but
+		// that artifact was never stored, so `archivedSessionFloor` reads it back
+		// unreadable. Its 10:15 bound is at-or-after the only owned turn (10:00), so
+		// the RETIRED worktree-wide fallback would have dropped that turn and reported
+		// B unrepairable; the current rule leaves the session untouched.
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[resolveStateRoot(repo), EDGE]]) },
+			globalDir,
+		);
+		const a = summary({
+			commitHash: "c".repeat(40),
+			transcripts: ["t-a"], // named but never stored → unreadable on read-back
+			transcriptsRepairedAt: "2026-08-18T00:00:00.000Z",
+			generatedAt: "2026-08-17T10:15:00.000Z", // sorts before B; bound covers the 10:00 turn
+		});
+		const b = summary({ commitHash: "d".repeat(40), transcripts: [], generatedAt: "2026-08-17T11:00:00.000Z" });
+
+		expect(
+			await transcriptRepairState(b, repo, { globalDir, siblingSummaries: () => Promise.resolve([a, b]) }),
+		).toBe("repairable");
 	});
 });
 
@@ -344,5 +487,66 @@ describe("repairSummaryTranscripts", () => {
 		await storeSummary(summary({ commitHash: presentHash, transcripts: ["existing-id"] }), repo);
 		const out = await repairSummaryTranscripts(presentHash, repo, { apply: true, globalDir });
 		expect(out.reason).toBe("already-present");
+	});
+});
+
+describe("repairSummaryTranscripts — cross-memory de-duplication (afterExclusive)", () => {
+	it("drops turns at or before the dedup floor, keeping the lower bound at firstSeenLine", async () => {
+		// Two turns; the earlier one was already archived to an earlier-bounded
+		// commit in this run, so a later commit's repair must not re-archive it.
+		// A user turn then an assistant turn, so they stay two distinct entries with
+		// distinct timestamps (the parser merges consecutive SAME-role turns).
+		await writeFile(
+			transcript,
+			`${JSON.stringify({ cwd: repo, timestamp: "2026-08-17T10:00:00.000Z", message: { role: "user", content: "first" } })}\n` +
+				`${JSON.stringify({ cwd: repo, timestamp: "2026-08-17T10:30:00.000Z", message: { role: "assistant", content: [{ type: "text", text: "reply" }] } })}\n`,
+			"utf-8",
+		);
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[resolveStateRoot(repo), EDGE]]) },
+			globalDir,
+		);
+		await storeSummary(summary({ transcripts: [] }), repo);
+
+		// No dedup floor → both turns.
+		const full = await repairSummaryTranscripts(HASH, repo, { apply: false, globalDir });
+		expect(full.entries).toBe(2);
+
+		// Floor at the first turn's instant → only the later turn survives.
+		const deduped = await repairSummaryTranscripts(HASH, repo, {
+			apply: false,
+			globalDir,
+			afterExclusive: "2026-08-17T10:00:00.000Z",
+		});
+		expect(deduped.entries).toBe(1);
+	});
+
+	it("compares the dedup floor NUMERICALLY, so an offset-form floor does not lexicographically drop a Z-form turn", async () => {
+		// The floor arrives as `generatedAt || commitDate`, which for a backfilled
+		// commit is git `%aI` offset form (`…+08:00`), while transcript timestamps
+		// are Claude's `Z` form. `2026-08-17T18:00:00.000+08:00` is the SAME instant
+		// as `2026-08-17T10:00:00.000Z`, but as a STRING it sorts AFTER the 10:30 Z
+		// turn — so a lexicographic `>` would drop that later turn too and report
+		// `no-entries-in-window` (silent data loss). Numeric comparison keeps it.
+		await writeFile(
+			transcript,
+			`${JSON.stringify({ cwd: repo, timestamp: "2026-08-17T10:00:00.000Z", message: { role: "user", content: "first" } })}\n` +
+				`${JSON.stringify({ cwd: repo, timestamp: "2026-08-17T10:30:00.000Z", message: { role: "assistant", content: [{ type: "text", text: "reply" }] } })}\n`,
+			"utf-8",
+		);
+		await recordClaudeOwners(
+			{ sessionId: "s", transcriptPath: transcript, edges: new Map([[resolveStateRoot(repo), EDGE]]) },
+			globalDir,
+		);
+		await storeSummary(summary({ transcripts: [] }), repo);
+
+		const deduped = await repairSummaryTranscripts(HASH, repo, {
+			apply: false,
+			globalDir,
+			afterExclusive: "2026-08-17T18:00:00.000+08:00", // == 10:00:00Z, the first turn
+		});
+		// The 10:30Z turn is strictly after 10:00:00Z, so it survives.
+		expect(deduped.repaired).toBe(true);
+		expect(deduped.entries).toBe(1);
 	});
 });

--- a/cli/src/core/TranscriptRepair.ts
+++ b/cli/src/core/TranscriptRepair.ts
@@ -9,11 +9,13 @@
 
 import { existsSync } from "node:fs";
 import { createLogger, errMsg } from "../Logger.js";
-import type { CommitSummary, StoredSession, TranscriptReadResult } from "../Types.js";
+import type { CommitSummary, StoredSession, TranscriptEntry, TranscriptReadResult } from "../Types.js";
 import { claudeSessionsOwnedBy } from "./ClaudeOwnership.js";
 import { resolveStateRoot } from "./GitOps.js";
 import { resolveArchivedTitle } from "./SessionTitleResolver.js";
-import { getSummary, storeSummary } from "./SummaryStore.js";
+import type { StorageProvider } from "./StorageProvider.js";
+import { getDisplayDate } from "./SummaryFormat.js";
+import { getSummary, readTranscriptsBatch, storeSummary } from "./SummaryStore.js";
 import { getTranscriptIds } from "./SummaryTree.js";
 import { generateTranscriptId } from "./TranscriptId.js";
 import { getParserForSource } from "./TranscriptParser.js";
@@ -35,10 +37,177 @@ const log = createLogger("TranscriptRepair");
  */
 export type TranscriptRepairState = "present" | "repaired" | "repairable" | "unrepairable";
 
+/**
+ * True when `summary` is an empty, not-yet-repaired memory — the set a
+ * `doctor --repair-transcripts` run and the UI's per-memory state both operate
+ * over. Shared so the runner and the display cannot disagree about scope.
+ */
+export function isTranscriptRepairCandidate(summary: CommitSummary): boolean {
+	return summary.transcriptsRepairedAt === undefined && getTranscriptIds(summary).length === 0;
+}
+
+/**
+ * The ONE canonical processing order for a multi-memory repair: oldest upper
+ * bound first, compared NUMERICALLY (epoch ms). ISO timestamps do not order
+ * lexicographically across formats (git `%aI` offset form vs Claude's `Z`), and
+ * the dedup floor is numeric, so a string sort could sequence a
+ * later-chronological memory as an earlier one's floor and drop its turns. A
+ * candidate whose bound is missing or unparseable sorts LAST (folded to
+ * `+Infinity` here). Only an EMPTY bound is then skipped with `no-upper-bound`:
+ * `planRepair` refuses on `!before`, so a truthy-but-unparseable string still
+ * proceeds (its NaN cutoff reads to EOF) — unreachable in practice, since bounds
+ * come from git `%aI` and `toISOString()`, but do not read "sorts last" as "is
+ * skipped". Both the CLI runner and {@link transcriptRepairState}'s floor replay
+ * walk this order, so they cannot drift — but only because the sort is a TOTAL
+ * order: `commitHash` breaks a bound tie. `getDisplayDate` falls back to git
+ * `%aI`, which is second-resolution, so two empty memories committed in the same
+ * second share a bound; without the tie-break the two callers (the runner
+ * concatenates `[...candidates, ...repairedSiblings]`, the floor replay filters
+ * the sibling list in place) feed differently-ordered inputs, and JS's stable
+ * sort would then sequence the tie oppositely on each path — the exact run/UI
+ * drift this shared helper exists to close. The hash compare is `<`/`>`, NOT
+ * `localeCompare`: a locale-sensitive compare would re-open the drift ACROSS
+ * machines (its result depends on the process locale), which is strictly worse.
+ * The bound is decorated once per memory rather than re-parsed inside the
+ * comparator (O(N) parses instead of O(N·log N)); this runs per empty-candidate
+ * detail open on the dashboard.
+ */
+export function orderTranscriptRepairCandidates(candidates: readonly CommitSummary[]): CommitSummary[] {
+	const boundMsOf = (s: CommitSummary): number => {
+		const iso = getDisplayDate(s);
+		const t = iso ? new Date(iso).getTime() : Number.NaN;
+		return Number.isNaN(t) ? Number.POSITIVE_INFINITY : t;
+	};
+	return candidates
+		.map((summary) => ({ summary, ms: boundMsOf(summary) }))
+		.sort((a, b) => {
+			if (a.ms !== b.ms) return a.ms - b.ms;
+			// Locale-independent total order on the (hex) commit hash, so the tie
+			// resolves identically on every path and every machine.
+			if (a.summary.commitHash < b.summary.commitHash) return -1;
+			if (a.summary.commitHash > b.summary.commitHash) return 1;
+			return 0;
+		})
+		.map((decorated) => decorated.summary);
+}
+
+/** The newest entry timestamp (epoch ms) in a session slice, or `undefined` when
+ *  every entry is missing/unparseable. Shared by the floor computed from a stored
+ *  transcript and the one a fresh repair reports, so the two are the same number. */
+function maxEntryTimestamp(entries: ReadonlyArray<TranscriptEntry>): number | undefined {
+	let max = Number.NEGATIVE_INFINITY;
+	for (const e of entries) {
+		if (e.timestamp === undefined) continue;
+		const ms = new Date(e.timestamp).getTime();
+		if (!Number.isNaN(ms) && ms > max) max = ms;
+	}
+	return max > Number.NEGATIVE_INFINITY ? max : undefined;
+}
+
+/**
+ * Advances a per-session dedup floor (sessionId → epoch ms) IN PLACE, keeping the
+ * LATER instant per session. This is the shape of the whole cross-memory dedup:
+ * each session dedups against only what earlier memories archived FROM THAT
+ * SESSION, never a single worktree-wide bound — which is what let a repaired
+ * memory suppress a session it never touched.
+ */
+export function mergeSessionFloor(floor: Map<string, number>, incoming: ReadonlyMap<string, number>): void {
+	for (const [sessionId, ms] of incoming) {
+		const prev = floor.get(sessionId);
+		if (prev === undefined || ms > prev) floor.set(sessionId, ms);
+	}
+}
+
+/**
+ * The per-session dedup floor an ALREADY-REPAIRED summary contributes, derived
+ * from what it PROVABLY archived — the newest entry timestamp per session in its
+ * STORED transcripts — not from its bound. Using the bound was the P1 data-loss
+ * bug: a session whose ownership edge appeared AFTER this memory was repaired was
+ * never in its window, yet a bound floor suppressed that session's earlier turns
+ * in every later memory, archiving them nowhere.
+ *
+ * `readable` is false when none of the transcript artifacts could be read
+ * (pruned, absent, or unparseable). The caller then contributes NOTHING from
+ * this sibling to the floor (§8.3's "prefer a gap" does NOT apply here): an
+ * unreadable stored transcript is invisible to the user, so its turns are not a
+ * duplicate the user could ever see twice — suppressing a later memory's copy of
+ * them by this sibling's bound would hide them from BOTH places, which is the P1
+ * data-loss shape one step along, not a conservative default.
+ *
+ * `storage` is threaded explicitly because the dashboard serves every registered
+ * repo from ONE machine-global process: {@link readTranscriptsBatch} resolves an
+ * absent argument through the process-global active storage, which — after a
+ * guided-front-door run set it to the launching repo — is the WRONG repository
+ * for every detail row but one, and would read every sibling's transcript back as
+ * unreadable. The caller passes storage built from the memory's own worktree root.
+ */
+export async function archivedSessionFloor(
+	summary: CommitSummary,
+	cwd: string,
+	storage?: StorageProvider,
+): Promise<{ readable: boolean; bySession: Map<string, number> }> {
+	const bySession = new Map<string, number>();
+	const ids = getTranscriptIds(summary);
+	if (ids.length === 0) return { readable: false, bySession };
+	const transcripts = await readTranscriptsBatch(ids, cwd, storage);
+	let readable = false;
+	for (const transcript of transcripts.values()) {
+		if (!transcript) continue;
+		readable = true;
+		for (const session of transcript.sessions) {
+			const max = maxEntryTimestamp(session.entries);
+			if (max === undefined) continue;
+			const prev = bySession.get(session.sessionId);
+			if (prev === undefined || max > prev) bySession.set(session.sessionId, max);
+		}
+	}
+	return { readable, bySession };
+}
+
+export interface TranscriptRepairStateOptions {
+	readonly globalDir?: string;
+	/**
+	 * The repo's empty-or-repaired memories, as a LAZY provider (the target may be
+	 * among them). Supplied by the caller because only it knows the storage-correct
+	 * source — the CLI/VS Code list local storage, the dashboard reads its own DB
+	 * (its process must NOT touch the post-cutover frozen orphan branch). When
+	 * present, the state reflects the dedup floor a real `doctor
+	 * --repair-transcripts` run would hand this memory, so the UI's "repairable"
+	 * cannot claim a memory the batch run would dedup to empty. Absent = the
+	 * single-memory verdict (no dedup), correct for a lone repair.
+	 *
+	 * It is a THUNK, not a resolved array, for two reasons that are one decision.
+	 * (1) Cost: computing it is O(all memories) — the CLI/VS Code list every
+	 * summary from storage (a `git show` per memory pre-cutover), the dashboard
+	 * runs a repo-wide query — and {@link transcriptRepairState} short-circuits
+	 * for the present/repaired majority BEFORE it needs any of this, so an eager
+	 * array made every memory-detail open pay a full enumeration the verdict then
+	 * threw away. The thunk is invoked only past that short-circuit, i.e. only for
+	 * an actual repair candidate (rare). (2) Scope: the set must be empty-AND-
+	 * already-repaired memories, not just the empties — see {@link dedupFloorForTarget}
+	 * for why a repaired sibling still bounds the floor. Callers pass the raw list;
+	 * the engine filters, so the "which siblings count" rule stays in one place.
+	 */
+	readonly siblingSummaries?: () => Promise<readonly CommitSummary[]>;
+	/**
+	 * Storage to read the siblings' stored transcripts from, threaded through to
+	 * {@link archivedSessionFloor}. Supply it whenever `cwd` may not match the
+	 * process-global active storage — the machine-global dashboard is the case
+	 * that forces it (see `archivedSessionFloor`). Absent = the active storage,
+	 * correct for a single-repo CLI/VS Code process whose override already names
+	 * this `cwd`.
+	 *
+	 * A LAZY provider, like {@link siblingSummaries}: it is resolved only past the
+	 * present/repaired short-circuit, so the present/repaired majority never pays
+	 * to build (and open) storage they will not read.
+	 */
+	readonly storage?: () => Promise<StorageProvider>;
+}
+
 export async function transcriptRepairState(
 	summary: CommitSummary,
 	cwd: string,
-	globalDir?: string,
+	opts: TranscriptRepairStateOptions = {},
 ): Promise<TranscriptRepairState> {
 	if (summary.transcriptsRepairedAt !== undefined) return "repaired";
 	if (getTranscriptIds(summary).length > 0) return "present";
@@ -50,8 +219,117 @@ export async function transcriptRepairState(
 	// optimism spec §9's repairable/unrepairable split exists to remove. One
 	// code path with `repairSummaryTranscripts`, so the sentence and the
 	// behaviour cannot drift apart.
-	const outcome = await planRepair(summary, cwd, { apply: false, globalDir });
+	//
+	// The ONLY repair path a user can trigger is the multi-memory batch run,
+	// which threads a dedup floor: without replaying that floor here, this
+	// dry run sees the memory's full window and can report "repairable" for a
+	// memory the batch dedups to empty (its shared turns belong to an earlier
+	// memory). So when the caller supplies the repo's empty siblings, compute
+	// the same floor the batch would hand this memory and bound the dry run by it.
+	// The thunk runs only here — past the present/repaired short-circuit above —
+	// so the O(all memories) sibling enumeration is paid only for an actual
+	// candidate, never for the present/repaired majority whose verdict never needs it.
+	const floor = opts.siblingSummaries
+		? await dedupFloorForTarget(
+				summary,
+				await opts.siblingSummaries(),
+				cwd,
+				opts.globalDir,
+				opts.storage ? await opts.storage() : undefined,
+			)
+		: undefined;
+	const outcome = await planRepair(summary, cwd, {
+		apply: false,
+		globalDir: opts.globalDir,
+		afterExclusiveBySession: floor?.afterExclusiveBySession,
+	});
 	return outcome.repaired ? "repairable" : "unrepairable";
+}
+
+/** The dedup floor a repair run hands a memory: a PER-SESSION exclusive bound
+ *  (`afterExclusiveBySession`, epoch ms per sessionId). A repaired sibling whose
+ *  stored transcript cannot be read contributes nothing (see
+ *  {@link archivedSessionFloor}), so there is no worktree-wide fallback here. */
+export interface DedupFloor {
+	readonly afterExclusiveBySession: ReadonlyMap<string, number>;
+}
+
+/**
+ * The dedup floor a full `doctor --repair-transcripts` run would hand `target`.
+ * Replays the run's prefix through the ONE shared ordering
+ * ({@link orderTranscriptRepairCandidates}) and the same floor-advance rule the
+ * CLI runner uses, so the per-memory UI state matches the batch outcome. Only
+ * predecessors are simulated, so the cost scales with how many empty-or-repaired
+ * memories are bounded earlier than the target — a rare capture failure, so
+ * typically zero.
+ *
+ * The floor is PER SESSION, not one worktree-wide bound (the P1 fix): each
+ * session dedups against only what earlier memories archived from THAT session.
+ * Two kinds of predecessor advance it, and BOTH must — the cross-run half of
+ * "no turn is archived to two memories":
+ *   - a not-yet-repaired CANDIDATE, if a dry run says it would repair: it merges
+ *     the per-session floor that run reports ({@link RepairOutcome.archivedBySession}); and
+ *   - an ALREADY-REPAIRED sibling (`transcriptsRepairedAt` set), whose window was
+ *     archived from `firstSeenLine` in a PRIOR run. Filtering to candidates alone
+ *     (an earlier bug) dropped it, so a later empty memory repaired in a SECOND
+ *     run re-archived every turn it already holds. It needs no dry run — its floor
+ *     is read from what it PROVABLY archived ({@link archivedSessionFloor}), which
+ *     is what stops it suppressing a session it never touched. When its transcript
+ *     is unreadable it contributes NOTHING (see `archivedSessionFloor`) — an
+ *     invisible copy is not a duplicate worth a gap.
+ *
+ * A PRESENT (live-captured) memory is deliberately NOT folded in: its turns were
+ * read incrementally (cursor-trimmed), not from `firstSeenLine`, so its window
+ * does not nest inside a candidate's and its bound is not a valid floor. That
+ * broader live/repair overlap is out of scope here (see the runner's note).
+ */
+async function dedupFloorForTarget(
+	target: CommitSummary,
+	siblings: readonly CommitSummary[],
+	cwd: string,
+	globalDir?: string,
+	storage?: StorageProvider,
+): Promise<DedupFloor> {
+	const relevant = siblings.filter((s) => isTranscriptRepairCandidate(s) || s.transcriptsRepairedAt !== undefined);
+	const ordered = orderTranscriptRepairCandidates(relevant);
+	const afterExclusiveBySession = new Map<string, number>();
+	// The floor is every sibling ordered BEFORE the target. Every caller supplies a
+	// list that includes the target (listSummaries returns all; the dashboard
+	// sibling query matches empty candidates), so this is a real precondition, not a
+	// fallback. Make it explicit rather than trusting a `break` to fire: if a
+	// tree/row inconsistency ever dropped the target from its own siblings, walking
+	// the whole list would fold LATER-bounded siblings into the floor and
+	// over-suppress the target's turns — data loss, the dangerous direction. When
+	// the target is absent we fold NOTHING instead (no dedup floor), and log it.
+	const targetIndex = ordered.findIndex((s) => s.commitHash === target.commitHash);
+	if (targetIndex === -1) {
+		log.debug("dedupFloorForTarget: target %s not among its siblings — folding no floor", target.commitHash);
+	}
+	const predecessors = targetIndex === -1 ? [] : ordered.slice(0, targetIndex);
+	for (const sibling of predecessors) {
+		// An already-repaired sibling archived its window in a prior run. Fold in
+		// what it PROVABLY archived, per session; when its stored transcript cannot
+		// be read, contribute nothing — an invisible copy is not a duplicate worth
+		// suppressing a later memory's turns for (§8.3 does not apply, see
+		// `archivedSessionFloor`). Identical to the CLI runner in
+		// DoctorCommand.runRepairTranscripts — keep the two in lockstep via the
+		// shared helpers, a divergent rule here silently re-opens the UI/run drift.
+		if (sibling.transcriptsRepairedAt !== undefined) {
+			const archived = await archivedSessionFloor(sibling, cwd, storage);
+			if (archived.readable) mergeSessionFloor(afterExclusiveBySession, archived.bySession);
+			continue;
+		}
+		const outcome = await planRepair(sibling, cwd, {
+			apply: false,
+			globalDir,
+			afterExclusiveBySession,
+		});
+		// Advance only on a repair, and only for the sessions it actually archived.
+		if (outcome.repaired && outcome.archivedBySession) {
+			mergeSessionFloor(afterExclusiveBySession, outcome.archivedBySession);
+		}
+	}
+	return { afterExclusiveBySession };
 }
 
 export interface RepairOutcome {
@@ -66,6 +344,13 @@ export interface RepairOutcome {
 		| "no-entries-in-window"
 		| "no-upper-bound";
 	readonly entries?: number;
+	/**
+	 * The newest entry timestamp (epoch ms) this repair archived, per sessionId —
+	 * the per-session dedup floor a LATER memory must apply to each session. Set on
+	 * dry runs too (there is one code path), so the UI replay and the batch run
+	 * advance the floor identically. Present only when `repaired` is true.
+	 */
+	readonly archivedBySession?: ReadonlyMap<string, number>;
 }
 
 /**
@@ -96,11 +381,45 @@ export interface RepairOutcome {
 export async function repairSummaryTranscripts(
 	commitHash: string,
 	cwd: string,
-	opts: { readonly apply?: boolean; readonly globalDir?: string } = {},
+	opts: RepairOptions = {},
 ): Promise<RepairOutcome> {
 	const summary = await getSummary(commitHash, cwd);
 	if (!summary) return { commitHash, repaired: false, reason: "no-owner-proof" };
 	return planRepair(summary, cwd, opts);
+}
+
+interface RepairOptions {
+	readonly apply?: boolean;
+	readonly globalDir?: string;
+	/**
+	 * Exclusive lower time bound (ISO 8601) for DE-DUPLICATION across a multi-memory
+	 * repair run. The per-owner lower bound stays `firstSeenLine` (unchanged), so a
+	 * later commit's read window still NESTS inside an earlier one's; this drops the
+	 * turns that window overlaps — those the caller already archived to an
+	 * earlier-bounded commit in the same run — so no turn is written to two memories.
+	 * A turn with no timestamp of its own is kept (it cannot be shown to be a
+	 * duplicate), matching the reader's own conservative treatment. Absent = no
+	 * dedup (the first memory in a run, and every single-memory caller).
+	 *
+	 * Worktree-WIDE: it drops matching turns from every owned session alike. It is
+	 * a general single-bound affordance (and is exercised as one by the tests);
+	 * production always prefers {@link afterExclusiveBySession}. In particular, do
+	 * NOT wire it as the fallback bound for a repaired sibling whose stored
+	 * transcript is unreadable — that path deliberately contributes NOTHING (see
+	 * `archivedSessionFloor` / `dedupFloorForTarget`), because a worktree-wide
+	 * bound guessed from an invisible copy would suppress a later memory's turns,
+	 * the P1 data-loss shape this module is built to avoid.
+	 */
+	readonly afterExclusive?: string;
+	/**
+	 * PER-SESSION exclusive dedup floor (epoch ms, keyed by sessionId). The floor a
+	 * multi-memory run carries: each session drops only turns an earlier memory
+	 * archived FROM THAT SESSION, so a repaired memory can no longer suppress a
+	 * session it never touched (the P1 data-loss fix). Combined with
+	 * {@link afterExclusive} by taking the LATER of the two per owner. Absent = no
+	 * per-session dedup.
+	 */
+	readonly afterExclusiveBySession?: ReadonlyMap<string, number>;
 }
 
 /**
@@ -110,18 +429,29 @@ export async function repairSummaryTranscripts(
  * possible). Keeping both on this one function is what stops the UI's
  * "repairable" sentence from drifting away from what a real run does.
  */
-async function planRepair(
-	summary: CommitSummary,
-	cwd: string,
-	opts: { readonly apply?: boolean; readonly globalDir?: string },
-): Promise<RepairOutcome> {
+async function planRepair(summary: CommitSummary, cwd: string, opts: RepairOptions): Promise<RepairOutcome> {
 	const commitHash = summary.commitHash;
 	if (summary.transcriptsRepairedAt !== undefined || getTranscriptIds(summary).length > 0) {
 		return { commitHash, repaired: false, reason: "already-present" };
 	}
 
-	const before = summary.generatedAt || summary.commitDate;
+	// `generatedAt || commitDate`, via the one helper every other display-date
+	// consumer shares (SummaryFormat.getDisplayDate). Reusing it — rather than
+	// re-spelling the precedence inline — is also what keeps this bound and the
+	// dedup floor below on the SAME numeric comparison the reader uses, instead
+	// of the lexicographic string compare a hand-rolled expression invited.
+	const before = getDisplayDate(summary);
 	if (!before) return { commitHash, repaired: false, reason: "no-upper-bound" };
+
+	// Worktree-wide exclusive lower bound for cross-memory dedup, parsed to epoch
+	// ms ONCE. ISO timestamps do NOT order lexicographically across formats (a git
+	// `%aI` offset form `…+08:00` vs Claude's `…Z`, with/without millis), so a raw
+	// string `>` silently dropped or duplicated turns whose format differed from
+	// the bound — the exact loss dedup exists to prevent. An absent/empty/
+	// unparseable bound means "no dedup" (NaN folds to undefined here), matching
+	// the first-memory-in-a-run and single-memory callers.
+	const parsedAfter = opts.afterExclusive ? new Date(opts.afterExclusive).getTime() : Number.NaN;
+	const afterTime = Number.isNaN(parsedAfter) ? undefined : parsedAfter;
 
 	const owned = await claudeSessionsOwnedBy(resolveStateRoot(cwd), opts.globalDir);
 	if (owned.length === 0) return { commitHash, repaired: false, reason: "no-owner-proof" };
@@ -146,7 +476,31 @@ async function planRepair(
 			log.debug("repair: cannot read %s: %s", owner.transcriptPath, errMsg(err));
 			continue;
 		}
-		if (read.entries.length === 0) continue;
+		// Drop turns already archived to an earlier-bounded commit in this run (see
+		// RepairOptions.afterExclusive / afterExclusiveBySession). The lower bound
+		// above stays firstSeenLine; this only removes the overlap so no turn lands
+		// on two memories. The effective floor is the LATER of the worktree-wide
+		// bound and THIS session's own per-session floor — so a repaired sibling's
+		// bound no longer suppresses a session it never archived. A turn with no
+		// timestamp — or one that cannot be parsed — is KEPT: it cannot be shown to
+		// be a duplicate, matching the reader's conservative treatment of unbounded
+		// lines.
+		const sessionFloor = opts.afterExclusiveBySession?.get(owner.sessionId);
+		const floor =
+			afterTime === undefined
+				? sessionFloor
+				: sessionFloor === undefined
+					? afterTime
+					: Math.max(afterTime, sessionFloor);
+		const entries =
+			floor === undefined
+				? read.entries
+				: read.entries.filter((e) => {
+						if (e.timestamp === undefined) return true;
+						const t = new Date(e.timestamp).getTime();
+						return Number.isNaN(t) || t > floor;
+					});
+		if (entries.length === 0) continue;
 		// Resolved here, not left off, per the archived-title contract every
 		// other stored-session writer follows (BackfillEngine.toStoredTranscript
 		// is the precedent for a writer outside QueueWorker's hot commit path):
@@ -157,24 +511,32 @@ async function planRepair(
 			sessionId: owner.sessionId,
 			source: "claude",
 			transcriptPath: owner.transcriptPath,
-			entries: read.entries,
+			entries,
 		});
 		sessions.push({
 			sessionId: owner.sessionId,
 			transcriptPath: owner.transcriptPath,
 			source: "claude",
-			entries: read.entries,
+			entries,
 			...(title ? { title } : {}),
 		});
 	}
 	if (sessions.length === 0) return { commitHash, repaired: false, reason: "no-entries-in-window" };
 
 	const entries = sessions.reduce((n, s) => n + s.entries.length, 0);
-	if (opts.apply !== true) return { commitHash, repaired: true, reason: "repaired", entries };
+	// The per-session floor a LATER memory must apply: the newest instant this
+	// repair archived FROM EACH session. Computed on the dry path too, so the UI
+	// replay and the batch run advance the floor from the same numbers.
+	const archivedBySession = new Map<string, number>();
+	for (const session of sessions) {
+		const max = maxEntryTimestamp(session.entries);
+		if (max !== undefined) archivedBySession.set(session.sessionId, max);
+	}
+	if (opts.apply !== true) return { commitHash, repaired: true, reason: "repaired", entries, archivedBySession };
 
 	const id = generateTranscriptId();
 	await storeSummary({ ...summary, transcripts: [id], transcriptsRepairedAt: new Date().toISOString() }, cwd, true, {
 		transcript: { id, data: { sessions } },
 	});
-	return { commitHash, repaired: true, reason: "repaired", entries };
+	return { commitHash, repaired: true, reason: "repaired", entries, archivedBySession };
 }

--- a/cli/src/core/TranscriptRepairWordingLockstep.test.ts
+++ b/cli/src/core/TranscriptRepairWordingLockstep.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The three-state memory-detail empty-conversations sentence (spec §9) is
+ * rendered INDEPENDENTLY on three surfaces — the dashboard, the VS Code webview,
+ * and the IntelliJ panel — because each host draws that panel itself. The strings
+ * must stay identical, or the same memory reads differently depending on where
+ * the user opens it, and the "repairable" wording that spec §9 exists to get
+ * right (a failed capture must not read as "not yet") drifts on whichever surface
+ * lags. Nothing else holds them together: the surfaces share no code here (one is
+ * Kotlin), so a prose comment "keep these in sync" cannot fail. This test is that
+ * forcing function — changing the wording means updating this pinned triple AND
+ * all three surfaces in the same change.
+ *
+ * Same shape as NodeFloorLockstep.test.ts / SourceLabelsLockstep.test.ts.
+ */
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const read = (rel: string): string => readFileSync(join(repoRoot, rel), "utf8");
+
+// The canonical strings, keyed by state. This test is their fourth copy on
+// purpose: it is the pinned source of truth the three renderers are checked against.
+const WORDING = {
+	repairable: "Conversation capture is missing but repair may still be possible",
+	repaired: "Conversation capture was repaired from local transcript history",
+	empty: "No conversations were captured for this memory",
+} as const;
+
+const SURFACES = [
+	"cli/src/dashboard/assets/js/memories.js",
+	"vscode/src/views/SummaryScriptBuilder.ts",
+	"intellij/src/main/kotlin/ai/jolli/jollimemory/core/TranscriptRepairState.kt",
+] as const;
+
+// The state each guarded sentence must be wired to. `empty` is deliberately
+// absent: on all three surfaces it is the DEFAULT arm (a bare `return` / `var
+// text = …` / `else ->`), reached when neither guard matched, so there is no
+// keyword to anchor it to — the guarded pair being correct is what leaves it
+// correct by construction.
+const GUARDED = { repairable: "repairable", repaired: "repaired" } as const;
+
+describe("transcript-repair empty-conversations wording is in lockstep across surfaces", () => {
+	// A self-check on the pinned triple itself: two states rendering the SAME
+	// sentence would make the per-surface mapping assertions below vacuously pass
+	// (the wrong-state guard would still sit next to a matching string).
+	it("pins three DISTINCT sentences", () => {
+		expect(new Set(Object.values(WORDING)).size).toBe(Object.values(WORDING).length);
+	});
+
+	for (const surface of SURFACES) {
+		it(`${surface} carries all three canonical strings verbatim`, () => {
+			const source = read(surface);
+			for (const [state, text] of Object.entries(WORDING)) {
+				expect(
+					source,
+					`${surface} is missing the "${state}" wording — it drifted from the pinned triple`,
+				).toContain(text);
+			}
+		});
+
+		// The contains-check above proves the strings are PRESENT; it cannot catch a
+		// mapping that points the `repairable` guard at the `repaired` sentence (or
+		// vice-versa) — both strings are present either way. This anchors each
+		// guarded sentence to its state token: the token must appear on the
+		// sentence's own line or the two lines above it (same-line on memories.js /
+		// Kotlin, one line up in the VS Code builder's `if (…) { text = … }`). Same
+		// bidirectional spirit as SourceLabelsLockstep.
+		it(`${surface} wires each guarded sentence to its own state`, () => {
+			const lines = read(surface).split("\n");
+			for (const [state, keyword] of Object.entries(GUARDED)) {
+				const idx = lines.findIndex((l) => l.includes(WORDING[state as keyof typeof WORDING]));
+				expect(idx, `${surface} is missing the "${state}" sentence`).toBeGreaterThanOrEqual(0);
+				const near = lines
+					.slice(Math.max(0, idx - 2), idx + 1)
+					.join("\n")
+					.toLowerCase();
+				expect(
+					near,
+					`${surface} renders the "${state}" sentence without a nearby "${keyword}" guard — the state→sentence mapping drifted`,
+				).toContain(keyword);
+			}
+			// The `empty` sentence must be the unguarded default, not a misrouted
+			// guarded arm: its own line carries neither guarded state token.
+			const emptyLine = lines.find((l) => l.includes(WORDING.empty)) ?? "";
+			for (const keyword of Object.values(GUARDED)) {
+				expect(
+					emptyLine.toLowerCase(),
+					`${surface} guards the empty-state sentence with "${keyword}" — it should be the default arm`,
+				).not.toContain(keyword);
+			}
+		});
+	}
+});

--- a/cli/src/dashboard/LocalDays.test.ts
+++ b/cli/src/dashboard/LocalDays.test.ts
@@ -97,3 +97,83 @@ describe("local-day arithmetic", () => {
 		expect(localDayKey(midnight as number, LA)).toBe("2026-03-08");
 	});
 });
+
+/**
+ * Regression for the availability defect: two real zones spring forward AT local
+ * midnight, so that day's 00:00 does not exist. The inversion used to converge on
+ * an instant in the PREVIOUS local day, which made `addLocalDays` a fixed point —
+ * the forward window walk never advanced and the whole read path hung. These are
+ * the only two zones on that shape (measured across the platform's zones), each
+ * recurring annually 2027–2040.
+ *
+ * The skipped-midnight day is DETECTED at runtime, not pinned to a date. Egypt's
+ * DST in particular is a political decision (it was cancelled outright 2015–2023),
+ * so the exact transition date can move under an ICU/tzdata update — while the
+ * INVARIANT under test (the walk must advance and never repeat a day, and the
+ * skipped-midnight day resolves to its own earliest instant) does not depend on
+ * WHICH day it is. Binding the assertions to the detected day keeps the test
+ * meaningful without making it hostage to the zone database; if a future tzdata
+ * removes the transition from the window entirely, the case skips rather than
+ * failing on a date that is no longer special. A skipped-midnight day is found by
+ * its signature: its earliest existing instant is 01:00 local, so `localHour` of
+ * it is not 0.
+ */
+describe("local-day engine — zones whose local midnight is skipped", () => {
+	const zones = [
+		{ zone: "Africa/Cairo", from: "2027-04-25", to: "2027-05-05" },
+		{ zone: "Asia/Beirut", from: "2027-03-24", to: "2027-04-02" },
+	];
+
+	/** The first day in [from,to) whose local midnight does not exist, or undefined. */
+	function findSkippedMidnightDay(
+		zone: string,
+		from: string,
+		to: string,
+	): { key: string; midnight: number } | undefined {
+		const end = dayKeyToMidnight(to, zone) as number;
+		let cursor = dayKeyToMidnight(from, zone) as number;
+		let guard = 0;
+		while (cursor < end) {
+			if (localHour(cursor, zone) !== 0) return { key: localDayKey(cursor, zone), midnight: cursor };
+			cursor = addLocalDays(cursor, 1, zone);
+			if (++guard > 100) break;
+		}
+		return undefined;
+	}
+
+	for (const { zone, from, to } of zones) {
+		const gap = findSkippedMidnightDay(zone, from, to);
+
+		it.skipIf(!gap)(`${zone}: a forward day-walk across the transition terminates and never repeats a day`, () => {
+			const start = dayKeyToMidnight(from, zone) as number;
+			const end = dayKeyToMidnight(to, zone) as number;
+			expect(start).toBeDefined();
+			expect(end).toBeDefined();
+
+			const keys: string[] = [];
+			let cursor = start;
+			let guard = 0;
+			while (cursor < end) {
+				keys.push(localDayKey(cursor, zone));
+				const next = addLocalDays(cursor, 1, zone);
+				// The fixed point: on the unfixed engine `next === cursor` here, so the
+				// real walk (a plain `cursor < end` loop) span forever.
+				expect(next).toBeGreaterThan(cursor);
+				cursor = next;
+				if (++guard > 100) throw new Error(`${zone}: forward walk did not terminate`);
+			}
+
+			expect(keys).toContain((gap as { key: string }).key); // the skipped-midnight day is visited...
+			expect(new Set(keys).size).toBe(keys.length); // ...exactly once, and every day is distinct
+			for (let i = 1; i < keys.length; i++) expect(keys[i] > keys[i - 1]).toBe(true);
+		});
+
+		it.skipIf(!gap)(
+			`${zone}: the skipped-midnight day resolves to its own earliest instant, not the previous day`,
+			() => {
+				const { key, midnight } = gap as { key: string; midnight: number };
+				expect(localDayKey(midnight, zone)).toBe(key);
+			},
+		);
+	}
+});

--- a/cli/src/dashboard/LocalDays.ts
+++ b/cli/src/dashboard/LocalDays.ts
@@ -72,22 +72,55 @@ export function localHour(ms: number, timeZone: string): number {
  *
  * `Intl` can only map epoch → wall clock; this inverts it by guessing the UTC
  * value of the wall-clock midnight and correcting by the observed error. Two
- * iterations settle every real zone including DST transitions: the first
- * correction lands within the zone's offset step, the second removes any
- * residue from a transition between guess and target. (On a "spring forward"
- * day where 00:00 does not exist, this lands on the earliest existing instant
- * of the day — exactly what a day boundary should be.)
+ * iterations settle every real zone including DST transitions whose 00:00
+ * exists: the first correction lands within the zone's offset step, the second
+ * removes any residue from a transition between guess and target, so the loop
+ * returns the moment `error` reaches zero.
+ *
+ * On a "spring forward" day whose 00:00 does NOT exist — the clocks jump over
+ * local midnight, as `Africa/Cairo` and `Asia/Beirut` do on their transition
+ * dates — no epoch maps to 00:00, so the correction never reaches zero and
+ * instead oscillates by the gap width. The earlier version returned that
+ * oscillating value, which landed an hour short **inside the previous local
+ * day**: `startOfLocalDay` then mapped it back to the previous day and the
+ * forward day-step became a fixed point, hanging the whole read path. We now
+ * fall through to {@link firstInstantOfLocalDay}, which returns the earliest
+ * instant that genuinely belongs to this day (the moment right after the gap) —
+ * a real day boundary, strictly inside the day, so stepping always advances.
  */
 function localMidnight(year: number, month: number, day: number, timeZone: string): number {
-	let guess = Date.UTC(year, month - 1, day);
+	const targetNaive = Date.UTC(year, month - 1, day);
+	let guess = targetNaive;
 	for (let i = 0; i < 3; i++) {
 		const seen = zonedParts(guess, timeZone);
-		const error =
-			Date.UTC(seen.year, seen.month - 1, seen.day, seen.hour, seen.minute) - Date.UTC(year, month - 1, day);
-		if (error === 0) break;
+		const error = Date.UTC(seen.year, seen.month - 1, seen.day, seen.hour, seen.minute) - targetNaive;
+		if (error === 0) return guess;
 		guess -= error;
 	}
-	return guess;
+	return firstInstantOfLocalDay(year, month, day, timeZone);
+}
+
+/**
+ * The earliest epoch-ms belonging to local day `year-month-day`, for the
+ * spring-forward case where that day's 00:00 is skipped. The day is real (only
+ * its first minute-or-two is missing), so its boundary is the instant right
+ * after the gap. Found by bisecting, at minute resolution, the point where the
+ * local day key first reaches the target — monotonic in time, and the engine is
+ * minute-granular, so the answer is exact. The bracket (`-15 h` / `+14 h` around
+ * naive midnight) is wider than any real UTC offset, so the low end is always in
+ * an earlier local day and the high end is always at or past this day's start.
+ */
+function firstInstantOfLocalDay(year: number, month: number, day: number, timeZone: string): number {
+	const targetKey = `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+	const naive = Date.UTC(year, month - 1, day);
+	let loMin = Math.floor((naive - 15 * 3_600_000) / 60_000);
+	let hiMin = Math.ceil((naive + 14 * 3_600_000) / 60_000);
+	while (hiMin - loMin > 1) {
+		const midMin = Math.floor((loMin + hiMin) / 2);
+		if (localDayKey(midMin * 60_000, timeZone) < targetKey) loMin = midMin;
+		else hiMin = midMin;
+	}
+	return hiMin * 60_000;
 }
 
 export function startOfLocalDay(ms: number, timeZone: string): number {

--- a/cli/src/dashboard/MemoriesQuery.test.ts
+++ b/cli/src/dashboard/MemoriesQuery.test.ts
@@ -19,7 +19,8 @@ import {
 // The predicate reads the machine-global `claude-owners.json` and stats every
 // transcript it names, so a real call would answer differently on each developer's
 // machine. Its own cases live in `TranscriptRepair.test.ts`; what these pin is the
-// wiring around it.
+// wiring around it. The `storage` provider the wiring hands it is a LAZY thunk the
+// mocked predicate never resolves, so the real `createStorage` is never reached.
 vi.mock("../core/TranscriptRepair.js", () => ({
 	transcriptRepairState: vi.fn().mockResolvedValue("unrepairable"),
 }));
@@ -1488,6 +1489,16 @@ describe("MemoriesQuery", () => {
 			expect(transcriptRepairState).toHaveBeenCalledWith(
 				expect.objectContaining({ commitHash: HASH }),
 				"/w/acme-api",
+				// `siblingSummaries` and `storage` are both LAZY providers (the repo-wide
+				// sibling query and the per-worktree storage build both run only for a real
+				// candidate, not on every detail open); the mocked predicate never invokes
+				// them, so assert their shape rather than resolved values. `storage` being
+				// threaded is what stops the machine-global dashboard from reading a
+				// sibling's transcripts through the wrong repo's active storage.
+				expect.objectContaining({
+					siblingSummaries: expect.any(Function),
+					storage: expect.any(Function),
+				}),
 			);
 		});
 

--- a/cli/src/dashboard/MemoriesQuery.ts
+++ b/cli/src/dashboard/MemoriesQuery.ts
@@ -37,6 +37,8 @@ import { sanitizeNativeIdForPath } from "../core/references/ReferenceStore.js";
 import { firstUserMessageTitleFromEntries } from "../core/SessionTitleResolver.js";
 import { buildSkillsAggregateMarkdown, buildSkillsSummaryLabel } from "../core/SkillsAggregateMarkdown.js";
 import { assembleMemoryTree } from "../core/SqliteStorage.js";
+import { createStorage } from "../core/StorageFactory.js";
+import type { StorageProvider } from "../core/StorageProvider.js";
 import { formatProviderLabel } from "../core/SummaryFormat.js";
 import {
 	aggregateConversationTokenBreakdown,
@@ -1001,9 +1003,67 @@ export async function readMemoryTranscriptRepairState(
 			| { repo_id: number; commit_hash: string; summary_json: string; worktree_root: string | null }
 			| undefined;
 		if (!row?.worktree_root) return undefined;
+		const worktreeRoot = row.worktree_root; // captured for the storage closure below (narrowing does not survive it)
 		const summary = (assembleMemoryTree(db, row.repo_id, row.commit_hash) ??
 			JSON.parse(row.summary_json)) as CommitSummary;
-		return await transcriptRepairState(summary, row.worktree_root);
+		// The repo's empty-OR-repaired siblings, so the verdict reflects the dedup
+		// floor a real `doctor --repair-transcripts` run would hand this memory (the
+		// only repair path a user can trigger) rather than the lone-repair window —
+		// otherwise the panel shows "repairable" for a memory the batch would dedup to
+		// empty. Read from the dashboard DB, NOT `listSummaries`: this process must
+		// never touch the post-cutover frozen orphan branch (JOLLI-2231). Two shapes
+		// count and both bound the floor: a memory with no `memory_transcripts` rows is
+		// an empty CANDIDATE, and one whose summary carries `transcriptsRepairedAt` was
+		// REPAIRED in a prior run (it has transcript rows, so the NOT EXISTS clause
+		// misses it — the LIKE catches it). `dedupFloorForTarget` re-filters the parsed
+		// rows via `isTranscriptRepairCandidate`/`transcriptsRepairedAt`, so a LIKE
+		// false-positive is harmless.
+		//
+		// A LAZY provider: `transcriptRepairState` short-circuits for the
+		// present/repaired majority before it needs siblings, so this repo-wide query
+		// runs only for an actual empty candidate.
+		// Assembled as a TREE, exactly like `summary` above: a squash/amend sibling
+		// keeps its transcripts on the folded children, so the bare `summary_json`
+		// row (children emptied) would read as an empty candidate and inject a
+		// phantom entry into the floor replay. `commit_hash` is selected for that
+		// assembly; the raw row is the fallback for a tree that cannot be rebuilt.
+		const siblingSummaries = (): Promise<readonly CommitSummary[]> =>
+			Promise.resolve(
+				(
+					db
+						.prepare(
+							`SELECT m.commit_hash, m.summary_json
+							   FROM memories m
+							  WHERE m.repo_id = ?
+							    AND (
+							        NOT EXISTS (
+							            SELECT 1 FROM memory_transcripts mt
+							             WHERE mt.repo_id = m.repo_id AND mt.commit_hash = m.commit_hash
+							        )
+							        OR m.summary_json LIKE '%"transcriptsRepairedAt"%'
+							    )`,
+						)
+						.all(row.repo_id) as ReadonlyArray<{ commit_hash: string; summary_json: string }>
+				).map(
+					(r) =>
+						(assembleMemoryTree(db, row.repo_id, r.commit_hash) ??
+							JSON.parse(r.summary_json)) as CommitSummary,
+				),
+			);
+		// The floor replay reads each sibling's STORED transcripts, which is NOT
+		// storage-independent: `readTranscriptsBatch` resolves an absent storage
+		// through the process-global active storage, and this dashboard process is
+		// machine-global — a guided-front-door run may have set that global to the
+		// launching repo, so every OTHER repo's detail row would read its siblings
+		// back as unreadable. Build storage from THIS memory's own worktree root and
+		// thread it in. LAZY, like `siblingSummaries`: `transcriptRepairState` resolves
+		// it only past the present/repaired short-circuit, so the routing (and any
+		// SQLite open it entails) is not paid on the hot path. `createStorage` routes a
+		// cutover/legacy-fenced repo to SQLite (never the frozen orphan branch,
+		// JOLLI-2231) and rejects only for a blocked one, which the outer catch renders
+		// as the plainest sentence.
+		const storage = (): Promise<StorageProvider> => createStorage(worktreeRoot, worktreeRoot);
+		return await transcriptRepairState(summary, worktreeRoot, { siblingSummaries, storage });
 	} catch (err) {
 		log.debug("transcript repair state unavailable for %s: %s", hash, errMsg(err));
 		return undefined;

--- a/cli/src/dashboard/StatsRollup.ts
+++ b/cli/src/dashboard/StatsRollup.ts
@@ -249,10 +249,16 @@ export function readAvailableDays(
 	const oldestBuild = Math.min(...sentinels.values());
 	// And bounded again by the candidate days' own span, which is what keeps this
 	// scan from growing with the machine's history — see `readSourcesWrittenSince`.
-	// `dayKeyToMidnight` round-trips by construction here (every key came out of
-	// `localDayKey`), so the fallbacks are unreachable; they are the widest range
-	// rather than the narrowest so an impossible key degrades to the old
-	// over-reading behaviour instead of silently declaring stale days fresh.
+	// Every key here came out of `localDayKey`, and `localMidnight` resolves every
+	// real local day — including a spring-forward day whose 00:00 is skipped, which
+	// it maps to that day's first existing instant rather than rejecting (that
+	// rejection is what used to make these fallbacks reachable, and made a
+	// window spanning such a day hang the forward walk before it ever reached
+	// here). So `dayKeyToMidnight` round-trips by construction and the fallbacks
+	// are unreachable; they are kept as the WIDEST range rather than the narrowest
+	// so any residual impossible key degrades to over-reading (one extra scan)
+	// instead of silently declaring stale days fresh, or hanging the day step on a
+	// not-a-number bound.
 	const rangeFromMs = dayKeyToMidnight(first, timeZone) ?? 0;
 	const lastStartMs = dayKeyToMidnight(last, timeZone);
 	const rangeToMs = lastStartMs === undefined ? Number.MAX_SAFE_INTEGER : addLocalDays(lastStartMs, 1, timeZone);

--- a/cli/src/dashboard/StatsWriter.test.ts
+++ b/cli/src/dashboard/StatsWriter.test.ts
@@ -2471,3 +2471,39 @@ describe("unparkStuckEvents", () => {
 		expect(() => unparkStuckEvents(handle)).toThrow(/malformed/);
 	});
 });
+
+describe("applyStatsEvents — rollup cache invalidation on a session day-move", () => {
+	it("forgets the SOURCE day's cached rows when a session's updated_at_ms moves to another day", async () => {
+		const T1 = 1_700_000_000_000; // 2023-11-14 (UTC)
+		const T2 = T1 + 3 * 86_400_000; // three days later — a different local day
+		const day1 = new Date(T1).toISOString().slice(0, 10);
+
+		// The session lands on day1 and a rollup is settled for that day.
+		await applyStatsEvents([envelope(session({ updatedAtMs: T1 }))], { producerKind: "cli", dbPath });
+		await withDashboardDb(
+			(db) => {
+				const repoId = (
+					db.prepare("SELECT id FROM repos WHERE repo_identity = ?").get("repo-1") as { id: number }
+				).id;
+				const ins = db.prepare(
+					`INSERT INTO stats_daily (repo_id, tz, day, kind, series_key, value, cost_usd, built_at_ms, updated_at_ms)
+					 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				);
+				ins.run(0, "UTC", day1, "built", "", 0, 0, T1, T1); // sentinel: day1 is settled
+				ins.run(repoId, "UTC", day1, "model", "claude-opus-5", 150, 0.5, T1, T1); // its data
+			},
+			{ dbPath },
+		);
+
+		// The SAME session, its clock moved to a different day. The staleness scan
+		// only notices the destination, so without an explicit forget day1 would stay
+		// cached and overstate forever.
+		await applyStatsEvents([envelope(session({ updatedAtMs: T2 }))], { producerKind: "cli", dbPath });
+
+		const remaining = await query<{ n: number }>(
+			"SELECT COUNT(*) AS n FROM stats_daily WHERE tz = 'UTC' AND day = ?",
+			day1,
+		);
+		expect(remaining[0].n).toBe(0);
+	});
+});

--- a/cli/src/dashboard/StatsWriter.ts
+++ b/cli/src/dashboard/StatsWriter.ts
@@ -837,6 +837,19 @@ function projectSession(db: DashboardDbHandle, event: SessionUpsertedEvent, nowM
 		if (prior.updated_at_ms > event.updatedAtMs) return;
 	}
 
+	// A session's OWN bucketing instant on the session-level axes is
+	// `updated_at_ms`, so when it moves to a new day the session's contribution
+	// moves with it — and the staleness scan only ever notices the DESTINATION
+	// day (the day the row now sits on, carrying the fresh write stamp). Left
+	// alone, the SOURCE day stays cached and overstated for good, because an old
+	// day gets no further writes to rebuild it. Forget the source day before the
+	// move. This is the session-level counterpart to the per-response day-forget
+	// below (which is Claude-only); every source is placed on the session axes by
+	// this instant, so this must not be gated on `usageEvents`.
+	if (prior !== undefined && prior.updated_at_ms !== event.updatedAtMs) {
+		forgetRollupDays(db, [prior.updated_at_ms]);
+	}
+
 	const repoId = ensureRepoRow(db, event.repoIdentity);
 	const models = event.models ?? [];
 	// An event that carries NO usage information at all (no model split, no

--- a/cli/src/hooks/StopHook.ts
+++ b/cli/src/hooks/StopHook.ts
@@ -279,10 +279,12 @@ async function discoverFromTranscript(sessionInfo: SessionInfo, cwd: string): Pr
 	// plan/reference cursor, and vice versa.
 	await scanSkillsWithCursor(transcriptPath, cwd, "claude");
 
-	// Fourth extractor, same protocol. This is the ONLY writer of the machine-global
-	// ownership ledger, and it is what lets a DIFFERENT checkout later prove it owns
-	// a slice of this session: the transcript's own `cwd` lines are the evidence, and
-	// they are only visible while the file is being scanned here.
+	// Fourth extractor, same protocol. This is the FORWARD writer of the
+	// machine-global ownership ledger (the commit-time backfill in QueueWorker is
+	// the other, through this same scanOwnersWithCursor + recordClaudeOwners), and
+	// it is what lets a DIFFERENT checkout later prove it owns a slice of this
+	// session: the transcript's own `cwd` lines are the evidence, and they are only
+	// visible while the file is being scanned here.
 	await scanOwnersWithCursor(transcriptPath, sessionInfo.sessionId, cwd);
 
 	// Hold the cursor if the plan scan threw: advancing past its window (the

--- a/intellij/src/main/kotlin/ai/jolli/jollimemory/core/TranscriptRepairState.kt
+++ b/intellij/src/main/kotlin/ai/jolli/jollimemory/core/TranscriptRepairState.kt
@@ -23,8 +23,16 @@ import com.google.gson.JsonObject
  * than on the dashboard about the same memory.
  *
  * What DOES live here is presentation: [emptyConversationsText] is the wording,
- * which is the host's job. The three sentences are identical on all four
- * surfaces (spec §9).
+ * which is the host's job. The three sentences are duplicated across THREE
+ * rendering surfaces — this Kotlin copy, the dashboard webview
+ * (assets/js/memories.js) and the VS Code editor webview
+ * (SummaryScriptBuilder.ts) — because each host draws that panel itself and they
+ * share no code here. TranscriptRepairWordingLockstep.test.ts is the forcing
+ * function that holds them together: it pins the canonical triple and fails if
+ * any surface drifts OR misroutes a guarded sentence to the wrong state, so a
+ * reword means updating that pinned triple AND all three surfaces in one change.
+ * (The CLI doctor --repair-transcripts output is NOT one of them: it prints its
+ * own operator-facing wording, not these sentences.)
  */
 object TranscriptRepairState {
 

--- a/vscode/src/views/SummaryWebviewPanel.test.ts
+++ b/vscode/src/views/SummaryWebviewPanel.test.ts
@@ -207,6 +207,7 @@ const {
 	mockStoreNotes,
 	mockStorePlans,
 	mockStoreSummary,
+	mockListSummaries,
 } = vi.hoisted(() => ({
 	mockGetTranscriptHashes: vi.fn().mockResolvedValue(new Set<string>()),
 	// Default: every read returns null so the inline-edit / preview "snapshot
@@ -220,6 +221,9 @@ const {
 	mockStoreNotes: vi.fn().mockResolvedValue(undefined),
 	mockStorePlans: vi.fn().mockResolvedValue(undefined),
 	mockStoreSummary: vi.fn().mockResolvedValue(undefined),
+	// The repo's empty siblings the panel now feeds to `transcriptRepairState`;
+	// none by default (the stubbed predicate answer is what these tests assert).
+	mockListSummaries: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("../../../cli/src/core/SummaryStore.js", () => ({
@@ -233,6 +237,7 @@ vi.mock("../../../cli/src/core/SummaryStore.js", () => ({
 	storeNotes: mockStoreNotes,
 	storePlans: mockStorePlans,
 	storeSummary: mockStoreSummary,
+	listSummaries: mockListSummaries,
 }));
 
 const { mockResolveSessionTitle } = vi.hoisted(() => ({
@@ -258,6 +263,11 @@ const { mockTranscriptRepairState } = vi.hoisted(() => ({
 
 vi.mock("../../../cli/src/core/TranscriptRepair.js", () => ({
 	transcriptRepairState: mockTranscriptRepairState,
+	// The panel hands `transcriptRepairState` a LAZY sibling provider (the engine,
+	// not the host, filters which siblings count), so it no longer imports
+	// `isTranscriptRepairCandidate` — this export is kept only so the module mock
+	// stays shape-complete for any other importer.
+	isTranscriptRepairCandidate: () => true,
 }));
 
 const { mockDeleteTopicInTree, mockUpdateTopicInTree } = vi.hoisted(() => ({
@@ -5294,11 +5304,47 @@ describe("SummaryWebviewPanel", () => {
 				);
 				expect(call?.[0].transcriptRepairState).toBe("repairable");
 				// The rule stays in the CLI: this host forwards the summary it is
-				// showing and its workspace root, and restates nothing.
+				// showing, its workspace root, and a LAZY provider for the repo's
+				// siblings (so the enumeration is paid only for a real candidate and the
+				// verdict reflects the batch dedup floor), and restates nothing.
 				expect(mockTranscriptRepairState).toHaveBeenCalledWith(
 					expect.objectContaining({ commitHash: makeSummary().commitHash }),
 					workspaceRoot,
+					expect.objectContaining({ siblingSummaries: expect.any(Function) }),
 				);
+			});
+
+			it("short-circuits a FOREIGN memory to unrepairable without consulting the current-repo ledger", async () => {
+				// A foreign memory's owner edges are keyed by ITS worktree root, which
+				// this panel does not have. Asking the core with THIS workspace's root
+				// could answer "repairable" for a repair that could never run here — the
+				// false promise the JVM host avoids by missing. Foreign mode must answer
+				// the mildest verdict and never call the predicate.
+				mockTranscriptRepairState.mockResolvedValue("repairable");
+				mockGetTranscriptHashes.mockResolvedValue(new Set());
+				mockReadTranscriptsForCommits.mockResolvedValue(new Map());
+				const foreignStorage = {
+					kind: "foreign-storage-stub",
+				} as unknown as import("../../../cli/src/core/StorageProvider.js").StorageProvider;
+				await SummaryWebviewPanel.show(
+					makeSummary(),
+					extensionUri,
+					workspaceRoot,
+					stubBridge,
+					mainBranch,
+					"memory",
+					"other-repo",
+					"https://github.com/x/foreign.git",
+					foreignStorage,
+				);
+				const dispatch = captureMessageHandler();
+
+				dispatch({ command: "loadConversations" });
+				await flushPromises();
+
+				const call = postMessage.mock.calls.find((c) => c[0]?.command === "conversationsData");
+				expect(call?.[0].transcriptRepairState).toBe("unrepairable");
+				expect(mockTranscriptRepairState).not.toHaveBeenCalled();
 			});
 
 			it("falls back to unrepairable when the panel holds no summary to ask about", async () => {

--- a/vscode/src/views/SummaryWebviewPanel.ts
+++ b/vscode/src/views/SummaryWebviewPanel.ts
@@ -42,14 +42,12 @@ import {
 	groupArchivedSessions,
 } from "../../../cli/src/core/ArchivedConversations.js";
 import { resolveSessionTitle } from "../../../cli/src/core/SessionTitleResolver.js";
-import {
-	type TranscriptRepairState,
-	transcriptRepairState,
-} from "../../../cli/src/core/TranscriptRepair.js";
+import { type TranscriptRepairState, transcriptRepairState } from "../../../cli/src/core/TranscriptRepair.js";
 import { track } from "../../../cli/src/core/Telemetry.js";
 import { runWithTrace } from "../../../cli/src/core/TraceContext.js";
 import {
 	getTranscriptHashes as coreGetTranscriptHashes,
+	listSummaries,
 	readNoteFromBranch,
 	readPlanFromBranch,
 	readReferenceFromBranch,
@@ -3982,19 +3980,36 @@ export class SummaryWebviewPanel {
 	 * unreadable owners ledger must not cost them the rows. Guessing the other
 	 * way would invite a repair that has nothing to work from.
 	 *
-	 * `this.workspaceRoot` is the cwd even in foreign-storage mode, matching
-	 * every other read in this class. A foreign memory's owner edges are keyed by
-	 * ITS worktree root, which this panel does not have, so such a memory falls to
-	 * `unrepairable` — the conservative answer, and the honest one: the repair
-	 * itself is per-repo and could not run from here either.
+	 * In foreign-storage mode the memory belongs to ANOTHER repository, whose owner
+	 * edges are keyed by ITS worktree root — which this panel does not have. Asking
+	 * the engine with `this.workspaceRoot` (the cwd, as every other read here uses)
+	 * would judge the foreign memory against the CURRENT repo's owned-session ledger
+	 * and could answer `repairable` for a commit whose repair could never run from
+	 * here — the false promise the JVM host avoids by resolving the memory in the
+	 * current repo and missing. So a foreign memory short-circuits to `unrepairable`,
+	 * the conservative and honest answer; the engine is asked only for a local one.
 	 */
 	private async readTranscriptRepairState(): Promise<TranscriptRepairState> {
 		const summary = this.currentSummary;
 		if (!summary) {
 			return "unrepairable";
 		}
+		if (this.foreignRepoName) {
+			return "unrepairable";
+		}
 		try {
-			return await transcriptRepairState(summary, this.workspaceRoot);
+			// The repo's empty-or-repaired siblings, so the verdict reflects the dedup
+			// floor a real `doctor --repair-transcripts` run would hand this memory (the
+			// only user-triggerable repair path), not the lone-repair window. Passed as a
+			// LAZY provider: `transcriptRepairState` short-circuits for the present/repaired
+			// majority before it needs siblings, so an eager `listSummaries(MAX)` (a read
+			// per memory) would be paid on every detail open and thrown away. The engine
+			// also owns the "which siblings count" filter — a repaired sibling still bounds
+			// the floor — so this passes the raw list rather than pre-filtering to empties.
+			// Local storage routed by workspaceRoot, as every other read in this panel is.
+			return await transcriptRepairState(summary, this.workspaceRoot, {
+				siblingSummaries: () => listSummaries(Number.MAX_SAFE_INTEGER, this.workspaceRoot),
+			});
 		} catch (err) {
 			log.warn(
 				"Transcript repair state unavailable: %s",


### PR DESCRIPTION
## Summary

Grounding the nightly spec update against live code surfaced real product defects across the ownership ledger, the session-statistics sync channel, the daily-stats rollup, and transcript repair. Each fix carries a regression test.

## Security
- Validate the inherited agent session id before it becomes a transcript path, reject a relative transcript cwd (it would anchor to the draining worker's own worktree), and require a regular file before reading it.

## Availability
- Stop the local-day engine hanging the dashboard on zones whose local midnight is skipped (Africa/Cairo, Asia/Beirut): resolve such a day to its earliest existing instant so the forward day-walk always advances.

## Data loss
- Reject a session-sync 2xx that carries neither an accepted map nor a cursor, instead of advancing the cursor over rows the server never stored.
- Write the session-sync channel state file atomically (temp + rename).
- Quarantine a present-but-corrupt ownership ledger instead of overwriting every other session with the one being written.
- Honor `doctor --dry-run` in the transcript-repair form.

## Correctness
- Strip inherited git-location env vars before the worktree resolver's git fallback, so a linked-worktree hook resolves the asked-about repo.
- Forget a session's source day in the stats rollup when its clock moves to another day, so the source day is not left overstating forever.
- De-duplicate turns across memories in a multi-memory repair run.
- Judge a foreign memory's repair verdict as unrepairable rather than against the current repository's ownership ledger.

## Comments
- Correct the ownership forward-writer's sole-writer note, the local midnight guarantee, the stats availability-fallback rationale, and the IntelliJ verdict-sentence surface count.

## Test plan
- Each fix carries a regression test; `npm run all` passes.
