### PR TITLE
Skills page auto-loads full list, drops Show more button

### DIFF
--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -1164,17 +1164,22 @@ const TOOL_USAGE_LISTS: ReadonlyArray<ToolUsageList> = ["skill", "server", "tool
  * Widest `?limit=` this route will serve — 25 pages of {@link TOOL_ROWS_LIMIT}.
  *
  * The limit used to be ours alone, because the only caller was a "Show more"
- * click and one click means one page. The 30 s poll needs the other shape: to
- * decide whether a list the reader has already expanded still looks the same, it
- * has to re-read exactly as many rows as are on screen, which is a number only
- * the client knows (see `carryForwardToolLists` in `assets/js/stats.js`).
+ * click and one click means one page. Two callers need the other shape now. The
+ * 30 s poll, to decide whether a list the reader has already expanded still
+ * looks the same, has to re-read exactly as many rows as are on screen, which is
+ * a number only the client knows (see `carryForwardToolLists` in
+ * `assets/js/stats.js`). And the Skills PAGE asks for the whole list outright —
+ * it has no button, so it reads to the end on arrival (`assets/js/skills.js`).
  *
  * Clamped rather than rejected, so a caller asking past the cap still gets a
- * readable page. On the poll path that degrades in the safe direction: a client
- * holding more rows than the cap receives fewer than it asked for, reads that as
- * "the card changed", and collapses back to the first page — the pre-existing
- * behaviour — rather than trusting rows it could not verify. It takes 25 clicks
- * on one list to get there.
+ * readable page, and each of the three degrades safely in its own way. A Show
+ * more click cannot reach the cap in under 25 clicks on one list. A poll holding
+ * more rows than the cap receives fewer than it asked for, reads that as "the
+ * card changed", and collapses back to the first page — the pre-existing
+ * behaviour — rather than trusting rows it could not verify. The Skills page
+ * reaches the cap on its FIRST request for any corpus past 200 skills, which is
+ * the case it is built for: the short answer advances its offset and it comes
+ * back for the remainder, so the clamp costs it a round trip rather than rows.
  *
  * A cap at all because this is an unauthenticated-shaped GET on a local server:
  * without one, `?limit=1e9` turns a card's paging endpoint into an unbounded
@@ -1617,10 +1622,11 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 			return;
 		}
 
-		// One page of a Skills / MCPs list, behind those cards' "Show more" button.
-		// Same shape as `/api/memories` above and for the same reason: the model is
-		// inlined into the page HTML, so only the first page can ride there. A read
-		// like every other GET here — no token.
+		// One page of a Skills / MCPs list — behind those cards' "Show more" button on
+		// the Stats page, and read straight through to the end by the Skills page, which
+		// has no button. Same shape as `/api/memories` above and for the same reason: the
+		// model is inlined into the page HTML, so only the first page can ride there. A
+		// read like every other GET here — no token.
 		//
 		// The window params ride along (`range`/`from`/`to`) because the rows are
 		// an aggregate OVER a window: paging with a different one than the card was

--- a/cli/src/dashboard/SkillsAsset.test.ts
+++ b/cli/src/dashboard/SkillsAsset.test.ts
@@ -11,26 +11,49 @@ interface SkillRow {
 	readonly agents: ReadonlyArray<{ source: string; calls: number }>;
 }
 
