### PR TITLE
release: intellij 0.99.14

### DIFF
--- a/intellij/CHANGELOG.md
+++ b/intellij/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.99.14
+
+### Fixes & Improvements
+
+- Bug fixes.
+
+### Performance
+
+- Performance improvements.
+
 ## 0.99.13
 
 ### Changes

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = "ai.jolli"
-version = "0.99.13"
+version = "0.99.14"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## Summary

Bumps the IntelliJ plugin to 0.99.14 so it lines up with the CLI and the VS Code extension, which are both already at 0.99.14, and adds the matching CHANGELOG entry.

## Motivation

The IntelliJ plugin was left behind at 0.99.13 while `cli/package.json` and `vscode/package.json` moved to 0.99.14. This release carries no IntelliJ feature work of its own — it is a version alignment, so the change notes record bug fixes and performance improvements only rather than restating the VS Code feature list.

## Changes

- `intellij/build.gradle.kts` — `version` 0.99.13 → 0.99.14. `patchPluginXml` reads `project.version`, so no other version file needs touching.
- `intellij/CHANGELOG.md` — new `## 0.99.14` section with `### Fixes & Improvements` and `### Performance`. Header shape and group names match the existing entries, so the `org.jetbrains.changelog` config (bare `## <version>` header, `groups = emptyList()`) renders it into the marketplace change notes unchanged.

The remaining `0.99.13` strings in `intellij/` are historical references inside code comments (`RepoProfileBridge.kt` documenting the 0.99.11–0.99.13 `userDisabled` split) and were deliberately left alone.

## Testing

Not run. The change is a version constant and a Markdown section; the root `npm run all` chain does not cover `intellij/` at all, and no Kotlin source was touched.

- [ ] Added/updated unit tests
- [ ] Ran `./gradlew test` locally
- [ ] Tested in sandbox IDE via `./gradlew runIde`
- [ ] Tested on:

## Checklist

- [x] Code follows the existing style
- [x] Documentation updated (README / CHANGELOG) if user-facing