-interface FakeButton {
-	onclick?: () => void;
+/** Just the two edges `isRowRevealed` reads off a `getBoundingClientRect`. */
+interface FakeRect {
+	top: number;
+	bottom: number;
 }
 
 /**
- * The rows region, as `draw` sees it. `offsetHeight` is what the page measures to cap
- * the region once Show more is pressed, and `scrollTop` is what it carries across a
- * repaint — neither exists without a layout, so the harness supplies both.
+ * The rows region, as `draw` sees it. `scrollTop` is what the page carries across a
+ * repaint and `rect` is the box a row's own is compared against — neither exists without a
+ * layout, so the harness supplies both.
+ *
+ * There used to be an `offsetHeight` here as well: the page measured the region's own
+ * height and wrote it back as a `max-height` cap once the rest of the list landed. The
+ * fixed frame took that over (the region's height comes from the flex chain now), so
+ * nothing reads it and the field is gone with the mechanism.
  */
 interface FakeList {
 	scrollTop: number;
-	offsetHeight: number;
+	rect: FakeRect;
+}
+
+/**
+ * The selected row. Returned only while the rendered HTML actually carries an
+ * `aria-current` row, which is what lets a test see the "selection names a skill still
+ * in the unfetched tail" case the reveal has to survive.
+ */
+interface FakeRow {
+	rect: FakeRect;
+	readonly scrollIntoViewCalls: Array<Record<string, unknown> | undefined>;
 }
 
 interface Harness {
 	readonly requests: string[];
 	readonly list: FakeList;
+	readonly currentRow: FakeRow;
 	html: () => string;
 	render: (model: unknown) => void;
-	clickMore: () => boolean;
+	/** Rewrites `?skill=`, standing in for a click or an arrival from the Stats card. */
+	selectSkill: (name: string | null) => void;
+	/** Shrinks the browser window, for the half of the reveal the panel cannot see. */
+	setViewportHeight: (height: number) => void;
+	/** Advances the page-owned retry clock without waiting in real time. */
+	advanceTimersBy: (milliseconds: number) => void;
 	respondWith: (handler: (path: string) => Promise<unknown>) => void;
 }
 
@@ -91,14 +114,49 @@ const detail = {
 	lastCallAtMs: Date.parse("2026-01-01T20:00:00Z"),
 };
 
+/** A row's box, expressed against the harness's default 100–600 panel. */
+const INSIDE_PANEL: FakeRect = { top: 200, bottom: 233 };
+const BELOW_PANEL: FakeRect = { top: 1400, bottom: 1433 };
+
 function loadHarness(): Harness {
 	const requests: string[] = [];
 	let html = "";
-	let moreButton: FakeButton | null = null;
-	/* 320 stands in for a laid-out first page. Any positive number does — what the
-	   assertions read is that the cap equals what was measured, not the figure itself —
-	   and a test sets it to 0 to stand in for a page that was never laid out. */
-	const list: FakeList = { scrollTop: 0, offsetHeight: 320 };
+	let timerClock = 0;
+	let nextTimerId = 1;
+	const timers = new Map<number, { readonly at: number; readonly run: () => void }>();
+	const advanceTimersBy = (milliseconds: number) => {
+		const target = timerClock + milliseconds;
+		for (;;) {
+			let dueId: number | undefined;
+			let dueAt = Number.POSITIVE_INFINITY;
+			for (const [id, timer] of timers) {
+				if (timer.at <= target && timer.at < dueAt) {
+					dueId = id;
+					dueAt = timer.at;
+				}
+			}
+			if (dueId === undefined) break;
+			const timer = timers.get(dueId);
+			timers.delete(dueId);
+			timerClock = dueAt;
+			timer?.run();
+		}
+		timerClock = target;
+	};
+	/* `rect` makes it a 500px-tall panel sitting well inside the 800px window below, so
+	   the viewport half of `isRowRevealed` is satisfied by default and a test that wants
+	   to exercise it says so by shrinking `innerHeight`. */
+	const list: FakeList = { scrollTop: 0, rect: { top: 100, bottom: 600 } };
+	/* Far below the panel by default — the arrival case, where the selection came from
+	   the Stats card and names a skill ranked past the first screenful. */
+	const currentRow: FakeRow = { rect: BELOW_PANEL, scrollIntoViewCalls: [] };
+	const rowNode = {
+		getBoundingClientRect: () => currentRow.rect,
+		scrollIntoView: (options?: Record<string, unknown>) => {
+			currentRow.scrollIntoViewCalls.push(options);
+		},
+	};
+	const listNode = Object.assign(list, { getBoundingClientRect: () => list.rect });
 	const app = {
 		get innerHTML() {
 			return html;
@@ -111,14 +169,12 @@ function loadHarness(): Harness {
 			list.scrollTop = 0;
 		},
 		querySelector: (selector: string) => {
-			if (selector === ".sk-list") return list;
-			if (selector === "[data-skillmore]") {
-				if (html.includes("data-skillmore")) {
-					moreButton = {};
-					return moreButton;
-				}
-				moreButton = null;
-			}
+			if (selector === ".sk-list") return listNode;
+			/* Present only when a row really carries the marker — `listHtml` writes it for
+			   the selected skill alone, so a selection whose row is still in the unfetched
+			   tail finds nothing here, exactly as in a browser. */
+			if (selector === '.sk-row[aria-current="true"]')
+				return html.includes('aria-current="true"') ? rowNode : null;
 			return null;
 		},
 		querySelectorAll: () => [] as ReadonlyArray<never>,
@@ -127,6 +183,13 @@ function loadHarness(): Harness {
 	const window = {
 		JD: {} as Record<string, unknown>,
 		location: new URL("http://127.0.0.1/skills"),
+		innerHeight: 800,
+		setTimeout: (run: () => void, delay = 0) => {
+			const id = nextTimerId++;
+			timers.set(id, { at: timerClock + Math.max(0, delay), run });
+			return id;
+		},
+		clearTimeout: (id: number) => timers.delete(id),
 		history: {
 			replaceState: (_state: unknown, _title: string, href: string) => {
 				window.location = new URL(href);
@@ -142,7 +205,19 @@ function loadHarness(): Harness {
 		fmtTokens: (n: number) => String(n),
 		seriesColor: () => "#000",
 		sourceIndex: () => 0,
-		stackedBars: () => "",
+		/* `stackedBarsFrame`, not `stackedBars` — the band moved to the text-free entry
+		   point so its height could be pinned while its width follows the page. Shaped
+		   rather than empty, on the same principle as `dayBars` below: the SVG geometry is
+		   `charts.js`', and what THIS page owns is laying the frame's ticks and endpoints
+		   out as HTML beside the plot, so the fake returns identifiable values for exactly
+		   those and leaves `svg` a marker carrying what it was handed. */
+		stackedBarsFrame: (series: ReadonlyArray<{ date: string }>, keys: ReadonlyArray<string>) => ({
+			svg: `<svg class="sk-bandbars" data-keys="${esc(keys.join(","))}" data-days="${series.length}"></svg>`,
+			/* Top-down, as the real one documents. */
+			ticks: ["4", "3", "2", "1", "0"],
+			firstDay: series.length > 0 ? String(series[0].date) : "",
+			lastDay: series.length > 1 ? String(series[series.length - 1].date) : "",
+		}),
 		dayKey: (atMs: number, timeZone: string) =>
 			new Intl.DateTimeFormat("en-CA", { timeZone, year: "numeric", month: "2-digit", day: "2-digit" }).format(
 				atMs,
@@ -181,15 +256,21 @@ function loadHarness(): Harness {
 	return {
 		requests,
 		list,
+		currentRow,
 		html: () => html,
 		render: (next: unknown) => {
 			(window.JD as { renderSkills: (model: unknown) => void }).renderSkills(next);
 		},
-		clickMore: () => {
-			if (!moreButton?.onclick) return false;
-			moreButton.onclick();
-			return true;
+		selectSkill: (name: string | null) => {
+			const url = new URL(window.location.href);
+			if (name) url.searchParams.set("skill", name);
+			else url.searchParams.delete("skill");
+			window.location = url;
 		},
+		setViewportHeight: (height: number) => {
+			window.innerHeight = height;
+		},
+		advanceTimersBy,
 		respondWith: (handler) => {
 			responder = handler;
 		},
@@ -283,7 +364,21 @@ describe("Skills page asset", () => {
 		expect(h.html()).toContain("<title>2026-01-01=1 session</title>");
 	});
 
-	it("pages beyond the server's 200-row per-request cap and preserves the expansion on poll", async () => {
+	it("asks for nothing when the model's own page is already every skill", async () => {
+		const h = loadHarness();
+		h.render(model([row(0)], 1));
+		await settle();
+
+		/* The common small-corpus case, and the one the automatic read must not tax: the
+		   payload already carries the whole column, so the first paint is the only paint. */
+		expect(h.requests.filter((path) => path.includes("/api/tool-usage"))).toEqual([]);
+		/* Nothing is loading and nothing is missing, so the band says nothing. A permanent
+		   `Showing 1 of 1 skill` would restate the header line above it. */
+		expect(h.html()).not.toContain("sk-paging");
+		expect(h.html()).not.toContain("Showing");
+	});
+
+	it("reads the whole list on arrival with no button, paging past the server's per-request cap", async () => {
 		const all = Array.from({ length: 205 }, (_, i) => row(i));
 		const h = loadHarness();
 		h.respondWith((path) => {
@@ -299,26 +394,124 @@ describe("Skills page asset", () => {
 				totalCount: all.length,
 			});
 		});
-		const first = model(all.slice(0, TOOL_ROWS_LIMIT), all.length);
-		h.render(first);
+		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
+
+		/* Before anything lands: the model's page, and a line saying the rest is coming.
+		   That line is the whole of what replaced the button — no control, because the
+		   reader is not being asked for anything. */
+		expect(h.html()).toContain("Showing 8 of 205 skills — loading the rest…");
+		expect(h.html()).not.toContain("data-skillmore");
+		expect(h.html()).not.toContain("Show more");
+
 		await settle();
 
-		for (let clicks = 0; clicks < 30 && h.clickMore(); clicks++) await settle();
-		expect(h.html()).toContain("Showing 205 of 205 skills");
-		expect(h.html()).not.toContain("data-skillmore");
+		/* Every skill, with no click anywhere in this test. Two requests, because the
+		   route clamps a page at 200 rows and the read keeps going while the server's own
+		   positions outrun what it has in hand. */
+		expect(h.html().match(/class="sk-row"/g)).toHaveLength(205);
+		expect(h.html()).toContain('data-skill="skill204"');
 		expect(h.requests.some((path) => path.includes("offset=200"))).toBe(true);
+		/* And a complete column says nothing at all: the header already prints the count. */
+		expect(h.html()).not.toContain("sk-paging");
+		expect(h.html()).not.toContain("Showing");
 
+		/* An explicit model refresh re-reads the same width rather than collapsing back
+		   to the payload's own page — a new model is a new list to verify, not a reset. */
 		h.requests.length = 0;
 		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
 		await settle();
-		expect(h.html()).toContain("Showing 205 of 205 skills");
+		expect(h.html().match(/class="sk-row"/g)).toHaveLength(205);
 		expect(h.requests.filter((path) => path.includes("/api/tool-usage"))).toEqual([
 			expect.stringContaining("offset=0"),
 			expect.stringContaining("offset=200"),
 		]);
 	});
 
-	it("keeps rows on failure, retries, and deduplicates a shifted boundary row", async () => {
+	it("finishes a list read that a re-render started during", async () => {
+		const all = Array.from({ length: 20 }, (_, i) => row(i));
+		const h = loadHarness();
+		/* A no-op until the list read is actually in flight, so a regression that never
+		   starts one fails on the row count below rather than on a null call. */
+		let release: (value: unknown) => void = () => {};
+		h.respondWith((path) => {
+			if (path.startsWith("/api/skill-detail")) return Promise.resolve(detail);
+			/* Held open so the re-render below lands squarely mid-flight. */
+			return new Promise((resolve) => {
+				release = resolve;
+			});
+		});
+		const payload = model(all.slice(0, TOOL_ROWS_LIMIT), all.length);
+		h.render(payload);
+
+		/* Opening a skill re-renders and bumps the render counter. While the list read was
+		   staled by that counter, this voided it — and with the button gone nothing would
+		   ever restart it, so the column sat at eight rows saying "loading the rest…" for
+		   the life of the payload. The read belongs to the PAYLOAD, which has not changed. */
+		h.render(payload);
+		release({ list: "skill", offset: 0, rows: all, totalCount: all.length });
+		await settle();
+
+		expect(h.html().match(/class="sk-row"/g)).toHaveLength(20);
+		expect(h.html()).not.toContain("loading the rest");
+	});
+
+	it("restarts a shifted offset partition instead of silently dropping its displaced row", async () => {
+		const all = Array.from({ length: 10 }, (_, i) => row(i));
+		const h = loadHarness();
+		let served = 0;
+		h.respondWith((path) => {
+			if (path.startsWith("/api/skill-detail")) return Promise.resolve(detail);
+			served++;
+			/* A short first answer, then a second page whose top row has slipped back
+			   across the boundary — the rank shifting under a read in flight. The stop is
+			   the SERVER's position, so the short page does not end the read the way a
+			   caller-fixed width used to. */
+			return Promise.resolve(
+				served === 1
+					? { list: "skill", offset: 0, rows: all.slice(0, 8), totalCount: 10 }
+					: served === 2
+						? { list: "skill", offset: 8, rows: [all[7], all[8]], totalCount: 10 }
+						: { list: "skill", offset: 0, rows: all, totalCount: 10 },
+			);
+		});
+		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
+		await settle();
+
+		expect(served).toBe(3);
+		/* The repeated boundary row proves the first partition moved, so that pass is
+		   discarded. The stable second pass returns all ten — the displaced last skill is
+		   not hidden by shrinking the server's total to nine. */
+		expect(h.html().match(/class="sk-row"/g)).toHaveLength(10);
+		expect(h.html().match(/data-skill="skill007"/g)).toHaveLength(1);
+		expect(h.html()).toContain('data-skill="skill009"');
+		expect(h.html()).not.toContain("sk-paging");
+	});
+
+	it("bounds an unstable partition instead of spinning or publishing a partial pass", async () => {
+		const all = Array.from({ length: 10 }, (_, i) => row(i));
+		const h = loadHarness();
+		h.respondWith((path) => {
+			if (path.startsWith("/api/skill-detail")) return Promise.resolve(detail);
+			const url = new URL(path, "http://127.0.0.1");
+			const offset = Number(url.searchParams.get("offset") ?? 0);
+			return Promise.resolve({
+				list: "skill",
+				offset,
+				rows: offset === 0 ? all.slice(0, 8) : [all[7], all[8]],
+				totalCount: all.length,
+			});
+		});
+		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
+		await settle();
+
+		/* Initial pass plus two clean retries, two pages each. The third repeated
+		   boundary becomes a recoverable failure instead of another synchronous pass. */
+		expect(h.requests.filter((path) => path.includes("/api/tool-usage"))).toHaveLength(6);
+		expect(h.html().match(/class="sk-row"/g)).toHaveLength(TOOL_ROWS_LIMIT);
+		expect(h.html()).toContain("Showing 8 of 10 skills — could not load the rest");
+	});
+
+	it("keeps the rows it has when the read fails and retries the same payload after 30 seconds", async () => {
 		const all = Array.from({ length: 10 }, (_, i) => row(i));
 		const h = loadHarness();
 		let fail = true;
@@ -328,22 +521,115 @@ describe("Skills page asset", () => {
 				fail = false;
 				return Promise.reject(new Error("offline"));
 			}
-			return Promise.resolve({ list: "skill", offset: 8, rows: [all[7], all[8], all[9]], totalCount: 10 });
+			return Promise.resolve({ list: "skill", offset: 0, rows: all, totalCount: 10 });
+		});
+		const payload = model(all.slice(0, TOOL_ROWS_LIMIT), all.length);
+		h.render(payload);
+		await settle();
+
+		/* A short column has to say it is short — eight rows with nothing else on screen
+		   is indistinguishable from a reader who owns eight skills. No `Try again`: the
+		   page-owned timer below is the retry, so a control would duplicate it. */
+		expect(h.html()).toContain("Showing 8 of 10 skills — could not load the rest");
+		expect(h.html()).not.toContain("Try again");
+		expect(h.html().match(/class="sk-row"/g)).toHaveLength(TOOL_ROWS_LIMIT);
+
+		/* A repaint of the SAME payload does not re-ask. Opening a pane re-renders, so
+		   without that guard every click on a failed column would fire the failing
+		   request again. */
+		h.requests.length = 0;
+		h.render(payload);
+		await settle();
+		expect(h.requests.filter((path) => path.includes("/api/tool-usage"))).toEqual([]);
+		expect(h.html()).toContain("could not load the rest");
+
+		/* Skills is deliberately outside the global page poll. The page's own timer must
+		   therefore retry this SAME payload, neither early nor only after a model refresh. */
+		h.advanceTimersBy(29_999);
+		await settle();
+		expect(h.requests.filter((path) => path.includes("/api/tool-usage"))).toEqual([]);
+		h.advanceTimersBy(1);
+		await settle();
+		expect(h.html().match(/class="sk-row"/g)).toHaveLength(10);
+		expect(h.html()).not.toContain("could not load the rest");
+	});
+
+	it("cancels a failed payload's pending retry when a refreshed payload takes ownership", async () => {
+		const all = Array.from({ length: 10 }, (_, i) => row(i));
+		const h = loadHarness();
+		let fail = true;
+		h.respondWith((path) => {
+			if (path.startsWith("/api/skill-detail")) return Promise.resolve(detail);
+			if (fail) {
+				fail = false;
+				return Promise.reject(new Error("offline"));
+			}
+			return Promise.resolve({ list: "skill", offset: 0, rows: all, totalCount: all.length });
 		});
 		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
 		await settle();
-		expect(h.clickMore()).toBe(true);
-		await settle();
-		expect(h.html()).toContain("Showing 8 of 10 skills — could not load more");
-		expect(h.html()).toContain("Try again");
+		expect(h.html()).toContain("could not load the rest");
 
-		expect(h.clickMore()).toBe(true);
+		/* A new model starts its own successful read and cancels the old timer. Advancing
+		   past the old deadline must not issue a stale third request or repaint old data. */
+		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
 		await settle();
-		expect(h.html()).toContain("Showing 10 of 10 skills");
-		expect(h.html().match(/data-skill="skill007"/g)).toHaveLength(1);
+		expect(h.html().match(/class="sk-row"/g)).toHaveLength(all.length);
+		h.requests.length = 0;
+		h.advanceTimersBy(30_000);
+		await settle();
+		expect(h.requests.filter((path) => path.includes("/api/tool-usage"))).toEqual([]);
+		expect(h.html().match(/class="sk-row"/g)).toHaveLength(all.length);
 	});
 
-	it("caps the rows region only once Show more is pressed, at the height the first page measured", async () => {
+	it("reads past the former 25-request safety ceiling instead of finalising a partial list", async () => {
+		const all = Array.from({ length: 5001 }, (_, i) => row(i));
+		const h = loadHarness();
+		h.respondWith((path) => {
+			if (path.startsWith("/api/skill-detail")) return Promise.resolve(detail);
+			const url = new URL(path, "http://127.0.0.1");
+			const offset = Number(url.searchParams.get("offset") ?? 0);
+			const requested = Number(url.searchParams.get("limit") ?? TOOL_ROWS_LIMIT);
+			return Promise.resolve({
+				list: "skill",
+				offset,
+				rows: all.slice(offset, offset + Math.min(requested, 200)),
+				totalCount: all.length,
+			});
+		});
+		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
+		await settle();
+
+		expect(h.requests.filter((path) => path.includes("/api/tool-usage"))).toHaveLength(26);
+		expect(h.html().match(/class="sk-row"/g)).toHaveLength(all.length);
+		expect(h.html()).toContain('data-skill="skill5000"');
+		expect(h.html()).not.toContain("could not load the rest");
+	});
+
+	it("bounds a response stream whose total grows as fast as its offset", async () => {
+		const h = loadHarness();
+		h.respondWith((path) => {
+			if (path.startsWith("/api/skill-detail")) return Promise.resolve(detail);
+			const url = new URL(path, "http://127.0.0.1");
+			const offset = Number(url.searchParams.get("offset") ?? 0);
+			return Promise.resolve({ list: "skill", offset, rows: [row(offset)], totalCount: offset + 2 });
+		});
+		h.render(
+			model(
+				Array.from({ length: TOOL_ROWS_LIMIT }, (_, i) => row(i)),
+				10,
+			),
+		);
+		await settle();
+
+		/* The initial ten-row corpus gets the 25-request minimum. Every answer moves the
+		   target one position away, so only the backstop can terminate this attempt. */
+		expect(h.requests.filter((path) => path.includes("/api/tool-usage"))).toHaveLength(25);
+		expect(h.html().match(/class="sk-row"/g)).toHaveLength(TOOL_ROWS_LIMIT);
+		expect(h.html()).toContain("could not load the rest");
+	});
+
+	it("never writes a cap onto the rows region, and carries the reader's place across a repaint", async () => {
 		const all = Array.from({ length: 20 }, (_, i) => row(i));
 		const h = loadHarness();
 		h.respondWith((path) => {
@@ -359,57 +645,165 @@ describe("Skills page asset", () => {
 			});
 		});
 		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
-		await settle();
 
-		/* The state every page load opens in. The column IS the whole first page, so it
-		   needs no window onto itself, and the page's own bar is the only one on screen. */
+		/* ONE SHAPE, BOTH PAINTS. The region used to be laid out free on the model's own
+		   page and then re-emitted with a MEASURED `max-height` (plus an `sk-scroll` marker)
+		   once the tail landed, because the page scrolled and the rows had to earn a window
+		   of their own. The page is a fixed frame now: `.sk-list` takes its height from the
+		   flex chain, scrolls unconditionally, and there is no pixel value for JS to write.
+		   Asserted before the fetch as well as after, because "the tag changed when the tail
+		   arrived" is exactly the old behaviour. */
 		expect(h.html()).toContain('<div class="sk-list">');
 		expect(h.html()).not.toContain("sk-scroll");
+		expect(h.html()).not.toContain("max-height");
 
-		expect(h.clickMore()).toBe(true);
 		await settle();
-		/* Capped at what the first page OCCUPIED, never at a declared constant: the region
-		   keeps the size it opened at, the twelve new rows land inside it, and the page
-		   below does not move. A constant would be a few pixels wrong on the corpora that
-		   carry the inferred footnote — and wrong LOW means a scrollbar on the first page,
-		   which is the one state that may not have one. */
-		expect(h.html()).toContain('<div class="sk-list sk-scroll" style="max-height:320px">');
-		expect(h.html()).toContain("Showing 16 of 20 skills");
-		/* The control that did this stays OUT of the region it capped. */
-		expect(h.html()).toContain('<div class="sk-paging">');
+		expect(h.html()).toContain('<div class="sk-list">');
+		expect(h.html()).not.toContain("sk-scroll");
+		expect(h.html()).not.toContain("max-height");
+		expect(h.html().match(/class="sk-row"/g)).toHaveLength(20);
 
-		/* And the reader's place inside that region survives a repaint — the 30 s poll
-		   replaces the node, so without the carry the column would jump back to its first
-		   row every half minute, mid-read. The harness zeroes `scrollTop` on every write
-		   for exactly this reason, so 120 here can only have been written back. */
+		/* The reader's place inside the region still survives a repaint, which is the half of
+		   the old behaviour that outlived the cap — an explicit model refresh replaces the
+		   node, so without the carry the column would jump back to its first row every half
+		   minute, mid-read. The harness zeroes `scrollTop` on every write for exactly this
+		   reason, so 120 here can only have been written back. */
 		h.list.scrollTop = 120;
 		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
 		await settle();
 		expect(h.list.scrollTop).toBe(120);
-		expect(h.html()).toContain("sk-scroll");
 	});
 
-	it("leaves the rows region uncapped when the first page measured nothing", async () => {
+	it("reveals a selection that arrived in the address, and only once the row exists", async () => {
 		const all = Array.from({ length: 20 }, (_, i) => row(i));
 		const h = loadHarness();
-		/* A page that has not been laid out measures 0, and capping there would collapse
-		   the region and hide every row — so nothing is recorded and the column simply
-		   stays tall. Uncapped is the safe way to be wrong; `stats.js` guards its own
-		   card cap the same way. */
-		h.list.offsetHeight = 0;
 		h.respondWith((path) =>
 			path.startsWith("/api/skill-detail")
 				? Promise.resolve(detail)
-				: Promise.resolve({ list: "skill", offset: 8, rows: all.slice(8, 16), totalCount: all.length }),
+				: Promise.resolve({ list: "skill", offset: 0, rows: all, totalCount: all.length }),
 		);
+		/* The Stats card links in with `?skill=`, and can name any skill in the window —
+		   here the last one, which the model's own first page does not carry. */
+		h.selectSkill("skill019");
+		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
+
+		/* Nothing to scroll to yet: the row is in the tail still being fetched. This paint
+		   must NOT count as the reveal, or the arriving tail would never get one. */
+		expect(h.html()).not.toContain('aria-current="true"');
+		expect(h.currentRow.scrollIntoViewCalls).toEqual([]);
+
+		await settle();
+		/* The tail landed, the row exists, and it is 800px below a 500px panel — centred,
+		   which also walks the page's own scroll so a panel hanging out of the viewport
+		   comes with it. */
+		expect(h.html()).toContain('aria-current="true"');
+		expect(h.currentRow.scrollIntoViewCalls).toEqual([{ block: "center" }]);
+	});
+
+	it("does not move the column for a row that is already on screen", async () => {
+		const all = Array.from({ length: 20 }, (_, i) => row(i));
+		const h = loadHarness();
+		h.respondWith((path) =>
+			path.startsWith("/api/skill-detail")
+				? Promise.resolve(detail)
+				: Promise.resolve({ list: "skill", offset: 0, rows: all, totalCount: all.length }),
+		);
+		/* Clicking a row in the list is the high-frequency action here, and such a row is
+		   on screen by definition — centring it would slide the column under the pointer. */
+		h.currentRow.rect = INSIDE_PANEL;
+		h.selectSkill("skill002");
 		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
 		await settle();
-		expect(h.clickMore()).toBe(true);
+
+		expect(h.html()).toContain('aria-current="true"');
+		expect(h.currentRow.scrollIntoViewCalls).toEqual([]);
+	});
+
+	it("scrolls a row the panel shows but the browser window cuts off", async () => {
+		const all = Array.from({ length: 20 }, (_, i) => row(i));
+		const h = loadHarness();
+		h.respondWith((path) =>
+			path.startsWith("/api/skill-detail")
+				? Promise.resolve(detail)
+				: Promise.resolve({ list: "skill", offset: 0, rows: all, totalCount: all.length }),
+		);
+		/* Inside the panel's own 100–600 window, so a panel-only check would call this
+		   revealed — but the window is 400px tall here, standing in for the real page,
+		   where the band above the panel pushes its lower ~93px off screen (measured). */
+		h.currentRow.rect = { top: 520, bottom: 553 };
+		h.setViewportHeight(400);
+		h.selectSkill("skill010");
+		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
 		await settle();
 
-		expect(h.html()).toContain("Showing 16 of 20 skills");
-		expect(h.html()).toContain('<div class="sk-list">');
-		expect(h.html()).not.toContain("sk-scroll");
-		expect(h.html()).not.toContain("max-height");
+		expect(h.currentRow.scrollIntoViewCalls).toEqual([{ block: "center" }]);
 	});
+
+	it("reveals once per selection, so neither a repaint nor a refresh drags the reader back", async () => {
+		const all = Array.from({ length: 20 }, (_, i) => row(i));
+		const h = loadHarness();
+		h.respondWith((path) =>
+			path.startsWith("/api/skill-detail")
+				? Promise.resolve(detail)
+				: Promise.resolve({ list: "skill", offset: 0, rows: all, totalCount: all.length }),
+		);
+		h.selectSkill("skill019");
+		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
+		await settle();
+		expect(h.currentRow.scrollIntoViewCalls).toHaveLength(1);
+
+		/* An explicit model refresh. Every path here repaints the whole page, so without the
+		   once-per-selection guard a reader browsing the list would be yanked back to the
+		   selected row twice a minute. */
+		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
+		await settle();
+		expect(h.currentRow.scrollIntoViewCalls).toHaveLength(1);
+	});
+
+	it("forgets the reveal when the pane closes, so re-opening the same skill scrolls again", async () => {
+		const all = Array.from({ length: 20 }, (_, i) => row(i));
+		const h = loadHarness();
+		h.respondWith((path) =>
+			path.startsWith("/api/skill-detail")
+				? Promise.resolve(detail)
+				: Promise.resolve({ list: "skill", offset: 0, rows: all, totalCount: all.length }),
+		);
+		/* Arriving with no `?skill=` opens the top row, which is on screen — so this first
+		   render answers the default-selection question without scrolling, and the counts
+		   below belong to the deliberate selections alone. */
+		h.currentRow.rect = INSIDE_PANEL;
+		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
+		await settle();
+		expect(h.currentRow.scrollIntoViewCalls).toEqual([]);
+
+		h.currentRow.rect = BELOW_PANEL;
+		h.selectSkill("skill019");
+		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
+		await settle();
+		expect(h.currentRow.scrollIntoViewCalls).toHaveLength(1);
+
+		/* Clicking the current row again closes the pane. Re-opening the same skill after
+		   scrolling elsewhere — from the band's key, say — has to move the column again,
+		   which it cannot do if the selection is still remembered as revealed. */
+		h.selectSkill(null);
+		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
+		await settle();
+		h.selectSkill("skill019");
+		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
+		await settle();
+		expect(h.currentRow.scrollIntoViewCalls).toHaveLength(2);
+	});
+
+	/* There was a sibling of the test above here: "leaves the rows region uncapped when the
+	   first page measured nothing", which set the harness list's `offsetHeight` to 0 to stand
+	   in for a page that had never been laid out and asserted that no cap was recorded. Both
+	   the measurement and the guard are gone with the fixed frame, and its assertions are the
+	   ones the test above now makes unconditionally.
+	 *
+	 * NOT COVERED HERE: the pane's two clamped paragraphs (`proseBlock` / `bindProse`) and the
+	 * agent list's roll-up at `AGENT_ROWS_SHOWN`. This harness reads rendered HTML as a string
+	 * and has no node to dispatch a click at, so the half of that behaviour that matters — the
+	 * `aria-expanded` toggle, which is the whole contract `main.css` keys off — is not
+	 * reachable from here. `src/dashboard/assets/**` is excluded from coverage, so this is a
+	 * gap by choice rather than one the thresholds would have caught. */
 });

--- a/cli/src/dashboard/assets/js/charts.js
+++ b/cli/src/dashboard/assets/js/charts.js
@@ -132,6 +132,31 @@ window.JD = window.JD || {};
 		return step * 4;
 	};
 
+	/* Typed read, not `|| 0`: `topSeries` hands its INPUT series straight back when the
+	   key count is within the limit, so `bySeries` here can still be the JSON.parse'd
+	   object with a prototype. A series named `constructor` then yields the inherited
+	   function on any day it is absent — `|| 0` treats it as a value, and the bar
+	   geometry becomes NaN. */
+	var readSeriesValue = (point, key) => (typeof point.bySeries[key] === "number" ? point.bySeries[key] : 0);
+
+	/* The axis bound for a stacked set. ONE function shared by both stacked-bar entry
+	   points below, because THE BARS ARE SCALED BY THIS SAME BOUND: a caller that
+	   rounded the LABELS on its own would leave a tallest bar touching the top gridline
+	   while the gridline claimed a larger number. That is the whole reason
+	   `stackedBarsFrame` returns its ticks rather than letting its caller derive them. */
+	var stackedAxisMax = (series, keys) => {
+		var max = 0;
+		series.forEach((point) => {
+			var total = 0;
+			keys.forEach((key) => {
+				total += readSeriesValue(point, key);
+			});
+			if (total > max) max = total;
+		});
+		/* Seeded at 0, not 1 — `niceAxisMax` owns the no-data case. */
+		return niceAxisMax(max);
+	};
+
 	/* Tokens' and Spend's daily chart.
 	 *
 	 * **The date axis is the two ENDPOINTS, not a tick per bar.** It used to label
@@ -162,25 +187,10 @@ window.JD = window.JD || {};
 		var plotW = W - left - 8;
 		var slot = plotW / Math.max(1, series.length);
 		var barW = slot * 0.58;
-		/* Seeded at 0, not 1 — `niceAxisMax` owns the no-data case. */
-		var max = 0;
-		/* Typed read, not `|| 0`: `topSeries` hands its INPUT series straight back
-		   when the key count is within the limit, so `bySeries` here can still be
-		   the JSON.parse'd object with a prototype. A series named `constructor`
-		   then yields the inherited function on any day it is absent — `|| 0`
-		   treats it as a value, and the bar geometry below becomes NaN. */
-		var read = (point, key) => (typeof point.bySeries[key] === "number" ? point.bySeries[key] : 0);
-		series.forEach((point) => {
-			var total = 0;
-			keys.forEach((key) => {
-				total += read(point, key);
-			});
-			if (total > max) max = total;
-		});
 		/* The bars are scaled by this same bound, deliberately. Rounding only the
 		   LABELS would leave a tallest bar that touches the top gridline while the
 		   gridline claims a larger number. */
-		max = niceAxisMax(max);
+		var max = stackedAxisMax(series, keys);
 		var svg =
 			'<svg viewBox="0 0 ' +
 			W +
@@ -213,7 +223,7 @@ window.JD = window.JD || {};
 			var x = left + dayIndex * slot + (slot - barW) / 2;
 			var yCursor = bottom;
 			keys.forEach((key, keyIndex) => {
-				var value = read(point, key);
+				var value = readSeriesValue(point, key);
 				if (value <= 0) return;
 				var h = ((bottom - 10) * value) / max;
 				yCursor -= h;
@@ -253,6 +263,112 @@ window.JD = window.JD || {};
 			if (series.length > 1) svg += axis(W - 8, "end", series[series.length - 1].date);
 		}
 		return svg + "</svg>";
+	};
+
+	/**
+	 * The same stacked bars with NO TEXT INSIDE THE SVG — the plot area alone, for a
+	 * caller that renders the axis in HTML beside it.
+	 *
+	 * WHY THIS IS A SECOND ENTRY POINT RATHER THAN A FLAG ON THE FIRST. `stackedBars`
+	 * puts 7 `<text>` nodes in its viewBox, which rules out `preserveAspectRatio="none"`:
+	 * text under a `none` aspect ratio is text that has been stretched. So that chart can
+	 * only scale UNIFORMLY — its height is width × 238/660, and a caller who has to bound
+	 * the height has no handle but `max-width`. The Skills band was paying exactly that:
+	 * its chart was pinned to a width derived from the WINDOW'S HEIGHT, so a wider browser
+	 * did nothing for it and its axis labels rendered at ~5px on a 1280x800 window.
+	 *
+	 * With the text out, the SVG is rectangles and lines only, `none` is safe, and the two
+	 * axes come apart: the caller pins the height in CSS and the bars stretch to whatever
+	 * width the page has. Same division of labour `JD.dayBars` below already draws for the
+	 * pane's small charts, and the same reason its own labels stay HTML.
+	 *
+	 * `stackedBars` is left untouched rather than growing a mode, because its three
+	 * callers in `stats.js` sit on a SCROLLING page with no height budget — there "wider
+	 * window → bigger, more legible chart" is the wanted behaviour and a pinned height
+	 * would be a regression. Its signature and string return value stay a contract they
+	 * never have to know about.
+	 *
+	 * Returns the pieces rather than assembled markup: the tick VALUES are the caller's to
+	 * lay out (this module has no business knowing the band's markup), while `max` stays
+	 * private inside `stackedAxisMax` so the ticks and the bars cannot end up scaled by
+	 * two different bounds.
+	 *
+	 * @returns {{svg: string, ticks: string[], firstDay: string, lastDay: string}}
+	 *   `ticks` runs TOP-DOWN (highest first), the order a column renders in, one per
+	 *   gridline. `firstDay`/`lastDay` are formatted, and `lastDay` is `""` on a
+	 *   single-day window — the same day at both ends would read as a range that is not
+	 *   one, which is the rule `stackedBars` states for its own endpoints.
+	 */
+	JD.stackedBarsFrame = (series, keys, valueLabel, fmt) => {
+		var format = fmt || JD.fmtTokens;
+		/* THE PLOT AREA ALONE: `stackedBars`' 660x238 box less its 42-wide tick gutter,
+		   its 8px right margin and the 24px band its endpoint labels sat in. Both numbers
+		   are arbitrary now that the box is scaled on each axis independently — nothing
+		   here is measured in viewBox units on screen — but keeping the plot's own
+		   proportions means the 0.58 bar/gap split below reads the same as in the chart it
+		   was lifted from. */
+		var W = 610;
+		var H = 204;
+		var max = stackedAxisMax(series, keys);
+		var slot = W / Math.max(1, series.length);
+		var barW = slot * 0.58;
+		var svg =
+			'<svg class="sk-bandbars" viewBox="0 0 ' +
+			W +
+			" " +
+			H +
+			'" preserveAspectRatio="none" role="img" aria-label="Daily ' +
+			JD.esc(valueLabel) +
+			', stacked bars">';
+		/* Five gridlines, baseline included, one per tick the caller prints.
+		 *
+		 * `vector-effect="non-scaling-stroke"` is load-bearing under `none`, not a
+		 * flourish: a horizontal line's stroke width is measured on the axis being
+		 * scaled, so a 1-unit stroke in a 204-unit box renders at height/204 px — a
+		 * hairline that thins or thickens with whatever height the caller pinned. The
+		 * attribute takes the stroke out of the transform and leaves it at 1 device
+		 * pixel at every size. */
+		for (var g = 0; g <= 4; g++) {
+			var y = H - (g * H) / 4;
+			svg +=
+				'<line x1="0" y1="' +
+				y +
+				'" x2="' +
+				W +
+				'" y2="' +
+				y +
+				'" stroke="var(--grid)" stroke-width="1" vector-effect="non-scaling-stroke"></line>';
+		}
+		series.forEach((point, dayIndex) => {
+			var x = dayIndex * slot + (slot - barW) / 2;
+			var yCursor = H;
+			keys.forEach((key, keyIndex) => {
+				var value = readSeriesValue(point, key);
+				if (value <= 0) return;
+				var h = (H * value) / max;
+				yCursor -= h;
+				svg +=
+					'<rect x="' +
+					x.toFixed(2) +
+					'" y="' +
+					yCursor.toFixed(2) +
+					'" width="' +
+					barW.toFixed(2) +
+					'" height="' +
+					Math.max(1, h).toFixed(2) +
+					'" fill="' +
+					JD.seriesColor(keyIndex) +
+					'"><title>' +
+					JD.esc(point.date + " · " + key + " · " + format(value)) +
+					"</title></rect>";
+			});
+		});
+		return {
+			svg: svg + "</svg>",
+			ticks: [4, 3, 2, 1, 0].map((g) => format((max * g) / 4)),
+			firstDay: series.length > 0 ? dayLabel(series[0].date) : "",
+			lastDay: series.length > 1 ? dayLabel(series[series.length - 1].date) : "",
+		};
 	};
 
 	/**

--- a/cli/src/dashboard/assets/js/skills.js
+++ b/cli/src/dashboard/assets/js/skills.js
@@ -1,7 +1,7 @@
 /* Skills page — a chart band, a chooser column, and a reading pane.
  *
  * THE SELECTION LIVES IN THE URL (`?skill=`), not in a module variable. It survives
- * the 30 s poll for free, it can be shared and reloaded, and it is what the Stats
+ * an explicit model refresh for free, it can be shared and reloaded, and it is what the Stats
  * card's rows link into — so "open this skill" has one implementation rather than a
  * modal here and a link there.
  *
@@ -12,6 +12,28 @@
  * answered once because "no skill in the address" ALSO means "the reader just closed
  * the pane": answering it again there would re-open the first row on the click that
  * closed it, and the row's own toggle would be unusable.
+ *
+ * THE COLUMN HOLDS EVERY SKILL, and it gets there without being asked. The model
+ * carries only the Stats card's first page, so anything past it is fetched as soon as
+ * the page is drawn — there is no "Show more" here any more. The button was removed
+ * because this view IS the skills view: a reader who opened it has already said which
+ * list they want, and making them click through it a page at a time hid the tail of
+ * their own corpus behind a control that answers a question they had already answered.
+ * The Stats card keeps its button (`stats.js`), where the list is one of three sharing
+ * a band and the reader came for something else.
+ *
+ * THE ROWS STILL LIVE IN A WINDOW, and it is now the page's ONLY one. The whole view is
+ * a fixed frame — the page does not scroll, the two columns are the same height, and the
+ * reading pane holds its whole skill without scrolling — so the rows are the one region
+ * with a scrollbar. `main.css`'s `.skills-page` header owns that rule and the measurements
+ * behind it; what matters here is that the height comes from a flex chain rather than from
+ * anything this file computes. The MEASURED inline cap that used to create the window
+ * (`listCapPx`, read off the first page) is gone with it.
+ *
+ * WHY THE ROWS AND NOT THE PANE: the corpus is unbounded while a skill's detail is not.
+ * A machine can hold hundreds of skills, but the server caps the outcome strip at 50
+ * entries, `agents` is an enum, and `The record` is five fixed fields — so the pane's
+ * height has a ceiling that the frame can be sized against, and the column's does not.
  *
  * THE FIGURES ARE THE SERVER'S, never a sum over the rows on screen: `usage.skills`
  * is ONE PAGE, so a header line computed from it changes every time more rows arrive
@@ -57,21 +79,18 @@
 (function (JD) {
 	"use strict";
 
-	/* How many rows ONE Show more click adds — matching the model's own first page (the
-	   Stats card's `TOOL_ROWS_LIMIT`), so the column pages in the size it opened at.
-
-	   IT WAS 60, and that number quietly deleted the control it was paging: one fetch
-	   loaded past it in a single go, so on any real corpus `shown >= total` held on the
-	   first paint and the button never existed (measured: 23 skills, every range, all
-	   ≤ 60 — the column read "Showing 23 of 23 skills" with nothing to click, which
-	   reads as a broken control rather than as a finished list). The design mock pages
-	   at its first page for this reason and its button is on screen doing its job. */
-	var PAGE_ROWS = 8;
-
 	/* Series kept in the band before the rest rolls into "Other". FIVE is the whole
 	   reason: the categorical ramp holds five CVD-validated colours, so four plus
 	   Other is what can be told apart. */
 	var BAND_SERIES = 4;
+	/* A failed tail read retries without opting the whole Skills page into the global
+	   model poll. That poll intentionally belongs to My Dashboard only; repainting this
+	   page underneath a reader would also re-fetch the open detail pane. */
+	var REST_RETRY_MS = 30000;
+	/* An absolute backstop for a server whose total grows at least as fast as pages can
+	   be consumed. Real reads stop on offset/total equality; this prevents a corrupt or
+	   adversarial response stream from keeping the browser in an unbounded request loop. */
+	var MAX_LIST_REQUESTS = 1000;
 
 	/* The `†` a row takes when any entry behind it was inferred rather than observed,
 	   and the sentence that spells it out.
@@ -82,11 +101,12 @@
 	   between its `†` and its footnote, and `buildSkillsSummaryLabel` leaves the
 	   marker to its caller for the same reason — a dagger where a footnote is in
 	   reach, words where it is not. Here the footnote IS in reach: it sits at the end of
-	   the rows, which on the first screenful is the page's own scroll and after a Show
-	   more is the bottom of the rows' own window — either way, the scroll that reaches
-	   the last row reaches it. So the column gets both. The paging row is NOT in there —
-	   it is a control, and a control may not be reachable only by scrolling the rows it
-	   pages; see `navPagingHtml`.
+	   the rows, which on a corpus small enough to need no window is the page's own
+	   scroll and on any larger one is the bottom of the rows' own window — either way,
+	   the scroll that reaches the last row reaches it. So the column gets both. The
+	   loading line is NOT in there — a reader waiting on the rest of the list may not
+	   have to scroll the half that arrived to find out more is coming; see
+	   `navPagingHtml`.
 
 	   IT NAMES THE COUNT, not just the inference. A reader who learns only "this was
 	   inferred" still reads `47 runs` as 47 runs; the count is the figure the
@@ -98,68 +118,70 @@
 	var INFERRED_MARK = ' <span class="sk-inferred" title="' + INFERRED_TITLE + '">†</span>';
 
 	/* Everything an async answer can land in, so the two fetches below do not have to
-	   re-render each other's half. Module-scoped because the poll re-enters
-	   `renderSkills`, and a local would be re-seeded from the payload on every tick —
-	   dropping a pane the reader is in the middle of. */
+	   re-render each other's half. Module-scoped because an explicit model refresh can
+	   re-enter `renderSkills`, and a local would be re-seeded from the payload — dropping
+	   a pane the reader is in the middle of. */
 	var state = { rows: null, paneName: null, pane: null, paneError: null };
 
-	/* Which render is current. An answer from an earlier one must not paint over a
-	   later one — the same staleness any polled surface has. */
+	/* Which render is current — the staleness guard for THE PANE'S detail fetch, and only
+	   that one. An answer for a skill the reader has since navigated away from must not
+	   paint over the one they are looking at.
+
+	   The list read next door is staled by a new PAYLOAD instead (`collectRows` records
+	   why): a render is not the same event as a refresh, and opening a skill is a render. */
 	var seq = 0;
 
-	/* How many rows the column asks the server for, or ZERO while the model's own first
-	   page is still the whole column — the state every page load opens in, so the common
-	   case costs no request at all and the first paint is the only paint.
-
-	   Grown by Show more, and THE POLL READS THE SAME FIGURE: the 30 s refresh re-fetches
-	   this list, so a fixed `PAGE_ROWS` there would silently throw away every click the
-	   reader had made and shrink the column back under them. Reset by a range change for
-	   free, since changing the range is a full page load.
-
-	   Its two companions are the button's own state. `moreError` is deliberately set
-	   by the POLL's failure too: once the column is short of the total, "could not
-	   load more" is the honest label for a list that may be missing rows, whoever
-	   asked last. */
-	var pageWidth = 0;
-	/* The next ranked position for a Show more read. Usually equal to rows.length;
-	   kept separately because a row can shift across an offset boundary and be
-	   deduped without changing the server position already consumed. */
-	var pageOffset = 0;
-	/* The freshest total belongs to the latest page response. A new polled model
+	/* The freshest total belongs to the latest page response. A newly refreshed model
 	   resets it before that model's expanded list is verified. */
 	var rowsTotal = null;
 	var renderedModel = null;
-	var moreLoading = false;
-	var moreError = false;
 
-	/* The height the rows region is capped at once the reader has paged past the column's
-	   first screenful — MEASURED off that screenful, never declared.
+	/* The model whose full list has already been asked for — the guard that keeps the
+	   automatic read to ONE per payload.
+
+	   It is the model OBJECT, not a row count, because two different things re-enter
+	   `renderSkills` and only one of them wants a fresh read. An explicit refresh hands
+	   over a new payload and must re-read the tail; a row click re-renders the SAME payload
+	   to open a pane, and re-reading the whole list on every click would spend a request
+	   per click for rows already in hand.
+	   A count cannot tell those apart — both see the same short first page.
+
+	   NOT RESET ON FAILURE, deliberately. The retry timer below owns another attempt;
+	   clearing it here would instead make every click on a failed column fire the failing
+	   request again. */
+	var fetchedModel = null;
+	/* The loading line's state. `restError` is what keeps a short column honest: while
+	   it is set, the column is missing rows and says so rather than reading as the
+	   whole list. */
+	var restLoading = false;
+	var restError = false;
+	/* The one pending retry for the current payload. Cleared on success and whenever a
+	   different payload takes ownership, so an old timer cannot wake a stale read. */
+	var restRetryTimer = null;
+
+	/* Which of the pane's two long fixed paragraphs the reader has opened.
 	 *
-	 * THE FIRST PAGE MUST NOT SCROLL. What it comes to in pixels is not something this
-	 * file can know: it is `PAGE_ROWS` rows plus the column header, plus a footnote that
-	 * is present only on a corpus with an inferred row. A declared constant is therefore
-	 * a few pixels wrong on one of those shapes, and being wrong LOW grows a scrollbar on
-	 * exactly the state that is supposed to have none. So the first paint is laid out
-	 * free, its own height is read back, and that becomes the cap: Show more then grows
-	 * the list INSIDE the region it opened at, instead of pushing the page down.
+	 * MODULE STATE, not DOM state, because every path in this file repaints the WHOLE pane
+	 * — a row click, that row's detail landing, the tail of the list arriving, a refresh —
+	 * so an `aria-expanded` left on the node would be discarded moments after the click
+	 * that set it. Keyed by the block's own class name, which is what `bindProse` below
+	 * reads back off the event target.
 	 *
-	 * `offsetHeight` is the BORDER box, and `.jd * { box-sizing: border-box }` makes
-	 * `max-height` mean the same box — so the cap is exactly the height just measured. If
-	 * that reset ever goes, this becomes 16px of padding short and the first page scrolls.
-	 *
-	 * RE-MEASURED ON EVERY UNPAGED PAINT rather than latched once, so it tracks what the
-	 * first page actually looks like now: a poll can bring in the row that adds the
-	 * footnote, and a window resize between load and click would otherwise leave a stale
-	 * figure. A HIDDEN page measures 0 and is never recorded (`stats.js` guards its own
-	 * cap the same way) — capping at 0 would collapse the region and hide every row, so
-	 * null stands for "no cap yet" and an uncapped column is the safe way to be wrong. */
-	var listCapPx = null;
+	 * DELIBERATELY NOT PER SKILL. The two paragraphs are FIXED text (the inferred caveat
+	 * and the basis line say the same thing on every skill), so "I have read this one" is a
+	 * fact about the reader, not about the row — resetting it per selection would make them
+	 * re-open the same sentence on every skill they looked at. */
+	var openProse = { "sk-caveat": false, "sk-basis": false };
 
 	/* Whether "the address names no skill" has already been answered for this page
 	   load — see the header. Nav is a full page reload, so this starts false on every
 	   arrival; it is set by the default pick AND by any click, because a click is the
 	   reader answering the same question themselves. */
 	var defaultAnswered = false;
+
+	/* The skill the column has already been scrolled to, so a selection is revealed ONCE
+	   rather than on every repaint — see `revealSelectedRow`. */
+	var scrolledToSkill = null;
 
 	/** The selected skill, read from the address rather than from a variable. */
 	function selectedSkill() {
@@ -190,9 +212,10 @@
 	}
 
 	/**
-	 * The rows the column is showing: the fetched page once it lands, else the first
+	 * The rows the column is showing: the fetched list once it lands, else the first
 	 * page the model already carries (`skills` view shares the Stats payload, so the
-	 * first paint is never empty for a window that has data).
+	 * first paint is never empty for a window that has data — and on a corpus that fits
+	 * in one page it is also the last).
 	 *
 	 * One helper rather than the same expression twice, because the default pick below
 	 * must name a row the reader can actually see — picking from a different list would
@@ -206,10 +229,13 @@
 	 * The page the model already carries, which IS the column's first page — the Stats
 	 * payload this view shares, capped at the card's `TOOL_ROWS_LIMIT`.
 	 *
-	 * Named rather than inlined because two callers ask different questions of it: the
-	 * fallback above ("what do I draw before a fetch lands") and the fetch guard in
-	 * `renderSkills` ("is a fetch needed at all"). The second is what keeps a fresh page
-	 * load at zero requests, so the two must read the same list.
+	 * Named rather than inlined because TWO callers ask different questions of it: the
+	 * fallback above ("what do I draw before the fetch lands") and the fetch guard in
+	 * `renderSkills` ("is there anything past this page to read"). The second is what keeps
+	 * a corpus that fits in one page at zero requests.
+	 *
+	 * There was a third, `isExpanded`, asking "has the tail landed, so the rows region needs
+	 * its measured cap". The fixed frame retired both it and the cap — see `listOpenTag`.
 	 */
 	function modelFirstPage(model) {
 		var usage = (model.stats && model.stats.toolUsage) || {};
@@ -246,10 +272,12 @@
 		if (!app) return;
 		var mine = ++seq;
 		if (renderedModel !== model) {
+			cancelRowsRetry();
 			renderedModel = model;
 			var freshUsage = (model.stats && model.stats.toolUsage) || {};
 			rowsTotal = freshUsage.skillsTotal || 0;
-			if (pageWidth === 0) pageOffset = modelFirstPage(model).length;
+			restLoading = false;
+			restError = false;
 		}
 		var selected = selectedSkill();
 		if (!selected) selected = defaultSelection(model);
@@ -257,15 +285,22 @@
 		   previous skill's figures under the new skill's name. */
 		if (state.paneName !== selected) state = { rows: state.rows, paneName: selected, pane: null, paneError: null };
 
+		/* THE REST OF THE LIST, on nobody's ask — this is what replaced the Show more
+		   button. Skipped entirely when the model's first page already IS every skill,
+		   which is the common small-corpus case and costs no request at all.
+		 *
+		 * The flags move BEFORE the draw below, so the loading line is on screen for the
+		 * whole flight rather than appearing one repaint late. */
+		var needsRest = skillTotal(model) > modelFirstPage(model).length && fetchedModel !== model;
+		if (needsRest) {
+			fetchedModel = model;
+			restLoading = true;
+			restError = false;
+		}
+
 		draw(app, model);
 
-		/* ONLY once a click has asked for more than the model already carries. The model's
-		   first page IS the column's first page, so an unconditional fetch re-requests
-		   rows already in hand — and while `PAGE_ROWS` was 60 it also loaded straight past
-		   the paging control, which is what made the control unreachable. */
-		if (pageWidth > modelFirstPage(model).length) {
-			fetchRows(app, model, mine, [], 0, Math.min(pageWidth, skillTotal(model)));
-		}
+		if (needsRest) fetchRows(app, model);
 
 		if (!selected) return;
 		JD.getJson(JD.withParams("/api/skill-detail" + JD.query(model, {}), { name: selected }))
@@ -295,47 +330,91 @@
 	}
 
 	/**
-	 * Reads enough ranked pages to reach `wanted`, starting at one explicit server
-	 * offset and deduping against rows already held.
+	 * Reads the whole ranked list, from the top.
 	 *
-	 * Show more starts after the current page and appends. The poll starts from zero and
-	 * rebuilds the width on screen; when that width exceeds the route's per-request cap,
-	 * the short response advances `offset` and the next request finishes it. Progress is
-	 * measured in raw server rows while identity dedupe is measured by skill name, so a
-	 * row shifting across a page boundary neither duplicates nor stalls the control.
+	 * ALWAYS FROM ZERO AND ALWAYS TO THE END — there is no caller-supplied width any
+	 * more, because every caller wants the same thing. Several requests are still the
+	 * normal case: `/api/tool-usage` clamps a page at 200 rows, so a short response
+	 * advances `offset` and the next request finishes the job.
+	 *
+	 * THE STOP IS THE SERVER'S POSITION, not a row count fixed when the read began. That
+	 * is the difference the button's removal forced: a width decided up front silently
+	 * lost whatever the window gained mid-read, which was invisible but harmless while a
+	 * click had asked for exactly one page, and is a short list presented as the complete
+	 * one now that nothing else will ask. `total` is therefore re-read from every
+	 * response and the loop keeps going while `offset` trails it.
+	 *
+	 * Progress is measured in raw server rows while identity is measured by skill name.
+	 * A row shifting across a page boundary can therefore make two offsets return the same
+	 * skill and skip the row it displaced. Such a pass is discarded and restarted from
+	 * zero; shrinking the total to the deduped count would present the skipped row as if it
+	 * had never existed.
+	 *
+	 * WHAT MAKES THIS READ STALE IS A NEW PAYLOAD, never the render counter `seq`. Those
+	 * are different questions and the distinction became load-bearing when the button
+	 * went: opening a skill re-renders and bumps `seq`, so a `seq` test would void a read
+	 * that is still perfectly current — and with nothing left to press, nothing would
+	 * ever start it again. The column would sit at the model's first page, still saying
+	 * "loading the rest…", for as long as the payload lived. `seq` stays where it belongs,
+	 * guarding the pane's own detail fetch, whose answer really is per selection.
 	 */
-	function collectRows(model, mine, initialRows, initialOffset, wanted) {
-		var rows = initialRows.slice();
+	function collectRows(model) {
+		var rows = [];
 		var names = Object.create(null);
-		rows.forEach((row) => {
-			names[row.name] = true;
-		});
-		var offset = initialOffset;
+		var offset = 0;
 		var total = skillTotal(model);
+		/* Two clean re-reads are enough to recover from a rank shift without turning an
+		   actively changing database into a tight loop. Exhaustion is a failed/incomplete
+		   read, never a smaller invented total; the retry timer starts a fresh attempt. */
+		var restartsLeft = 2;
+		/* Scales with the corpus the model announced, using its small first page as a
+		   deliberately conservative width, so a legitimate list far beyond 5,000 rows is
+		   not cut off by the old fixed 25-request ceiling. The absolute cap above only owns
+		   the pathological case where the target runs away while it is being read. */
+		var requestBudget = Math.min(
+			MAX_LIST_REQUESTS,
+			Math.max(25, Math.ceil(total / Math.max(1, modelFirstPage(model).length)) * (restartsLeft + 1)),
+		);
+
+		function restart() {
+			if (restartsLeft <= 0) return Promise.reject(new Error("skill list changed while it was being read"));
+			restartsLeft--;
+			rows = [];
+			names = Object.create(null);
+			offset = 0;
+			return next();
+		}
 
 		function next() {
-			if (mine !== seq || rows.length >= wanted || offset >= total) {
-				if (offset >= total && rows.length < total) total = rows.length;
-				return Promise.resolve({ rows: rows, offset: offset, total: total });
+			if (renderedModel !== model) return Promise.resolve({ rows: rows, total: total });
+			if (offset >= total) {
+				if (rows.length === total) return Promise.resolve({ rows: rows, total: total });
+				return restart();
 			}
+			if (requestBudget <= 0) return Promise.reject(new Error("skill list kept growing while it was being read"));
+			requestBudget--;
 			return JD.getJson(
 				JD.withParams("/api/tool-usage" + JD.query(model, {}), {
 					list: "skill",
 					offset: String(offset),
-					limit: String(wanted - rows.length),
+					limit: String(total - offset),
 				}),
 			).then((page) => {
-				if (mine !== seq) return { rows: rows, offset: offset, total: total };
+				if (renderedModel !== model) return { rows: rows, total: total };
 				var incoming = (page && page.rows) || [];
 				if (page && typeof page.totalCount === "number") total = page.totalCount;
+				var repeated = false;
 				incoming.forEach((row) => {
 					if (!names[row.name]) {
 						names[row.name] = true;
 						rows.push(row);
-					}
+					} else repeated = true;
 				});
 				offset += incoming.length;
-				if (incoming.length === 0) total = rows.length;
+				/* A repeated identity proves this offset partition moved. An empty page while
+				   positions remain is the same inconsistency in another shape. Start from the
+				   latest total rather than finalising a partial set. */
+				if (repeated || (incoming.length === 0 && offset < total)) return restart();
 				return next();
 			});
 		}
@@ -343,58 +422,55 @@
 		return next();
 	}
 
-	function fetchRows(app, model, mine, initialRows, initialOffset, wanted) {
-		collectRows(model, mine, initialRows, initialOffset, wanted)
+	function cancelRowsRetry() {
+		if (restRetryTimer === null) return;
+		window.clearTimeout(restRetryTimer);
+		restRetryTimer = null;
+	}
+
+	/** Retries only the list tail; the open detail pane and the rest of the page stay put. */
+	function scheduleRowsRetry(app, model) {
+		cancelRowsRetry();
+		restRetryTimer = window.setTimeout(() => {
+			restRetryTimer = null;
+			if (renderedModel !== model || fetchedModel !== model || !restError || restLoading) return;
+			restLoading = true;
+			restError = false;
+			draw(app, model);
+			fetchRows(app, model);
+		}, REST_RETRY_MS);
+	}
+
+	function fetchRows(app, model) {
+		cancelRowsRetry();
+		collectRows(model)
 			.then(
 				(result) => {
-					if (mine !== seq) return false;
+					if (renderedModel !== model) return false;
 					state.rows = result.rows;
-					pageWidth = result.rows.length;
-					pageOffset = result.offset;
 					rowsTotal = result.total;
-					moreLoading = false;
-					moreError = false;
+					restLoading = false;
+					restError = false;
+					cancelRowsRetry();
 					return true;
 				},
 				/* Two callbacks, for the reason `renderSkills` states: under a trailing
 				   `.catch` a throw from the repaint would land here and paint "could not
-				   load more" over a page of rows that had just arrived intact. */
+				   load the rest" over a list that had just arrived intact. */
 				() => {
-					if (mine !== seq) return false;
+					if (renderedModel !== model) return false;
 					/* THE ROWS ARE LEFT ALONE — a list that empties itself over one failed
-					   fetch is worse than a short one, and the poll asks again in 30 s. Only
-					   the button's state moves, because a click that silently stayed on
-					   "Loading…" forever is the one failure the reader cannot wait out. */
-					moreLoading = false;
-					moreError = true;
+					   fetch is worse than a short one. Only the loading line moves, and the
+					   page-owned timer retries this same payload without re-fetching its pane. */
+					restLoading = false;
+					restError = true;
+					scheduleRowsRetry(app, model);
 					return true;
 				},
 			)
 			.then((changed) => {
 				if (changed) draw(app, model);
 			});
-	}
-
-	/**
-	 * One more page, on the reader's ask.
-	 *
-	 * Deliberately NOT `renderSkills`, which would also re-fetch the open pane's detail
-	 * — a second round trip for a pane whose skill has not changed. This grows the
-	 * width, paints the button as busy, and re-reads the rows and nothing else.
-	 */
-	function loadMoreRows(app, model) {
-		if (moreLoading) return;
-		var current = visibleRows(model);
-		var shown = current.length;
-		var total = skillTotal(model);
-		if (shown >= total) return;
-		pageWidth = Math.min(shown + PAGE_ROWS, total);
-		moreLoading = true;
-		moreError = false;
-		/* Paint the busy label before the request, so a slow answer is visibly pending
-		   rather than a click that appeared to do nothing. */
-		draw(app, model);
-		fetchRows(app, model, seq, current, pageOffset || shown, pageWidth);
 	}
 
 	function skillTotal(model) {
@@ -439,37 +515,98 @@
 	}
 
 	/**
-	 * Whether the reader has asked for rows beyond the page the column opened with.
+	 * The rows region's opening tag.
 	 *
-	 * `pageWidth` is the one thing that answers it: it is zero for the whole life of a
-	 * page load that never presses Show more, and only `loadMoreRows` (and the fetch it
-	 * starts) ever raises it. Row COUNTS cannot answer it — the poll can return a
-	 * different number of first-page rows without the reader having asked for anything.
+	 * NOTHING TO DECIDE ANY MORE, and that is the point. This used to choose between an
+	 * uncapped region and one carrying a MEASURED inline `max-height` (plus an `sk-scroll`
+	 * marker class), because the page was what scrolled and the rows had to earn a window
+	 * of their own by outgrowing the model's first page. The page is now a fixed frame and
+	 * `.sk-list` takes its height from the flex chain, so the region is always the same
+	 * shape and there is no pixel value for JS to measure. `isExpanded` went with it — its
+	 * only reader was the branch here.
+	 *
+	 * Kept as a function rather than inlined into `draw`'s template so the region stays one
+	 * named thing that `main.css` and this file can be read against together.
 	 */
-	function isPaged() {
-		return pageWidth > 0;
+	function listOpenTag() {
+		return '<div class="sk-list">';
 	}
 
 	/**
-	 * The rows region's opening tag — a scroll region ONLY once Show more has been
-	 * pressed, and then only as tall as the first page measured.
+	 * Whether the current row is already somewhere the reader can see it.
 	 *
-	 * THE FIRST SCREENFUL HAS ONE SCROLLBAR, the window's. That is the whole rule: a
-	 * column showing everything it has needs no window onto itself, and a second bar
-	 * there on arrival is one more scroll region for the reader to discover before they
-	 * have asked for anything. A click asking for more rows than the column opened with
-	 * is what puts them behind a window — an outcome the reader can attribute to what
-	 * they just did.
+	 * TWO BOXES, and each answers for a different layout. The rows live in a scroll region,
+	 * so a row can be far outside it while the page looks fine — that is the common case,
+	 * since the column holds every skill. The viewport check then covers the case where the
+	 * region ITSELF is off screen, which is what the ≤899px breakpoint produces: there the
+	 * fixed frame comes off, the columns stack and the page scrolls again, so the list can
+	 * sit an arbitrary distance below the fold. Inside the desktop frame the second check is
+	 * always satisfied — the region cannot leave a viewport the frame is pinned to — and it
+	 * is kept rather than dropped because that is true of the frame, not of the page.
+	 * It also used to be load-bearing on the desktop, when the band was ~450px tall and a
+	 * row "visible" in the panel could still be under the fold.
 	 *
-	 * THE CAP IS AN INLINE STYLE because it is a measured pixel value (see `listCapPx`),
-	 * which no stylesheet constant can stand in for; `.sk-list.sk-scroll` in `main.css`
-	 * carries everything about it that is not that number, including the visible
-	 * scrollbar the platform will not draw. With no cap recorded yet the region stays
-	 * uncapped — the safe direction, since an uncapped column is merely tall.
+	 * A HOST THAT CANNOT MEASURE gets `true` — do not scroll. Every branch here degrades
+	 * that way on purpose: without layout there is nothing to be outside of, and a
+	 * scroll computed from zeroes is a jump to an arbitrary place rather than a fix.
 	 */
-	function listOpenTag() {
-		if (!isPaged() || listCapPx === null) return '<div class="sk-list">';
-		return '<div class="sk-list sk-scroll" style="max-height:' + Math.round(listCapPx) + 'px">';
+	function isRowRevealed(list, row) {
+		if (!row.getBoundingClientRect || !list || !list.getBoundingClientRect) return true;
+		var rect = row.getBoundingClientRect();
+		var box = list.getBoundingClientRect();
+		if (rect.top < box.top || rect.bottom > box.bottom) return false;
+		var viewportHeight = window.innerHeight || 0;
+		if (!viewportHeight) return true;
+		return rect.top >= 0 && rect.bottom <= viewportHeight;
+	}
+
+	/**
+	 * Brings the selected row into view, ONCE per selection.
+	 *
+	 * WHY AT ALL: the Stats card's rows link in here with `?skill=`, so a reader can
+	 * arrive with the 25th skill selected — the pane opens on it correctly while the
+	 * column sits at row 1, with the highlighted row 1,222px down a 504px window
+	 * (measured). Nothing on screen connects the two, and the reader has no reason to
+	 * think the list is scrollable at all. The band's key does the same thing to any
+	 * skill outside its top four.
+	 *
+	 * ONCE PER SELECTION, which is what `scrolledToSkill` buys and what makes this safe
+	 * to run from `draw`. Every path here repaints the whole page — an explicit refresh among
+	 * them — so scrolling on each repaint would drag a reader browsing the list back to
+	 * the selected row twice a minute. The one thing that MAY move the column is the
+	 * reader changing what is selected.
+	 *
+	 * NOT RECORDED WHEN THE ROW IS ABSENT, for the reason `memories.js` states about its
+	 * anchor: the selection can name a skill sitting in the tail of the list, which is
+	 * fetched a moment after the first paint, and recording here would spend the single
+	 * chance to reveal it on a paint where it did not exist. The arriving tail repaints,
+	 * and that is the paint that scrolls.
+	 *
+	 * ALREADY-VISIBLE ROWS ARE LEFT ALONE, unlike `memories.js`'s unconditional centring.
+	 * The high-frequency action on this page is clicking a row in the list — a row that
+	 * is on screen by definition, since the reader just clicked it — and centring it
+	 * would slide the column under the pointer for no reason. The selection is still
+	 * recorded, so this stays once-per-selection either way.
+	 *
+	 * CENTRED when it does move: the neighbours above and below say where in the ranking
+	 * the skill sits, which top-alignment throws away. `scrollIntoView` also walks every
+	 * scrollable ancestor, so it fixes the viewport half of `isRowRevealed` in the same
+	 * call — on a window tall enough for the panel, the page does not move at all.
+	 */
+	function revealSelectedRow(app, list) {
+		var name = state.paneName;
+		/* Closing the pane forgets the scroll, so re-opening the same skill later — from
+		   the band's key, after the reader has scrolled elsewhere — reveals it again. */
+		if (!name) {
+			scrolledToSkill = null;
+			return;
+		}
+		if (scrolledToSkill === name) return;
+		var row = app.querySelector('.sk-row[aria-current="true"]');
+		if (!row) return;
+		scrolledToSkill = name;
+		if (isRowRevealed(list, row)) return;
+		if (row.scrollIntoView) row.scrollIntoView({ block: "center" });
 	}
 
 	function draw(app, model) {
@@ -479,10 +616,10 @@
 		   node that holds it — and only that node scrolls, so this is the whole of it.
 		 *
 		 * Every path here repaints the WHOLE page — a row click, that row's detail landing
-		 * moments later, a Show more, the 30 s poll — so without this the column snapped
-		 * back to its first row on all four. Clicking the 18th skill scrolled the list away
-		 * from the row that was just clicked, which also takes the `aria-current` row off
-		 * screen; and the poll did it unprompted every 30 s, mid-read.
+		 * moments later, the tail of the list arriving, an explicit refresh — so without this the
+		 * column snapped back to its first row on all four. Clicking the 18th skill
+		 * scrolled the list away from the row that was just clicked, which also takes the
+		 * `aria-current` row off screen; and a refresh did it unprompted, mid-read.
 		 *
 		 * A whole-page repaint is what this view is built on (`renderSkills` re-reads the
 		 * address on every render), so restoring the offset is the fix that fits it —
@@ -505,20 +642,23 @@
 			paneHtml(usage, model.timeZone) +
 			"</article>" +
 			"</section>";
-		/* Both halves address the NEW node. The measurement runs BEFORE the restore for no
-		   reason beyond reading order — they touch different properties — but it must run
-		   while the region is still uncapped, which `isPaged` is what guarantees.
+		/* Addresses the NEW node. The restore is conditional because assigning 0 to a fresh
+		   render is a no-op that would still cost a layout write. A shrunk list (a refresh
+		   returning fewer rows) is clamped by the browser, so this cannot leave the column
+		   past its own content.
 		 *
-		 * The restore is conditional because assigning 0 to a fresh render is a no-op that
-		 * would still cost a layout write. A shrunk list (the poll returning fewer rows) is
-		 * clamped by the browser, so this cannot leave the column past its own content. */
+		 * There used to be a MEASUREMENT here too, reading the uncapped region's height back
+		 * to use as its own cap. The flex chain supplies that height now — see `listOpenTag`. */
 		var list = app.querySelector(".sk-list");
 		if (list) {
-			if (!isPaged() && rows.length > 0 && list.offsetHeight > 0) listCapPx = list.offsetHeight;
 			if (offset > 0) list.scrollTop = offset;
+			/* AFTER the restore, never before: this measures where the row actually sits,
+			   and it is the one thing allowed to overrule the carried-across offset — a
+			   new selection is the reader asking to look somewhere else. */
+			revealSelectedRow(app, list);
 		}
 		bindSelection(app, model);
-		bindMore(app, model);
+		bindProse(app);
 	}
 
 	// ── The band ────────────────────────────────────────────────────────────────
@@ -598,13 +738,40 @@
 			})
 			.join("");
 
+		/* `stackedBarsFrame`, NOT `stackedBars`: this chart's height is a budget (the pane
+		   below it needs the rest of the window), and the plain entry point can only be
+		   bounded through its WIDTH — its axis text lives in the viewBox, so the whole box
+		   scales uniformly. That coupling is what used to pin this chart to a width derived
+		   from the window's height, leaving a wide browser with a 477px chart and a
+		   1280x800 one with 240px of chart and 5px axis labels. The frame hands back a
+		   text-free plot that CSS pins by height, so the width is free to follow the page.
+		   `charts.js` carries the full reasoning.
+		 *
+		   An integer formatter, not the default `fmtTokens`: "0.5" on an axis counting
+		   sessions is a claim the unit cannot make. */
+		var frame = JD.stackedBarsFrame(rolled, keys, "skill sessions", (n) => String(Math.round(n)));
+		/* The ticks come from the frame rather than being derived here, so the labels and
+		   the bars cannot be scaled by two different bounds. */
+		var ticks = frame.ticks.map((tick) => "<span>" + JD.esc(tick) + "</span>").join("");
+		/* The endpoint labels sit INSIDE `.sk-bandmain`, beside the plot and not beside the
+		   tick column, so `space-between` lines them up with the plot's own edges — the
+		   same thing `stackedBars` achieved by anchoring them to its plot bounds. A
+		   single-day window prints one, matching the pane's small charts. */
+		var axis =
+			'<div class="sk-axis"><span>' +
+			JD.esc(frame.firstDay) +
+			"</span>" +
+			(frame.lastDay ? "<span>" + JD.esc(frame.lastDay) + "</span>" : "") +
+			"</div>";
 		return (
 			head +
-			'<div class="sk-bandrow"><div class="chart-box">' +
-			/* An integer formatter, not the default `fmtTokens`: "0.5" on an axis counting
-			   sessions is a claim the unit cannot make. */
-			JD.stackedBars(rolled, keys, "skill sessions", (n) => String(Math.round(n))) +
-			'</div><div class="sk-key">' +
+			'<div class="sk-bandrow"><div class="chart-box"><div class="sk-bandplot">' +
+			'<div class="sk-bandticks">' +
+			ticks +
+			'</div><div class="sk-bandmain">' +
+			frame.svg +
+			axis +
+			'</div></div></div><div class="sk-key">' +
 			legend +
 			"</div></div></div>"
 		);
@@ -629,8 +796,12 @@
 
 	/**
 	 * The list. THE ORDER IS THE SERVER'S (adoption) and the header is NOT a sort
-	 * control: these rows are one page of a ranked list, so re-sorting them by tokens
-	 * would name a "heaviest" that may sit unloaded on the next page.
+	 * control. That rule survived the loss of its first reason: while these rows were one
+	 * page of a ranked list, a client-side re-sort by tokens would name a "heaviest" that
+	 * might sit unloaded on the next page. The column now holds every skill, so the same
+	 * re-sort would usually be right — but only usually, since the tail is still absent
+	 * while it is in flight and after a failed read, and a header that silently sorts a
+	 * partial list is the same lie arriving less often.
 	 */
 	function listHtml(rows) {
 		if (rows.length === 0) return '<div class="empty-note">No skill invocations recorded in this window.</div>';
@@ -675,66 +846,60 @@
 	}
 
 	/**
-	 * The paging row, PINNED BELOW THE ROWS rather than inside them.
+	 * The loading line's band, PINNED BELOW THE ROWS rather than inside them.
 	 *
-	 * IT IS A CONTROL, so it may not be reachable only by scrolling the very rows it
-	 * pages — and from the first Show more onwards those rows ARE a capped region, so
-	 * inside it that is exactly what it would be. Measured back when the region was
-	 * capped from the first paint: at a 1440x900 viewport the list showed 7 of 23 rows
-	 * and the row sat 882px past its fold, while the window itself scrolled 3px, so a
-	 * reader spinning the wheel over the page never moved the list at all. The first
-	 * screenful no longer has that problem (nothing is capped until a click), but the
-	 * click that creates the cap is the same click that needs this button again, so the
-	 * placement is what keeps it in reach. The head and the coverage foot are pinned for
-	 * this same reason; this belongs with them, and the region keeps only the rows and
-	 * their footnote.
+	 * IT SAYS THE COLUMN IS INCOMPLETE, so it may not be reachable only by scrolling the
+	 * very rows that are missing their tail — and on any corpus that can show this line
+	 * those rows ARE a capped region, so inside it that is exactly what it would be.
+	 * Measured back when the region was capped from the first paint: at a 1440x900
+	 * viewport the list showed 7 of 23 rows and the row sat 882px past its fold, while
+	 * the window itself scrolled 3px, so a reader spinning the wheel over the page never
+	 * moved the list at all. The head and the coverage foot are pinned for this same
+	 * reason; this belongs with them, and the region keeps only the rows and their
+	 * footnote.
 	 *
-	 * NOTHING AT ALL on an empty column, which is what a row inside `listHtml` got for
-	 * free from its early return: `Showing 0 of 0 skills` under a note that already
-	 * says there are no invocations is the same sentence twice.
+	 * NOTHING AT ALL on a complete column — which is the steady state, so the band is
+	 * normally absent. It used to be permanent, carrying `Showing 12 of 40 skills`
+	 * because that was the only place the reader learnt the column was NOT the whole
+	 * list. Now it always is, `navHeadHtml` already prints the skill count, and a
+	 * permanent `Showing 25 of 25 skills` under a header reading `25 skills` is the same
+	 * sentence twice. Nothing on an empty column either, for the same reason its
+	 * predecessor said nothing there.
 	 */
 	function navPagingHtml(rows, usage) {
 		if (rows.length === 0) return "";
-		return '<div class="sk-paging">' + moreRowHtml(rows, usage) + "</div>";
+		var body = restStatusHtml(rows, usage);
+		return body ? '<div class="sk-paging">' + body + "</div>" : "";
 	}
 
 	/**
-	 * `Showing 12 of 40 skills`, plus the button that fetches the next page.
+	 * `Showing 8 of 25 skills — loading the rest…`, and only while that is true.
 	 *
-	 * ALWAYS PRESENT once there is a row, unlike the Stats cards' version which hides
-	 * itself until a click has grown the list. That rule exists because those three
-	 * cards share one equal-third band and dropping the row resized the card under the
-	 * reader; here the row is the last band of a column whose height is its own content,
-	 * so keeping it costs one line — and it is the only place the reader is told the
-	 * column IS the whole list. Without it a 60-row column and a 60-of-300 column look
-	 * identical.
+	 * TWO STATES, NO BUTTON. The reader is not being asked for anything: the rest of the
+	 * list is already on its way, and on a failure this page's 30 s timer asks again — so
+	 * a `Try again` control here would duplicate a retry that happens automatically, on the one
+	 * page whose entire point is that the reader does not click to see their own skills.
+	 * The failure still has to be SAID, because a column short of its total is otherwise
+	 * indistinguishable from a reader who owns eight skills.
 	 *
-	 * Same classes and same wording as `stats.js`'s `toolMoreRow`, so the two read as
-	 * one control at two zooms rather than two conventions.
+	 * The count and its classes are `stats.js`'s `toolMoreRow`'s, so the two lines read
+	 * as one convention at two zooms even though only one of them still has a button.
 	 */
-	function moreRowHtml(rows, usage) {
+	function restStatusHtml(rows, usage) {
+		if (!restLoading && !restError) return "";
 		var shown = rows.length;
 		var total = rowsTotal === null ? (usage && usage.skillsTotal) || shown : rowsTotal;
-		var count =
-			'<span class="more-count">Showing ' +
+		/* A total the column already meets has nothing left to report, whichever flag is
+		   still up — a stale `restError` beside a full list would call it short. */
+		if (shown >= total) return "";
+		return (
+			'<div class="more-row"><span class="more-count">Showing ' +
 			shown +
 			" of " +
 			total +
 			(total === 1 ? " skill" : " skills") +
-			/* The failure belongs beside the count it stopped from growing: this button
-			   still being here IS why it matters. */
-			(moreError && !moreLoading ? " — could not load more" : "") +
-			"</span>";
-		if (shown >= total) return '<div class="more-row is-done">' + count + "</div>";
-		var label = moreLoading ? "Loading…" : moreError ? "Try again" : "Show more";
-		return (
-			'<div class="more-row">' +
-			count +
-			'<button type="button" class="cta ghost sm" data-skillmore' +
-			(moreLoading ? " disabled" : "") +
-			">" +
-			label +
-			"</button></div>"
+			(restLoading ? " — loading the rest…" : " — could not load the rest; retrying shortly") +
+			"</span></div>"
 		);
 	}
 
@@ -742,9 +907,9 @@
 	 * The `†` spelled out under the column, and only when a loaded row wears one.
 	 *
 	 * ON THE ROWS IN HAND, not on a window-wide flag: a footnote explaining a mark that
-	 * is nowhere on screen is a reader hunting for something that is not there. So a
-	 * Show more click can bring the footnote in, which is correct — the mark arrived
-	 * with it.
+	 * is nowhere on screen is a reader hunting for something that is not there. So the
+	 * tail of the list landing can bring the footnote in, which is correct — the mark
+	 * arrived with it.
 	 */
 	function inferredFootnoteHtml(rows) {
 		var marked = rows.some((row) => row.detection === "heuristic");
@@ -829,11 +994,13 @@
 		html += section("The record", recordHtml(detail, timeZone));
 		html += section("Who ran it", agentsHtml(detail));
 
-		html +=
-			'<span class="sk-basis">Runs, sessions and the agent split are counted over this window. The two ' +
-			"charts above share the day axis the chart at the top of the page uses, so a column is the same day " +
-			"in all three; spend is attributed per session and summed per day, never per run. Outcomes are per " +
-			"recorded run and carry no date axis.</span>";
+		html += proseBlock(
+			"sk-basis",
+			"Runs, sessions and the agent split are counted over this window. The two " +
+				"charts above share the day axis the chart at the top of the page uses, so a column is the same day " +
+				"in all three; spend is attributed per session and summed per day, never per run. Outcomes are per " +
+				"recorded run and carry no date axis.",
+		);
 		return html + "</div>";
 	}
 
@@ -859,11 +1026,45 @@
 	 */
 	function inferredCaveatHtml(detail) {
 		if (detail.detection !== "heuristic") return "";
+		return proseBlock(
+			"sk-caveat",
+			"† At least one entry here was inferred from a command that read the skill " +
+				"file, not from an observed invocation — a person reading that file leaves the same trace, and " +
+				"reading it is not the same as using it. Inferred entries are counted once per session however " +
+				"many reads produced them, so the run figures above are a floor rather than a count.",
+		);
+	}
+
+	/**
+	 * One of the pane's two long fixed paragraphs, shown as a single line until clicked.
+	 *
+	 * WHY THESE TWO AND NOTHING ELSE: they are ~4 lines each and 82px of the pane's height
+	 * budget between them (measured), and they are the only blocks here whose text is FIXED
+	 * rather than a measurement. Clamping a data row would destroy a count; clamping these
+	 * hides a qualifier one click brings back. `main.css`'s `.sk-clamp` owns the visual side.
+	 *
+	 * TEXT ONLY, NEVER MARKUP. The whole string is repeated into `title` (so a pointer user
+	 * gets it without clicking) and `JD.esc` there would mangle any tags — so callers pass
+	 * prose, and the one non-ASCII character in it, the inferred dagger, is a literal.
+	 *
+	 * `role="button"` + `tabindex="0"` rather than a real `<button>`: the clickable thing IS
+	 * the paragraph, and a button element would inherit type/appearance resets and take the
+	 * text out of the reading flow for a screen reader. `aria-expanded` is what makes the
+	 * collapsed state audible rather than merely visual, and `main.css` keys the open state
+	 * off that same attribute so there is ONE source of truth on the node.
+	 */
+	function proseBlock(cls, text) {
+		var open = openProse[cls] === true;
 		return (
-			'<div class="sk-caveat">† At least one entry here was inferred from a command that read the skill ' +
-			"file, not from an observed invocation — a person reading that file leaves the same trace, and " +
-			"reading it is not the same as using it. Inferred entries are counted once per session however " +
-			"many reads produced them, so the run figures above are a floor rather than a count.</div>"
+			'<div class="' +
+			cls +
+			' sk-clamp" role="button" tabindex="0" aria-expanded="' +
+			(open ? "true" : "false") +
+			'" title="' +
+			JD.esc(text) +
+			'">' +
+			JD.esc(text) +
+			"</div>"
 		);
 	}
 
@@ -1191,11 +1392,28 @@
 		return command ? "you" : null;
 	}
 
+	/**
+	 * Rows of the agent split shown in full before the rest are rolled into one line.
+	 *
+	 * THE ONLY UNBOUNDED-ENOUGH LIST IN THE PANE. Every other section has a ceiling the
+	 * fixed frame can be sized against — the outcome strip is capped at 50 ticks by the
+	 * server, `The record` is five fixed fields — but this one is one row per agent that
+	 * ran the skill, and the product recognises a dozen-odd of them. Measured with 12 rows
+	 * at 1440x900 the pane overflowed its frame by 54px; capped at 5 it fits with room.
+	 *
+	 * FIVE, not three: a skill genuinely shared between the agents on a machine is the
+	 * interesting case, and a cap that rolls up the third one stops answering the question
+	 * the section exists for. Five covers every real row measured on this machine, so the
+	 * roll-up is a guard rather than something a reader meets day to day.
+	 */
+	var AGENT_ROWS_SHOWN = 5;
+
 	/** Per-agent runs, most first. The swatch is the agent's colour, page-wide. */
 	function agentsHtml(detail) {
 		var agents = (detail.agents || []).slice().sort((a, b) => b.calls - a.calls);
 		if (agents.length === 0) return '<div class="sk-note">No agent recorded against this skill.</div>';
-		return agents
+		var html = agents
+			.slice(0, AGENT_ROWS_SHOWN)
 			.map((agent) =>
 				line(
 					agent.source,
@@ -1204,6 +1422,22 @@
 				),
 			)
 			.join("");
+		var rest = agents.slice(AGENT_ROWS_SHOWN);
+		if (rest.length === 0) return html;
+		/* The rolled-up line carries its own RUN TOTAL, not just a count of agents — the
+		   section is a split of the runs, so "3 further agents" alone would drop runs out of
+		   a total the four figures above still count in full. Same rule the outcome strip's
+		   own capped note follows: the cap changes what is drawn, never what is claimed. */
+		var restCalls = rest.reduce((sum, agent) => sum + agent.calls, 0);
+		return (
+			html +
+			'<div class="sk-note">' +
+			rest.length +
+			(rest.length === 1 ? " further agent ran it, " : " further agents ran it, ") +
+			restCalls +
+			(restCalls === 1 ? " run" : " runs") +
+			" between them.</div>"
+		);
 	}
 
 	// ── Interaction ─────────────────────────────────────────────────────────────
@@ -1231,10 +1465,35 @@
 		});
 	}
 
-	/** The paging button. Absent on a fully-loaded column, so this binds nothing. */
-	function bindMore(app, model) {
-		var button = app.querySelector("[data-skillmore]");
-		if (button) button.onclick = () => loadMoreRows(app, model);
+	/**
+	 * Wires the two clamped paragraphs (see `proseBlock`).
+	 *
+	 * IT TOGGLES THE ATTRIBUTE AND DOES NOT RE-RENDER, which is the opposite of every other
+	 * interaction on this page. Opening a sentence is not a change of what the page is
+	 * about: a repaint would cost the rows their scroll offset and the pane its own, for a
+	 * result CSS reaches from `aria-expanded` alone. `openProse` is updated in step so the
+	 * next repaint — driven by something else — still renders it open.
+	 *
+	 * SPACE IS PREVENTED, Enter is not. On a `role="button"` element the browser supplies
+	 * neither activation, so both are handled here; Space would otherwise also scroll the
+	 * nearest scrollable ancestor, which on this page is a column the reader is reading.
+	 */
+	function bindProse(app) {
+		Array.prototype.forEach.call(app.querySelectorAll(".sk-clamp"), (element) => {
+			/* Read back off the node rather than closed over, so one binder serves both
+			   blocks and the key cannot drift from the class the stylesheet matches. */
+			var key = element.classList.contains("sk-caveat") ? "sk-caveat" : "sk-basis";
+			var toggle = () => {
+				openProse[key] = openProse[key] !== true;
+				element.setAttribute("aria-expanded", openProse[key] ? "true" : "false");
+			};
+			element.onclick = toggle;
+			element.onkeydown = (event) => {
+				if (event.key !== "Enter" && event.key !== " ") return;
+				event.preventDefault();
+				toggle();
+			};
+		});
 	}
 
 	JD.renderSkills = renderSkills;

--- a/cli/src/dashboard/assets/styles/main.css
+++ b/cli/src/dashboard/assets/styles/main.css
@@ -1863,34 +1863,112 @@ body {
    of pane in the mockup against 982px full-bleed at a 1600px viewport, which is
    wider than the 560px the pane's own figures and caveat are capped at.
 
-   THE PAGE IS WHAT SCROLLS, with ONE earned exception — and this is the height rule
-   the rest of the section is written against. Every box here is as tall as what it
-   holds and the page grows past the fold like every other view; the single exception
-   is the chooser's rows, which take a MEASURED cap the moment the reader presses Show
-   more (`listOpenTag` in skills.js owns that, and `.sk-list.sk-scroll` below styles
-   it). So the first screenful has exactly one scrollbar, the window's, and a second
-   appears only as the visible result of a click asking for more rows than the column
-   opened with.
+   ONE FIXED FRAME, AND EXACTLY ONE SCROLL REGION: THE CHOOSER'S ROWS. The page does
+   not scroll, the two columns are the same height, the rows scroll inside their own
+   card, and the reading pane holds its whole skill without scrolling. That is the
+   height rule the rest of this section is written against, and every value below
+   exists to keep the pane's content under the frame it is given.
 
-   It used to be three viewport-height boxes summing to exactly 100vh: a declared
+   THIS IS THE SECOND ATTEMPT AT A FIXED FRAME AND IT IS NOT THE FIRST ONE RESTORED.
+   The first was three viewport-height boxes summing to exactly 100vh — a declared
    `--sk-band-h`, a `--sk-col-h` deriving the rest from `100vh`, and a scroll region
-   inside each column, present from the first paint. That bought a fixed frame and
-   charged the reader three scroll regions to find — measured at 1440x900, the wheel
-   over the rows moved the WINDOW 3px while the list itself stayed put, the pane
-   carried a second bar of its own, and anything at the end of either box (the paging
-   control, the coverage foot, the pane's basis line) was reachable only by
-   discovering which box it lived in. The `100vh` arithmetic went with it, and so did
-   `.main`'s dropped bottom padding — that override existed only to stop the exact
-   sum spilling 20px past the fold. What came back is the ONE region that earns a
-   window: the rows, once there are more of them than the reader asked to see. */
-.jd .grid:has(.skills-page) { display: block; }
+   inside EACH column from the first paint. It was removed because it charged the
+   reader three scroll regions to find: measured at 1440x900, the wheel over the rows
+   moved the WINDOW 3px while the list itself stayed put, the pane carried a second bar
+   of its own, and anything at the end of either box (the paging control, the coverage
+   foot, the pane's basis line) was reachable only by discovering which box it lived in.
+   Two things differ here and both are what make the outcome different. The heights come
+   from a FLEX CHAIN (`.main` → `.wrap` → `#app` → the grid's second row), never from
+   `100vh` arithmetic, so the band's real height is subtracted rather than declared —
+   that arithmetic being 3px off the truth is what left the window scrollable. And the
+   PANE DOES NOT SCROLL: the rows are the only region with a bar, so there is no longer
+   a box whose end the reader has to go looking for.
+
+   WHY THE ROWS ARE THE ONE REGION THAT KEEPS A BAR: the corpus is unbounded (a machine
+   can hold hundreds of skills) while a skill's detail is not — the server caps the
+   outcome strip at 50 entries, agents are an enum, and `The record` is five fixed
+   fields. So the rows are the only content whose height cannot be bounded by design,
+   and the flex chain hands them whatever the frame has left instead of the measured
+   pixel cap `listOpenTag` used to write inline.
+
+   THE BAND'S CHART IS SIZED FROM THE VIEWPORT'S HEIGHT, which is the one thing that
+   makes the pane fit on a short window. It is the chart's OWN HEIGHT that `clamp()`
+   trades against pane room — 256px on a tall window, shrinking as the window does,
+   floored at 68px where the short-window budget below takes over. Its width is free and
+   simply follows the page. The `728px` the budget is built on is measured, not guessed —
+   61 topbar + 20 wrap top + 12 wrap bottom + 6 gap + 24 band padding + 575 for the WORST
+   pane + 30 slack.
+
+   THAT USED TO BE A `max-width`, and the reason is worth keeping: `JD.stackedBars` draws
+   7 `<text>` nodes inside its 660x238 viewBox, which rules out `preserveAspectRatio="none"`
+   + a pinned height (the trick `.sk-daybars` uses), so the box could only scale uniformly
+   and width was the only handle there was on height. The chart therefore ignored the page's
+   width entirely and paid for a short window in width instead — 240px of chart at 1280x800,
+   its labels scaled to ~5px with it. `JD.stackedBarsFrame` moves that text out to the HTML
+   beside the plot, which is what lets the height be pinned directly; `.sk-band .chart-box`
+   carries the term-by-term translation of the old expression into the new one.
+   That 575 is not the tallest real skill (574, jolli-recall) but a FORCED worst case: the
+   skill-detail response stubbed with 12 agents and `detection: "heuristic"`, so the agent
+   roll-up and the inferred caveat are both on at once. Sizing to the tallest real row
+   would leave the frame 5px short the first time a skill is shared across a machine's
+   whole agent set.
+
+   Re-derive it the same way if the pane grows a section, or if any of those terms change:
+   stub the response at its worst, then shave the constant until `.sk-pane`'s `scrollHeight`
+   stops exceeding its `clientHeight`, and leave slack. Three earlier passes are worth
+   knowing about — 696 was 9px short because the two clamped paragraphs come to 41px
+   between them rather than the ~30 the arithmetic assumed (each carries a border and
+   padding its one visible line does not reveal); 710 cleared every real skill while still
+   missing the forced case by 5px; and 716 was correct until the wrap grew its 12px bottom
+   padding, which this budget pays for one-for-one.
+
+   THE WRAP'S 1200px CAP STAYS HERE, which is where this page parts from
+   `.memories-page`. It survived the chart's width becoming free, and the reason narrowed
+   rather than disappeared. It used to rest on two things — a capped chart and a fixed
+   344px list — so that every pixel a release added landed in the reading pane alone:
+   802px of pane in the mockup against 982px full-bleed at a 1600px viewport, wider than
+   the 560px the pane's own figures and caveat are capped at. The first of those is gone;
+   the second is not, and the pane's 560px is not. So a release now buys a wider chart
+   (worth something) at the price of a pane stretched past what its content uses (worth
+   nothing) — and the chart already reaches ~900px inside the cap, because the band spans
+   BOTH columns and never shared the width with the list. Not enough to trade the page's
+   alignment with every other view for. Revisit it if the pane's own caps ever come off. */
+/* `#app`, NOT `.grid`: main.js sets `#app.className = view.grid ? "grid" : ""`, and
+   `skills` is declared `grid: false` in shell.js — so `#app` carries NO class here and
+   the `.grid:has(.skills-page)` rule this replaces never matched anything. It was inert
+   for as long as it shipped (harmless while the page was `display: block` by default,
+   and a silent no-op the moment the flex chain below started depending on it). */
+.jd:has(.skills-page) { height: 100vh; overflow: hidden; }
+.jd .main:has(.skills-page) {
+	padding-bottom: 0; display: flex; flex-direction: column; height: 100vh; min-height: 0;
+}
+/* Deliberately NOT hidden the way Knowledge hides its own: this note is empty on this
+   view today, and `.main`'s flex column simply gives it its natural height if it ever
+   fills — which shortens the frame and is absorbed by the pane's fallback bar rather
+   than pushing the page past the fold. */
+/* `padding-bottom` so the two column cards do not sit flush against the window's bottom
+   edge — the base `.wrap` rule ends in `0` because a scrolling page has `.main`'s 48px
+   below it, and this frame has nothing. It comes out of the SAME vertical budget as
+   everything else (see the chart's `clamp()`), so the 12px is 33px of chart width; that
+   trade is why it is 12 and not the 20 that would mirror the padding above. */
+.jd .wrap:has(.skills-page) {
+	flex: 1; min-height: 0; display: flex; flex-direction: column; padding-bottom: 12px;
+}
+.jd #app:has(.skills-page) { display: flex; flex-direction: column; flex: 1; min-height: 0; }
 
 .jd .skills-page {
 	display: grid; grid-template-columns: 344px minmax(0, 1fr); gap: 6px;
-	/* `start`, not the default stretch: the two columns hold unrelated amounts of
-	   content, so stretching makes the shorter card as tall as the taller one and
-	   leaves its own foot floating in the middle of an empty card. */
-	align-items: start;
+	/* The band takes its own height; the columns take everything left. `minmax(0, 1fr)`
+	   rather than `1fr` so the row can be SHORTER than its content — a bare `1fr` floors
+	   at max-content, which is exactly how a nested scroll region fails to appear. */
+	grid-template-rows: auto minmax(0, 1fr);
+	flex: 1; min-height: 0;
+	/* `stretch` (the default, restated because this used to be `start`): the columns are
+	   now a frame rather than two cards sized to their own content, so they must be the
+	   same height. What `start` was protecting against — a short card stretched tall with
+	   its foot floating mid-card — is handled instead by the foot being pinned to the
+	   bottom of a flex column. */
+	align-items: stretch;
 }
 
 /* Same chrome as the chooser column, spanning both. */
@@ -1899,17 +1977,111 @@ body {
 	border: 1px solid var(--border); border-radius: 12px; background: var(--surface);
 	box-shadow: 0 2px 5px rgba(20, 30, 50, .05); padding: 14px 20px 10px;
 	display: flex; flex-direction: column;
+	/* The plot's height, and the band's whole vertical budget. Declared HERE rather than
+	   on `.chart-box` because `.sk-key` is the chart box's SIBLING, not its descendant, and
+	   caps its own height against this — a custom property only inherits downwards, so on
+	   the chart box the key would silently read it as invalid and lose its cap. Every term
+	   is derived where `.chart-box` is defined below. */
+	--sk-band-plot-h: clamp(68px, 100vh - 746px, 256px);
 }
 .jd .sk-bandrow { display: flex; gap: 28px; align-items: flex-start; min-height: 0; }
-/* Capped and left-aligned rather than stretched: `JD.stackedBars` is an SVG with a
-   fixed 660-wide viewBox and `width: 100%`, so at full page width it scales to
-   roughly 400px tall. The cap keeps it chart-sized and the slack carries the key. */
-.jd .sk-band .chart-box { flex: 1; max-width: 760px; min-width: 0; }
+/* The plot stretches to the page; its HEIGHT is what the window's height buys.
+ *
+ * THIS WAS A `max-width`, AND THAT WAS THE PROBLEM. `JD.stackedBars` keeps its axis text
+ * inside its viewBox, so the SVG can only scale uniformly — which left `max-width` as the
+ * only handle this frame had on the chart's HEIGHT. Two costs followed. A wider browser
+ * did nothing for the chart (pinned at 477px however much page it was given), and a
+ * shorter window was paid for in WIDTH: 240px of chart at 1280x800, with the axis labels
+ * scaled down to ~5px along with it.
+ *
+ * `JD.stackedBarsFrame` takes the text out of the viewBox (see `charts.js` for why that
+ * is a second entry point and not a flag), so the SVG carries `preserveAspectRatio="none"`
+ * and the two axes come apart. The height below keeps the budget the `max-width` used to
+ * encode; the width just follows the page.
+ *
+ * THE HEIGHT IS THE OLD EXPRESSION RESTATED IN THE AXIS IT WAS ALWAYS ABOUT. The old
+ * chart rendered at width × 238/660, so `clamp(240px, (100vh - 728px) * 2.773, 760px)`
+ * WAS `clamp(86.5px, 100vh - 728px, 274px)` of height wearing a width's clothes — which
+ * is why the slope here is 1 rather than 2.773. Each term is the old one less the 18px the
+ * endpoint labels now take as HTML (`.sk-axis`: a 14px line plus its 4px margin):
+ *     floor   86.5 - 18  ->  68px    at 1280x800, where the short-window budget below
+ *                                    takes over as the binding constraint, exactly as it
+ *                                    did when the floor was 240px of width
+ *     base     728 + 18  -> 746px    the section header has how 728 was measured
+ *     cap      274 - 18  -> 256px    reached at 1002px of window height and up
+ * So the pane's room is unchanged at every window height, while the chart goes from 477px
+ * to ~900px wide at this page's 1200px cap — the band spans BOTH grid columns, so it never
+ * had to share the width with the 344px list. Re-derive the base the way the section
+ * header says if the pane grows a section; the other two terms follow from it.
+ *
+ * The 760px width cap is gone rather than raised. It existed to stop the chart eating the
+ * key's room back when stretching it also made it taller; with the height pinned, the key
+ * wraps into columns against this same height and takes only the width it needs.
+ *
+ * The declaration itself lives on `.sk-band` above, because the key reads it too. */
+.jd .sk-band .chart-box { flex: 1; min-width: 0; }
+/* The tick column beside the plot. `flex-start`, so the ticks are as tall as the PLOT and
+   not as tall as the plot plus the endpoint row underneath it. */
+.jd .sk-bandplot { display: flex; gap: 10px; align-items: flex-start; }
+/* The tick values, landing ON the gridlines the SVG draws.
+ *
+ * THE COLUMN IS ONE LINE TALLER THAN THE PLOT, then pulled back by half a line at each
+ * end. Both halves of that are load-bearing and the obvious version — the plot's exact
+ * height plus the same negative margin — is wrong in a way that looks nearly right:
+ * `space-between` spreads the LEFTOVER space, so N spans in a box of height H sit
+ * `(H - N*lineH)/(N-1)` apart, which is `lineH` short of the `H/(N-1)` the gridlines use.
+ * Measured at 1440x900: the top value landed on its line and each one below drifted
+ * another 2.75px, ending 11px low.
+ *
+ * With the box a line taller the leftover is `H - (N-1)*lineH`, so the gap becomes
+ * `H/(N-1) - lineH` and consecutive span CENTRES land exactly `H/(N-1)` apart — the
+ * gridline spacing, for any N. The `-0.5em` then shifts the whole column up by half a
+ * line so the first centre meets the top line rather than sitting a half-line below it,
+ * and the matching bottom margin keeps the column's OUTER height equal to the plot's, so
+ * it cannot be what sizes `.sk-bandplot`.
+ *
+ * `line-height: 1` is what makes a line exactly `1em`, which is what both offsets are
+ * written in. Aligned right so the digits meet the plot, and `tabular-nums` (the `.num`
+ * class the old `<text>` nodes carried) so they form a column instead of drifting with
+ * the glyph widths. */
+.jd .sk-bandticks {
+	height: calc(var(--sk-band-plot-h) + 1em); flex: none;
+	display: flex; flex-direction: column; justify-content: space-between; align-items: flex-end;
+	margin: -0.5em 0; font-size: 11px; line-height: 1; color: var(--muted);
+	font-variant-numeric: tabular-nums;
+}
+.jd .sk-bandmain { flex: 1; min-width: 0; }
+/* `display: block` drops the inline baseline gap under the SVG; the pinned height is the
+   whole point of the change above. */
+.jd .sk-bandbars { display: block; width: 100%; height: var(--sk-band-plot-h); }
 /* The key, stacked in that spare width. INSIDE THIS BAND THE RAMP MEANS SKILL,
    while everywhere else on the dashboard it means agent — which is why the key sits
    against the chart rather than at the page edge. A colour may not be read across
    this boundary. */
-.jd .sk-key { display: flex; flex-direction: column; align-items: flex-start; gap: 7px; margin-top: 8px; flex: none; }
+/* The key, in the width the plot does not take. IT WRAPS INTO COLUMNS, capped at the
+   plot's own height.
+ *
+ * `column` + `wrap` + `max-height` is one rule doing what two used to: a key taller than
+ * the plot would set `.sk-bandrow`'s height and eat into the pane, so it fills a column,
+ * hits the plot's height and starts another beside it. Height is bounded by construction
+ * at every window size, and a long skill name can only cost WIDTH.
+ *
+ * This replaced a `@media (max-height: 816px)` rule that turned the key into a wrapping
+ * ROW for the same reason (104px stacked → ~40px lying down, 816 being where the stacked
+ * key stopped being shorter than the chart box). Two things retired it. The height cap
+ * reaches the goal directly instead of at one breakpoint, and a row is now actively wrong:
+ * with the chart's width freed, a `flex: none` row laid its items out in one line and took
+ * 602px of a 980px band, leaving 324px of chart at 1280x800 — where a stacked key had cost
+ * it nothing, because the chart was pinned to 240px anyway and the leftover was the key's
+ * to use. The measured result is 2 columns and 326px at that size.
+ *
+ * `align-content: flex-start` so the columns sit together at the left rather than being
+ * spread across the cap, and the 14px column gap is the row gap the old rule used. */
+.jd .sk-key {
+	display: flex; flex-direction: column; flex-wrap: wrap; align-items: flex-start;
+	align-content: flex-start; max-height: var(--sk-band-plot-h);
+	gap: 7px 14px; margin-top: 8px; flex: none;
+}
 .jd .sk-legend {
 	display: inline-flex; align-items: center; gap: 6px; background: none; border: 0;
 	padding: 2px 6px; margin: -2px -6px; border-radius: 6px; font: inherit; font-size: 11.5px;
@@ -1925,12 +2097,14 @@ body {
 /* Recessed, not recoloured: a dimmed series must stay recognisably itself. */
 .jd .sk-dim { opacity: .38; }
 
-/* The chooser column: `.mem-navigator`'s chrome at the height of its own content.
-   Head, rows, paging row and coverage foot stack, so the card is as tall as the four
-   of them — the rows are the only one that can be capped, and the card follows that
-   cap rather than setting it. `overflow: hidden` is here for the rounded corners. */
+/* The chooser column: `.mem-navigator`'s chrome, filling the frame's second row. Head,
+   rows, the (usually absent) loading line and coverage foot stack; the rows are the one
+   member that flexes, so head and foot stay pinned to the card's own edges whatever the
+   window's height. `min-height: 0` is what lets the rows shrink below their content —
+   without it a flex item floors at max-content and the card grows past the frame
+   instead. `overflow: hidden` is here for the rounded corners. */
 .jd .sk-nav {
-	min-width: 0; overflow: hidden;
+	min-width: 0; overflow: hidden; min-height: 0;
 	border: 1px solid var(--border); border-radius: 12px; background: var(--surface);
 	box-shadow: 0 2px 5px rgba(20, 30, 50, .05); display: flex; flex-direction: column;
 }
@@ -1941,39 +2115,43 @@ body {
 	border-bottom: 1px solid var(--grid);
 }
 .jd .sk-nav-head b { color: var(--ink); font-weight: 600; }
-/* Every row — with no height and no scrollbar of its own until the reader pages past
-   the column's first screenful. `sk-scroll` and the inline `max-height` are written by
-   `listOpenTag` in skills.js, which records why the cap is measured rather than
-   declared and why the first page may not scroll.
+/* Every row, and THE PAGE'S ONE SCROLL REGION. It takes whatever height the frame has
+   left and scrolls inside it — unconditionally, where this used to become a scroller
+   only once the list outgrew the model's first page, at a MEASURED pixel cap written
+   inline by `listOpenTag`. Both the cap and the `sk-scroll` marker class are gone: the
+   flex chain now supplies the height, so there is no number for JS to measure and no
+   second state to mark.
  *
  * THE THIN BAR IS NOT DECORATION, and it is copied off `.ranklist.rl-scroll` so the
- * page's two scrollers read alike. macOS overlay bars are absent until a scroll is
- * already under way, so a capped region carrying only the platform's own bar is a
- * window with a hard bottom edge and nothing saying fifteen more rows sit below it —
- * and the reader has to know this region scrolls before the footnote at its end is
- * reachable at all. It hangs off `.sk-scroll` rather than off `.sk-list` because the
- * uncapped state has nothing to mark. */
-.jd .sk-list { min-width: 0; padding: 8px 14px; }
-.jd .sk-list.sk-scroll {
+ * dashboard's scrollers read alike. macOS overlay bars are absent until a scroll is
+ * already under way, so a region carrying only the platform's own bar is a window with a
+ * hard bottom edge and nothing saying fifteen more rows sit below it — and the reader has
+ * to know this region scrolls before the footnote at its end is reachable at all. It is
+ * on `.sk-list` itself now precisely because there is no longer an uncapped state for it
+ * to be absent in. */
+.jd .sk-list {
+	min-width: 0; min-height: 0; flex: 1; padding: 8px 14px;
 	overflow-y: auto;
 	scrollbar-width: thin; scrollbar-color: color-mix(in srgb, var(--muted) 42%, transparent) transparent;
 }
-.jd .sk-list.sk-scroll::-webkit-scrollbar { width: 10px; }
-.jd .sk-list.sk-scroll::-webkit-scrollbar-track { background: transparent; }
-.jd .sk-list.sk-scroll::-webkit-scrollbar-thumb {
+.jd .sk-list::-webkit-scrollbar { width: 10px; }
+.jd .sk-list::-webkit-scrollbar-track { background: transparent; }
+.jd .sk-list::-webkit-scrollbar-thumb {
 	background: color-mix(in srgb, var(--muted) 38%, transparent); border-radius: 999px;
 	border: 3px solid transparent; background-clip: padding-box;
 }
-.jd .sk-list.sk-scroll:hover::-webkit-scrollbar-thumb {
+.jd .sk-list:hover::-webkit-scrollbar-thumb {
 	background: color-mix(in srgb, var(--muted) 55%, transparent); background-clip: padding-box;
 }
-/* The paging row's own band, between the rows and the coverage foot — `flex: none` is
-   what holds it OUT of the rows' region, which is exactly where it may not be: from the
-   first Show more onwards that region is capped, so a control living inside it would be
-   reachable only by scrolling the very list it grows (see `navPagingHtml`). The head and
-   the coverage foot are out for the same reason; the region keeps only the rows and their
-   footnote. `.more-row`'s `margin-top` is dropped because this rule's own border and
-   padding already separate it from the last row. */
+/* The loading line's own band, between the rows and the coverage foot — normally ABSENT,
+   since it is written only while the tail of the list is in flight or has failed to
+   arrive (see `navPagingHtml`). `flex: none` is what holds it OUT of the rows' region,
+   which is exactly where it may not be: any column that can show this line is a capped
+   one, so a "some rows are missing" notice inside it would be reachable only by
+   scrolling the rows that are missing their tail. The head and the coverage foot are out
+   for the same reason; the region keeps only the rows and their footnote. `.more-row`'s
+   `margin-top` is dropped because this rule's own border and padding already separate it
+   from the last row. */
 .jd .sk-paging { flex: none; padding: 9px 20px; border-top: 1px solid var(--grid); }
 .jd .sk-paging .more-row { margin-top: 0; }
 /* `.w-foot` / `.w-measure` are reused verbatim; this only pins the row into the flex
@@ -2007,18 +2185,42 @@ body {
 .jd .sk-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; }
 .jd .sk-tok { font-size: 11.5px; color: var(--ink-2); }
 
-/* The reading pane, mirroring `.mem-detail` MINUS its scroll: recessed on `--page`
-   against the chooser's `--surface` so the two columns read as chooser and reader,
-   and as tall as the sections it holds so the page is what scrolls them. */
+/* The reading pane: recessed on `--page` against the chooser's `--surface` so the two
+   columns read as chooser and reader, filling the frame's second row beside the rows.
+ *
+ * `overflow-y: auto` IS A FALLBACK, NOT THE DESIGN — and it may not become `hidden`.
+ * Everything else (the band's height budget, the short-window budget, the compressions
+ * below, the two clamped prose blocks, the capped agent list) exists so this bar never
+ * appears, and measured it does not: every skill fits at 1440x900 and at 1280x800, the
+ * forced worst case included. It still CAN — a reader at 150% browser zoom, a window
+ * shorter than the budget was derived against, or a future section added to the pane.
+ * `hidden` there would silently cut the end off a section with nothing on screen saying
+ * so, which is strictly worse than a bar this page otherwise never shows. Opening one of
+ * the clamped paragraphs can also summon it, and that is correct: the reader asked for
+ * more text. */
+/* THE PADDING IS PART OF THE HEIGHT BUDGET, which is why it is tighter than a card's.
+   `clamp()` hands this pane a CONSTANT height — it is tuned so the chart absorbs every
+   spare pixel, so the pane gets `716 - 139 = 577px` at every window height in range — but
+   the pane's CONTENT height depends on the window's WIDTH, which that budget cannot see.
+   Narrower columns wrap more lines: the tallest skill measured 570px at 1440 wide and
+   579px at 1280. 577 clears the first and misses the second, which showed up as a 5px
+   overflow at 1280x817. Trimming 20/28 to 16/20 buys 12px and covers every width; the
+   alternative was raising the height constant, which would have cost EVERY window 22px of
+   chart to fix one width. */
 .jd .sk-pane {
-	min-width: 0;
-	border: 1px solid var(--border); border-radius: 10px; padding: 20px 24px 28px; background: var(--page);
+	min-width: 0; min-height: 0; overflow-y: auto;
+	border: 1px solid var(--border); border-radius: 10px; padding: 16px 24px 20px; background: var(--page);
 }
-/* Sections flow into as many columns as the pane's width affords. `auto-fit` against
-   a 300px floor rather than a fixed count, so one markup serves every width; the
-   identity row, the figures and the basis line span all columns because they are
-   about the whole skill rather than one reading of it. */
-.jd .sk-panebody { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 0 32px; align-items: start; }
+/* TWO COLUMNS, PINNED — not `repeat(auto-fit, minmax(300px, 1fr))`, which made the pane's
+   HEIGHT a function of its width in a way a fixed frame cannot absorb. The pane is 802px
+   at 1440 and 670px at 1280; against a 300px floor plus the 32px gap, the second track
+   drops out somewhere between them, and the same skill that needed 727px at 1440 needed
+   892px at 1280 (both measured). A frame sized for the two-column reading would then be
+   165px short for one viewport width — with nothing about the window's HEIGHT having
+   changed. Pinning trades ~6px of column width at 1280 for a height that only depends on
+   the content. The identity row, the figures, the caveat and the basis line still span
+   both because they are about the whole skill rather than one reading of it. */
+.jd .sk-panebody { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0 32px; align-items: start; }
 .jd .sk-panebody > .sk-title,
 .jd .sk-panebody > .sk-figs,
 .jd .sk-panebody > .sk-caveat,
@@ -2028,14 +2230,20 @@ body {
 .jd .sk-title { font-size: 14px; font-weight: 600; color: var(--ink); word-break: break-all; }
 .jd .sk-kind { display: inline-block; margin-left: 6px; font-size: 11px; color: var(--ink-2); font-weight: 400; }
 
-/* Two across, because four figures on one row at this width wrapped their labels. */
-.jd .sk-figs { display: grid; grid-template-columns: 1fr 1fr; gap: 10px 12px; margin-top: 12px; }
+/* Two across, because four figures on one row at this width wrapped their labels. The
+   gaps are tighter than a card's would be — see the section header: every vertical
+   measurement in this pane is spending the frame's fixed budget. */
+.jd .sk-figs { display: grid; grid-template-columns: 1fr 1fr; gap: 6px 12px; margin-top: 8px; }
 .jd .sk-fig b { display: block; font-size: 17px; font-weight: 600; color: var(--ink); line-height: 1.2; }
 .jd .sk-fig span { display: block; font-size: 11px; color: var(--ink-2); margin-top: 2px; }
 
-.jd .sk-sec { margin-top: 14px; padding-top: 12px; border-top: 1px solid var(--border); }
+/* Section chrome, tightened from 14/12/8 to 8/6/4. Five sections land on three grid rows,
+   so each 1px here is spent three times — the three together are 66px of the pane's
+   budget (measured), which is the single largest saving available inside this pane and
+   the reason the band's chart gets to stay as wide as it does. */
+.jd .sk-sec { margin-top: 8px; padding-top: 6px; border-top: 1px solid var(--border); }
 .jd .sk-sec h4 {
-	margin: 0 0 8px; font-size: 11px; font-weight: 600; letter-spacing: .04em;
+	margin: 0 0 4px; font-size: 11px; font-weight: 600; letter-spacing: .04em;
 	text-transform: uppercase; color: var(--ink-2);
 }
 .jd .sk-line { display: flex; align-items: center; gap: 8px; font-size: 12px; margin-top: 6px; }
@@ -2066,7 +2274,11 @@ body {
    BOTH charts read in `--accent` and neither may take an `--s*` colour: the ramp
    means agent two sections below, so a cadence chart in codex's orange would read as
    "codex's sessions". Same reasoning as the selected row's edge. */
-.jd .sk-daybars { display: block; width: 100%; height: 46px; margin-top: 2px; opacity: .85; }
+/* 32px, down from 46px. The two charts sit in the SAME grid row (cadence beside cost), so
+   this is 14px off the pane once, not twice — a small saving kept because the bars are
+   read for their shape rather than their absolute height, and `preserveAspectRatio="none"`
+   means a shorter box loses no bars and no labels. */
+.jd .sk-daybars { display: block; width: 100%; height: 32px; margin-top: 2px; opacity: .85; }
 .jd .sk-axis { display: flex; justify-content: space-between; margin-top: 4px; font-size: 10.5px; color: var(--muted); }
 
 /* Outcome ticks — one per recorded run, oldest left. TWO states, matching the mockup:
@@ -2084,11 +2296,40 @@ body {
    sentence explaining what a figure means is exactly the thing that must not lose
    its ending. */
 .jd .sk-note { margin-top: 6px; font-size: 11px; line-height: 1.5; color: var(--ink-2); }
-/* Small print naming where the figures came from, in the voice the cards use. */
+/* Small print naming where the figures came from, in the voice the cards use.
+ *
+ * TWO PRODUCERS SHARE THIS CLASS: the pane's basis line (`paneHtml`) and the column's `†`
+ * footnote (`inferredFootnoteHtml`), which sits at the end of the rows. So the tightened
+ * 8/6 above reaches both — wanted in the pane, where it is spending a fixed budget, and
+ * harmless in the column, which scrolls. Only the pane's copy is wrapped in `.sk-clamp`
+ * below, so the column's footnote is never collapsed and never becomes clickable. Scope
+ * any future rule that is genuinely pane-only to `.sk-panebody > .sk-basis`, which is
+ * where the grid span already lives. */
 .jd .sk-basis {
-	display: block; margin-top: 14px; padding-top: 12px; border-top: 1px solid var(--border);
+	display: block; margin-top: 8px; padding-top: 6px; border-top: 1px solid var(--border);
 	font-size: 11px; line-height: 1.5; color: var(--ink-2);
 }
+
+/* THE TWO LONG FIXED PARAGRAPHS, COLLAPSED TO ONE LINE. `.sk-caveat` and `.sk-basis` are
+   ~4 lines each and 82px of the pane's budget between them (measured) — the second largest
+   saving after the section chrome, and the cheapest, because these two are the only blocks
+   in the pane whose text is FIXED rather than a measurement. Clamping a data row would
+   destroy a count; clamping these hides a qualifier the reader can bring back with a click.
+   Chosen over a `title` tooltip on its own, which no touch device can reach.
+ *
+ * `-webkit-line-clamp` needs `display: -webkit-box`, so the open state has to restore
+ * `display: block` as well as releasing the clamp — dropping the clamp alone leaves the
+ * paragraph a one-line flex box. Both keywords are unprefixed-equivalent in every engine
+ * this dashboard runs in (it is a local page in the viewer's own browser).
+ *
+ * Opening one can push the pane past its frame and summon the fallback bar above. That is
+ * correct: the reader asked for more text, and the bar is a truthful response to it. */
+.jd .sk-clamp {
+	display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 1;
+	overflow: hidden; cursor: pointer;
+}
+.jd .sk-clamp[aria-expanded="true"] { display: block; -webkit-line-clamp: none; overflow: visible; }
+.jd .sk-clamp:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 3px; }
 /* A chip rather than more grey text: the plugin is the one identity fact on the row
    that is not a measurement. */
 .jd .sk-plugin {
@@ -2109,19 +2350,96 @@ body {
 	font-size: 11px; line-height: 1.5; color: var(--ink-2);
 }
 
+/* ── THE SHORT-WINDOW BUDGET ────────────────────────────────────────────────────────
+   Two rules that only make sense together: on a window this short the band's chart has
+   already bottomed out on its `clamp()` floor, so the last pixels the pane needs have to
+   come from somewhere that is not the chart. Both give up WHITESPACE, never a measurement
+   or a word.
+
+   THERE WERE THREE, AND THE THIRD IS NOW UNCONDITIONAL. Lying the key down was the
+   largest single saving here (14px, below); `.sk-key` caps its own height against the
+   plot's at every window size instead, so the key can no longer be what the band's height
+   is made of and there is nothing left for this breakpoint to reclaim from it. That rule
+   carries why a wrapping ROW became the wrong shape once the chart's width was freed.
+
+   IT MUST STAY BELOW ANY RULE IT OVERRIDES. A media query adds no specificity, so between
+   two `.jd .sk-band` rules source order is the only thing deciding the winner. Written
+   next to `.sk-key` — its most interesting member — this block sat ABOVE `.sk-pane`, and
+   the pane's padding silently did not apply while the band's did: the shape of bug that
+   looks like the whole block working.
+
+   816px WAS DERIVED, NOT PICKED, and it is worth keeping the derivation even though what
+   it was derived FOR has moved. The chart's height then reduced to `100vh - 712px` (its
+   `clamp()` slope was `2.773` = 660/238 and its height was width × 238/660 — exact
+   reciprocals). Stacked, the key is 104px, five rows plus its margin. Set the two equal
+   and the crossover is 816px: above it the chart was the taller of the pair and lying the
+   key down saved nothing, below it the KEY was what the band's height was made of. The
+   key's own cap now holds on both sides of that line, so this is no longer the crossover
+   of anything — it survives as the measured threshold for the two whitespace trims, which
+   were tuned against 1280x800 and are not needed above it.
+
+   A height media query, which this stylesheet has none of otherwise — and it has to be
+   one: the quantity being traded IS vertical space, and the same window at twice the
+   width has exactly the same problem.
+
+   MEASURED AT 1280x800, on the two skills that were overflowing the pane by 21px:
+     key lying down    band 154 → 140   (−14, and this was the whole of it — the key was
+                                         104 against the chart box's 90, so only the
+                                         difference was ever available. NOW UNCONDITIONAL
+                                         and larger: the key's cap is the plot's height,
+                                         so it gives back everything, not the difference)
+     band padding      band 140 → 134   (−6, 14/10 → 10/8)
+     wrap bottom       12px → 8px       (−4, the last 2px the pane was missing at 800)
+   …and the pane's own padding, now trimmed at every width (see `.sk-pane`), covers the
+   rest. Dropping the chart's floor to 220px was the other way to find those pixels and
+   was rejected: padding is whitespace, a narrower chart is less of the thing the band
+   exists to show.
+
+   The bottom gap narrows rather than disappearing: by this point the chart is already on
+   its floor, so the pixels have to come from somewhere, and 8px still reads as a gap
+   while 0 reads as a card welded to the window's edge. */
+@media (max-height: 816px) {
+	.jd .sk-band { padding: 10px 20px 8px; }
+	.jd .wrap:has(.skills-page) { padding-bottom: 8px; }
+}
+
 /* No wrap-padding overrides at either breakpoint: the wrap keeps its own 24px and
    its cap is already inert below 1200px, so there is nothing left to reclaim. */
 @media (max-width: 1180px) {
 	.jd .skills-page { grid-template-columns: 320px minmax(0, 1fr); }
 }
 @media (max-width: 899px) {
-	/* The columns stack — and the rows' cap comes off with them. A scroll region nested
-	   in a scrolling page is awkward under a mouse and worse under a thumb, and at this
-	   width there is no second column beside it for a short list to be keeping room for.
-	   `!important` is not a preference here: the cap is an inline style (a measured pixel
-	   value, which no stylesheet constant can stand in for), and nothing else outranks
-	   one. The rest of what this block used to release now describes the desktop layout
-	   too, so it is gone from both. */
-	.jd .skills-page { grid-template-columns: minmax(0, 1fr); }
-	.jd .sk-list.sk-scroll { max-height: none !important; overflow: visible; }
+	/* THE WHOLE FIXED FRAME COMES OFF HERE, not just the second column. Once the columns
+	   stack there is no frame worth holding: the two cards are above and below each other
+	   rather than side by side, so pinning them to a shared height would make the reader
+	   scroll INSIDE a card to reach content that has the whole page below it. A scroll
+	   region nested in a scrolling page is awkward under a mouse and worse under a thumb,
+	   and at this width there is no second column beside the list for a short one to be
+	   keeping room for. So every rule the desktop frame installs is reversed and the page
+	   scrolls again, which is also what the `.main` bottom padding is back for.
+	 *
+	 * `.sk-list`'s cap needs no `!important` any more: it used to be an inline pixel value
+	   written by `listOpenTag`, which nothing but `!important` outranks, and the flex chain
+	   replaced it with a stylesheet rule this block can simply override. */
+	.jd:has(.skills-page) { height: auto; overflow: visible; }
+	.jd .main:has(.skills-page) { display: block; height: auto; padding-bottom: 48px; }
+	.jd .wrap:has(.skills-page) { display: block; flex: none; }
+	.jd #app:has(.skills-page) { display: block; flex: none; }
+	.jd .skills-page {
+		grid-template-columns: minmax(0, 1fr); grid-template-rows: none;
+		flex: none; align-items: start;
+	}
+	.jd .sk-nav { min-height: 0; }
+	.jd .sk-list { flex: none; min-height: 0; overflow: visible; }
+	.jd .sk-pane { overflow: visible; }
+	/* One column inside the pane too — two 300px-floor tracks cannot fit a stacked pane
+	   at this width, and the pinned pair above would otherwise force a horizontal scroll. */
+	.jd .sk-panebody { grid-template-columns: minmax(0, 1fr); }
+	/* The band's chart is sized from the window's HEIGHT above, which is a budget that only
+	   means something inside the frame. With the page scrolling again there is nothing left
+	   to save those pixels for, so the plot takes one flat readable height instead of a
+	   share of a viewport it no longer competes for. (This rule used to restore the chart's
+	   WIDTH, which the frame had to borrow; width is unconstrained at every breakpoint now,
+	   so height is all that is left to hand back.) */
+	.jd .sk-band { --sk-band-plot-h: 180px; }
 }


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Context (3)

- Search
- Recall
- Skills used — 4 skills · some inferred

## Quick recap

The Skills page in the dashboard no longer requires clicking a "Show more" button to see additional skills — the full list now loads automatically as soon as the page opens. The chooser panel keeps its own internal scroll, sized to the height of the first screenful; a large skill list stays contained inside the panel instead of stretching past the page. When a reader arrives at the Skills page from another part of the dashboard with a specific skill already selected, or clicks a skill in the summary chart's legend, the list now scrolls that skill into view and centers it, accounting for cases where the panel itself is partially cut off by the browser window.

Before merging this branch, the developer reviewed the uncommitted changes and found two correctness issues in the new full-list loading logic. A failed load previously had no way to recover: the Skills page does not participate in the dashboard's regular refresh cycle, and a single network hiccup could leave the list permanently stuck showing only a partial set of skills with no way for a reader to retry. The list-loading logic could also silently under-report the total skill count when rankings shifted mid-load, hiding a skill rather than surfacing an error. Both issues were fixed: failed loads now retry automatically on a short timer scoped to this page, and a detected shift in rankings now triggers a clean restart of the read, keeping the reported count accurate.

---

## Topics (3)
<details>
<summary><strong>01 · Skills page loads full list automatically instead of requiring Show more clicks</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The user wanted the dashboard's Skills page to stop requiring clicks on a "Show more" button and instead display the entire skill list right away.

**💡 Decisions Behind the Code**

- **Keep the panel-internal scroll instead of removing height limits entirely**: the user explicitly asked to preserve the existing scrollable panel behavior, just without requiring a click to fill it, so the height-capping logic was kept and simply triggered earlier (on page load instead of on click).
- **Key "already loaded" state off the data payload, not a render counter**: a render event (clicking a skill to open its details) and a data refresh event look identical to a counter-based check, but only a real data refresh should restart the full-list fetch — using the payload as the identity check avoids re-fetching on every click while still correctly restarting on genuine refreshes.

**✅ What Was Implemented**

- Removed the "Show more" button and its click handler from `skills.js`; the page now automatically fetches the remainder of the skill list right after the first screenful renders, with no user action required.
- Kept the chooser panel's own scroll region, capped at the height measured from the first page of rows, so a long list stays contained inside the panel instead of growing past the page fold.
- Fixed a related bug where opening a skill's detail pane (which triggers a re-render and increments an internal render counter) would incorrectly invalidate the in-flight full-list fetch; without the old button there was no way to retry, so the list would get permanently stuck at 8 rows. The staleness check was moved to key off the data payload itself rather than the render counter.
- Changed the underlying pagination loop's stopping condition from "read enough rows for the caller" to "read until the server's read position reaches its own reported total," preventing silent row loss if the total grows while a read is in progress.

**📁 FILES**
- `cli/src/dashboard/assets/js/skills.js`
- `cli/src/dashboard/DashboardServer.ts`
- `cli/src/dashboard/assets/styles/main.css`

</blockquote>
</details>
<details>
<summary><strong>02 · Auto-scroll selected skill row into view when navigating from other dashboard views</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The user noticed that clicking a skill elsewhere in the dashboard and landing on the Skills page correctly opened that skill's details, but the list on the left stayed scrolled to the top, leaving the highlighted row invisible.

**💡 Decisions Behind the Code**

- **Two-layer visibility check instead of checking only the panel's internal scroll**: measurements showed the panel's bottom edge can sit outside the browser's visible window even when a row looks "visible" within the panel's own scroll area, so both layers needed checking to actually guarantee visibility.
- **Skip scrolling rows that are already visible, unlike the Memories page's unconditional centering**: clicking a row in this list is the most common action and the clicked row is already on screen, so unconditionally re-centering it would visually yank the list out from under the reader's cursor for no benefit.

**✅ What Was Implemented**

- Added logic that scrolls the selected skill's row into view and centers it, following the same pattern already used on the Memories page, whenever the selection changes and the row isn't already visible.
- Built a two-layer visibility check: one for whether the row is inside the panel's own scrollable area, and a second for whether the panel itself is cut off by the browser window (the chart above the panel can push its lower portion out of the visible viewport even when the panel's internal scroll looks fine).
- Made the reveal happen exactly once per selection — not on every automatic repaint — so background refreshes don't yank a reader's attention back to the selected row while they're browsing elsewhere in the list, and made it skip rows that were already visible (e.g., a row the reader just clicked directly).
- Delayed recording "already revealed" until the target row actually exists in the rendered list, since a selection can point at a skill still in the tail of the list that hasn't finished loading yet.

**📁 FILES**
- `cli/src/dashboard/assets/js/skills.js`

</blockquote>
</details>
<details>
<summary><strong>03 · Fix unrecoverable failure state and silent row loss in Skills list loading</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A self-review of the branch before merging found two problems: if the automatic full-list fetch failed there was no way to retry it, and if skill rankings shifted while the list was loading, some skills could be silently dropped from the count.

**💡 Decisions Behind the Code**

- **Dedicated per-page retry timer instead of joining the global refresh cycle**: the Skills page deliberately doesn't participate in the dashboard-wide polling used by "My Dashboard," because that would also re-fetch and re-render the open skill detail pane on every cycle; a scoped timer retries just the list without that side effect.
- **Restart the read on detected rank drift instead of accepting a partial result**: shrinking the reported skill count to match what was successfully fetched would silently hide a real skill from the reader, which was judged worse than the cost of a couple of extra network requests to re-read the list correctly.
- **Keep an absolute request cap even after removing the fixed page-count limit**: the primary stopping condition is now based on catching up to the server's reported total, but a hard cap remains as a safety net against a corrupted or adversarial server response where the total keeps growing faster than it can be read.

**✅ What Was Implemented**

- Added a dedicated 30-second retry timer for the Skills page's list-tail fetch, separate from the dashboard's global refresh cycle (which only applies to the "My Dashboard" view), so a failed load retries automatically without requiring a manual page refresh.
- Made the timer payload-aware: it cancels itself once a new data payload takes over, preventing a stale retry from overwriting fresh results.
- Changed the pagination logic to detect when a row appears twice across page boundaries (a sign that skill rankings shifted mid-read) and restart the read from the beginning rather than shrinking the reported total to hide the missing row.
- Replaced a fixed 25-request safety ceiling with a scaled request budget plus an absolute backstop, so very large skill lists (tested up to 5,000+ skills) can still load completely while a runaway or malformed response stream is still bounded.

**📁 FILES**
- `cli/src/dashboard/assets/js/skills.js`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 21, 2026 at 1:35 PM · via Local agent - Claude Code*
<!-- jollimemory-summary-end -->