### PR TITLE
Add MCP usage details to the dashboard

### DIFF
--- a/claude-plugin/scripts/_publish-lib.sh
+++ b/claude-plugin/scripts/_publish-lib.sh
@@ -46,6 +46,7 @@ PUBLISH_REQUIRED_DIST=(
 	dashboard-assets/js/shell.js
 	dashboard-assets/js/stats.js
 	dashboard-assets/js/skills.js
+	dashboard-assets/js/mcps.js
 	dashboard-assets/js/standup.js
 	dashboard-assets/js/memories.js
 	dashboard-assets/js/journeys.js

--- a/cli/src/dashboard/DashboardModel.ts
+++ b/cli/src/dashboard/DashboardModel.ts
@@ -407,6 +407,7 @@ export type DashboardView =
 	| "stats"
 	| "standup"
 	| "skills"
+	| "mcps"
 	| "journeys"
 	| "memories"
 	| "knowledge"
@@ -1923,6 +1924,153 @@ export interface SkillDetail {
 	readonly bodyChars?: number;
 }
 
+/** One tool of a server, over the window — a row of the detail view's tool list. */
+export interface McpServerToolRow {
+	/**
+	 * The tool's own name, with the server segment ALREADY STRIPPED — `execute_sql`,
+	 * not `dbhub.execute_sql`.
+	 *
+	 * Stripped here rather than in the client because the split is a property of how
+	 * `parseToolUse` wrote the row (`<server>.<tool>`, and the server half may itself
+	 * carry a host's `plugin_…` registration prefix), which is this layer's knowledge.
+	 * A client slicing at the first `.` would be doing schema archaeology, and would be
+	 * wrong for a server whose own name contains one.
+	 */
+	readonly name: string;
+	/** Calls of this tool in the window. */
+	readonly calls: number;
+	/**
+	 * Distinct sessions that called it — EXACT for this row, and deliberately not
+	 * summable across rows. A session that called three of a server's tools counts in
+	 * all three, so these do not add up to {@link McpServerDetail.sessions}; a surface
+	 * printing them must not total the column.
+	 */
+	readonly sessions: number;
+}
+
+/** One local calendar day of a server's detail charts. */
+export interface McpServerDayPoint {
+	/** The local calendar day, `YYYY-MM-DD`. */
+	readonly date: string;
+	/** Distinct sessions whose last recorded call to this server falls on this day. */
+	readonly sessions: number;
+	/** Calls made by those sessions, summed over the server's tools. */
+	readonly calls: number;
+}
+
+/** One session's whole traffic to a server, oldest first. */
+export interface McpServerSessionPoint {
+	/** Epoch-ms of the session's LAST recorded call to this server (a floor for its first). */
+	readonly atMs: number;
+	/** Sum of calls that session made across this server's tools. */
+	readonly calls: number;
+}
+
+/**
+ * Everything the MCP detail view shows — the answer to `/api/mcp-detail`.
+ *
+ * Scoped to the same window and repo selection as the row it was opened from, so the
+ * figures here agree with the list beside it. Modelled on {@link SkillDetail}, and the
+ * differences are the record's rather than the page's:
+ *
+ *   - **No outcomes, no entry paths, no arguments and no token figures.** `skill_invocations`
+ *     gives a skill a per-invocation record; MCP has no such table, so a call's result,
+ *     its arguments and its cost are not merely unrendered here — they were never
+ *     written. The page says so in words rather than drawing an empty section.
+ *   - **No commit list.** A skill's usage is archived onto a commit as `SkillCommitRef`;
+ *     an MCP call is not archived anywhere, so there is nothing to join.
+ *   - **{@link tools} exists instead**, which a skill has no counterpart for: a server is
+ *     a namespace of tools, and which of them the reader actually reaches for is the
+ *     question this page is opened to answer.
+ *
+ * Absent when the window holds no call to that server, which the route turns into a 404.
+ */
+export interface McpServerDetail {
+	/** The folded server name, as {@link McpServerRow.server} spells it. */
+	readonly server: string;
+	/** Distinct sessions that called ANY of its tools — exact, not a bound. */
+	readonly sessions: number;
+	readonly calls: number;
+	/** Distinct tools of this server actually called — the length {@link tools} would have uncapped. */
+	readonly toolCount: number;
+	/**
+	 * Its tools, busiest first, capped at {@link MCP_DETAIL_TOOL_LIMIT}.
+	 *
+	 * {@link toolCount} is the honest total and travels beside it, so a capped list can
+	 * say what it is not showing. Ranked by calls, matching the row the reader clicked
+	 * (`TOOL_LIST_ORDER.server`), so "busiest" means the same thing in both columns.
+	 */
+	readonly tools: ReadonlyArray<McpServerToolRow>;
+	/** Which agents called it, most calls first — same shape and rule as {@link McpServerRow.agents}. */
+	readonly agents: ReadonlyArray<ToolUsageAgentShare>;
+	/**
+	 * One point per LOCAL DAY in the window, oldest first — what BOTH charts read.
+	 *
+	 * Empty days are present with zeroes, so neither chart compresses a quiet gap. The
+	 * window itself is capped at 366 days, which bounds this payload without dropping
+	 * older sessions and silently changing the shape of a busy server's trend.
+	 *
+	 * A session is filed under the local day of its LAST recorded call to this server,
+	 * matching {@link ToolUsage.serverDays}; `session_tool_use` has no per-call MCP table
+	 * from which a finer split could be reconstructed.
+	 */
+	readonly daySeries: ReadonlyArray<McpServerDayPoint>;
+	/**
+	 * One point per SESSION that called this server in the window, oldest first within
+	 * the retained recent set — what the "Calls per session" chart draws.
+	 *
+	 * The X axis is session index in arrival order, not a time axis: the record holds one
+	 * instant per (session, tool) and it is the last call, so an even-time-spacing chart
+	 * would misrepresent the record. `atMs` rides along so tooltips and the two axis
+	 * endpoints can name the sessions by date. `calls` is the sum over this server's
+	 * tools within one session, matching how {@link daySeries} sums a day. This series
+	 * is capped at 400 points; {@link sessions} and {@link daySeries} remain exact.
+	 */
+	readonly sessionSeries: ReadonlyArray<McpServerSessionPoint>;
+	/**
+	 * Earliest call recorded in the window — a FLOOR, not the first call.
+	 *
+	 * `session_tool_use` stores one instant per (session, tool) and it is the LAST call,
+	 * so the earliest such instant is "the last call of the earliest session", which is
+	 * at or after the true first call. Measured on a real database, the two agree at day
+	 * resolution for 140 of 141 (session, server) pairs — the spread inside one pair
+	 * averages 8.7 minutes — so a date is a fair thing to print while a time would not
+	 * be. Nothing can be backfilled to improve it: adding a `first_call_at_ms` column
+	 * would only sharpen rows written after it shipped.
+	 */
+	readonly firstCallAtMs?: number;
+	/** Latest call recorded in the window. Exact, unlike {@link firstCallAtMs}. */
+	readonly lastCallAtMs?: number;
+	/**
+	 * Repositories it was called in, by name, alphabetically.
+	 *
+	 * From the SESSIONS, the only place it could come from — an MCP call is never
+	 * archived onto a commit, so there is no second answer to reconcile with.
+	 */
+	readonly repos: ReadonlyArray<string>;
+}
+
+/**
+ * Tools listed in one server's detail view.
+ *
+ * A HEIGHT BUDGET, not a paging decision — this list is the MCP pane's one section
+ * whose length is a property of the SERVER rather than of the record's own ceilings, so
+ * it is what decides whether the pane fits its fixed frame (`main.css`'s browser-page
+ * block owns that frame and the 579px the pane gets at 1440x900).
+ *
+ * MEASURED, at that viewport: a tool row is 14.5px plus a 6px gap, the rest of the pane
+ * comes to 343px, and the truncation note below the list costs another 20px. So 10 rows
+ * plus the note is 569px and clears the budget, while the 12 rows a real
+ * `chrome-devtools` registration produced came to 589px and summoned the pane's fallback
+ * scrollbar — which `.sk-pane` documents as a fallback rather than the design.
+ *
+ * Re-derive it the same way if the pane grows a section: stub the widest server, then
+ * raise this until `.sk-pane`'s `scrollHeight` exceeds its `clientHeight`, and step back
+ * one. Raising it without measuring trades a section the reader can see for a scrollbar
+ * they have to discover.
+ */
+export const MCP_DETAIL_TOOL_LIMIT = 10;
+
 /**
  * How many rows ONE PAGE of a skill / server / MCP-tool list carries.
  *
@@ -2117,12 +2265,45 @@ export interface ToolUsage {
 	/** Every MCP call in the window that carries a server, including rows past the first page. */
 	readonly serverCallsTotal: number;
 	/**
+	 * Day-by-day adoption for the MCPs page's stacked band, oldest first — the
+	 * server-side twin of {@link skillDays}, and the same shape for the same reason.
+	 *
+	 * Every rule stated on `skillDays` holds here unchanged: one point per LOCAL day of
+	 * the window including days nothing ran (the chart lays bars out by index, so a
+	 * dropped day compresses the axis), every server in the window rather than
+	 * {@link servers}' first page, and the unit is a SERVER-SESSION — a session that
+	 * called two servers counts once in each series, so a bar's total is not distinct
+	 * sessions.
+	 *
+	 * **The series key is the FOLDED server name**, the same one {@link McpServerRow.server}
+	 * carries, so a server reached under both a bare and a plugin-prefixed registration is
+	 * one series here and one row there. Keyed any other way the band would draw two
+	 * series the list below it presents as one.
+	 *
+	 * A session is filed under ONE day — the day of its last recorded call to that server,
+	 * since `session_tool_use` keeps a single timestamp per (session, tool). Measured on a
+	 * real database: 1 of 141 (session, server) pairs spanned more than one local day, so
+	 * the cost here is smaller than the 5-of-68 `skillDays` records. There is no per-call
+	 * table for MCP the way `skill_invocations` is one for skills, so this is not a choice
+	 * between two grains — it is the only grain the record holds.
+	 */
+	readonly serverDays: ReadonlyArray<SkillDayPoint>;
+	/**
 	 * Individual MCP tools (name already `server.tool`), busiest first — the "by
 	 * tool" split of `servers`, same rule, and ONE PAGE like the other two.
 	 */
 	readonly mcpTools: ReadonlyArray<ToolUsageRow>;
 	/** Distinct MCP tools called in the window — the paging total behind `mcpTools`. */
 	readonly mcpToolsTotal: number;
+	/**
+	 * Distinct MCP tools that belong to a named server — the whole-window total shown
+	 * on the MCPs page beside {@link serversTotal}.
+	 *
+	 * Kept separate from {@link mcpToolsTotal}: the general "by tool" list also admits
+	 * legacy MCP rows whose `server` is null, while the MCPs page's server chooser and
+	 * its headline deliberately do not.
+	 */
+	readonly serverToolsTotal: number;
 	/**
 	 * The recall feature's own row (`jollimemory.recall`), from its OWN query
 	 * rather than out of `mcpTools` — recall can rank outside the first page of

--- a/cli/src/dashboard/DashboardQuery.test.ts
+++ b/cli/src/dashboard/DashboardQuery.test.ts
@@ -23,13 +23,14 @@ import type {
 	StatsModel,
 	ToolUsageRow,
 } from "./DashboardModel.js";
-import { MEMORY_CARDS_LIMIT, TOOL_ROWS_LIMIT } from "./DashboardModel.js";
+import { MCP_DETAIL_TOOL_LIMIT, MEMORY_CARDS_LIMIT, TOOL_ROWS_LIMIT } from "./DashboardModel.js";
 
 /** UTC+8, no DST — the zone the day-boundary cases below contrast with UTC. */
 const SH = "Asia/Shanghai";
 
 import {
 	buildDashboardModel,
+	buildMcpServerDetail,
 	buildSkillDetail,
 	buildToolUsagePage,
 	type QueryOptions,
@@ -2936,6 +2937,438 @@ describe("buildDashboardModel — skill adoption band (skillDays)", () => {
 			{ date: "2026-07-29", bySeries: {} },
 			{ date: "2026-07-30", bySeries: {} },
 		]);
+	});
+});
+
+/**
+ * The MCPs page's band — `skillDays`' twin, through the same `buildDayPoints`.
+ *
+ * Only what DIFFERS from the skills band is tested here; everything the two share
+ * (local-day bucketing, a point per day of the window, the DST cursor) is covered
+ * above and cannot diverge, because there is one implementation.
+ */
+describe("buildDashboardModel — MCP adoption band (serverDays)", () => {
+	let dir: string;
+	let dbPath: string;
+	const nowMs = Date.parse("2026-07-30T12:00:00Z");
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "jolli-mcpband-"));
+		dbPath = join(dir, "dashboard.db");
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	const repoEvent: StatsEventEnvelope = {
+		producerKind: "cli",
+		event: {
+			type: "repo.enabled",
+			repoIdentity: "repo-1",
+			repoName: "jolli",
+			worktreeRoot: "/w",
+			enabledAt: "t",
+		},
+	};
+
+	const sessionAt = (
+		sessionId: string,
+		callAtMs: number,
+		tools: ReadonlyArray<{ server: string; tool: string }>,
+	): StatsEventEnvelope => ({
+		producerKind: "cli",
+		event: {
+			type: "session.upserted",
+			repoIdentity: "repo-1",
+			source: "claude",
+			sessionId,
+			updatedAtMs: nowMs - 3_600_000,
+			tools: tools.map((t) => ({
+				name: `${t.server}.${t.tool}`,
+				kind: "mcp" as const,
+				server: t.server,
+				calls: 1,
+				lastCallAtMs: callAtMs,
+			})),
+		},
+	});
+
+	const band = async (customFrom: string, customTo: string) =>
+		(
+			await withDashboardDb(
+				(db) =>
+					buildDashboardModel(db, {
+						view: "mcps",
+						scope: { kind: "all" },
+						timeZone: "UTC",
+						nowMs,
+						range: "custom",
+						customFrom,
+						customTo,
+					}),
+				{ dbPath },
+			)
+		).stats?.toolUsage?.serverDays;
+
+	/**
+	 * The one rule the skills band does not need, because a skill has one row per
+	 * session and a SERVER has one per tool it was reached through.
+	 */
+	it("counts a session once per server however many of its tools it called", async () => {
+		await applySummaryEvents(
+			[
+				repoEvent,
+				sessionAt("s1", Date.parse("2026-07-29T10:00:00Z"), [
+					{ server: "linear", tool: "list_issues" },
+					{ server: "linear", tool: "get_issue" },
+					{ server: "linear", tool: "comment" },
+					{ server: "github", tool: "list_prs" },
+				]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		// Three rows for linear, one session. Counting rows would say 3.
+		expect(await band("2026-07-29", "2026-07-29")).toEqual([
+			{ date: "2026-07-29", bySeries: { linear: 1, github: 1 } },
+		]);
+	});
+
+	it("keys the series by the FOLDED server, so the band and the list agree", async () => {
+		await applySummaryEvents(
+			[
+				repoEvent,
+				sessionAt("s1", Date.parse("2026-07-29T10:00:00Z"), [{ server: "jollimemory", tool: "recall" }]),
+				sessionAt("s2", Date.parse("2026-07-29T11:00:00Z"), [
+					{ server: "plugin_jolli_jollimemory", tool: "recall" },
+				]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		// ONE series, not two. Keyed on `t.server` the band would draw a bar the
+		// chooser column below it has no row for.
+		expect(await band("2026-07-29", "2026-07-29")).toEqual([{ date: "2026-07-29", bySeries: { jollimemory: 2 } }]);
+	});
+
+	it("leaves out an MCP row that carries no server", async () => {
+		await applySummaryEvents(
+			[
+				repoEvent,
+				{
+					producerKind: "cli",
+					event: {
+						type: "session.upserted",
+						repoIdentity: "repo-1",
+						source: "claude",
+						sessionId: "s1",
+						updatedAtMs: nowMs - 3_600_000,
+						tools: [
+							{ name: "linear.list_issues", kind: "mcp", server: "linear", calls: 1 },
+							// No `server`: the server list's own WHERE drops it, so the band must too.
+							{ name: "mystery", kind: "mcp", calls: 4 },
+						],
+					},
+				},
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		const model = await withDashboardDb(
+			(db) => buildDashboardModel(db, { view: "mcps", scope: { kind: "all" }, timeZone: "UTC", nowMs }),
+			{ dbPath },
+		);
+		const keys = (model.stats?.toolUsage?.serverDays ?? []).flatMap((point) => Object.keys(point.bySeries));
+		expect([...new Set(keys)]).toEqual(["linear"]);
+		expect(model.stats?.toolUsage?.serversTotal).toBe(1);
+		// The general MCP-tool list keeps the serverless legacy row; the MCP page's
+		// headline counts only tools belonging to one of the servers it can list.
+		expect(model.stats?.toolUsage?.mcpToolsTotal).toBe(2);
+		expect(model.stats?.toolUsage?.serverToolsTotal).toBe(1);
+	});
+
+	it("returns a point per day even with no MCP rows at all", async () => {
+		await applySummaryEvents([repoEvent], { producerKind: "cli", dbPath });
+		expect(await band("2026-07-29", "2026-07-30")).toEqual([
+			{ date: "2026-07-29", bySeries: {} },
+			{ date: "2026-07-30", bySeries: {} },
+		]);
+	});
+});
+
+describe("buildMcpServerDetail", () => {
+	let dir: string;
+	let dbPath: string;
+	const nowMs = Date.parse("2026-07-30T12:00:00Z");
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "jolli-mcpdetail-"));
+		dbPath = join(dir, "dashboard.db");
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	const repoEvent = (repoIdentity: string, repoName: string): StatsEventEnvelope => ({
+		producerKind: "cli",
+		event: { type: "repo.enabled", repoIdentity, repoName, worktreeRoot: `/w/${repoName}`, enabledAt: "t" },
+	});
+
+	const session = (
+		sessionId: string,
+		tools: ReadonlyArray<{ name: string; server: string; calls: number; atMs: number }>,
+		options: { source?: "claude" | "codex"; repoIdentity?: string } = {},
+	): StatsEventEnvelope => ({
+		producerKind: "cli",
+		event: {
+			type: "session.upserted",
+			repoIdentity: options.repoIdentity ?? "repo-1",
+			source: options.source ?? "claude",
+			sessionId,
+			updatedAtMs: nowMs - 3_600_000,
+			tools: tools.map((t) => ({
+				name: t.name,
+				kind: "mcp" as const,
+				server: t.server,
+				calls: t.calls,
+				lastCallAtMs: t.atMs,
+			})),
+		},
+	});
+
+	const detail = async (server: string) =>
+		await withDashboardDb(
+			(db) => buildMcpServerDetail(db, { scope: { kind: "all" }, server, timeZone: "UTC", nowMs }),
+			{ dbPath },
+		);
+
+	it("rolls one server up across its tools, sessions, agents and repos", async () => {
+		await applySummaryEvents(
+			[
+				repoEvent("repo-1", "jolli"),
+				repoEvent("repo-2", "course"),
+				session("s1", [
+					{
+						name: "linear.list_issues",
+						server: "linear",
+						calls: 5,
+						atMs: Date.parse("2026-07-28T09:00:00Z"),
+					},
+					{ name: "linear.get_issue", server: "linear", calls: 2, atMs: Date.parse("2026-07-28T10:00:00Z") },
+				]),
+				session(
+					"s2",
+					[
+						{
+							name: "linear.list_issues",
+							server: "linear",
+							calls: 3,
+							atMs: Date.parse("2026-07-29T09:00:00Z"),
+						},
+					],
+					{ source: "codex", repoIdentity: "repo-2" },
+				),
+				// A different server must not leak into any of the four groupings.
+				session("s3", [
+					{ name: "github.list_prs", server: "github", calls: 99, atMs: Date.parse("2026-07-29T09:00:00Z") },
+				]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+
+		const got = await detail("linear");
+		expect(got).toMatchObject({
+			server: "linear",
+			calls: 10,
+			// TWO sessions, not the three tool rows behind them.
+			sessions: 2,
+			toolCount: 2,
+			// The tool name has the server segment stripped; ranked by calls.
+			tools: [
+				{ name: "list_issues", calls: 8, sessions: 2 },
+				{ name: "get_issue", calls: 2, sessions: 1 },
+			],
+			agents: [
+				{ source: "claude", calls: 7 },
+				{ source: "codex", calls: 3 },
+			],
+			// Alphabetical, and from the SESSIONS — an MCP call is archived onto no commit.
+			repos: ["course", "jolli"],
+			firstCallAtMs: Date.parse("2026-07-28T09:00:00Z"),
+			lastCallAtMs: Date.parse("2026-07-29T09:00:00Z"),
+		});
+		// One point per WINDOW DAY, including quiet days. The first session lands on
+		// Jul 28 because its LAST tool call was at 10:00, and both of its tools sum to 7.
+		expect(got?.daySeries.filter((point) => point.sessions > 0 || point.calls > 0)).toEqual([
+			{ date: "2026-07-28", sessions: 1, calls: 7 },
+			{ date: "2026-07-29", sessions: 1, calls: 3 },
+		]);
+		expect(got?.daySeries).toHaveLength(30);
+	});
+
+	it("keeps every session in a busy server's daily trend instead of truncating the oldest one", async () => {
+		const sessions = Array.from({ length: 401 }, (_unused, index) => {
+			const date = index < 201 ? "2026-07-28" : "2026-07-29";
+			return session(`busy-${index}`, [
+				{
+					name: "busy.call",
+					server: "busy",
+					calls: 1,
+					atMs: Date.parse(`${date}T09:00:00Z`) + index,
+				},
+			]);
+		});
+		await applySummaryEvents([repoEvent("repo-1", "jolli"), ...sessions], { producerKind: "cli", dbPath });
+
+		const got = await detail("busy");
+		expect(got).toMatchObject({ sessions: 401, calls: 401 });
+		expect(got?.daySeries.filter((point) => point.sessions > 0 || point.calls > 0)).toEqual([
+			{ date: "2026-07-28", sessions: 201, calls: 201 },
+			{ date: "2026-07-29", sessions: 200, calls: 200 },
+		]);
+		expect(got?.daySeries.reduce((sum, point) => sum + point.sessions, 0)).toBe(401);
+		expect(got?.daySeries.reduce((sum, point) => sum + point.calls, 0)).toBe(401);
+		expect(got?.sessionSeries).toHaveLength(400);
+		expect(got?.sessionSeries[0]?.atMs).toBe(Date.parse("2026-07-28T09:00:00Z") + 1);
+		expect(got?.sessionSeries.at(-1)?.atMs).toBe(Date.parse("2026-07-29T09:00:00Z") + 400);
+	});
+
+	/**
+	 * The tool session counts are per row and do not re-sum, which is what the pane
+	 * prints them without a total for.
+	 */
+	it("counts each tool's sessions independently of the server's own total", async () => {
+		await applySummaryEvents(
+			[
+				repoEvent("repo-1", "jolli"),
+				session("s1", [
+					{ name: "dbhub.query", server: "dbhub", calls: 1, atMs: Date.parse("2026-07-29T09:00:00Z") },
+					{ name: "dbhub.search", server: "dbhub", calls: 1, atMs: Date.parse("2026-07-29T09:00:00Z") },
+				]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		const got = await detail("dbhub");
+		expect(got?.sessions).toBe(1);
+		// 1 + 1 = 2 ≠ 1. Both rows are right; the column is read row by row.
+		expect(got?.tools.map((t) => t.sessions)).toEqual([1, 1]);
+	});
+
+	it("matches the FOLDED server name and strips the folded prefix off its tools", async () => {
+		await applySummaryEvents(
+			[
+				repoEvent("repo-1", "jolli"),
+				session("s1", [
+					{
+						name: "jollimemory.recall",
+						server: "jollimemory",
+						calls: 4,
+						atMs: Date.parse("2026-07-29T09:00:00Z"),
+					},
+				]),
+				session("s2", [
+					{
+						name: "plugin_jolli_jollimemory.recall",
+						server: "plugin_jolli_jollimemory",
+						calls: 6,
+						atMs: Date.parse("2026-07-29T10:00:00Z"),
+					},
+				]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		// The list row spells the folded name, so that is what the pane is opened with.
+		// A `t.server = ?` match would 404 on it.
+		const got = await detail("jollimemory");
+		expect(got).toMatchObject({
+			server: "jollimemory",
+			calls: 10,
+			sessions: 2,
+			// One tool, not two: the stored name embeds the server, so both spellings fold.
+			toolCount: 1,
+			tools: [{ name: "recall", calls: 10, sessions: 2 }],
+		});
+		// And the raw spelling is not separately readable — it is not a server.
+		expect(await detail("plugin_jolli_jollimemory")).toBeUndefined();
+	});
+
+	it("caps the tool list while keeping the count exact", async () => {
+		const many = Array.from({ length: MCP_DETAIL_TOOL_LIMIT + 3 }, (_unused, index) => ({
+			name: `wide.tool_${String(index).padStart(2, "0")}`,
+			server: "wide",
+			// Descending, so the cap keeps the busiest and the dropped ones are the quiet tail.
+			calls: 100 - index,
+			atMs: Date.parse("2026-07-29T09:00:00Z"),
+		}));
+		await applySummaryEvents([repoEvent("repo-1", "jolli"), session("s1", many)], {
+			producerKind: "cli",
+			dbPath,
+		});
+		const got = await detail("wide");
+		expect(got?.tools).toHaveLength(MCP_DETAIL_TOOL_LIMIT);
+		// The figure the pane prints, and what its "N busiest of M" note is built from.
+		expect(got?.toolCount).toBe(MCP_DETAIL_TOOL_LIMIT + 3);
+		expect(got?.tools[0]?.name).toBe("tool_00");
+		// Every call still counted, including the ones whose row was dropped.
+		expect(got?.calls).toBe(many.reduce((sum, t) => sum + t.calls, 0));
+	});
+
+	it("answers undefined for a server with no call in the window", async () => {
+		await applySummaryEvents(
+			[
+				repoEvent("repo-1", "jolli"),
+				session("s1", [
+					{
+						name: "linear.list_issues",
+						server: "linear",
+						calls: 1,
+						atMs: Date.parse("2026-06-01T09:00:00Z"),
+					},
+				]),
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		// In the table, outside the week — the route turns this into a 404, which is
+		// the same answer a server nobody has ever called gets.
+		expect(
+			await withDashboardDb(
+				(db) =>
+					buildMcpServerDetail(db, {
+						scope: { kind: "all" },
+						server: "linear",
+						range: "week",
+						timeZone: "UTC",
+						nowMs,
+					}),
+				{ dbPath },
+			),
+		).toBeUndefined();
+		expect(await detail("never-called")).toBeUndefined();
+	});
+
+	it("ignores a skill that shares the server's name", async () => {
+		await applySummaryEvents(
+			[
+				repoEvent("repo-1", "jolli"),
+				{
+					producerKind: "cli",
+					event: {
+						type: "session.upserted",
+						repoIdentity: "repo-1",
+						source: "claude",
+						sessionId: "s1",
+						updatedAtMs: nowMs - 3_600_000,
+						tools: [
+							{ name: "linear.list_issues", kind: "mcp", server: "linear", calls: 2 },
+							// Same bare name, different kind. `(session, name, kind)` is the
+							// primary key precisely because these are two different things.
+							{ name: "linear", kind: "skill", calls: 40 },
+						],
+					},
+				},
+			],
+			{ producerKind: "cli", dbPath },
+		);
+		expect(await detail("linear")).toMatchObject({ calls: 2, toolCount: 1 });
 	});
 });
 

--- a/cli/src/dashboard/DashboardQuery.ts
+++ b/cli/src/dashboard/DashboardQuery.ts
@@ -43,6 +43,8 @@ import type {
 	HeatmapCell,
 	HourBucket,
 	KnowledgeModel,
+	McpServerDayPoint,
+	McpServerDetail,
 	McpServerRow,
 	MemoryCard,
 	RecentSession,
@@ -93,6 +95,7 @@ const log = createLogger("DashboardQuery");
 
 import {
 	isRecallMcpToolName,
+	MCP_DETAIL_TOOL_LIMIT,
 	MEMORY_CARD_MAJOR_LINES,
 	MEMORY_CARDS_LIMIT,
 	RECALL_MCP_TOOL_NAME,
@@ -1636,13 +1639,26 @@ function sortAgents<T extends ToolUsageAgentShare>(agents: ReadonlyArray<T>): T[
  * three lists, their totals, the per-row agent splits and the recall row must
  * all be answering about the same set of rows, and `scopeToRepoIds` is a lookup
  * this section would otherwise repeat six times.
+ *
+ * Runs `resolveScope` first, so a `?repo=<repoName>` token from `JD.repoToken`
+ * — the short name a UI link carries when it is globally unique — is looked up
+ * in the `repos` table and folded onto its identity before `scopeToRepoIds`
+ * matches. Without this, the skill-detail / mcp-detail / tool-usage routes
+ * receive the same short-name token every other route does, `scopeToRepoIds`
+ * finds nothing (it only compares `repo_identity`) and returns `[-1]`, so the
+ * detail pane reports "no captured calls" for a repo that is actually the
+ * majority of the data. The other routes reach this state through
+ * `buildDashboardModel` / `MemoriesQuery`, which each already `resolveScope`
+ * up front; folding it in here is what closes that gap for the shared WHERE.
+ * `resolveScope` is an identity map on `{kind:"all"}` and on tokens already
+ * spelled as identities, so it costs nothing where the bug did not fire.
  */
 function toolUsageWhere(
 	db: DashboardDbHandle,
 	scope: DashboardScope,
 	window: ResolvedWindow,
 ): { sql: string; params: unknown[] } {
-	const filter = scopeFilter(scopeToRepoIds(db, scope), "s.repo_id");
+	const filter = scopeFilter(scopeToRepoIds(db, resolveScope(db, scope)), "s.repo_id");
 	return {
 		sql: `${TOOL_CALL_TIME_SQL} >= ? AND ${TOOL_CALL_TIME_SQL} < ?${filter.sql}`,
 		params: [window.startMs, window.endMs, ...filter.params],
@@ -2155,11 +2171,26 @@ const SKILL_INVOCATION_ROWS_LIMIT = 50;
 const SKILL_SESSION_SERIES_LIMIT = 400;
 
 /**
- * Folds `(skill, session, call time)` rows into the stacked-bar series, one point
+ * Session points returned for an MCP server's per-session chart.
+ *
+ * The daily series remains exact over the whole window; only the one-rectangle-per-
+ * session chart is bounded. The retained points are the most recent ones and are
+ * returned oldest first within that retained set.
+ */
+const MCP_SESSION_SERIES_LIMIT = 400;
+
+/**
+ * Folds `(series, session, call time)` rows into the stacked-bar series, one point
  * per LOCAL day of the window.
  *
+ * TWO CALLERS, ONE FUNCTION: the Skills band keys its series by skill name, the MCPs
+ * band by folded server name (`ToolUsage.skillDays` / `ToolUsage.serverDays`). Both
+ * bands are the same chart of the same table asking the same question — which sessions
+ * reached for each thing, day by day — so a second implementation could only differ
+ * from this one by being wrong on a DST day or a boundary row.
+ *
  * The window is walked rather than the data: every day between its bounds is emitted,
- * whether or not a skill ran. The chart lays bars out by index, so a dropped day would
+ * whether or not anything ran. The chart lays bars out by index, so a dropped day would
  * silently compress the axis and make a week-long gap look like a busy stretch. Walking
  * the window is also what bounds the result — `resolveWindow` already clamps a custom
  * range to {@link MAX_CUSTOM_DAYS}, so the retired week-bucket cap has no work left.
@@ -2169,17 +2200,18 @@ const SKILL_SESSION_SERIES_LIMIT = 400;
  * heatmap and the token series draw. A day key from `localDayKey` is the same key those
  * use, so `Aug 6` means one thing across the whole page.
  *
- * Sessions are counted through a Set rather than by counting rows. `session_tool_use`
- * is keyed `(session, tool, kind)`, so one row per (session, skill) is what the table
- * guarantees today and counting rows would agree — but the figure this feeds is defined
- * as "sessions that reached for the skill", and spelling that as a de-duplication keeps
- * it right if a row ever splits.
+ * Sessions are counted through a Set rather than by counting rows, and for the MCP
+ * caller that is load-bearing rather than defensive. `session_tool_use` is keyed
+ * `(session, tool, kind)`, so a skill really does have one row per (session, skill) and
+ * counting rows would agree — but a SERVER has one row per tool it was reached through,
+ * so a session that called three of a server's tools arrives here three times and must
+ * still count once.
  *
  * `addLocalDays` steps the cursor, never a fixed 86_400_000: a 23- or 25-hour DST day
  * would otherwise skip or repeat a bucket.
  */
-function buildSkillDays(
-	rows: ReadonlyArray<{ tool_name: string; session_event_id: string; at_ms: number }>,
+function buildDayPoints(
+	rows: ReadonlyArray<{ series: string; session_event_id: string; at_ms: number }>,
 	window: ResolvedWindow,
 	timeZone: string,
 ): SkillDayPoint[] {
@@ -2195,14 +2227,41 @@ function buildSkillDays(
 		// worse than omitting it.
 		const bucket = byDay.get(localDayKey(row.at_ms, timeZone));
 		if (!bucket) continue;
-		const sessions = bucket.get(row.tool_name) ?? new Set<string>();
+		const sessions = bucket.get(row.series) ?? new Set<string>();
 		sessions.add(row.session_event_id);
-		bucket.set(row.tool_name, sessions);
+		bucket.set(row.series, sessions);
 	}
-	return [...byDay.entries()].map(([date, skills]) => ({
+	return [...byDay.entries()].map(([date, series]) => ({
 		date,
-		bySeries: Object.fromEntries([...skills.entries()].map(([skill, sessions]) => [skill, sessions.size])),
+		bySeries: Object.fromEntries([...series.entries()].map(([key, sessions]) => [key, sessions.size])),
 	}));
+}
+
+/**
+ * One server's per-session rows folded into the complete local-day window.
+ *
+ * The SQL has already reduced every session to the instant of its LAST call to the
+ * server and the sum of its calls. Bucketing stays in JS for the dashboard's single
+ * time-zone rule, and walks the window so quiet days remain visible. The maximum custom
+ * range is 366 days, which bounds the returned array without truncating the sessions
+ * behind its totals.
+ */
+function buildMcpDetailDays(
+	rows: ReadonlyArray<{ at_ms: number; calls: number }>,
+	window: ResolvedWindow,
+	timeZone: string,
+): McpServerDayPoint[] {
+	const byDay = new Map<string, { sessions: number; calls: number }>();
+	for (let dayStart = window.startMs; dayStart < window.endMs; dayStart = addLocalDays(dayStart, 1, timeZone)) {
+		byDay.set(localDayKey(dayStart, timeZone), { sessions: 0, calls: 0 });
+	}
+	for (const row of rows) {
+		const bucket = byDay.get(localDayKey(row.at_ms, timeZone));
+		if (!bucket) continue;
+		bucket.sessions += 1;
+		bucket.calls += row.calls;
+	}
+	return [...byDay.entries()].map(([date, totals]) => ({ date, ...totals }));
 }
 
 /** The four token columns plus the coverage counters, shared by both roll-ups. */
@@ -2605,6 +2664,187 @@ export function buildSkillDetail(db: DashboardDbHandle, opts: SkillDetailOptions
 	};
 }
 
+/** What one `/api/mcp-detail` request names: a server, and the window to read it over. */
+export interface McpServerDetailOptions {
+	readonly scope: DashboardScope;
+	/** The FOLDED server name, as a list row spells it — see {@link SERVER_KEY_SQL}. */
+	readonly server: string;
+	readonly range?: DashboardRange;
+	readonly customFrom?: string;
+	readonly customTo?: string;
+	readonly timeZone?: string;
+	readonly nowMs?: number;
+}
+
+/**
+ * One MCP server's whole story over the window — per tool, per session, per agent.
+ *
+ * FOUR QUERIES OVER ONE SET OF ROWS, and unlike {@link buildSkillDetail} none of them
+ * is separated to dodge a fan-out: there is nothing to join out to. An MCP call has no
+ * per-invocation table (`skill_invocations` has no MCP counterpart) and is never
+ * archived onto a commit, so every figure on this page comes from `session_tool_use`
+ * joined to `sessions`, grouped four different ways. They are separate statements
+ * because they group differently, not because a join would multiply anything.
+ *
+ * THE SERVER IS MATCHED THROUGH `SERVER_KEY_SQL`, never `t.server = ?`. A server
+ * registered through a host's plugin manifest is stored under a `plugin_…` prefix, so
+ * an equality test would answer 404 for exactly the row the reader clicked (the list
+ * shows the folded name) — and where both spellings exist it would report half the
+ * calls with nothing saying so.
+ *
+ * Returns undefined when the window holds no call to that server, which the route
+ * turns into a 404 — the same contract `buildSkillDetail` has.
+ */
+export function buildMcpServerDetail(db: DashboardDbHandle, opts: McpServerDetailOptions): McpServerDetail | undefined {
+	const timeZone = opts.timeZone ?? machineTimeZone();
+	const window = resolveWindow(opts.range, opts.customFrom, opts.customTo, opts.nowMs ?? Date.now(), timeZone);
+	const where = toolUsageWhere(db, opts.scope, window);
+	// `kind = 'mcp'` plus a non-null server, matching `serverRowsPage` exactly: a row
+	// the list could not show must not be readable here either.
+	const scopedSql = `${where.sql} AND t.kind = 'mcp' AND t.server IS NOT NULL AND ${SERVER_KEY_SQL} = ?`;
+	const scoped = [...where.params, opts.server];
+
+	const total = db
+		.prepare(
+			// `tool_count` counts the FOLDED tool key for the reason `serverRowsPage`
+			// states: the stored name embeds the server, so a server reached under two
+			// registrations carries two spellings of each of its tools.
+			`SELECT COUNT(DISTINCT t.session_event_id) AS session_count,
+			        COALESCE(SUM(t.calls), 0) AS call_count,
+			        COUNT(DISTINCT ${TOOL_KEY_SQL}) AS tool_count,
+			        MIN(${TOOL_CALL_TIME_SQL}) AS first_call_at_ms,
+			        MAX(${TOOL_CALL_TIME_SQL}) AS last_call_at_ms
+			   FROM session_tool_use t
+			   JOIN sessions s ON s.event_id = t.session_event_id
+			  WHERE ${scopedSql}`,
+		)
+		.get(...scoped) as
+		| {
+				session_count: number;
+				call_count: number;
+				tool_count: number;
+				first_call_at_ms: number | null;
+				last_call_at_ms: number | null;
+		  }
+		| undefined;
+	// An aggregate always returns a row, so `session_count` is what says "not here" —
+	// never the row's absence.
+	if (!total || total.session_count === 0) return undefined;
+
+	// One row per tool, ranked by the figure the row PRINTS. `MCP_DETAIL_TOOL_LIMIT + 1`
+	// is not asked for: `toolCount` above is the honest total, so the pane can say what
+	// a capped list is hiding without a probe row.
+	const toolRows = db
+		.prepare(
+			`SELECT ${TOOL_KEY_SQL} AS tool_name,
+			        COALESCE(SUM(t.calls), 0) AS call_count,
+			        COUNT(DISTINCT t.session_event_id) AS session_count
+			   FROM session_tool_use t
+			   JOIN sessions s ON s.event_id = t.session_event_id
+			  WHERE ${scopedSql}
+			  GROUP BY ${TOOL_KEY_SQL}
+			  ORDER BY call_count DESC, session_count DESC, tool_name ASC
+			  LIMIT ?`,
+		)
+		.all(...scoped, MCP_DETAIL_TOOL_LIMIT) as ReadonlyArray<{
+		tool_name: string;
+		call_count: number;
+		session_count: number;
+	}>;
+
+	const agentRows = db
+		.prepare(
+			// CALLS only, never sessions — `ToolUsageAgentShare` carries the rule: a
+			// per-source session count does not survive being re-summed at this grouping.
+			`SELECT s.source, COALESCE(SUM(t.calls), 0) AS call_count
+			   FROM session_tool_use t
+			   JOIN sessions s ON s.event_id = t.session_event_id
+			  WHERE ${scopedSql}
+			  GROUP BY s.source`,
+		)
+		.all(...scoped) as ReadonlyArray<{ source: string; call_count: number }>;
+
+	const repoRows = db
+		.prepare(
+			`SELECT DISTINCT r.repo_name
+			   FROM session_tool_use t
+			   JOIN sessions s ON s.event_id = t.session_event_id
+			   JOIN repos r    ON r.id = s.repo_id
+			  WHERE ${scopedSql}
+			  ORDER BY r.repo_name`,
+		)
+		.all(...scoped) as ReadonlyArray<{ repo_name: string }>;
+
+	// One row per SESSION before it is folded into local days below. Grouped rather
+	// than listed: a session reaches a server through as many rows as it called tools,
+	// and the chart's bar is that session's whole traffic to the server. The time is
+	// the LATEST of those rows — see `McpServerDetail.firstCallAtMs` on the grain.
+	const seriesRows = db
+		.prepare(
+			`SELECT t.session_event_id,
+			        MAX(${TOOL_CALL_TIME_SQL}) AS at_ms,
+			        COALESCE(SUM(t.calls), 0) AS calls
+			   FROM session_tool_use t
+			   JOIN sessions s ON s.event_id = t.session_event_id
+			  WHERE ${scopedSql}
+			  GROUP BY t.session_event_id`,
+		)
+		.all(...scoped) as ReadonlyArray<{ session_event_id: string; at_ms: number; calls: number }>;
+	const retainedSeriesRows = [...seriesRows]
+		.sort(
+			(a, b) =>
+				b.at_ms - a.at_ms ||
+				(a.session_event_id < b.session_event_id ? 1 : a.session_event_id > b.session_event_id ? -1 : 0),
+		)
+		.slice(0, MCP_SESSION_SERIES_LIMIT)
+		.sort(
+			(a, b) =>
+				a.at_ms - b.at_ms ||
+				(a.session_event_id < b.session_event_id ? -1 : a.session_event_id > b.session_event_id ? 1 : 0),
+		);
+
+	return {
+		server: opts.server,
+		sessions: total.session_count,
+		calls: total.call_count,
+		toolCount: total.tool_count,
+		tools: toolRows.map((row) => ({
+			name: stripServerPrefix(row.tool_name, opts.server),
+			calls: row.call_count,
+			sessions: row.session_count,
+		})),
+		agents: sortAgents(agentRows.map((row) => ({ source: row.source, calls: row.call_count }))),
+		daySeries: buildMcpDetailDays(seriesRows, window, timeZone),
+		// `seriesRows` above remains complete for the exact daily roll-up. Only the
+		// one-bar-per-session chart is capped, oldest first within the retained recent set.
+		sessionSeries: retainedSeriesRows.map((row) => ({ atMs: row.at_ms, calls: row.calls })),
+		...(total.first_call_at_ms !== null ? { firstCallAtMs: total.first_call_at_ms } : {}),
+		...(total.last_call_at_ms !== null ? { lastCallAtMs: total.last_call_at_ms } : {}),
+		repos: repoRows.map((row) => row.repo_name),
+	};
+}
+
+/**
+ * `dbhub.execute_sql` → `execute_sql`, for a tool of the named server.
+ *
+ * ANCHORED ON THE SERVER NAME, not on the first `.`: a server whose own name contains
+ * one (a hostname-shaped registration) would otherwise have its tool reported as the
+ * remainder after that first dot, which is neither the tool nor anything else. The
+ * prefix is what `parseToolUse` joined, so removing exactly it is the inverse.
+ *
+ * The prefix SHOULD always be there and the fallback is still not dead code. Both
+ * arguments come through the same `plugin_…` fold, and it removes a prefix of the
+ * stored `<server>.<tool>` — so a server folded to `chrome-devtools` has its tools
+ * folded to `chrome-devtools.<tool>`, matching by construction. What the fallback
+ * covers is a row that reached the table by some other route than `parseToolUse`
+ * joining those two halves. There, printing the stored name is honest and slicing at a
+ * dot that means nothing is not.
+ */
+function stripServerPrefix(toolName: string, server: string): string {
+	const prefix = `${server}.`;
+	return toolName.startsWith(prefix) ? toolName.slice(prefix.length) : toolName;
+}
+
 /**
  * Skills, MCP servers and the tool mix over the window, each row carrying the
  * agents that produced it — the FIRST page of each of the three lists, plus the
@@ -2634,6 +2874,19 @@ function buildToolUsage(
 	const skillTotals = toolListTotals(db, where, "skill");
 	const serverTotals = toolListTotals(db, where, "server");
 	const mcpToolTotals = toolListTotals(db, where, "tool");
+	const serverToolsTotal =
+		(
+			db
+				.prepare(
+					`SELECT COUNT(DISTINCT ${TOOL_KEY_SQL}) AS tool_count
+				   FROM session_tool_use t
+				   JOIN sessions s ON s.event_id = t.session_event_id
+				  WHERE ${where.sql}
+				    AND t.kind = 'mcp'
+				    AND t.server IS NOT NULL`,
+				)
+				.get(...where.params) as { tool_count: number } | undefined
+		)?.tool_count ?? 0;
 	const skills = toolNameRowsPage(db, where, "skill", 0, TOOL_ROWS_LIMIT);
 	const mcpTools = toolNameRowsPage(db, where, "tool", 0, TOOL_ROWS_LIMIT);
 	const servers = serverRowsPage(db, where, 0, TOOL_ROWS_LIMIT);
@@ -2669,18 +2922,31 @@ function buildToolUsage(
 
 	// Adoption per skill per local day, over EVERY skill in the window rather than the
 	// first page — see `ToolUsage.skillDays`. Unaggregated on purpose: the bucket is a
-	// LOCAL calendar day, which only `buildSkillDays` can compute (see this file's
+	// LOCAL calendar day, which only `buildDayPoints` can compute (see this file's
 	// header on why SQLite's `localtime` is never used), so grouping here would have to
 	// group by a boundary the rest of the page does not share. The call-time expression
 	// is the one the rankings use, so a row's bar and its rank agree about when it ran.
 	const dayRows = db
 		.prepare(
-			`SELECT t.tool_name, t.session_event_id, ${TOOL_CALL_TIME_SQL} AS at_ms
+			`SELECT t.tool_name AS series, t.session_event_id, ${TOOL_CALL_TIME_SQL} AS at_ms
 			   FROM session_tool_use t
 			   JOIN sessions s ON s.event_id = t.session_event_id
 			  WHERE ${where.sql} AND t.kind = 'skill'`,
 		)
-		.all(...where.params) as ReadonlyArray<{ tool_name: string; session_event_id: string; at_ms: number }>;
+		.all(...where.params) as ReadonlyArray<{ series: string; session_event_id: string; at_ms: number }>;
+
+	// The same series for the MCPs band, keyed by FOLDED server rather than by
+	// `t.server` — `SERVER_KEY_SQL` is what makes a plugin-prefixed registration one
+	// series here and one row in the list beside it. `server IS NOT NULL` matches the
+	// server list's own WHERE, so the band cannot carry a bar the chooser has no row for.
+	const serverDayRows = db
+		.prepare(
+			`SELECT ${SERVER_KEY_SQL} AS series, t.session_event_id, ${TOOL_CALL_TIME_SQL} AS at_ms
+			   FROM session_tool_use t
+			   JOIN sessions s ON s.event_id = t.session_event_id
+			  WHERE ${where.sql} AND t.kind = 'mcp' AND t.server IS NOT NULL`,
+		)
+		.all(...where.params) as ReadonlyArray<{ series: string; session_event_id: string; at_ms: number }>;
 
 	// Coverage from the FULL session population, never from the join above — and
 	// windowed by the SESSION's own time OR by any call it made, which is the
@@ -2738,13 +3004,15 @@ function buildToolUsage(
 		skills,
 		skillsTotal: skillTotals.totalCount,
 		skillCallsTotal: skillTotals.callsTotal,
-		skillDays: buildSkillDays(dayRows, window, timeZone),
+		skillDays: buildDayPoints(dayRows, window, timeZone),
 		mcpTools,
 		mcpToolsTotal: mcpToolTotals.totalCount,
+		serverToolsTotal,
 		recallCalls,
 		servers,
 		serversTotal: serverTotals.totalCount,
 		serverCallsTotal: serverTotals.callsTotal,
+		serverDays: buildDayPoints(serverDayRows, window, timeZone),
 		skillAgents: agentTotals("skill"),
 		mcpAgents: agentTotals("mcp"),
 		sessionsWithTools: sessionRows.reduce((sum, row) => sum + row.with_tools, 0),
@@ -3013,10 +3281,10 @@ export function buildDashboardModel(db: DashboardDbHandle, opts: QueryOptions): 
 		"stats" | "standup" | "memories" | "knowledge" | "graph" | "settings" | "coaching"
 	> => {
 		switch (options.view) {
-			// Skills reads `stats.toolUsage` and nothing else, so it shares this payload
-			// rather than declaring one of its own — which is also what lets its list and
-			// the Stats card's Skills card agree by construction instead of by two queries
-			// that have to be kept in step.
+			// Skills and MCPs read `stats.toolUsage` and nothing else, so they share this
+			// payload rather than declaring one of their own — which is also what lets each
+			// page's list agree with its Stats card by construction instead of by two
+			// queries that have to be kept in step.
 			//
 			// It does pay for the whole of `buildStats` (the feed, the activity series, the
 			// token dimensions) to read one field of it. Accepted for now: the alternative
@@ -3026,6 +3294,7 @@ export function buildDashboardModel(db: DashboardDbHandle, opts: QueryOptions): 
 			// query over `session_tool_use`.
 			case "stats":
 			case "skills":
+			case "mcps":
 				return {
 					stats: buildStats(
 						db,

--- a/cli/src/dashboard/DashboardServer.test.ts
+++ b/cli/src/dashboard/DashboardServer.test.ts
@@ -642,6 +642,12 @@ describe("routes", () => {
 		const cases: ReadonlyArray<[string, DashboardModel["view"]]> = [
 			["/dashboard", "stats"],
 			["/dashboard/standup", "standup"],
+			["/skills", "skills"],
+			// The router speaks PATHS and the API speaks view TOKENS, and the two lists
+			// are separate for that reason (see `VIEW_TOKENS`) — so a page reachable at
+			// its path can still be unreachable through `?view=`, silently falling back
+			// to Stats. Every pair belongs in this table.
+			["/mcps", "mcps"],
 			["/memories", "memories"],
 			["/knowledge", "knowledge"],
 			["/graph", "graph"],
@@ -2531,6 +2537,120 @@ describe("defaultModelBuilder (no injected buildModel)", () => {
 		expect((await get(port, "/api/skill-detail?name=missing")).status).toBe(404);
 	});
 
+	it("serves one MCP server detail and distinguishes a bad name from a silent server", async () => {
+		const dbPath = join(dir, "mcp-detail.db");
+		const configDir = join(dir, "config-mcp-detail");
+		await applyStatsEvents(
+			[
+				{
+					producerKind: "cli",
+					event: {
+						type: "repo.enabled",
+						repoIdentity: "repo-1",
+						repoName: "jolli",
+						worktreeRoot: "/w/jolli",
+						enabledAt: "t",
+					},
+				},
+				{
+					producerKind: "cli",
+					event: {
+						type: "session.upserted",
+						repoIdentity: "repo-1",
+						source: "claude",
+						sessionId: "linear-session",
+						updatedAtMs: Date.now() - 3_600_000,
+						tools: [
+							{ name: "linear.list_issues", kind: "mcp", server: "linear", calls: 4 },
+							{ name: "linear.get_issue", kind: "mcp", server: "linear", calls: 1 },
+						],
+					},
+				},
+			],
+			{ producerKind: "cli", dbPath },
+		);
+
+		const port = await listen(createDashboardServer({ port: 0, assetsDir, dbPath, configDir }));
+		// Trimmed, and the window params are read the same way `/api/skill-detail` reads them.
+		const ok = await get(port, "/api/mcp-detail?server=%20linear%20&range=3m&from=ignored&to=ignored");
+		expect(ok.status).toBe(200);
+		expect(await ok.json()).toMatchObject({
+			server: "linear",
+			sessions: 1,
+			calls: 5,
+			toolCount: 2,
+			tools: [
+				{ name: "list_issues", calls: 4, sessions: 1 },
+				{ name: "get_issue", calls: 1, sessions: 1 },
+			],
+			agents: [{ source: "claude", calls: 5 }],
+			repos: ["jolli"],
+		});
+
+		expect((await get(port, "/api/mcp-detail")).status).toBe(400);
+		expect((await get(port, "/api/mcp-detail?server=%20%20")).status).toBe(400);
+		// A server with no captured call in the window is a 404 — this page never
+		// claims to list CONFIGURED servers, so there is no third state to report.
+		expect((await get(port, "/api/mcp-detail?server=missing")).status).toBe(404);
+	});
+
+	it("anchors tool usage and both detail presets to the page model's clock", async () => {
+		const dbPath = join(dir, "mcp-detail-anchor.db");
+		const configDir = join(dir, "config-mcp-detail-anchor");
+		// 23:59 in Asia/Shanghai, this test process's configured zone. By the time
+		// the route is exercised the real clock is long past this day; without the
+		// anchor a visible `today` row therefore becomes a 404 deterministically.
+		const generatedAtMs = Date.parse("2026-07-30T15:59:00Z");
+		await applyStatsEvents(
+			[
+				{
+					producerKind: "cli",
+					event: {
+						type: "repo.enabled",
+						repoIdentity: "repo-1",
+						repoName: "jolli",
+						worktreeRoot: "/w/jolli",
+						enabledAt: "t",
+					},
+				},
+				{
+					producerKind: "cli",
+					event: {
+						type: "session.upserted",
+						repoIdentity: "repo-1",
+						source: "claude",
+						sessionId: "linear-before-midnight",
+						updatedAtMs: generatedAtMs - 3_600_000,
+						tools: [
+							{ name: "linear.list_issues", kind: "mcp", server: "linear", calls: 1 },
+							{ name: "code-review", kind: "skill", calls: 1 },
+						],
+					},
+				},
+			],
+			{ producerKind: "cli", dbPath },
+		);
+
+		const port = await listen(createDashboardServer({ port: 0, assetsDir, dbPath, configDir }));
+		expect((await get(port, `/api/mcp-detail?server=linear&range=today&nowMs=${generatedAtMs}`)).status).toBe(200);
+		expect((await get(port, `/api/skill-detail?name=code-review&range=today&nowMs=${generatedAtMs}`)).status).toBe(
+			200,
+		);
+		const usage = await get(port, `/api/tool-usage?list=skill&range=today&nowMs=${generatedAtMs}`);
+		expect(usage.status).toBe(200);
+		expect(await usage.json()).toMatchObject({ totalCount: 1, rows: [{ name: "code-review" }] });
+
+		for (const bad of ["", "nope", "-1", "1.5", "8640000000000000", "9007199254740992"]) {
+			for (const path of [
+				`/api/mcp-detail?server=linear&range=today&nowMs=${bad}`,
+				`/api/skill-detail?name=code-review&range=today&nowMs=${bad}`,
+				`/api/tool-usage?list=skill&range=today&nowMs=${bad}`,
+			]) {
+				expect((await get(port, path)).status).toBe(400);
+			}
+		}
+	});
+
 	it("500s dashboard detail reads when the dashboard database is invalid", async () => {
 		const dbPath = join(dir, "broken-tool-reads.db");
 		writeFileSync(dbPath, "this is not a database");
@@ -2540,6 +2660,7 @@ describe("defaultModelBuilder (no injected buildModel)", () => {
 
 		expect((await get(port, "/api/tool-usage?list=skill")).status).toBe(500);
 		expect((await get(port, "/api/skill-detail?name=code-review")).status).toBe(500);
+		expect((await get(port, "/api/mcp-detail?server=linear")).status).toBe(500);
 		expect((await get(port, "/api/context?repo=repo-1&kind=plan&key=p1")).status).toBe(500);
 		expect((await get(port, "/api/conversation?repo=repo-1&hash=abc&source=claude&session=s1")).status).toBe(500);
 	});

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -124,6 +124,7 @@ import {
 } from "./DashboardModel.js";
 import {
 	buildDashboardModel,
+	buildMcpServerDetail,
 	buildSkillDetail,
 	buildToolUsagePage,
 	clearWorktreeExistenceCache,
@@ -216,6 +217,9 @@ export const DASHBOARD_SCRIPT_FILES = [
 	// fetch helpers; nothing in stats.js. Ordered here rather than earlier only to keep
 	// the list reading in nav order.
 	"skills.js",
+	// Same dependencies as skills.js and no dependency ON it: the two pages share their
+	// CSS grammar, not their code.
+	"mcps.js",
 	"standup.js",
 	"memories.js",
 	"journeys.js",
@@ -1106,6 +1110,24 @@ function parseWindow(url: URL): Omit<ModelRequest, "view" | "scope"> {
 }
 
 /**
+ * The page model's clock, carried by follow-up reads so a preset window cannot
+ * cross a local-day boundary between the model response and a detail/page fetch.
+ *
+ * `null` means the caller supplied an invalid value; `undefined` means it supplied
+ * none, preserving the current-clock fallback for direct API calls. Leave enough
+ * valid-Date headroom for the widest dashboard window and its end boundary. A safe
+ * integer can still lie beyond JavaScript's Date range, where resolving a window
+ * would otherwise throw and turn a malformed local URL into a 500.
+ */
+function parseNowMs(url: URL): number | null | undefined {
+	const raw = url.searchParams.get("nowMs");
+	if (raw === null) return undefined;
+	const nowMs = Number(raw);
+	const validThroughWindowEnd = Number.isFinite(new Date(nowMs + 367 * 86_400_000).getTime());
+	return raw.trim() !== "" && nowMs >= 0 && Number.isSafeInteger(nowMs) && validThroughWindowEnd ? nowMs : null;
+}
+
+/**
  * Parses the `fromMs`/`toMs` echo-back pair the two journeys routes share —
  * the SAME window the feed resolved, sent back by the client rather than left
  * for the route to re-derive (see the `/api/journey` handler's comment for why
@@ -1172,6 +1194,7 @@ const VIEW_PATHS: Readonly<Record<string, DashboardView>> = {
 	"/dashboard": "stats",
 	"/dashboard/standup": "standup",
 	"/skills": "skills",
+	"/mcps": "mcps",
 	"/dashboard/journeys": "journeys",
 	"/memories": "memories",
 	"/knowledge": "knowledge",
@@ -1190,6 +1213,7 @@ const VIEW_TOKENS: ReadonlySet<string> = new Set<DashboardView>([
 	"stats",
 	"standup",
 	"skills",
+	"mcps",
 	"memories",
 	"journeys",
 	"knowledge",
@@ -1721,6 +1745,11 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 				}
 				limit = Math.min(Math.max(1, Math.trunc(parsed)), TOOL_USAGE_MAX_LIMIT);
 			}
+			const pageNowMs = parseNowMs(url);
+			if (pageNowMs === null) {
+				sendJson(res, 400, { error: "nowMs must be an epoch-millisecond integer" });
+				return;
+			}
 			// Spelled out rather than spread from `parseWindow`: that helper also
 			// carries the series axis and the Memories view's `hash`/`detailRepo`,
 			// none of which this route has any business receiving.
@@ -1736,6 +1765,7 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 							...(requestedWindow.range ? { range: requestedWindow.range } : {}),
 							...(requestedWindow.customFrom ? { customFrom: requestedWindow.customFrom } : {}),
 							...(requestedWindow.customTo ? { customTo: requestedWindow.customTo } : {}),
+							...(pageNowMs !== undefined ? { nowMs: pageNowMs } : {}),
 						}),
 					{ ...(options.dbPath ? { dbPath: options.dbPath } : {}) },
 				);
@@ -1760,6 +1790,11 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 				sendJson(res, 400, { error: "name is required" });
 				return;
 			}
+			const detailNowMs = parseNowMs(url);
+			if (detailNowMs === null) {
+				sendJson(res, 400, { error: "nowMs must be an epoch-millisecond integer" });
+				return;
+			}
 			const requestedWindow = parseWindow(url);
 			try {
 				const detail = await withReadonlyDashboardDb(
@@ -1770,6 +1805,7 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 							...(requestedWindow.range ? { range: requestedWindow.range } : {}),
 							...(requestedWindow.customFrom ? { customFrom: requestedWindow.customFrom } : {}),
 							...(requestedWindow.customTo ? { customTo: requestedWindow.customTo } : {}),
+							...(detailNowMs !== undefined ? { nowMs: detailNowMs } : {}),
 						}),
 					{ ...(options.dbPath ? { dbPath: options.dbPath } : {}) },
 				);
@@ -1784,6 +1820,54 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 			} catch (err) {
 				log.warn("skill detail read failed: %s", errMsg(err));
 				sendJson(res, 500, { error: "could not read that skill's detail" });
+			}
+			return;
+		}
+
+		// One MCP server's breakdown, for the MCPs page's reading pane — the
+		// server-side twin of `/api/skill-detail` above, and a fetch for the same
+		// reason: the page model carries ONE PAGE of servers and none of the per-tool
+		// or per-session detail.
+		if (url.pathname === "/api/mcp-detail") {
+			// Trimmed for the reason the skill name is: the value rides in a query
+			// string, and a stray space is a server that matches nothing —
+			// indistinguishable, to the reader, from a server with no recorded calls.
+			const server = (url.searchParams.get("server") ?? "").trim();
+			if (server === "") {
+				sendJson(res, 400, { error: "server is required" });
+				return;
+			}
+			const detailNowMs = parseNowMs(url);
+			if (detailNowMs === null) {
+				sendJson(res, 400, { error: "nowMs must be an epoch-millisecond integer" });
+				return;
+			}
+			const requestedWindow = parseWindow(url);
+			try {
+				const detail = await withReadonlyDashboardDb(
+					(db) =>
+						buildMcpServerDetail(db, {
+							scope: parseScope(url),
+							server,
+							...(requestedWindow.range ? { range: requestedWindow.range } : {}),
+							...(requestedWindow.customFrom ? { customFrom: requestedWindow.customFrom } : {}),
+							...(requestedWindow.customTo ? { customTo: requestedWindow.customTo } : {}),
+							...(detailNowMs !== undefined ? { nowMs: detailNowMs } : {}),
+						}),
+					{ ...(options.dbPath ? { dbPath: options.dbPath } : {}) },
+				);
+				// 404 for "no call to that server in this window" — a real answer, and
+				// the one a missing server has. This page never claims to list
+				// CONFIGURED servers, so there is no "registered but silent" state for
+				// this route to distinguish.
+				if (!detail) {
+					sendJson(res, 404, { error: "no recorded calls for that MCP server in this window" });
+					return;
+				}
+				sendJson(res, 200, detail);
+			} catch (err) {
+				log.warn("mcp detail read failed: %s", errMsg(err));
+				sendJson(res, 500, { error: "could not read that MCP server's detail" });
 			}
 			return;
 		}

--- a/cli/src/dashboard/FeedCardAsset.test.ts
+++ b/cli/src/dashboard/FeedCardAsset.test.ts
@@ -152,6 +152,7 @@ function model(over: Record<string, unknown> = {}, statsOver: Record<string, unk
 				serverCallsTotal: 0,
 				mcpTools: [],
 				mcpToolsTotal: 0,
+				serverToolsTotal: 0,
 				skillAgents: [],
 				mcpAgents: [],
 				sessionsWithTools: 0,

--- a/cli/src/dashboard/McpsAsset.test.ts
+++ b/cli/src/dashboard/McpsAsset.test.ts
@@ -1,0 +1,632 @@
+/** Runtime coverage for the plain-JavaScript MCPs page. */
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { TOOL_ROWS_LIMIT } from "./DashboardModel.js";
+
+interface FakeRect {
+	top: number;
+	bottom: number;
+}
+
+interface FakeList {
+	scrollTop: number;
+	rect: FakeRect;
+	getBoundingClientRect: () => FakeRect;
+}
+
+interface FakeRow {
+	rect: FakeRect;
+	readonly scrollIntoViewCalls: Array<Record<string, unknown> | undefined>;
+	getBoundingClientRect: () => FakeRect;
+	scrollIntoView: (options?: Record<string, unknown>) => void;
+}
+
+interface FakeClickable {
+	onclick?: () => void;
+	onkeydown?: (event: { key: string; preventDefault: () => void }) => void;
+	getAttribute: (name: string) => string | null;
+	setAttribute?: (name: string, value: string) => void;
+	removeAttribute?: (name: string) => void;
+	classList?: { contains: (name: string) => boolean };
+	focus?: () => void;
+}
+
+interface Harness {
+	readonly requests: string[];
+	readonly list: FakeList;
+	readonly currentRow: FakeRow;
+	html: () => string;
+	render: (model: unknown) => void;
+	selectServer: (name: string | null) => void;
+	selectedServer: () => string | null;
+	clickServer: (name: string) => void;
+	clickFocusedLegend: (name: string) => void;
+	focusedSelection: () => { name: string | null; legend: boolean; replaced: boolean };
+	useTargetedDom: () => void;
+	clickProse: () => void;
+	proseExpanded: () => string | null;
+	advanceTimersBy: (milliseconds: number) => void;
+	respondWith: (handler: (path: string) => Promise<unknown>) => void;
+}
+
+const GENERATED_AT_MS = Date.parse("2026-07-30T15:59:00Z");
+
+const serverNames = ["Other", "__proto__", "constructor", "b", "c"];
+const serverRows = serverNames.map((server, index) => ({
+	server,
+	sessions: 10 - index,
+	calls: 10 - index,
+	tools: 1,
+	agents: [{ source: "claude", calls: 10 - index }],
+}));
+
+const serverRow = (index: number) => ({
+	server: `server${String(index).padStart(3, "0")}`,
+	sessions: 20 - index,
+	calls: 20 - index,
+	tools: 1,
+	agents: [{ source: "claude", calls: 20 - index }],
+});
+
+const dangerousSeries = Object.fromEntries([
+	["Other", 10],
+	["__proto__", 9],
+	["constructor", 8],
+	["b", 7],
+	["c", 1],
+]);
+
+function model(
+	rows: ReadonlyArray<(typeof serverRows)[number]> = serverRows,
+	total = rows.length,
+	usageOver: Record<string, unknown> = {},
+): unknown {
+	return {
+		view: "mcps",
+		generatedAtMs: GENERATED_AT_MS,
+		timeZone: "UTC",
+		stats: {
+			range: "today",
+			toolUsage: {
+				servers: rows,
+				serversTotal: total,
+				serverCallsTotal: 35,
+				serverToolsTotal: 5,
+				// Includes one legacy MCP row without a server. The MCPs header must not.
+				mcpToolsTotal: 6,
+				serverDays: [{ date: "2026-07-30", bySeries: dangerousSeries }],
+				mcpAgents: [{ source: "claude", sessions: 10, calls: 35 }],
+				sessionsWithTools: 10,
+				sessionsInWindow: 10,
+				uncoveredSources: [],
+				...usageOver,
+			},
+		},
+	};
+}
+
+const detail = {
+	server: "Other",
+	sessions: 2,
+	calls: 7,
+	toolCount: 1,
+	tools: [{ name: "call", sessions: 2, calls: 7 }],
+	agents: [{ source: "claude", calls: 7 }],
+	daySeries: [
+		{ date: "2026-07-28", sessions: 1, calls: 2 },
+		{ date: "2026-07-29", sessions: 0, calls: 0 },
+		{ date: "2026-07-30", sessions: 1, calls: 5 },
+	],
+	sessionSeries: [
+		{ atMs: Date.parse("2026-07-28T09:00:00Z"), calls: 2 },
+		{ atMs: Date.parse("2026-07-30T09:00:00Z"), calls: 5 },
+	],
+	firstCallAtMs: Date.parse("2026-07-28T09:00:00Z"),
+	lastCallAtMs: Date.parse("2026-07-30T09:00:00Z"),
+	repos: ["jolli"],
+};
+
+function loadHarness(): Harness {
+	const requests: string[] = [];
+	let html = "";
+	let timerClock = 0;
+	let nextTimerId = 1;
+	const timers = new Map<number, { readonly at: number; readonly run: () => void }>();
+	const advanceTimersBy = (milliseconds: number) => {
+		const target = timerClock + milliseconds;
+		for (;;) {
+			let dueId: number | undefined;
+			let dueAt = Number.POSITIVE_INFINITY;
+			for (const [id, timer] of timers) {
+				if (timer.at <= target && timer.at < dueAt) {
+					dueId = id;
+					dueAt = timer.at;
+				}
+			}
+			if (dueId === undefined) break;
+			const timer = timers.get(dueId);
+			timers.delete(dueId);
+			timerClock = dueAt;
+			timer?.run();
+		}
+		timerClock = target;
+	};
+	const list: FakeList = {
+		scrollTop: 0,
+		rect: { top: 100, bottom: 600 },
+		getBoundingClientRect: () => list.rect,
+	};
+	const currentRow: FakeRow = {
+		rect: { top: 1400, bottom: 1433 },
+		scrollIntoViewCalls: [],
+		getBoundingClientRect: () => currentRow.rect,
+		scrollIntoView: (options) => currentRow.scrollIntoViewCalls.push(options),
+	};
+	let selectionNodes: FakeClickable[] = [];
+	let proseNodes: FakeClickable[] = [];
+	let clickedNode: FakeClickable | null = null;
+	let targetedDom = false;
+	let targetedBandHtml = "";
+	const bandNode = {
+		replaceWith: (next: { readonly html?: string }) => {
+			targetedBandHtml = next.html ?? "";
+		},
+	};
+	const paneNode = { innerHTML: "" };
+	const app = {
+		get innerHTML() {
+			return html;
+		},
+		set innerHTML(next: string) {
+			html = next;
+			list.scrollTop = 0;
+		},
+		querySelector: (selector: string) => {
+			if (selector === ".sk-list") return list;
+			if (selector === ".sk-band") return targetedDom ? bandNode : null;
+			if (selector === ".sk-pane") return targetedDom ? paneNode : null;
+			if (selector === '.sk-row[aria-current="true"]') {
+				return html.includes('aria-current="true"') ||
+					selectionNodes.some(
+						(node) => node.classList?.contains("sk-row") && node.getAttribute("aria-current") === "true",
+					)
+					? currentRow
+					: null;
+			}
+			return null;
+		},
+		querySelectorAll: (selector: string): FakeClickable[] => {
+			if (selector === ".sk-row") return selectionNodes.filter((node) => node.classList?.contains("sk-row"));
+			if (selector === "[data-mcp]") {
+				const selectionHtml = targetedBandHtml
+					? targetedBandHtml + html.slice(Math.max(0, html.indexOf("<aside")))
+					: html;
+				selectionNodes = Array.from(
+					selectionHtml.matchAll(/<button\b[^>]*data-mcp="([^"]+)"[^>]*>/g),
+					(match) => {
+						const tag = match[0];
+						const server = match[1] as string;
+						const classes = /class="([^"]*)"/.exec(tag)?.[1]?.split(/\s+/) ?? [];
+						const attributes = new Map<string, string>([["data-mcp", server]]);
+						if (tag.includes('aria-current="true"')) attributes.set("aria-current", "true");
+						const node: FakeClickable = {
+							getAttribute: (name) => attributes.get(name) ?? null,
+							setAttribute: (name, value) => attributes.set(name, value),
+							removeAttribute: (name) => attributes.delete(name),
+							classList: { contains: (name) => classes.includes(name) },
+							focus: () => {
+								document.activeElement = node;
+							},
+						};
+						return node;
+					},
+				);
+				return selectionNodes;
+			}
+			if (selector === ".sk-clamp") {
+				proseNodes = Array.from(
+					html.matchAll(/class="([^"]*\bsk-clamp\b[^"]*)"[^>]*aria-expanded="(true|false)"/g),
+					(match) => {
+						const classes = (match[1] as string).split(/\s+/);
+						const attributes = new Map([["aria-expanded", match[2] as string]]);
+						return {
+							getAttribute: (name: string) => attributes.get(name) ?? null,
+							setAttribute: (name: string, value: string) => attributes.set(name, value),
+							classList: { contains: (name: string) => classes.includes(name) },
+						};
+					},
+				);
+				return proseNodes;
+			}
+			return [];
+		},
+	};
+	const document = {
+		activeElement: null as FakeClickable | null,
+		getElementById: (id: string) => (id === "app" ? app : null),
+		createElement: (_tag: string) => {
+			let content = "";
+			return {
+				set innerHTML(next: string) {
+					content = next;
+				},
+				get firstChild() {
+					return { html: content };
+				},
+			};
+		},
+	};
+	const win = {
+		JD: {} as Record<string, unknown>,
+		location: new URL("http://127.0.0.1/mcps"),
+		innerHeight: 800,
+		setTimeout: (run: () => void, delay = 0) => {
+			const id = nextTimerId++;
+			timers.set(id, { at: timerClock + Math.max(0, delay), run });
+			return id;
+		},
+		clearTimeout: (id: number) => timers.delete(id),
+		history: {
+			replaceState: (_state: unknown, _title: string, href: string) => {
+				win.location = new URL(href);
+			},
+		},
+	};
+	let responder = (path: string): Promise<unknown> => {
+		if (path.startsWith("/api/mcp-detail")) {
+			const server = new URL(path, "http://127.0.0.1").searchParams.get("server") ?? detail.server;
+			return Promise.resolve({ ...detail, server });
+		}
+		return Promise.resolve({ list: "server", offset: 0, rows: [], totalCount: 0 });
+	};
+	const esc = (value: unknown) =>
+		String(value).replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+	Object.assign(win.JD, {
+		esc,
+		seriesColor: () => "#000",
+		sourceIndex: () => 0,
+		query: () => "?range=today",
+		withParams: (path: string, params: Record<string, unknown>) => {
+			const url = new URL(path, "http://127.0.0.1");
+			for (const [key, value] of Object.entries(params)) url.searchParams.set(key, String(value));
+			return url.pathname + url.search;
+		},
+		getJson: (path: string) => {
+			requests.push(path);
+			return responder(path);
+		},
+		dayKey: (atMs: number, timeZone: string) =>
+			new Intl.DateTimeFormat("en-CA", { timeZone, year: "numeric", month: "2-digit", day: "2-digit" }).format(
+				atMs,
+			),
+		dayLabel: (key: string) => key,
+		dayBars: (days: ReadonlyArray<string>, values: ReadonlyArray<number>) =>
+			`<svg>${days.map((day, index) => `<title>${day}=${values[index] ?? 0}</title>`).join("")}</svg>`,
+		stackedBarsFrame: (
+			series: ReadonlyArray<{ readonly bySeries: Readonly<Record<string, number>> }>,
+			keys: ReadonlyArray<string>,
+		) => ({
+			svg: `<svg data-keys="${esc(keys.join("|"))}" data-total="${keys.reduce(
+				(sum, key) => sum + (series[0]?.bySeries[key] ?? 0),
+				0,
+			)}"></svg>`,
+			ticks: ["40", "30", "20", "10", "0"],
+			firstDay: "2026-07-30",
+			lastDay: "",
+		}),
+	});
+	const source = readFileSync(new URL("./assets/js/mcps.js", import.meta.url), "utf8");
+	new Function("window", "document", source)(win, document);
+	return {
+		requests,
+		list,
+		currentRow,
+		html: () => html,
+		render: (next: unknown) => {
+			(win.JD as { renderMcps: (value: unknown) => void }).renderMcps(next);
+		},
+		selectServer: (name) => {
+			const url = new URL(win.location.href);
+			if (name) url.searchParams.set("mcp", name);
+			else url.searchParams.delete("mcp");
+			win.location = url;
+		},
+		selectedServer: () => win.location.searchParams.get("mcp"),
+		clickServer: (name) => {
+			const node = selectionNodes.find((candidate) => candidate.getAttribute("data-mcp") === name);
+			if (!node?.onclick) throw new Error(`no wired MCP selection for ${name}`);
+			node.onclick();
+		},
+		clickFocusedLegend: (name) => {
+			const node = selectionNodes.find(
+				(candidate) =>
+					candidate.classList?.contains("sk-legend") && candidate.getAttribute("data-mcp") === name,
+			);
+			if (!node?.onclick) throw new Error(`no wired MCP legend for ${name}`);
+			clickedNode = node;
+			document.activeElement = node;
+			node.onclick();
+		},
+		focusedSelection: () => ({
+			name: document.activeElement?.getAttribute("data-mcp") ?? null,
+			legend: document.activeElement?.classList?.contains("sk-legend") ?? false,
+			replaced: document.activeElement !== null && document.activeElement !== clickedNode,
+		}),
+		useTargetedDom: () => {
+			targetedDom = true;
+		},
+		clickProse: () => {
+			if (!proseNodes[0]?.onclick) throw new Error("no wired prose block");
+			proseNodes[0].onclick();
+		},
+		proseExpanded: () => proseNodes[0]?.getAttribute("aria-expanded") ?? null,
+		advanceTimersBy,
+		respondWith: (handler) => {
+			responder = handler;
+		},
+	};
+}
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("MCPs page asset", () => {
+	it("anchors its detail request and charts every server-side day, including zero days", async () => {
+		const h = loadHarness();
+		h.render(model());
+		await settle();
+
+		expect(h.requests[0]).toBe(`/api/mcp-detail?range=today&server=Other&nowMs=${GENERATED_AT_MS}`);
+		for (const day of detail.daySeries) {
+			expect(h.html()).toContain(`<title>${day.date}=${day.sessions}</title>`);
+		}
+		// The per-session chart's titles are rendered locally rather than through
+		// `JD.dayBars`, and they carry the SESSION's date plus its call count.
+		for (const point of detail.sessionSeries) {
+			const dayKey = new Intl.DateTimeFormat("en-CA", {
+				timeZone: "UTC",
+				year: "numeric",
+				month: "2-digit",
+				day: "2-digit",
+			}).format(point.atMs);
+			expect(h.html()).toContain(
+				`<title>${dayKey} · ${point.calls} ${point.calls === 1 ? "call" : "calls"}</title>`,
+			);
+		}
+		expect(h.html()).toContain(
+			'<b title="Lower bound: only the last call per session and tool is recorded.">First seen</b>',
+		);
+		expect(h.html()).toContain("of all MCP calls");
+	});
+
+	it("renders epoch-zero record timestamps instead of treating them as absent", async () => {
+		const h = loadHarness();
+		h.respondWith((path) =>
+			Promise.resolve(path.startsWith("/api/mcp-detail") ? { ...detail, firstCallAtMs: 0, lastCallAtMs: 0 } : {}),
+		);
+		h.render(model());
+		await settle();
+
+		expect(h.html()).toContain("First seen");
+		expect(h.html()).toContain("Last seen");
+		expect(h.html()).toContain("1970-01-01");
+	});
+
+	it("discloses when the per-session chart retains only the newest sessions", async () => {
+		const h = loadHarness();
+		h.respondWith((path) =>
+			Promise.resolve(path.startsWith("/api/mcp-detail") ? { ...detail, sessions: 401 } : {}),
+		);
+		h.render(model());
+		await settle();
+
+		expect(h.html()).toContain("Most recent 2 of 401 sessions shown; totals and daily cadence remain exact.");
+	});
+
+	it("uses the named-server tool total in its header", () => {
+		const h = loadHarness();
+		h.render(model());
+		expect(h.html()).toContain("<b>35</b> calls · <b>5</b> servers · <b>5</b> tools");
+		expect(h.html()).not.toContain("<b>6</b> tools");
+	});
+
+	it("keeps prototype-shaped and real Other server names distinct from the roll-up", () => {
+		const h = loadHarness();
+		h.render(model());
+		const html = h.html();
+
+		for (const name of ["Other", "__proto__", "constructor"]) {
+			expect(html).toContain(`data-mcp="${name}"`);
+		}
+		// Four real series plus a collision-free aggregate, conserving 10+9+8+7+1.
+		expect(html).toContain('data-keys="Other|__proto__|constructor|b|Other "');
+		expect(html).toContain('data-total="35"');
+		expect(html).toContain("<b>Other (1 server)</b> 1");
+		expect(html).not.toContain("<b>Other </b>");
+	});
+
+	it("states when the tool list is capped and spells out session counts", async () => {
+		const h = loadHarness();
+		h.respondWith((path) =>
+			Promise.resolve(
+				path.startsWith("/api/mcp-detail")
+					? {
+							...detail,
+							toolCount: 3,
+							tools: [
+								{ name: "search", calls: 4, sessions: 1 },
+								{ name: "recall", calls: 3, sessions: 2 },
+							],
+						}
+					: { list: "server", rows: [] },
+			),
+		);
+		h.render(model());
+		await settle();
+
+		expect(h.html()).toContain("2 busiest of 3 tools called; the figures above stay exact.");
+		expect(h.html()).toContain('<span class="mcp-tool-sess">1 session</span>');
+		expect(h.html()).toContain('<span class="mcp-tool-sess">2 sessions</span>');
+		expect(h.html()).not.toContain(" sess</span>");
+	});
+
+	it("restarts a shifted list partition instead of losing the displaced server", async () => {
+		const all = Array.from({ length: 10 }, (_, index) => serverRow(index));
+		const h = loadHarness();
+		let served = 0;
+		h.respondWith((path) => {
+			if (path.startsWith("/api/mcp-detail")) return Promise.resolve({ ...detail, server: "server000" });
+			served++;
+			return Promise.resolve(
+				served === 1
+					? { list: "server", offset: 0, rows: all.slice(0, 8), totalCount: 10 }
+					: served === 2
+						? { list: "server", offset: 8, rows: [all[7], all[8]], totalCount: 10 }
+						: { list: "server", offset: 0, rows: all, totalCount: 10 },
+			);
+		});
+		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
+		await settle();
+
+		expect(served).toBe(3);
+		expect(h.html().match(/class="sk-row"/g)).toHaveLength(all.length);
+		expect(h.html()).toContain('data-mcp="server009"');
+		expect(h.requests.filter((path) => path.startsWith("/api/tool-usage"))).toEqual([
+			expect.stringContaining(`nowMs=${GENERATED_AT_MS}`),
+			expect.stringContaining(`nowMs=${GENERATED_AT_MS}`),
+			expect.stringContaining(`nowMs=${GENERATED_AT_MS}`),
+		]);
+	});
+
+	it("bounds a growing list response instead of spinning or publishing a partial pass", async () => {
+		const firstPage = Array.from({ length: TOOL_ROWS_LIMIT }, (_, index) => serverRow(index));
+		const h = loadHarness();
+		h.respondWith((path) => {
+			if (path.startsWith("/api/mcp-detail")) return Promise.resolve({ ...detail, server: "server000" });
+			const offset = Number(new URL(path, "http://127.0.0.1").searchParams.get("offset") ?? 0);
+			return Promise.resolve({ list: "server", offset, rows: [serverRow(offset)], totalCount: offset + 2 });
+		});
+		h.render(model(firstPage, 10));
+		await settle();
+
+		expect(h.requests.filter((path) => path.startsWith("/api/tool-usage"))).toHaveLength(25);
+		expect(h.html().match(/class="sk-row"/g)).toHaveLength(TOOL_ROWS_LIMIT);
+		expect(h.html()).toContain("Showing 8 of 10 servers — could not load the rest");
+	});
+
+	it("keeps the first page on a failed tail read and retries it after 30 seconds", async () => {
+		const all = Array.from({ length: 10 }, (_, index) => serverRow(index));
+		const h = loadHarness();
+		let fail = true;
+		h.respondWith((path) => {
+			if (path.startsWith("/api/mcp-detail")) return Promise.resolve({ ...detail, server: "server000" });
+			if (fail) {
+				fail = false;
+				return Promise.reject(new Error("offline"));
+			}
+			return Promise.resolve({ list: "server", offset: 0, rows: all, totalCount: all.length });
+		});
+		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
+		await settle();
+		expect(h.html()).toContain("Showing 8 of 10 servers — could not load the rest");
+
+		h.advanceTimersBy(29_999);
+		await settle();
+		expect(h.html().match(/class="sk-row"/g)).toHaveLength(TOOL_ROWS_LIMIT);
+		h.advanceTimersBy(1);
+		await settle();
+		expect(h.html().match(/class="sk-row"/g)).toHaveLength(all.length);
+		expect(h.html()).not.toContain("could not load the rest");
+	});
+
+	it("lets the current row close the pane without the default selection reopening it", async () => {
+		const h = loadHarness();
+		const payload = model();
+		h.render(payload);
+		await settle();
+		const detailReads = () => h.requests.filter((path) => path.startsWith("/api/mcp-detail")).length;
+		const beforeClose = detailReads();
+
+		h.clickServer("Other");
+		await settle();
+		expect(h.selectedServer()).toBeNull();
+		expect(h.html()).not.toContain('aria-current="true"');
+		expect(h.html()).toContain("Select an MCP server");
+
+		h.render(payload);
+		await settle();
+		expect(h.selectedServer()).toBeNull();
+		expect(detailReads()).toBe(beforeClose);
+	});
+
+	it("opens the prose block by default and preserves a manual collapse across repaints", async () => {
+		const h = loadHarness();
+		const payload = model();
+		h.render(payload);
+		await settle();
+		// The basis line reads on first arrival: the reader should not have to click to see
+		// what the page is claiming.
+		expect(h.proseExpanded()).toBe("true");
+
+		// A click collapses it; a repaint MUST preserve that (module-scoped `openProse`).
+		h.clickProse();
+		expect(h.proseExpanded()).toBe("false");
+		h.render(payload);
+		expect(h.html()).toMatch(/sk-basis sk-clamp[^>]*aria-expanded="false"/);
+	});
+
+	it("reveals a selected server once its row arrives in the fetched tail", async () => {
+		const all = Array.from({ length: 10 }, (_, index) => serverRow(index));
+		const h = loadHarness();
+		h.respondWith((path) =>
+			Promise.resolve(
+				path.startsWith("/api/mcp-detail")
+					? { ...detail, server: "server009" }
+					: { list: "server", offset: 0, rows: all, totalCount: all.length },
+			),
+		);
+		h.selectServer("server009");
+		h.render(model(all.slice(0, TOOL_ROWS_LIMIT), all.length));
+		expect(h.currentRow.scrollIntoViewCalls).toEqual([]);
+		await settle();
+
+		expect(h.html()).toContain('data-mcp="server009" aria-current="true"');
+		expect(h.currentRow.scrollIntoViewCalls).toEqual([{ block: "center" }]);
+	});
+
+	it("reveals a legend selection and restores keyboard focus after its targeted repaint", () => {
+		const h = loadHarness();
+		h.render(model());
+		h.currentRow.scrollIntoViewCalls.length = 0;
+		h.useTargetedDom();
+
+		h.clickFocusedLegend("__proto__");
+
+		expect(h.currentRow.scrollIntoViewCalls).toEqual([{ block: "center" }]);
+		expect(h.focusedSelection()).toEqual({ name: "__proto__", legend: true, replaced: true });
+	});
+
+	it("moves focus to the list row when deselection removes an out-of-band legend", () => {
+		const h = loadHarness();
+		h.selectServer("c");
+		h.render(model());
+		h.useTargetedDom();
+
+		h.clickFocusedLegend("c");
+
+		expect(h.focusedSelection()).toEqual({ name: "c", legend: false, replaced: true });
+	});
+
+	it("describes a 404 as an empty window instead of a stale dashboard", async () => {
+		const h = loadHarness();
+		h.respondWith((path) =>
+			path.startsWith("/api/mcp-detail")
+				? Promise.reject({ status: 404 })
+				: Promise.resolve({ list: "server", rows: [] }),
+		);
+		h.render(model());
+		await settle();
+
+		expect(h.html()).toContain("No captured calls for this MCP server in this window.");
+		expect(h.html()).not.toContain("restart it");
+	});
+});

--- a/cli/src/dashboard/ShellAsset.test.ts
+++ b/cli/src/dashboard/ShellAsset.test.ts
@@ -1073,19 +1073,28 @@ describe("JD.renderShell — optional nav rows", () => {
 	it("hides Knowledge and Graph when both flags are off", () => {
 		const h = loadJD();
 		h.JD.renderShell(model({ menus: menus(false, false) }));
-		expect(navViews(h)).toEqual(["stats", "standup", "skills", "journeys", "memories"]);
+		expect(navViews(h)).toEqual(["stats", "standup", "skills", "mcps", "journeys", "memories"]);
 	});
 
 	it("shows each row only when its own flag is on, keeping NAV_MIDDLE's order", () => {
 		const h = loadJD();
 		h.JD.renderShell(model({ menus: menus(true, false) }));
-		expect(navViews(h)).toEqual(["stats", "standup", "skills", "journeys", "memories", "knowledge"]);
+		expect(navViews(h)).toEqual(["stats", "standup", "skills", "mcps", "journeys", "memories", "knowledge"]);
 
 		h.JD.renderShell(model({ menus: menus(false, true) }));
-		expect(navViews(h)).toEqual(["stats", "standup", "skills", "journeys", "memories", "graph"]);
+		expect(navViews(h)).toEqual(["stats", "standup", "skills", "mcps", "journeys", "memories", "graph"]);
 
 		h.JD.renderShell(model({ menus: menus(true, true) }));
-		expect(navViews(h)).toEqual(["stats", "standup", "skills", "journeys", "memories", "knowledge", "graph"]);
+		expect(navViews(h)).toEqual([
+			"stats",
+			"standup",
+			"skills",
+			"mcps",
+			"journeys",
+			"memories",
+			"knowledge",
+			"graph",
+		]);
 	});
 
 	// The rows carry their icon and path from the same tables the always-on rows
@@ -1106,6 +1115,7 @@ describe("JD.renderShell — optional nav rows", () => {
 			stats: 1,
 			standup: 1,
 			skills: 1,
+			mcps: 1,
 			journeys: 1,
 			memories: 1,
 			knowledge: 1,
@@ -1120,7 +1130,7 @@ describe("JD.renderShell — optional nav rows", () => {
 	it("treats an absent menus slice as both rows hidden", () => {
 		const h = loadJD();
 		h.JD.renderShell(model());
-		expect(navViews(h)).toEqual(["stats", "standup", "skills", "journeys", "memories"]);
+		expect(navViews(h)).toEqual(["stats", "standup", "skills", "mcps", "journeys", "memories"]);
 	});
 
 	// A slice naming only one row, or holding a non-boolean, must degrade the same
@@ -1129,10 +1139,10 @@ describe("JD.renderShell — optional nav rows", () => {
 	it("treats a partial or non-boolean menus slice as hidden", () => {
 		const h = loadJD();
 		h.JD.renderShell(model({ menus: { knowledge: true } }));
-		expect(navViews(h)).toEqual(["stats", "standup", "skills", "journeys", "memories", "knowledge"]);
+		expect(navViews(h)).toEqual(["stats", "standup", "skills", "mcps", "journeys", "memories", "knowledge"]);
 
 		h.JD.renderShell(model({ menus: { knowledge: "yes", graph: 1 } }));
-		expect(navViews(h)).toEqual(["stats", "standup", "skills", "journeys", "memories"]);
+		expect(navViews(h)).toEqual(["stats", "standup", "skills", "mcps", "journeys", "memories"]);
 	});
 
 	// Only the ROW is gated. Landing on /graph with the flag off still renders the
@@ -1143,7 +1153,7 @@ describe("JD.renderShell — optional nav rows", () => {
 		const h = loadJD();
 		h.JD.renderShell(model({ view: "graph", menus: menus(false, false) }));
 		expect(h.element("pageTitle").textContent).toBe("Graph");
-		expect(navViews(h)).toEqual(["stats", "standup", "skills", "journeys", "memories"]);
+		expect(navViews(h)).toEqual(["stats", "standup", "skills", "mcps", "journeys", "memories"]);
 	});
 
 	// Settings is built from NAV_BOTTOM, outside the filtered loop, so no change to

--- a/cli/src/dashboard/SkillsAsset.test.ts
+++ b/cli/src/dashboard/SkillsAsset.test.ts
@@ -42,6 +42,15 @@ interface FakeRow {
 	readonly scrollIntoViewCalls: Array<Record<string, unknown> | undefined>;
 }
 
+interface FakeClickable {
+	onclick?: () => void;
+	getAttribute: (name: string) => string | null;
+	setAttribute: (name: string, value: string) => void;
+	removeAttribute: (name: string) => void;
+	classList: { contains: (name: string) => boolean };
+	focus: () => void;
+}
+
 interface Harness {
 	readonly requests: string[];
 	readonly list: FakeList;
@@ -50,6 +59,10 @@ interface Harness {
 	render: (model: unknown) => void;
 	/** Rewrites `?skill=`, standing in for a click or an arrival from the Stats card. */
 	selectSkill: (name: string | null) => void;
+	/** Activates a keyboard-focused legend and returns the focus state after repaint. */
+	clickFocusedLegend: (name: string) => void;
+	focusedSelection: () => { name: string | null; legend: boolean; replaced: boolean };
+	useTargetedDom: () => void;
 	/** Shrinks the browser window, for the half of the reveal the panel cannot see. */
 	setViewportHeight: (height: number) => void;
 	/** Advances the page-owned retry clock without waiting in real time. */
@@ -74,10 +87,12 @@ const row = (i: number): SkillRow => ({
  * the window.
  */
 const WINDOW_DAYS = ["2025-12-30", "2025-12-31", "2026-01-01", "2026-01-02", "2026-01-03"];
+const GENERATED_AT_MS = Date.parse("2026-01-03T12:00:00Z");
 
-function model(rows: ReadonlyArray<SkillRow>, total: number): unknown {
+function model(rows: ReadonlyArray<SkillRow>, total: number, usageOver: Record<string, unknown> = {}): unknown {
 	return {
 		view: "skills",
+		generatedAtMs: GENERATED_AT_MS,
 		timeZone: "Asia/Shanghai",
 		stats: {
 			toolUsage: {
@@ -88,6 +103,7 @@ function model(rows: ReadonlyArray<SkillRow>, total: number): unknown {
 				sessionsWithTools: total,
 				sessionsInWindow: total,
 				skillDays: WINDOW_DAYS.map((date) => ({ date, bySeries: { skill000: 1 } })),
+				...usageOver,
 			},
 		},
 	};
@@ -157,6 +173,16 @@ function loadHarness(): Harness {
 		},
 	};
 	const listNode = Object.assign(list, { getBoundingClientRect: () => list.rect });
+	let selectionNodes: FakeClickable[] = [];
+	let clickedNode: FakeClickable | null = null;
+	let targetedDom = false;
+	let targetedBandHtml = "";
+	const bandNode = {
+		replaceWith: (next: { readonly html?: string }) => {
+			targetedBandHtml = next.html ?? "";
+		},
+	};
+	const paneNode = { innerHTML: "" };
 	const app = {
 		get innerHTML() {
 			return html;
@@ -170,16 +196,63 @@ function loadHarness(): Harness {
 		},
 		querySelector: (selector: string) => {
 			if (selector === ".sk-list") return listNode;
+			if (selector === ".sk-band") return targetedDom ? bandNode : null;
+			if (selector === ".sk-pane") return targetedDom ? paneNode : null;
 			/* Present only when a row really carries the marker — `listHtml` writes it for
 			   the selected skill alone, so a selection whose row is still in the unfetched
 			   tail finds nothing here, exactly as in a browser. */
 			if (selector === '.sk-row[aria-current="true"]')
-				return html.includes('aria-current="true"') ? rowNode : null;
+				return html.includes('aria-current="true"') ||
+					selectionNodes.some(
+						(node) => node.classList.contains("sk-row") && node.getAttribute("aria-current") === "true",
+					)
+					? rowNode
+					: null;
 			return null;
 		},
-		querySelectorAll: () => [] as ReadonlyArray<never>,
+		querySelectorAll: (selector: string): FakeClickable[] => {
+			if (selector === ".sk-row") return selectionNodes.filter((node) => node.classList.contains("sk-row"));
+			if (selector !== "[data-skill]") return [];
+			const selectionHtml = targetedBandHtml
+				? targetedBandHtml + html.slice(Math.max(0, html.indexOf("<aside")))
+				: html;
+			selectionNodes = Array.from(
+				selectionHtml.matchAll(/<button\b[^>]*data-skill="([^"]+)"[^>]*>/g),
+				(match) => {
+					const tag = match[0];
+					const classes = /class="([^"]*)"/.exec(tag)?.[1]?.split(/\s+/) ?? [];
+					const attributes = new Map<string, string>([["data-skill", match[1] as string]]);
+					if (tag.includes('aria-current="true"')) attributes.set("aria-current", "true");
+					const node: FakeClickable = {
+						getAttribute: (name) => attributes.get(name) ?? null,
+						setAttribute: (name, value) => attributes.set(name, value),
+						removeAttribute: (name) => attributes.delete(name),
+						classList: { contains: (name) => classes.includes(name) },
+						focus: () => {
+							document.activeElement = node;
+						},
+					};
+					return node;
+				},
+			);
+			return selectionNodes;
+		},
 	};
-	const document = { getElementById: (id: string) => (id === "app" ? app : null) };
+	const document = {
+		activeElement: null as FakeClickable | null,
+		getElementById: (id: string) => (id === "app" ? app : null),
+		createElement: (_tag: string) => {
+			let content = "";
+			return {
+				set innerHTML(next: string) {
+					content = next;
+				},
+				get firstChild() {
+					return { html: content };
+				},
+			};
+		},
+	};
 	const window = {
 		JD: {} as Record<string, unknown>,
 		location: new URL("http://127.0.0.1/skills"),
@@ -267,6 +340,24 @@ function loadHarness(): Harness {
 			else url.searchParams.delete("skill");
 			window.location = url;
 		},
+		clickFocusedLegend: (name: string) => {
+			const node = selectionNodes.find(
+				(candidate) =>
+					candidate.classList.contains("sk-legend") && candidate.getAttribute("data-skill") === name,
+			);
+			if (!node?.onclick) throw new Error(`no wired skill legend for ${name}`);
+			clickedNode = node;
+			document.activeElement = node;
+			node.onclick();
+		},
+		focusedSelection: () => ({
+			name: document.activeElement?.getAttribute("data-skill") ?? null,
+			legend: document.activeElement?.classList.contains("sk-legend") ?? false,
+			replaced: document.activeElement !== null && document.activeElement !== clickedNode,
+		}),
+		useTargetedDom: () => {
+			targetedDom = true;
+		},
 		setViewportHeight: (height: number) => {
 			window.innerHeight = height;
 		},
@@ -288,6 +379,37 @@ describe("Skills page asset", () => {
 		expect(h.html()).toContain("Jan 1");
 		expect(h.html()).toContain("outcome not recorded");
 		expect(h.html()).not.toContain("Could not reach the dashboard server");
+		expect(h.requests[0]).toBe(`/api/skill-detail?range=month&name=skill000&nowMs=${GENERATED_AT_MS}`);
+	});
+
+	it("keeps prototype-shaped and real Other skill names distinct from the roll-up", () => {
+		const names = ["Other", "__proto__", "constructor", "b", "c"];
+		const rows = names.map((name, index) => ({ ...row(index), name }));
+		const bySeries = Object.fromEntries(names.map((name, index) => [name, 10 - index * 2]));
+		const h = loadHarness();
+		h.render(model(rows, rows.length, { skillDays: [{ date: "2026-01-03", bySeries }] }));
+		const html = h.html();
+
+		for (const name of ["Other", "__proto__", "constructor"]) {
+			expect(html).toContain(`data-skill="${name}"`);
+		}
+		expect(html).toContain('data-keys="Other,__proto__,constructor,b,Other "');
+		expect(html).toContain("<b>Other (1 skill)</b> 2");
+		expect(html).not.toContain("<b>Other </b>");
+	});
+
+	it("describes a 404 as an empty window instead of a stale dashboard", async () => {
+		const h = loadHarness();
+		h.respondWith((path) =>
+			path.startsWith("/api/skill-detail")
+				? Promise.reject({ status: 404 })
+				: Promise.resolve({ list: "skill", rows: [] }),
+		);
+		h.render(model([row(0)], 1));
+		await settle();
+
+		expect(h.html()).toContain("No captured calls for this skill in this window.");
+		expect(h.html()).not.toContain("restart it");
 	});
 
 	it("draws both pane charts over the band's window days rather than their own data's extent", async () => {
@@ -318,8 +440,8 @@ describe("Skills page asset", () => {
 		expect(html.split("<span>Jan 3</span>").length - 1).toBe(2);
 		/* The record's dates stay the DATA's — `Jan 1` is on no axis here. That split is
 		   the honest version of what used to be spelled as two disagreeing axes. */
-		expect(html).toContain("<b>First used</b><span>Jan 1</span>");
-		expect(html).toContain("<b>Last used</b><span>Jan 2</span>");
+		expect(html).toContain('<b>First used</b><span title="Jan 1">Jan 1</span>');
+		expect(html).toContain('<b>Last used</b><span title="Jan 2">Jan 2</span>');
 	});
 
 	it("falls back to the skill's own days when the payload carried no band series", async () => {
@@ -337,7 +459,8 @@ describe("Skills page asset", () => {
 		expect(html).toContain("<title>2026-01-01=1 session</title>");
 		expect(html).toContain("<title>2026-01-02=1 session</title>");
 		expect(html).not.toContain("<title>2025-12-30=");
-		expect(html.split("<span>Jan 1</span>").length - 1).toBe(3);
+		expect(html.split('<span title="Jan 1">Jan 1</span>').length - 1).toBe(1);
+		expect(html.split("<span>Jan 1</span>").length - 1).toBe(2);
 	});
 
 	it("says how many sessions attributed no spend, so an empty day in the cost chart reads", async () => {
@@ -698,6 +821,44 @@ describe("Skills page asset", () => {
 		   comes with it. */
 		expect(h.html()).toContain('aria-current="true"');
 		expect(h.currentRow.scrollIntoViewCalls).toEqual([{ block: "center" }]);
+	});
+
+	it("reveals a legend selection and restores keyboard focus after its targeted repaint", () => {
+		const h = loadHarness();
+		const rows = [row(0), row(1)];
+		h.render(
+			model(rows, rows.length, {
+				skillDays: [{ date: "2026-01-03", bySeries: { skill000: 2, skill001: 1 } }],
+			}),
+		);
+		h.currentRow.scrollIntoViewCalls.length = 0;
+		h.useTargetedDom();
+
+		h.clickFocusedLegend("skill001");
+
+		expect(h.currentRow.scrollIntoViewCalls).toEqual([{ block: "center" }]);
+		expect(h.focusedSelection()).toEqual({ name: "skill001", legend: true, replaced: true });
+	});
+
+	it("moves focus to the list row when deselection removes an out-of-band legend", () => {
+		const rows = Array.from({ length: 5 }, (_, index) => row(index));
+		const h = loadHarness();
+		h.selectSkill("skill004");
+		h.render(
+			model(rows, rows.length, {
+				skillDays: [
+					{
+						date: "2026-01-03",
+						bySeries: { skill000: 5, skill001: 4, skill002: 3, skill003: 2, skill004: 1 },
+					},
+				],
+			}),
+		);
+		h.useTargetedDom();
+
+		h.clickFocusedLegend("skill004");
+
+		expect(h.focusedSelection()).toEqual({ name: "skill004", legend: false, replaced: true });
 	});
 
 	it("does not move the column for a row that is already on screen", async () => {

--- a/cli/src/dashboard/ToolUsagePagingAsset.test.ts
+++ b/cli/src/dashboard/ToolUsagePagingAsset.test.ts
@@ -74,6 +74,7 @@ interface Harness {
  */
 const ROW_PITCH = 50;
 const ROW_HEIGHT = 40;
+const GENERATED_AT_MS = Date.parse("2026-07-30T12:00:00Z");
 
 function loadHarness(rowCounts: Record<string, number> = {}): Harness {
 	const fetched: string[] = [];
@@ -224,7 +225,7 @@ function model(toolUsageOver: Record<string, unknown> = {}): unknown {
 		schemaVersion: 1,
 		view: "stats",
 		tier: "memory",
-		generatedAtMs: Date.parse("2026-07-30T12:00:00Z"),
+		generatedAtMs: GENERATED_AT_MS,
 		timeZone: "UTC",
 		scope: { kind: "all" },
 		// One enrolled repo, because `renderStats` short-circuits an empty registry
@@ -261,6 +262,7 @@ function model(toolUsageOver: Record<string, unknown> = {}): unknown {
 				serverCallsTotal: 375,
 				mcpTools: Array.from({ length: TOOL_ROWS_LIMIT }, (_, i) => ({ ...skillRow(i), kind: "mcp" })),
 				mcpToolsTotal: 42,
+				serverToolsTotal: 41,
 				skillAgents: [{ source: "claude", sessions: 4, calls: 200 }],
 				mcpAgents: [{ source: "claude", sessions: 4, calls: 375 }],
 				sessionsWithTools: 4,
@@ -442,7 +444,9 @@ describe("tool-usage lists — fetching a page", () => {
 		// The window params ride along because the rows are an aggregate OVER a
 		// window: paging with a different one would append rows counted from a
 		// different set.
-		expect(h.fetched).toEqual([`/api/tool-usage?range=month&dimension=model&list=skill&offset=${TOOL_ROWS_LIMIT}`]);
+		expect(h.fetched).toEqual([
+			`/api/tool-usage?range=month&dimension=model&list=skill&offset=${TOOL_ROWS_LIMIT}&nowMs=${GENERATED_AT_MS}`,
+		]);
 	});
 
 	it("appends the page and moves the footer, keeping the card's other rows", async () => {
@@ -667,7 +671,9 @@ describe("tool-usage lists — carrying an expansion across the 30 s poll", () =
 		// screen and never a click count: a page that came back holding a row already
 		// loaded is deduped, and from then on a counter asks for more rows than are
 		// displayed, which reads as "changed" forever.
-		expect(h.fetched).toEqual([`/api/tool-usage?range=month&dimension=model&list=skill&offset=0&limit=${GROWN}`]);
+		expect(h.fetched).toEqual([
+			`/api/tool-usage?range=month&dimension=model&list=skill&offset=0&limit=${GROWN}&nowMs=${GENERATED_AT_MS}`,
+		]);
 		// Nothing moved, so the poll left the card exactly as the reader had it. Before
 		// this, `/api/model`'s first page silently replaced it every 30 s.
 		expect(h.html()).toContain(`Showing ${GROWN} of ${SKILLS_TOTAL} skills`);
@@ -742,7 +748,9 @@ describe("tool-usage lists — carrying an expansion across the 30 s poll", () =
 
 		// One request, for the clicked list only. The three lists are independent in
 		// the payload, so paging one must not re-read — or reset — another.
-		expect(h.fetched).toEqual([`/api/tool-usage?range=month&dimension=model&list=skill&offset=${TOOL_ROWS_LIMIT}`]);
+		expect(h.fetched).toEqual([
+			`/api/tool-usage?range=month&dimension=model&list=skill&offset=${TOOL_ROWS_LIMIT}&nowMs=${GENERATED_AT_MS}`,
+		]);
 		expect(h.html()).toContain(`Showing ${GROWN} of ${SKILLS_TOTAL} skills`);
 		expect(h.html()).toContain(`Showing ${GROWN} of ${SERVERS_TOTAL} servers`);
 		// And the untouched card does not move. A Show more ends in a whole-page

--- a/cli/src/dashboard/assets/index.html
+++ b/cli/src/dashboard/assets/index.html
@@ -215,6 +215,7 @@
 <script src="js/shell.js"></script>
 <script src="js/stats.js"></script>
 <script src="js/skills.js"></script>
+<script src="js/mcps.js"></script>
 <script src="js/standup.js"></script>
 <script src="js/memories.js"></script>
 <script src="js/journeys.js"></script>

--- a/cli/src/dashboard/assets/js/charts.js
+++ b/cli/src/dashboard/assets/js/charts.js
@@ -347,6 +347,12 @@ window.JD = window.JD || {};
 				if (value <= 0) return;
 				var h = (H * value) / max;
 				yCursor -= h;
+				/* `data-series` names the SERIES this rect belongs to (a skill or an MCP
+				   server), so the band's chooser column can highlight the chart alongside
+				   the row it selected — CSS keys on `.sk-band[data-selected]` +
+				   `rect[data-active]` to dim every other series to ~.22 opacity without
+				   redrawing the SVG. Escaped through `JD.esc` because a server or skill
+				   name is user-authored and can carry `"` in the wild. */
 				svg +=
 					'<rect x="' +
 					x.toFixed(2) +
@@ -358,6 +364,8 @@ window.JD = window.JD || {};
 					Math.max(1, h).toFixed(2) +
 					'" fill="' +
 					JD.seriesColor(keyIndex) +
+					'" data-series="' +
+					JD.esc(key) +
 					'"><title>' +
 					JD.esc(point.date + " · " + key + " · " + format(value)) +
 					"</title></rect>";

--- a/cli/src/dashboard/assets/js/main.js
+++ b/cli/src/dashboard/assets/js/main.js
@@ -6,8 +6,10 @@
 		stats: { render: (model) => window.JD.renderStats(model), grid: true },
 		standup: { render: (model) => window.JD.renderStandup(model), grid: false },
 		/* Page mode, not the card grid: the list is one full-height column, the same
-		   shape the browser pages below use. */
+		   shape the browser pages below use. `mcps` is the same page for MCP servers —
+		   both render `.browser-page`, which `main.css` sizes as a fixed frame. */
 		skills: { render: (model) => window.JD.renderSkills(model), grid: false },
+		mcps: { render: (model) => window.JD.renderMcps(model), grid: false },
 		journeys: { render: (model) => window.JD.renderCoaching(model), grid: false },
 		memories: { render: (model) => window.JD.renderMemories(model), grid: false },
 		knowledge: { render: (model) => window.JD.renderKnowledge(model), grid: false },

--- a/cli/src/dashboard/assets/js/mcps.js
+++ b/cli/src/dashboard/assets/js/mcps.js
@@ -1,0 +1,1077 @@
+/* MCPs page — a chart band, a chooser column, and a reading pane.
+ *
+ * THE SKILLS PAGE'S TWIN, DELIBERATELY. It takes that page's grammar wholesale (the
+ * `.sk-*` classes, the URL-borne selection, the read-the-whole-list-on-arrival column,
+ * the shared day axis) because the two answer the same shape of question about the same
+ * table: which of my things did my agents reach for, how often, and when. Every rule in
+ * `skills.js`'s header applies here and is not restated — read that file first.
+ *
+ * WHAT IS NOT SHARED IS THE CODE. The two pages have separate modules and separate
+ * state, and that is not an oversight: a shared module would have to carry a "which
+ * list" parameter through every function, and the two panes differ in what the RECORD
+ * holds rather than in presentation (see below). The shared part is the stylesheet, and
+ * `main.css`'s browser-page block is where that sharing is declared.
+ *
+ * WHAT THE RECORD CANNOT SAY HERE, and why three of the Skills pane's sections have no
+ * counterpart:
+ *
+ *   - **No cost.** Nothing writes an MCP row's token columns, so there is no spend to
+ *     attribute — not "we do not show it", but "it was never measured".
+ *   - **No outcomes.** `skill_invocations` gives a skill a row per invocation with its
+ *     own `ok`; MCP has no such table, so whether a call succeeded is not on record.
+ *   - **No arguments, no results.** Same absence, and the one the page states out loud
+ *     in its basis line: a reader who expects a call log has to be told there is none
+ *     rather than left to read an empty section as a bug.
+ *
+ * `tools` is the section that exists here and nowhere else. A server is a NAMESPACE, so
+ * "which of its tools do I actually use" is the question this page is opened for, and it
+ * is the one figure a server row cannot carry.
+ *
+ * THE TWO CHARTS COUNT DIFFERENT THINGS, and the difference is the point: `Call cadence`
+ * counts SESSIONS by day (how often it was reached for) and `Calls per session` counts
+ * CALLS per session in arrival order (how hard it was worked in each). A busy day with
+ * one session and a quiet day with four are the two shapes those charts exist to tell
+ * apart.
+ *
+ * The two DELIBERATELY carry different X axes: the cadence chart is on the band's own
+ * day buckets so a reader can line it up with the top chart, while `Calls per session`
+ * is one bar per session in arrival order because the record holds one instant per
+ * session and a per-day rewrite of it would drop the exact "session A made 40 calls"
+ * signal this section is opened for. The two endpoint labels below each chart name the
+ * span they cover, so the axes cannot be misread as the same clock.
+ */
+(function (JD) {
+	"use strict";
+
+	/* Series kept in the band before the rest rolls into "Other" — `skills.js`'s
+	   constant and its reason: the categorical ramp holds five CVD-validated colours. */
+	var BAND_SERIES = 4;
+	/* A failed tail read retries without opting this page into the global model poll. */
+	var REST_RETRY_MS = 30000;
+	/* An absolute backstop against an unbounded request loop on a corrupt response
+	   stream. Real reads stop on offset/total equality. */
+	var MAX_LIST_REQUESTS = 1000;
+
+	/* Everything an async answer can land in, so the two fetches below do not have to
+	   re-render each other's half. Module-scoped for the reason `skills.js` states: an
+	   explicit model refresh re-enters `renderMcps`, and a local would be re-seeded from
+	   the payload, dropping a pane the reader is in the middle of. */
+	var state = { rows: null, paneName: null, pane: null, paneError: null };
+
+	/* Which render is current — the staleness guard for THE PANE'S detail fetch alone.
+	   The list read next door is staled by a new PAYLOAD instead (see `collectRows`). */
+	var seq = 0;
+
+	var rowsTotal = null;
+	var renderedModel = null;
+	/* The model whose full list has already been asked for — the guard that keeps the
+	   automatic read to ONE per payload. The model OBJECT, not a row count, because a
+	   row click re-renders the same payload and must not re-read the list. */
+	var fetchedModel = null;
+	var restLoading = false;
+	var restError = false;
+	var restRetryTimer = null;
+
+	/* Whether the pane's one long fixed paragraph is open. Module state rather than DOM
+	   state because every path here repaints the whole pane; keyed by the block's own
+	   class, which `bindProse` reads back off the event target. Defaults to OPEN because
+	   the mockup shows the sentence in full and a first-time reader needs to see what the
+	   page is claiming without a click; a click still collapses it back. */
+	var openProse = { "sk-basis": true };
+
+	/* Whether "the address names no server" has already been answered for this page
+	   load. Nav is a full page reload, so this starts false on every arrival. */
+	var defaultAnswered = false;
+
+	/* The server the column has already been scrolled to, so a selection is revealed
+	   ONCE rather than on every repaint. */
+	var scrolledToServer = null;
+
+	/** The selected server, read from the address rather than from a variable. */
+	function selectedServer() {
+		try {
+			return new URLSearchParams(window.location.search).get("mcp") || null;
+		} catch (_err) {
+			return null;
+		}
+	}
+
+	/**
+	 * Writes the selection into the address without adding a history entry.
+	 *
+	 * `?mcp=`, not `?server=`: the query string is shared with the topbar's own
+	 * parameters (`repo`, `range`, `dimension`), and `server` reads as if it named the
+	 * dashboard server rather than one row of this page.
+	 */
+	function setSelectedServer(name) {
+		try {
+			var url = new URL(window.location.href);
+			if (name) url.searchParams.set("mcp", name);
+			else url.searchParams.delete("mcp");
+			window.history.replaceState(null, "", url.toString());
+		} catch (_err) {
+			/* A blocked History API must not stop the pane from opening — the render
+			   below reads `state.paneName`, which is set either way. */
+		}
+	}
+
+	/** The rows the column is showing: the fetched list once it lands, else the model's own page. */
+	function visibleRows(model) {
+		return state.rows || modelFirstPage(model);
+	}
+
+	/** The page the model already carries, which IS the column's first page. */
+	function modelFirstPage(model) {
+		var usage = (model.stats && model.stats.toolUsage) || {};
+		return usage.servers || [];
+	}
+
+	/**
+	 * The server to open when the address names none — the top row, which is the
+	 * server's own volume ranking.
+	 *
+	 * Written into the ADDRESS, not just into `state`, for the reason `skills.js` gives:
+	 * every render re-reads the address, so a selection living only in `state` is wiped
+	 * by the next one. An empty list leaves the question open.
+	 */
+	function defaultSelection(model) {
+		if (defaultAnswered) return null;
+		var rows = visibleRows(model);
+		if (rows.length === 0) return null;
+		defaultAnswered = true;
+		setSelectedServer(rows[0].server);
+		return rows[0].server;
+	}
+
+	/** Extracted from `renderMcps` so the row-click handler can start a new detail
+	 *  fetch without going through the full render. Mirror of `skills.js`'s `fetchDetail`. */
+	function fetchDetail(app, model) {
+		var selected = state.paneName;
+		if (!selected) return;
+		var mine = ++seq;
+		JD.getJson(
+			JD.withParams("/api/mcp-detail" + JD.query(model, {}), {
+				server: selected,
+				/* The page model and its chooser rows were resolved against this clock.
+				   Carry it into the detail read so `today` cannot cross midnight between
+				   the render and a click and turn a visible row into a 404. */
+				nowMs: model.generatedAtMs,
+			}),
+		)
+			.then(
+				(detail) => {
+					if (mine !== seq || state.paneName !== selected) return false;
+					state.pane = detail;
+					return true;
+				},
+				/* THE TWO-CALLBACK FORM, never a trailing `.catch`, with the repaint moved
+				   out of both — `skills.js` carries the measurement: under a shared handler a
+				   render fault in a chart was reported to the reader as a dashboard that had
+				   stopped, because `paneErrorText` reads a missing `status` that way. */
+				(err) => {
+					if (mine !== seq || state.paneName !== selected) return false;
+					state.paneError = paneErrorText(err);
+					return true;
+				},
+			)
+			.then((changed) => {
+				if (changed) drawPane(app, model);
+			});
+	}
+
+	function renderMcps(model) {
+		var app = document.getElementById("app");
+		if (!app) return;
+		if (renderedModel !== model) {
+			cancelRowsRetry();
+			renderedModel = model;
+			var freshUsage = (model.stats && model.stats.toolUsage) || {};
+			rowsTotal = freshUsage.serversTotal || 0;
+			restLoading = false;
+			restError = false;
+		}
+		var selected = selectedServer();
+		if (!selected) selected = defaultSelection(model);
+		/* A different server invalidates the cached pane, so the reader never sees the
+		   previous server's figures under the new server's name. */
+		if (state.paneName !== selected) state = { rows: state.rows, paneName: selected, pane: null, paneError: null };
+
+		/* The rest of the list, on nobody's ask. Skipped when the model's first page
+		   already IS every server, which is the common case: a machine runs far fewer
+		   servers than skills, so this page usually costs no request at all. The flags
+		   move BEFORE the draw so the loading line is on screen for the whole flight. */
+		var needsRest = serverTotal(model) > modelFirstPage(model).length && fetchedModel !== model;
+		if (needsRest) {
+			fetchedModel = model;
+			restLoading = true;
+			restError = false;
+		}
+
+		draw(app, model);
+
+		if (needsRest) fetchRows(app, model);
+		fetchDetail(app, model);
+	}
+
+	/**
+	 * Reads the whole ranked list, from the top.
+	 *
+	 * `skills.js`'s `collectRows` with the identity changed from `row.name` to
+	 * `row.server`; every rule there holds here. The stop is the SERVER's position rather
+	 * than a row count fixed when the read began, a repeated identity restarts the pass
+	 * (an offset partition that moved would otherwise skip the row it displaced), and
+	 * what stales the read is a new PAYLOAD rather than the render counter `seq`.
+	 */
+	function collectRows(model) {
+		var rows = [];
+		var names = Object.create(null);
+		var offset = 0;
+		var total = serverTotal(model);
+		var restartsLeft = 2;
+		var requestBudget = Math.min(
+			MAX_LIST_REQUESTS,
+			Math.max(25, Math.ceil(total / Math.max(1, modelFirstPage(model).length)) * (restartsLeft + 1)),
+		);
+
+		function restart() {
+			if (restartsLeft <= 0) return Promise.reject(new Error("MCP server list changed while it was being read"));
+			restartsLeft--;
+			rows = [];
+			names = Object.create(null);
+			offset = 0;
+			return next();
+		}
+
+		function next() {
+			if (renderedModel !== model) return Promise.resolve({ rows: rows, total: total });
+			if (offset >= total) {
+				if (rows.length === total) return Promise.resolve({ rows: rows, total: total });
+				return restart();
+			}
+			if (requestBudget <= 0) {
+				return Promise.reject(new Error("MCP server list kept growing while it was being read"));
+			}
+			requestBudget--;
+			return JD.getJson(
+				JD.withParams("/api/tool-usage" + JD.query(model, {}), {
+					list: "server",
+					offset: String(offset),
+					limit: String(total - offset),
+					nowMs: model.generatedAtMs,
+				}),
+			).then((page) => {
+				if (renderedModel !== model) return { rows: rows, total: total };
+				var incoming = (page && page.rows) || [];
+				if (page && typeof page.totalCount === "number") total = page.totalCount;
+				var repeated = false;
+				incoming.forEach((row) => {
+					if (!names[row.server]) {
+						names[row.server] = true;
+						rows.push(row);
+					} else repeated = true;
+				});
+				offset += incoming.length;
+				if (repeated || (incoming.length === 0 && offset < total)) return restart();
+				return next();
+			});
+		}
+
+		return next();
+	}
+
+	function cancelRowsRetry() {
+		if (restRetryTimer === null) return;
+		window.clearTimeout(restRetryTimer);
+		restRetryTimer = null;
+	}
+
+	/** Retries only the list tail; the open detail pane and the rest of the page stay put. */
+	function scheduleRowsRetry(app, model) {
+		cancelRowsRetry();
+		restRetryTimer = window.setTimeout(() => {
+			restRetryTimer = null;
+			if (renderedModel !== model || fetchedModel !== model || !restError || restLoading) return;
+			restLoading = true;
+			restError = false;
+			draw(app, model);
+			fetchRows(app, model);
+		}, REST_RETRY_MS);
+	}
+
+	function fetchRows(app, model) {
+		cancelRowsRetry();
+		collectRows(model)
+			.then(
+				(result) => {
+					if (renderedModel !== model) return false;
+					state.rows = result.rows;
+					rowsTotal = result.total;
+					restLoading = false;
+					restError = false;
+					cancelRowsRetry();
+					return true;
+				},
+				() => {
+					if (renderedModel !== model) return false;
+					/* THE ROWS ARE LEFT ALONE — a list that empties itself over one failed
+					   fetch is worse than a short one. Only the loading line moves. */
+					restLoading = false;
+					restError = true;
+					scheduleRowsRetry(app, model);
+					return true;
+				},
+			)
+			.then((changed) => {
+				if (changed) draw(app, model);
+			});
+	}
+
+	function serverTotal(model) {
+		if (rowsTotal !== null) return rowsTotal;
+		var usage = (model.stats && model.stats.toolUsage) || {};
+		return usage.serversTotal || 0;
+	}
+
+	/**
+	 * What to tell the reader when the detail could not be loaded. No `status` means
+	 * nothing reached the dashboard; 404 is the valid answer that this server has no
+	 * captured call in the selected window; every other status is a server refusal.
+	 */
+	function paneErrorText(err) {
+		if (err && err.status === 404) return "No captured calls for this MCP server in this window.";
+		if (err && typeof err.status === "number") {
+			return (
+				"Could not load this MCP server — the dashboard answered " +
+				err.status +
+				". If it has been running since before this view existed, restart it." +
+				" This view needs a current server."
+			);
+		}
+		return "Could not reach the dashboard server. It may have stopped — run `jolli dashboard` again.";
+	}
+
+	/** Whether the current row is already somewhere the reader can see it. */
+	function isRowRevealed(list, row) {
+		if (!row.getBoundingClientRect || !list || !list.getBoundingClientRect) return true;
+		var rect = row.getBoundingClientRect();
+		var box = list.getBoundingClientRect();
+		if (rect.top < box.top || rect.bottom > box.bottom) return false;
+		var viewportHeight = window.innerHeight || 0;
+		if (!viewportHeight) return true;
+		return rect.top >= 0 && rect.bottom <= viewportHeight;
+	}
+
+	/**
+	 * Brings the selected row into view, ONCE per selection — `skills.js`'s
+	 * `revealSelectedRow`, and its reasons hold unchanged: the Stats card's MCP rows can
+	 * link in with a server selected that sits far down the column, and the band's key
+	 * can select one outside its top four. Not recorded when the row is absent, because
+	 * the selection may name a server still in the list's in-flight tail.
+	 */
+	function revealSelectedRow(app, list) {
+		var name = state.paneName;
+		if (!name) {
+			scrolledToServer = null;
+			return;
+		}
+		if (scrolledToServer === name) return;
+		var row = app.querySelector('.sk-row[aria-current="true"]');
+		if (!row) return;
+		scrolledToServer = name;
+		if (isRowRevealed(list, row)) return;
+		if (row.scrollIntoView) row.scrollIntoView({ block: "center" });
+	}
+
+	/**
+	 * Rewrites ONLY the reading pane, leaving the band chart's SVG, the row column and its
+	 * scroll offset in place. Used when the detail fetch lands for the currently selected
+	 * server — nothing above the pane changed between the two frames, and rebuilding the
+	 * band SVG and the list every time was where the row-click flicker came from. Falls
+	 * back to the full `draw` if the pane node is missing, so a caller that lands here
+	 * before the frame has been rendered cannot silently no-op. Prose handlers are re-bound
+	 * because the clamped paragraph lives inside the pane and its listener rode the old
+	 * node down. Mirror of `drawPane` in `skills.js`. */
+	function drawPane(app, model) {
+		var pane = app.querySelector(".sk-pane");
+		if (!pane) {
+			draw(app, model);
+			return;
+		}
+		var usage = (model.stats && model.stats.toolUsage) || {};
+		pane.innerHTML = paneHtml(usage, model.timeZone);
+		bindProse(app);
+	}
+
+	/** Chart/list linking helper: marks bar rects belonging to the selected series with
+	 *  `data-active` so the CSS in `main.css` keeps them at full opacity while the others
+	 *  fade. Mirror of `skills.js`'s `applyBandActive`; the rule is one line, one comment. */
+	function applyBandActive(app) {
+		var name = state.paneName || "";
+		var rects = app.querySelectorAll(".sk-band .sk-bandbars rect[data-series]");
+		Array.prototype.forEach.call(rects, (rect) => {
+			if (name && rect.getAttribute("data-series") === name) rect.setAttribute("data-active", "");
+			else rect.removeAttribute("data-active");
+		});
+	}
+
+	/** Redraws ONLY `.sk-band`, leaving the nav column and pane in place. Needed on
+	 *  selection change because a server outside the top four swaps into the fourth slot
+	 *  — a pure attribute toggle would leave that case wrong. Rebinds selection because
+	 *  the legend buttons ride the new band. Mirror of `skills.js`'s `drawBand`. */
+	function drawBand(app, model) {
+		var band = app.querySelector(".sk-band");
+		if (!band) return;
+		var usage = (model.stats && model.stats.toolUsage) || {};
+		var host = document.createElement("div");
+		host.innerHTML = bandHtml(usage);
+		var next = host.firstChild;
+		band.replaceWith(next);
+		applyBandActive(app);
+		bindSelection(app, model);
+	}
+
+	/** Restores keyboard focus after `drawBand` replaces the legend buttons. Compare
+	 *  attributes directly instead of building a selector from a user-authored server
+	 *  name; fall back to the matching list row if deselection removes the legend. */
+	function restoreSelectionFocus(app, name) {
+		var legend = null;
+		var row = null;
+		Array.prototype.forEach.call(app.querySelectorAll("[data-mcp]"), (element) => {
+			if (element.getAttribute("data-mcp") !== name) return;
+			if (element.classList && element.classList.contains("sk-legend")) legend = element;
+			else if (element.classList && element.classList.contains("sk-row")) row = element;
+		});
+		var target = legend || row;
+		if (target && target.focus) target.focus();
+	}
+
+	/** The selection-only repaint (list aria-current + band + pane). Called from the
+	 *  row-click handler in place of the old full `renderMcps(model)`, which tore down
+	 *  the whole `.browser-page` section on every click. Mirror of `skills.js`'s
+	 *  `updateSelection`. */
+	function updateSelection(app, model, focusedLegendName) {
+		var name = state.paneName;
+		Array.prototype.forEach.call(app.querySelectorAll(".sk-row"), (row) => {
+			if (row.getAttribute("data-mcp") === name) row.setAttribute("aria-current", "true");
+			else row.removeAttribute("aria-current");
+		});
+		revealSelectedRow(app, app.querySelector(".sk-list"));
+		drawBand(app, model);
+		drawPane(app, model);
+		if (focusedLegendName !== null) restoreSelectionFocus(app, focusedLegendName);
+	}
+
+	function draw(app, model) {
+		var usage = (model.stats && model.stats.toolUsage) || {};
+		var rows = visibleRows(model);
+		/* The rows' offset is carried across by hand: the write below replaces the node
+		   that holds it, and only that node scrolls. Without it the column snapped back
+		   to its first row on every repaint that reaches HERE — a row click, the tail of
+		   the list arriving, an explicit refresh. The detail-fetch path no longer reaches
+		   this function (see `drawPane` above), so it needs no carry-across at all — the
+		   list node is untouched there. */
+		var previous = app.querySelector(".sk-list");
+		var offset = previous ? previous.scrollTop : 0;
+		app.innerHTML =
+			'<section class="browser-page mcp-page">' +
+			bandHtml(usage) +
+			'<aside class="sk-nav" aria-label="MCP server browser">' +
+			navHeadHtml(usage) +
+			'<div class="sk-list">' +
+			listHtml(rows) +
+			"</div>" +
+			navPagingHtml(rows, usage) +
+			navFootHtml(usage) +
+			"</aside>" +
+			'<article class="sk-pane" aria-label="MCP server detail">' +
+			paneHtml(usage, model.timeZone) +
+			"</article>" +
+			"</section>";
+		var list = app.querySelector(".sk-list");
+		if (list) {
+			if (offset > 0) list.scrollTop = offset;
+			/* AFTER the restore: this measures where the row actually sits, and a new
+			   selection is the one thing allowed to overrule the carried-across offset. */
+			revealSelectedRow(app, list);
+		}
+		bindSelection(app, model);
+		bindProse(app);
+		applyBandActive(app);
+	}
+
+	// ── The band ────────────────────────────────────────────────────────────────
+
+	/**
+	 * Every server's adoption, day by day.
+	 *
+	 * `skills.js`'s `bandHtml` against `usage.serverDays`, including the rule
+	 * `JD.topSeries` cannot express: a SELECTED server outside the top four is swapped
+	 * into the fourth slot, because otherwise "highlight this server" fails for exactly
+	 * the servers the roll-up hides, and dimming the Other segments instead would claim
+	 * several servers' aggregate is one server.
+	 */
+	function bandHtml(usage) {
+		var series = usage.serverDays || [];
+
+		var totals = Object.create(null);
+		series.forEach((point) => {
+			Object.keys(point.bySeries || {}).forEach((name) => {
+				totals[name] = (totals[name] || 0) + point.bySeries[name];
+			});
+		});
+		var names = Object.keys(totals);
+		var selected = state.paneName && totals[state.paneName] !== undefined ? state.paneName : null;
+		/* `data-selected` on the band is what dims non-active rects (see `skills.js`'s
+		   `bandHtml` — one comment for both). Empty when nothing is selected. */
+		var head =
+			'<div class="sk-band" data-selected="' +
+			(selected ? JD.esc(selected) : "") +
+			'"><div class="sk-nav-head" style="padding:0 0 10px;border-bottom:0">' +
+			"<b>All MCP servers, day by day</b> · sessions that made at least one captured call " +
+			"through each server · a session using several servers counts once per server</div>";
+
+		/* THE EMPTY TEST IS "no series", NOT "no points": `serverDays` carries one point
+		   per day of the window whether or not anything ran, so a `series.length` test
+		   would draw an axis and an empty legend for a window with no MCP calls. */
+		if (names.length === 0) {
+			return head + '<div class="empty-note">No MCP server calls recorded in this window.</div></div>';
+		}
+		var ranked = names.slice().sort((a, b) => totals[b] - totals[a] || (a < b ? -1 : a > b ? 1 : 0));
+		var kept = ranked.slice(0, BAND_SERIES);
+		if (selected && kept.indexOf(selected) === -1) kept = kept.slice(0, BAND_SERIES - 1).concat([selected]);
+		var keptSet = Object.create(null);
+		kept.forEach((name) => {
+			keptSet[name] = true;
+		});
+
+		/* A server is user-controlled and can really be named `Other`. The roll-up
+		   therefore takes the first free INTERNAL key, matching `JD.topSeries`; otherwise
+		   the aggregate overwrites the real server. Its visible label below says how many
+		   servers it contains, so a collision cannot leave two identical legend rows. */
+		var otherKey = "Other";
+		while (otherKey in totals) otherKey += " ";
+		var rolled = series.map((point) => {
+			var bySeries = Object.create(null);
+			var other = 0;
+			Object.keys(point.bySeries || {}).forEach((name) => {
+				if (keptSet[name]) bySeries[name] = point.bySeries[name];
+				else other += point.bySeries[name];
+			});
+			bySeries[otherKey] = other;
+			return { date: point.date, bySeries: bySeries };
+		});
+		var keys = kept.concat([otherKey]);
+		var otherNames = names.filter((name) => !keptSet[name]);
+		var otherTotal = otherNames.reduce((sum, name) => sum + totals[name], 0);
+		var otherLabel = "Other (" + otherNames.length + (otherNames.length === 1 ? " server)" : " servers)");
+
+		var legend = keys
+			.map((key, index) => {
+				var value = key === otherKey ? otherTotal : totals[key];
+				var label = key === otherKey ? otherLabel : key;
+				var body =
+					'<i style="background:' + JD.seriesColor(index) + '"></i><b>' + JD.esc(label) + "</b> " + value;
+				/* Other is a span, not a button: an aggregate of several servers is not a
+				   subject a reader can open. */
+				if (key === otherKey)
+					return '<span class="sk-legend' + (selected ? " sk-dim" : "") + '">' + body + "</span>";
+				return (
+					'<button type="button" class="sk-legend' +
+					(selected && key !== selected ? " sk-dim" : "") +
+					'" data-mcp="' +
+					JD.esc(key) +
+					'" aria-pressed="' +
+					String(key === selected) +
+					'">' +
+					body +
+					"</button>"
+				);
+			})
+			.join("");
+
+		/* `stackedBarsFrame`, NOT `stackedBars`, for the reason `skills.js` states: this
+		   chart's height is a budget the pane below it shares, and the plain entry point
+		   keeps its axis text inside the viewBox so it can only be bounded through its
+		   WIDTH. An integer formatter, because "0.5" on an axis counting sessions is a
+		   claim the unit cannot make. */
+		var frame = JD.stackedBarsFrame(rolled, keys, "server sessions", (n) => String(Math.round(n)));
+		var ticks = frame.ticks.map((tick) => "<span>" + JD.esc(tick) + "</span>").join("");
+		var axis =
+			'<div class="sk-axis"><span>' +
+			JD.esc(frame.firstDay) +
+			"</span>" +
+			(frame.lastDay ? "<span>" + JD.esc(frame.lastDay) + "</span>" : "") +
+			"</div>";
+		return (
+			head +
+			'<div class="sk-bandrow"><div class="chart-box"><div class="sk-bandplot">' +
+			'<div class="sk-bandticks">' +
+			ticks +
+			'</div><div class="sk-bandmain">' +
+			frame.svg +
+			axis +
+			'</div></div></div><div class="sk-key">' +
+			legend +
+			"</div></div></div>"
+		);
+	}
+
+	// ── The chooser column ──────────────────────────────────────────────────────
+
+	/**
+	 * `128 calls · 4 servers · 16 tools`.
+	 *
+	 * THE FIGURES ARE THE SERVER'S, never a sum over the rows on screen: `usage.servers`
+	 * is one page, so a header computed from it would change every time more rows
+	 * arrived. `serverToolsTotal` is scoped to the named servers this page can actually
+	 * list; `mcpToolsTotal` also includes legacy MCP rows with no server and belongs to
+	 * the Stats page's general "by tool" list.
+	 */
+	function navHeadHtml(usage) {
+		var calls = usage.serverCallsTotal || 0;
+		var servers = rowsTotal === null ? usage.serversTotal || 0 : rowsTotal;
+		var tools = usage.serverToolsTotal || 0;
+		return (
+			'<div class="sk-nav-head"><b>' +
+			calls +
+			(calls === 1 ? "</b> call · <b>" : "</b> calls · <b>") +
+			servers +
+			(servers === 1 ? "</b> server · <b>" : "</b> servers · <b>") +
+			tools +
+			(tools === 1 ? "</b> tool</div>" : "</b> tools</div>")
+		);
+	}
+
+	/**
+	 * The list. THE ORDER IS THE SERVER'S (calls, then sessions) and the header is NOT a
+	 * sort control — `skills.js` carries the reasoning, which survives the column holding
+	 * every row: the tail is still absent while it is in flight and after a failed read,
+	 * and a header that silently sorts a partial list is the same lie arriving less often.
+	 */
+	function listHtml(rows) {
+		if (rows.length === 0) return '<div class="empty-note">No MCP server calls recorded in this window.</div>';
+		var selected = state.paneName;
+		var html =
+			'<div class="sk-cols" aria-hidden="true"><span>Server</span><span>Calls</span><span>Tools</span></div>' +
+			'<ul class="ranklist">';
+		rows.forEach((row) => {
+			html +=
+				'<li><button type="button" class="sk-row" data-mcp="' +
+				JD.esc(row.server) +
+				'"' +
+				(row.server === selected ? ' aria-current="true"' : "") +
+				' aria-label="' +
+				(row.server === selected ? "Clear selection of " : "Read ") +
+				JD.esc(row.server) +
+				": " +
+				row.calls +
+				(row.calls === 1 ? " call through " : " calls through ") +
+				row.tools +
+				(row.tools === 1 ? " tool" : " tools") +
+				'">' +
+				'<span class="sk-name mono" title="' +
+				JD.esc(row.server) +
+				'">' +
+				JD.esc(row.server) +
+				"</span>" +
+				'<span class="num">' +
+				row.calls +
+				"</span>" +
+				'<span class="num sk-tok">' +
+				row.tools +
+				"</span>" +
+				"</button></li>";
+		});
+		return html + "</ul>";
+	}
+
+	/** The loading line's band, pinned BELOW the rows — see `skills.js`'s `navPagingHtml`. */
+	function navPagingHtml(rows, usage) {
+		if (rows.length === 0) return "";
+		var body = restStatusHtml(rows, usage);
+		return body ? '<div class="sk-paging">' + body + "</div>" : "";
+	}
+
+	/** `Showing 8 of 11 servers — loading the rest…`, and only while that is true. */
+	function restStatusHtml(rows, usage) {
+		if (!restLoading && !restError) return "";
+		var shown = rows.length;
+		var total = rowsTotal === null ? (usage && usage.serversTotal) || shown : rowsTotal;
+		/* A total the column already meets has nothing left to report, whichever flag is
+		   still up — a stale `restError` beside a full list would call it short. */
+		if (shown >= total) return "";
+		return (
+			'<div class="more-row"><span class="more-count">Showing ' +
+			shown +
+			" of " +
+			total +
+			(total === 1 ? " server" : " servers") +
+			(restLoading ? " — loading the rest…" : " — could not load the rest; retrying shortly") +
+			"</span></div>"
+		);
+	}
+
+	/**
+	 * The coverage denominator, in the grammar the Skills and MCPs cards print. Without
+	 * it every figure above reads as if it covered every session — and on this page that
+	 * matters twice over, because a server absent from the list may simply have been
+	 * called only from an agent whose transcripts cannot be read.
+	 */
+	function navFootHtml(usage) {
+		var withTools = usage.sessionsWithTools || 0;
+		var inWindow = usage.sessionsInWindow || 0;
+		return (
+			'<div class="w-foot"><span class="w-measure">ⓘ from <b>' +
+			withTools +
+			"</b> of " +
+			inWindow +
+			(inWindow === 1 ? " session" : " sessions") +
+			" in this window</span></div>"
+		);
+	}
+
+	// ── The reading pane ────────────────────────────────────────────────────────
+
+	function paneHtml(usage, timeZone) {
+		if (!state.paneName) {
+			return '<div class="sk-pane-empty">Select an MCP server to read which of its tools your agents called, and when.</div>';
+		}
+		if (state.paneError) return '<div class="sk-pane-empty">' + JD.esc(state.paneError) + "</div>";
+		var detail = state.pane;
+		if (!detail) return '<div class="sk-pane-empty">Loading…</div>';
+
+		var callsTotal = usage.serverCallsTotal || 0;
+		var share = callsTotal ? Math.round((detail.calls / callsTotal) * 100) : 0;
+
+		var html =
+			'<div class="sk-panebody"><div class="sk-title mono">' +
+			JD.esc(detail.server) +
+			'<span class="sk-kind">mcp server</span>' +
+			"</div>" +
+			'<div class="sk-figs">' +
+			fig(detail.calls, "tool calls") +
+			fig(detail.sessions, "sessions") +
+			fig(detail.toolCount, "tools called") +
+			fig(share + "%", "of all MCP calls") +
+			"</div>";
+
+		html += section("Call cadence", cadenceHtml(detail));
+		html += section("Calls per session", volumeHtml(detail, timeZone));
+		html += section("Tools called", toolsHtml(detail));
+		html += section("The record", recordHtml(detail, timeZone));
+		html += section("Who called it", agentsHtml(detail));
+
+		html += proseBlock(
+			"sk-basis",
+			"MCP rows come from captured transcript tool calls grouped by server. This page shows which " +
+				"server, which tool name and how often; it deliberately does not render arguments, results, " +
+				"or servers that made no captured call in this window.",
+		);
+		return html + "</div>";
+	}
+
+	function fig(value, label) {
+		return '<div class="sk-fig"><b class="num">' + JD.esc(String(value)) + "</b><span>" + label + "</span></div>";
+	}
+
+	/** One of the pane's long fixed paragraphs, shown as a single line until clicked. */
+	function proseBlock(cls, text) {
+		var open = openProse[cls] === true;
+		return (
+			'<div class="' +
+			cls +
+			' sk-clamp" role="button" tabindex="0" aria-expanded="' +
+			(open ? "true" : "false") +
+			'" title="' +
+			JD.esc(text) +
+			'">' +
+			JD.esc(text) +
+			"</div>"
+		);
+	}
+
+	function section(title, body) {
+		return '<div class="sk-sec"><h4>' + title + "</h4>" + body + "</div>";
+	}
+
+	function line(label, value, swatch, labelTitle) {
+		/* `title="value"` on the span so a truncated value in `.sk-facts` is readable on
+		   hover. Same rule `skills.js`'s `line` carries — the two grids share the CSS that
+		   truncates the cell, so both need the recovery. */
+		return (
+			'<div class="sk-line">' +
+			(swatch ? '<i style="background:' + swatch + '"></i>' : "") +
+			"<b" +
+			(labelTitle ? ' title="' + JD.esc(labelTitle) + '"' : "") +
+			">" +
+			JD.esc(label) +
+			'</b><span title="' +
+			JD.esc(value) +
+			'">' +
+			JD.esc(value) +
+			"</span></div>"
+		);
+	}
+
+	/** `Aug 17`, routed through the day key so the record and the axes agree by construction. */
+	function shortDay(atMs, timeZone) {
+		return JD.dayLabel(JD.dayKey(atMs, timeZone));
+	}
+
+	/** A day-bucketed chart plus the two endpoint labels — the shape both charts share. */
+	function barsHtml(days, values, label, fmt) {
+		if (days.length === 0) return "";
+		return (
+			JD.dayBars(days, values, { label: label, fmt: fmt }) +
+			'<div class="sk-axis"><span>' +
+			JD.esc(JD.dayLabel(days[0])) +
+			"</span>" +
+			/* One label on a single-day window: the same day at both ends would read as a
+			   range that is not one. */
+			(days.length > 1 ? "<span>" + JD.esc(JD.dayLabel(days[days.length - 1])) + "</span>" : "") +
+			"</div>"
+		);
+	}
+
+	/**
+	 * Sessions per day over the window — "was it reached for more or less".
+	 *
+	 * Every day of the window is drawn, empty ones included, for the reason the band
+	 * walks the window: bars are laid out by index, so dropping a quiet day compresses
+	 * the axis and makes a fortnight's gap look like a busy stretch.
+	 */
+	function cadenceHtml(detail) {
+		var points = detail.daySeries || [];
+		if (points.length === 0) return '<div class="sk-note">No daily record survives for this server.</div>';
+		return barsHtml(
+			points.map((point) => point.date),
+			points.map((point) => point.sessions),
+			"Sessions per day",
+			(n) => n + (n === 1 ? " session" : " sessions"),
+		);
+	}
+
+	/**
+	 * Calls per session in arrival order — "how hard was each session working it".
+	 *
+	 * ONE BAR PER SESSION on an INDEX axis, not a time axis: `session_tool_use` stores one
+	 * instant per (session, tool) and it is the last call, so an even-time chart would
+	 * misplace bars by up to the session's own span. The two endpoint labels below carry
+	 * the dates of the first and last session, so a reader can still see the span the
+	 * bars cover without the chart claiming a spacing it does not have.
+	 */
+	function volumeHtml(detail, timeZone) {
+		var sessions = detail.sessionSeries || [];
+		if (sessions.length === 0) return '<div class="sk-note">No per-session record survives for this server.</div>';
+		var hidden = Math.max(0, (detail.sessions || 0) - sessions.length);
+		var max = 0;
+		sessions.forEach((point) => {
+			if (point.calls > max) max = point.calls;
+		});
+		var BAR_W = 0.58;
+		var svg =
+			'<svg class="sk-daybars" viewBox="0 0 ' +
+			Math.max(1, sessions.length) +
+			' 100" preserveAspectRatio="none" role="img" aria-label="Calls per session, in time order">';
+		sessions.forEach((point, index) => {
+			/* Floors at 20 so a single-call session is still a visible bar rather than a
+			   hairline; identical rule to `JD.dayBars`, kept here rather than shared
+			   because the X axis is session index, not a day key. */
+			var height = point.calls > 0 ? Math.max(20, max > 0 ? (point.calls / max) * 100 : 100) : 6;
+			svg +=
+				'<rect x="' +
+				(index + (1 - BAR_W) / 2).toFixed(3) +
+				'" y="' +
+				(100 - height).toFixed(2) +
+				'" width="' +
+				BAR_W +
+				'" height="' +
+				height.toFixed(2) +
+				'" fill="var(--accent)"><title>' +
+				JD.esc(shortDay(point.atMs, timeZone) + " · " + point.calls + (point.calls === 1 ? " call" : " calls")) +
+				"</title></rect>";
+		});
+		svg += "</svg>";
+		return (
+			svg +
+			'<div class="sk-axis"><span>' +
+			JD.esc(shortDay(sessions[0].atMs, timeZone)) +
+			"</span>" +
+			(sessions.length > 1
+				? "<span>" + JD.esc(shortDay(sessions[sessions.length - 1].atMs, timeZone)) + "</span>"
+				: "") +
+			"</div>" +
+			(hidden > 0
+				? '<div class="sk-note">Most recent ' +
+					sessions.length +
+					" of " +
+					detail.sessions +
+					" sessions shown; totals and daily cadence remain exact.</div>"
+				: "")
+		);
+	}
+
+	/**
+	 * The server's tools, busiest first.
+	 *
+	 * THE SESSION COUNTS DO NOT ADD UP TO THE PANE'S `sessions` FIGURE, and that is
+	 * correct rather than a rounding artefact: a session that called three of this
+	 * server's tools counts in all three rows. The column is read row by row, so it is
+	 * printed without a total — see `McpServerToolRow.sessions`.
+	 */
+	function toolsHtml(detail) {
+		var tools = detail.tools || [];
+		if (tools.length === 0) return '<div class="sk-note">No tool name was recorded for this server.</div>';
+		var rows = tools
+			.map(
+				(tool) =>
+					'<div class="mcp-tool"><b class="mono" title="' +
+					JD.esc(tool.name) +
+					'">' +
+					JD.esc(tool.name) +
+					"</b><span>" +
+					tool.calls +
+					'</span><span class="mcp-tool-sess">' +
+					tool.sessions +
+					(tool.sessions === 1 ? " session" : " sessions") +
+					"</span></div>",
+			)
+			.join("");
+		var hidden = (detail.toolCount || tools.length) - tools.length;
+		/* The cap changes what is drawn, never what is claimed — the same rule the
+		   Skills pane's capped agent list and outcome strip follow. `toolCount` is the
+		   server's real total, so this says what is missing rather than implying the
+		   list is complete. */
+		var note =
+			hidden > 0
+				? '<div class="sk-note">' +
+					tools.length +
+					" busiest of " +
+					(detail.toolCount || tools.length) +
+					" tools called; the figures above stay exact.</div>"
+				: "";
+		return '<div class="mcp-tools">' + rows + "</div>" + note;
+	}
+
+	/**
+	 * Everything that is a fact rather than a trend.
+	 *
+	 * `First seen` IS A FLOOR AND SAYS SO. `session_tool_use` stores one instant per
+	 * (session, tool) and it is the LAST call, so the earliest such instant is the last
+	 * call of the earliest session — at or after the true first call. Measured, the two
+	 * agree at day resolution for 140 of 141 (session, server) pairs, which is why a
+	 * DATE is printed and the qualifier rides in the label's tooltip rather than
+	 * replacing the figure. `Payloads` states an absence, in the row grammar, because a
+	 * reader looking for a call log needs to be told there is none.
+	 */
+	function recordHtml(detail, timeZone) {
+		var rows = "";
+		if (detail.firstCallAtMs != null)
+			rows += line(
+				"First seen",
+				shortDay(detail.firstCallAtMs, timeZone),
+				null,
+				"Lower bound: only the last call per session and tool is recorded.",
+			);
+		if (detail.lastCallAtMs != null) rows += line("Last seen", shortDay(detail.lastCallAtMs, timeZone));
+		if ((detail.repos || []).length > 0) rows += line("Ran in", detail.repos.join(", "));
+		rows += line("Payloads", "not recorded");
+		return '<div class="sk-facts">' + rows + "</div>";
+	}
+
+	/**
+	 * Rows of the agent split shown in full before the rest are rolled into one line —
+	 * `skills.js`'s cap, for its reason: this is the pane's one list whose length is a
+	 * property of the machine rather than of the record's own ceilings.
+	 */
+	var AGENT_ROWS_SHOWN = 5;
+
+	/** Per-agent calls, most first. The swatch is the agent's colour, page-wide. */
+	function agentsHtml(detail) {
+		var agents = (detail.agents || []).slice().sort((a, b) => b.calls - a.calls);
+		if (agents.length === 0) return '<div class="sk-note">No agent recorded against this server.</div>';
+		var html = agents
+			.slice(0, AGENT_ROWS_SHOWN)
+			.map((agent) =>
+				line(
+					agent.source,
+					agent.calls + (agent.calls === 1 ? " call" : " calls"),
+					JD.seriesColor(JD.sourceIndex(agent.source)),
+				),
+			)
+			.join("");
+		var rest = agents.slice(AGENT_ROWS_SHOWN);
+		if (rest.length === 0) return html;
+		/* The rolled-up line carries its own CALL TOTAL, not just a count of agents: the
+		   section is a split of the calls, so "3 further agents" alone would drop calls
+		   out of a total the four figures above still count in full. */
+		var restCalls = rest.reduce((sum, agent) => sum + agent.calls, 0);
+		return (
+			html +
+			'<div class="sk-note">' +
+			rest.length +
+			(rest.length === 1 ? " further agent called it, " : " further agents called it, ") +
+			restCalls +
+			(restCalls === 1 ? " call" : " calls") +
+			" between them.</div>"
+		);
+	}
+
+	// ── Interaction ─────────────────────────────────────────────────────────────
+
+	/**
+	 * One binder for the list rows AND the band's key: both carry `data-mcp`, and a click
+	 * on either toggles, so the empty pane stays reachable once something has been opened.
+	 */
+	function bindSelection(app, model) {
+		Array.prototype.forEach.call(app.querySelectorAll("[data-mcp]"), (element) => {
+			element.onclick = () => {
+				var name = element.getAttribute("data-mcp");
+				var focusedLegendName =
+					document.activeElement === element &&
+					element.classList &&
+					element.classList.contains("sk-legend")
+						? name
+						: null;
+				var next = state.paneName === name ? null : name;
+				/* The reader has now answered "which server" themselves, so the default pick
+				   must not run again — otherwise the click that closes the pane re-opens the
+				   top row on the very next render. */
+				defaultAnswered = true;
+				setSelectedServer(next);
+				state.paneName = next;
+				state.pane = null;
+				state.paneError = null;
+				/* Targeted repaint (band + list highlights + pane) plus the detail refetch —
+				   NOT `renderMcps(model)`, which would tear down the whole `.browser-page`
+				   section on every click (the visible flicker readers reported, plus the
+				   loss of the nav column's scroll position). Same rewrite as `skills.js`. */
+				updateSelection(app, model, focusedLegendName);
+				fetchDetail(app, model);
+			};
+		});
+	}
+
+	/**
+	 * Wires the clamped paragraph. It toggles the attribute and does NOT re-render: a
+	 * repaint would cost the rows their scroll offset for a result CSS reaches from
+	 * `aria-expanded` alone. Space is prevented (it would scroll the column the reader is
+	 * reading), Enter is not.
+	 */
+	function bindProse(app) {
+		Array.prototype.forEach.call(app.querySelectorAll(".sk-clamp"), (element) => {
+			var toggle = () => {
+				openProse["sk-basis"] = openProse["sk-basis"] !== true;
+				element.setAttribute("aria-expanded", openProse["sk-basis"] ? "true" : "false");
+			};
+			element.onclick = toggle;
+			element.onkeydown = (event) => {
+				if (event.key !== "Enter" && event.key !== " ") return;
+				event.preventDefault();
+				toggle();
+			};
+		});
+	}
+
+	JD.renderMcps = renderMcps;
+})(window.JD);

--- a/cli/src/dashboard/assets/js/shell.js
+++ b/cli/src/dashboard/assets/js/shell.js
@@ -152,6 +152,7 @@ window.JD = window.JD || {};
 		{ view: "stats", label: "My Dashboard", sub: "individual · local" },
 		{ view: "standup", label: "Daily Standup", sub: "sprint · local" },
 		{ view: "skills", label: "Skills", sub: "usage · per-skill" },
+		{ view: "mcps", label: "MCPs", sub: "captured calls · per-server" },
 		{ view: "journeys", label: "Coaching", sub: "enablement · against your own earlier line", beta: true },
 		{ view: "memories", label: "Memories", sub: "browse · per-commit" },
 		{ view: "knowledge", label: "Knowledge", sub: "wiki · per-repo" },
@@ -167,6 +168,7 @@ window.JD = window.JD || {};
 		stats: "/dashboard",
 		standup: "/dashboard/standup",
 		skills: "/skills",
+		mcps: "/mcps",
 		journeys: "/dashboard/journeys",
 		memories: "/memories",
 		knowledge: "/knowledge",
@@ -218,6 +220,11 @@ window.JD = window.JD || {};
 		   Skills card is a summary of the same data, and this page answers a
 		   different question (one skill's whole history) at a different grain. */
 		{ view: "skills", path: "/skills", label: "Skills" },
+		/* Beside Skills, and above Coaching, because it is the same reading at the same
+		   grain about the other half of what an agent reaches for: the rows from here up
+		   read THIS MACHINE's own activity, while everything below Memories is a per-repo
+		   browser. */
+		{ view: "mcps", path: "/mcps", label: "MCPs" },
 		{ view: "journeys", path: "/dashboard/journeys", label: "Coaching", beta: true },
 		{ view: "memories", path: "/memories", label: "Memories" },
 		/* Knowledge / Graph browse the Memory Bank FOLDER, whose repo set differs
@@ -256,6 +263,13 @@ window.JD = window.JD || {};
 		   replaced a `zap` bolt, which said nothing about skills at all. */
 		puzzle:
 			'<path d="M15.39 4.39a1 1 0 0 0 1.68-.474 2.5 2.5 0 1 1 3.014 3.015 1 1 0 0 0-.474 1.68l1.683 1.682a2.414 2.414 0 0 1 0 3.414L19.61 15.39a1 1 0 0 1-1.68-.474 2.5 2.5 0 1 0-3.014 3.015 1 1 0 0 1 .474 1.68l-1.683 1.682a2.414 2.414 0 0 1-3.414 0L8.61 19.61a1 1 0 0 0-1.68.474 2.5 2.5 0 1 1-3.014-3.015 1 1 0 0 0 .474-1.68l-1.683-1.682a2.414 2.414 0 0 1 0-3.414L4.39 8.61a1 1 0 0 1 1.68.474 2.5 2.5 0 1 0 3.014-3.015 1 1 0 0 1-.474-1.68l1.683-1.682a2.414 2.414 0 0 1 3.414 0z"/>',
+		/* Lucide `plug` — THE SAME MARK THE MCPs CARD DRAWS (stats.js `mcpCard`), for the
+		   reason `puzzle` above carries: a nav row for the same subject has to wear the
+		   same mark, or the card and the page read as two different features. A plug is
+		   also the honest glyph for what an MCP server is to a session — something the
+		   agent connects to, rather than a part it is built from (`puzzle`) or a place
+		   its work is stored (`database`). */
+		plug: '<path d="M12 22v-5"/><path d="M9 8V2"/><path d="M15 8V2"/><path d="M18 8v5a4 4 0 0 1-4 4h-4a4 4 0 0 1-4-4V8Z"/>',
 		database:
 			'<ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5V19A9 3 0 0 0 21 19V5"/><path d="M3 12A9 3 0 0 0 21 12"/>',
 		book: '<path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>',
@@ -280,6 +294,7 @@ window.JD = window.JD || {};
 			stats: "dashboard",
 			standup: "calendar",
 			skills: "puzzle",
+			mcps: "plug",
 			journeys: "compass",
 			memories: "database",
 			knowledge: "book",
@@ -322,7 +337,7 @@ window.JD = window.JD || {};
 	   removed. Kept as a table rather than collapsed to `true` so a future view
 	   that ignores the scope hides the control instead of lying about it; the
 	   picker hides rather than disables, same as the range control on standup. */
-	var SCOPED_VIEWS = { stats: true, standup: true, skills: true, memories: true, journeys: true };
+	var SCOPED_VIEWS = { stats: true, standup: true, skills: true, mcps: true, memories: true, journeys: true };
 
 	/* Button label for a selection: the repo's name at one, a count past that.
 	   Names past one would either truncate or push the range control off the row,

--- a/cli/src/dashboard/assets/js/skills.js
+++ b/cli/src/dashboard/assets/js/skills.js
@@ -25,7 +25,7 @@
  * THE ROWS STILL LIVE IN A WINDOW, and it is now the page's ONLY one. The whole view is
  * a fixed frame — the page does not scroll, the two columns are the same height, and the
  * reading pane holds its whole skill without scrolling — so the rows are the one region
- * with a scrollbar. `main.css`'s `.skills-page` header owns that rule and the measurements
+ * with a scrollbar. `main.css`'s `.browser-page` header owns that rule and the measurements
  * behind it; what matters here is that the height comes from a flex chain rather than from
  * anything this file computes. The MEASURED inline cap that used to create the window
  * (`listCapPx`, read off the first page) is gone with it.
@@ -56,7 +56,7 @@
  * ALL THREE CHARTS SHARE ONE TIME AXIS, and they share it by reading the SAME array
  * rather than by each deriving the same bounds. `ToolUsage.skillDays` is the band's own
  * series — one point per LOCAL DAY of the window, emitted whether or not anything ran
- * (`buildSkillDays` walks the window, not the data) — and `windowDays` hands its day
+ * (`buildDayPoints` walks the window, not the data) — and `windowDays` hands its day
  * keys to the pane's two charts as their buckets. So the reader can read straight down
  * the page: the same column is the same day in all three.
  *
@@ -159,7 +159,14 @@
 	   different payload takes ownership, so an old timer cannot wake a stale read. */
 	var restRetryTimer = null;
 
-	/* Which of the pane's two long fixed paragraphs the reader has opened.
+	/* Whether each of the pane's two long fixed paragraphs is open.
+	 *
+	 * BOTH DEFAULT TO OPEN, matching the MCPs pane next door (`mcps.js`) and the mockup. A
+	 * first-time reader needs to see what the page is claiming without a click, and the
+	 * caveat is the stronger case of the two: it qualifies the four figures directly above
+	 * it, so folded to a single line it is met only once the reader has already believed
+	 * the number it limits — the very failure `inferredCaveatHtml` places it there to
+	 * avoid. A click still collapses either back.
 	 *
 	 * MODULE STATE, not DOM state, because every path in this file repaints the WHOLE pane
 	 * — a row click, that row's detail landing, the tail of the list arriving, a refresh —
@@ -168,10 +175,10 @@
 	 * reads back off the event target.
 	 *
 	 * DELIBERATELY NOT PER SKILL. The two paragraphs are FIXED text (the inferred caveat
-	 * and the basis line say the same thing on every skill), so "I have read this one" is a
-	 * fact about the reader, not about the row — resetting it per selection would make them
-	 * re-open the same sentence on every skill they looked at. */
-	var openProse = { "sk-caveat": false, "sk-basis": false };
+	 * and the basis line say the same thing on every skill), so a collapse is a fact about
+	 * the reader, not about the row — resetting it per selection would make them re-close
+	 * the same sentence on every skill they looked at. */
+	var openProse = { "sk-caveat": true, "sk-basis": true };
 
 	/* Whether "the address names no skill" has already been answered for this page
 	   load — see the header. Nav is a full page reload, so this starts false on every
@@ -267,10 +274,51 @@
 		return rows[0].name;
 	}
 
+	/**
+	 * Extracted from `renderSkills` so the row-click handler can trigger a new detail
+	 * fetch without going through the full render (which would tear the whole frame
+	 * down). `seq` is bumped here so a click that lands its detail late is invalidated
+	 * by a newer click the same way — the staleness rule is identical whether the fetch
+	 * was started by a render or by a selection change. */
+	function fetchDetail(app, model) {
+		var selected = state.paneName;
+		if (!selected) return;
+		var mine = ++seq;
+		JD.getJson(
+			JD.withParams("/api/skill-detail" + JD.query(model, {}), {
+				name: selected,
+				nowMs: model.generatedAtMs,
+			}),
+		)
+			.then(
+				(detail) => {
+					if (mine !== seq || state.paneName !== selected) return false;
+					state.pane = detail;
+					return true;
+				},
+				/* THE TWO-CALLBACK FORM, never a trailing `.catch`, and the repaint moved out
+				   of both: this handler must see the REQUEST's failure and nothing else.
+				   While the repaint sat inside the success callback, a throw from ANY chart
+				   in the pane landed here instead — and `paneErrorText` reads a missing
+				   `status` as "nothing reached a server", so a `ReferenceError` in a tick
+				   title was reported to the reader as a dashboard that had stopped, while it
+				   was answering fine. A render fault is now unhandled and reaches the
+				   console, which is where a bug in this file belongs. */
+				(err) => {
+					if (mine !== seq || state.paneName !== selected) return false;
+					state.paneError = paneErrorText(err);
+					return true;
+				},
+			)
+			.then((changed) => {
+				/* `drawPane`, NOT `draw`: the detail landing changes only the reading pane. */
+				if (changed) drawPane(app, model);
+			});
+	}
+
 	function renderSkills(model) {
 		var app = document.getElementById("app");
 		if (!app) return;
-		var mine = ++seq;
 		if (renderedModel !== model) {
 			cancelRowsRetry();
 			renderedModel = model;
@@ -301,32 +349,7 @@
 		draw(app, model);
 
 		if (needsRest) fetchRows(app, model);
-
-		if (!selected) return;
-		JD.getJson(JD.withParams("/api/skill-detail" + JD.query(model, {}), { name: selected }))
-			.then(
-				(detail) => {
-					if (mine !== seq || state.paneName !== selected) return false;
-					state.pane = detail;
-					return true;
-				},
-				/* THE TWO-CALLBACK FORM, never a trailing `.catch`, and the repaint moved out
-				   of both: this handler must see the REQUEST's failure and nothing else.
-				   While the repaint sat inside the success callback, a throw from ANY chart
-				   in the pane landed here instead — and `paneErrorText` reads a missing
-				   `status` as "nothing reached a server", so a `ReferenceError` in a tick
-				   title was reported to the reader as a dashboard that had stopped, while it
-				   was answering fine. A render fault is now unhandled and reaches the
-				   console, which is where a bug in this file belongs. */
-				(err) => {
-					if (mine !== seq || state.paneName !== selected) return false;
-					state.paneError = paneErrorText(err);
-					return true;
-				},
-			)
-			.then((changed) => {
-				if (changed) draw(app, model);
-			});
+		fetchDetail(app, model);
 	}
 
 	/**
@@ -398,6 +421,7 @@
 					list: "skill",
 					offset: String(offset),
 					limit: String(total - offset),
+					nowMs: model.generatedAtMs,
 				}),
 			).then((page) => {
 				if (renderedModel !== model) return { rows: rows, total: total };
@@ -482,15 +506,16 @@
 	/**
 	 * What to tell the reader when the detail could not be loaded.
 	 *
-	 * The two failures need OPPOSITE advice, and they used to be reported as one:
+	 * These failures need different advice, and they used to be reported as one:
 	 *
 	 *   - **No `status`** — `fetch` itself rejected, so nothing reached a server. Its
 	 *     message is the browser's own "Failed to fetch", which said nothing about a
 	 *     server having gone away and read as "HTTP Failed to fetch" once a caller
 	 *     labelled it. The dashboard is not running any more; start it again.
-	 *   - **A `status`** — a server answered and refused. A build predating this route
-	 *     404s exactly as a skill with no calls in the window does, and only the first
-	 *     of those is fixed by restarting.
+	 *   - **404** — the dashboard answered that this skill has no calls in the window.
+	 *     That is normal for a shared link opened under a different time range.
+	 *   - **Another `status`** — a server answered and refused; bringing that server up
+	 *     to date may help.
 	 *
 	 * `status` rather than a message pattern, because the message is a browser string
 	 * on one path and a server's `error` field on the other — neither is ours to match on.
@@ -503,6 +528,7 @@
 	 * as the two shared a handler.
 	 */
 	function paneErrorText(err) {
+		if (err && err.status === 404) return "No captured calls for this skill in this window.";
 		if (err && typeof err.status === "number") {
 			return (
 				"Could not load this skill — the dashboard answered " +
@@ -609,17 +635,113 @@
 		if (row.scrollIntoView) row.scrollIntoView({ block: "center" });
 	}
 
+	/**
+	 * Rewrites ONLY the reading pane, leaving the band chart's SVG, the row column and its
+	 * scroll offset untouched. Used when the detail fetch lands for the currently selected
+	 * skill — at that point nothing above the pane has changed, and rebuilding the band and
+	 * the list was where the visible flicker came from on every row click (the SVG was torn
+	 * down and re-rasterised for a state it never left). Falls back to the full `draw` when
+	 * the pane node is missing (a shape only reachable if the frame was never rendered on
+	 * this page — nothing does that today, but the fallback is what keeps this helper safe
+	 * to add without auditing every future caller). Prose handlers are re-bound because the
+	 * clamped paragraphs live inside the pane and their listeners rode the old nodes down. */
+	function drawPane(app, model) {
+		var pane = app.querySelector(".sk-pane");
+		if (!pane) {
+			draw(app, model);
+			return;
+		}
+		var usage = (model.stats && model.stats.toolUsage) || {};
+		pane.innerHTML = paneHtml(usage, model.timeZone);
+		bindProse(app);
+	}
+
+	/**
+	 * Marks the bar rects that match the current selection with `data-active` so the CSS
+	 * rule in `main.css` keeps them at full opacity while the others fade — the visual half
+	 * of the chart/list linking. Rewritten on every band render and on every selection
+	 * change, so the invariant "at most one series has `data-active` at a time" is enforced
+	 * by iteration rather than by tracking which rect had it before. Cheap: a 30-day band
+	 * with five series holds ~150 rects. */
+	function applyBandActive(app) {
+		var name = state.paneName || "";
+		var rects = app.querySelectorAll(".sk-band .sk-bandbars rect[data-series]");
+		Array.prototype.forEach.call(rects, (rect) => {
+			if (name && rect.getAttribute("data-series") === name) rect.setAttribute("data-active", "");
+			else rect.removeAttribute("data-active");
+		});
+	}
+
+	/**
+	 * Redraws ONLY the `.sk-band` element (chart + legend), leaving the nav column and the
+	 * pane in place. Used from the selection click handler because the band's kept-set can
+	 * shift with the selection (a skill outside the top four swaps into the fourth slot),
+	 * so the SVG itself has to be regenerated — a pure attribute toggle would leave that
+	 * case wrong. Re-binds selection because the legend buttons ride the new band, and
+	 * calls `applyBandActive` so the freshly-rendered rects come up with the highlight
+	 * already applied. `<template>` unwrap because `outerHTML` on the target node would
+	 * lose the reference to the newly-inserted `.sk-band`. */
+	function drawBand(app, model) {
+		var band = app.querySelector(".sk-band");
+		if (!band) return;
+		var usage = (model.stats && model.stats.toolUsage) || {};
+		var host = document.createElement("div");
+		host.innerHTML = bandHtml(usage);
+		var next = host.firstChild;
+		band.replaceWith(next);
+		applyBandActive(app);
+		bindSelection(app, model);
+	}
+
+	/** Restores keyboard focus after `drawBand` replaces the legend buttons. Names are
+	 *  compared as attributes instead of interpolated into selectors because skill names
+	 *  are user-authored. If deselection drops an out-of-band legend, its list row is the
+	 *  stable fallback. */
+	function restoreSelectionFocus(app, name) {
+		var legend = null;
+		var row = null;
+		Array.prototype.forEach.call(app.querySelectorAll("[data-skill]"), (element) => {
+			if (element.getAttribute("data-skill") !== name) return;
+			if (element.classList && element.classList.contains("sk-legend")) legend = element;
+			else if (element.classList && element.classList.contains("sk-row")) row = element;
+		});
+		var target = legend || row;
+		if (target && target.focus) target.focus();
+	}
+
+	/**
+	 * The selection-only repaint. Called from the row-click handler in place of the old
+	 * full `renderSkills(model)` — same visible outcome without tearing down the whole
+	 * `.browser-page` section, which is what made the row click flash every SVG in the
+	 * frame. Three targeted updates: `aria-current` on the list rows (a plain attribute
+	 * toggle, no DOM churn), `drawBand` for the chart and its legend (their kept-set can
+	 * shift with the selection), and `drawPane` for the reading pane. The detail fetch is
+	 * started separately by the click handler through `fetchDetail`. */
+	function updateSelection(app, model, focusedLegendName) {
+		var name = state.paneName;
+		Array.prototype.forEach.call(app.querySelectorAll(".sk-row"), (row) => {
+			if (row.getAttribute("data-skill") === name) row.setAttribute("aria-current", "true");
+			else row.removeAttribute("aria-current");
+		});
+		revealSelectedRow(app, app.querySelector(".sk-list"));
+		drawBand(app, model);
+		drawPane(app, model);
+		if (focusedLegendName !== null) restoreSelectionFocus(app, focusedLegendName);
+	}
+
 	function draw(app, model) {
 		var usage = (model.stats && model.stats.toolUsage) || {};
 		var rows = visibleRows(model);
 		/* THE ROWS' OFFSET IS CARRIED ACROSS BY HAND, because the write below replaces the
 		   node that holds it — and only that node scrolls, so this is the whole of it.
 		 *
-		 * Every path here repaints the WHOLE page — a row click, that row's detail landing
-		 * moments later, the tail of the list arriving, an explicit refresh — so without this the
-		 * column snapped back to its first row on all four. Clicking the 18th skill
-		 * scrolled the list away from the row that was just clicked, which also takes the
-		 * `aria-current` row off screen; and a refresh did it unprompted, mid-read.
+		 * Every path here that reaches THIS function repaints the WHOLE page — a row click,
+		 * the tail of the list arriving, an explicit refresh — so without this the column
+		 * snapped back to its first row on each of them. Clicking the 18th skill scrolled the
+		 * list away from the row that was just clicked, which also takes the `aria-current`
+		 * row off screen; and a refresh did it unprompted, mid-read. The FOURTH path that used
+		 * to reach here — the detail fetch landing — now goes through `drawPane` above, which
+		 * leaves the list node in place and so needs no carry-across at all.
 		 *
 		 * A whole-page repaint is what this view is built on (`renderSkills` re-reads the
 		 * address on every render), so restoring the offset is the fix that fits it —
@@ -628,7 +750,12 @@
 		var previous = app.querySelector(".sk-list");
 		var offset = previous ? previous.scrollTop : 0;
 		app.innerHTML =
-			'<section class="skills-page">' +
+			/* `browser-page` is the FRAME, shared with the MCPs page — `main.css`'s
+			   "Skills and MCPs pages" block owns it and explains why it is named after
+			   the shape rather than after either page. No `skills-page` beside it: this
+			   page has no rule of its own, and a class no stylesheet matches is a hook
+			   the next reader has to prove is dead. */
+			'<section class="browser-page">' +
 			bandHtml(usage) +
 			'<aside class="sk-nav" aria-label="Skills browser">' +
 			navHeadHtml(usage) +
@@ -659,6 +786,7 @@
 		}
 		bindSelection(app, model);
 		bindProse(app);
+		applyBandActive(app);
 	}
 
 	// ── The band ────────────────────────────────────────────────────────────────
@@ -674,18 +802,28 @@
 	 */
 	function bandHtml(usage) {
 		var series = usage.skillDays || [];
-		var head =
-			'<div class="sk-band"><div class="sk-nav-head" style="padding:0 0 10px;border-bottom:0">' +
-			"<b>All skills, day by day</b> · sessions that reached for each skill · " +
-			"a session using several skills counts once per skill</div>";
 
-		var totals = {};
+		var totals = Object.create(null);
 		series.forEach((point) => {
 			Object.keys(point.bySeries || {}).forEach((name) => {
 				totals[name] = (totals[name] || 0) + point.bySeries[name];
 			});
 		});
 		var names = Object.keys(totals);
+		var selected = state.paneName && totals[state.paneName] !== undefined ? state.paneName : null;
+		/* `data-selected` on the band is what the CSS keys off to dim non-active rects in
+		   the SVG — the highlight that links the chart to the chooser row so a click reads
+		   at both ends. Empty when nothing is selected, so the `:not([data-selected=""])`
+		   guard in `main.css` keeps every rect at full opacity for the default view.
+		   Computed BEFORE the head is written because the attribute has to sit on the
+		   `.sk-band` open tag, not on a nested element. */
+		var head =
+			'<div class="sk-band" data-selected="' +
+			(selected ? JD.esc(selected) : "") +
+			'"><div class="sk-nav-head" style="padding:0 0 10px;border-bottom:0">' +
+			"<b>All skills, day by day</b> · sessions that reached for each skill · " +
+			"a session using several skills counts once per skill</div>";
+
 		/* THE EMPTY TEST IS "no series", NOT "no points". `skillDays` carries one point
 		   per day of the window whether or not anything ran, so it is never empty once
 		   a window exists — a `series.length` test (what the week buckets needed, since
@@ -694,36 +832,41 @@
 		if (names.length === 0) {
 			return head + '<div class="empty-note">No skill invocations recorded in this window.</div></div>';
 		}
-		var selected = state.paneName && totals[state.paneName] !== undefined ? state.paneName : null;
 		var ranked = names.slice().sort((a, b) => totals[b] - totals[a] || (a < b ? -1 : a > b ? 1 : 0));
 		var kept = ranked.slice(0, BAND_SERIES);
 		if (selected && kept.indexOf(selected) === -1) kept = kept.slice(0, BAND_SERIES - 1).concat([selected]);
-		var keptSet = {};
+		var keptSet = Object.create(null);
 		kept.forEach((name) => {
 			keptSet[name] = true;
 		});
 
+		var otherKey = "Other";
+		while (otherKey in totals) otherKey += " ";
 		var rolled = series.map((point) => {
-			var bySeries = {};
+			var bySeries = Object.create(null);
 			var other = 0;
 			Object.keys(point.bySeries || {}).forEach((name) => {
 				if (keptSet[name]) bySeries[name] = point.bySeries[name];
 				else other += point.bySeries[name];
 			});
-			bySeries.Other = other;
+			bySeries[otherKey] = other;
 			return { date: point.date, bySeries: bySeries };
 		});
-		var keys = kept.concat(["Other"]);
-		var otherTotal = names.reduce((sum, name) => sum + (keptSet[name] ? 0 : totals[name]), 0);
+		var keys = kept.concat([otherKey]);
+		var otherNames = names.filter((name) => !keptSet[name]);
+		var otherTotal = otherNames.reduce((sum, name) => sum + totals[name], 0);
+		var otherLabel = "Other (" + otherNames.length + (otherNames.length === 1 ? " skill)" : " skills)");
 
 		var legend = keys
 			.map((key, index) => {
-				var value = key === "Other" ? otherTotal : totals[key];
+				var value = key === otherKey ? otherTotal : totals[key];
+				var label = key === otherKey ? otherLabel : key;
 				var body =
-					'<i style="background:' + JD.seriesColor(index) + '"></i><b>' + JD.esc(key) + "</b> " + value;
+					'<i style="background:' + JD.seriesColor(index) + '"></i><b>' + JD.esc(label) + "</b> " + value;
 				/* Other is a span, not a button: an aggregate of several skills is not a
 				   subject a reader can open. */
-				if (key === "Other") return '<span class="sk-legend' + (selected ? " sk-dim" : "") + '">' + body + "</span>";
+				if (key === otherKey)
+					return '<span class="sk-legend' + (selected ? " sk-dim" : "") + '">' + body + "</span>";
 				return (
 					'<button type="button" class="sk-legend' +
 					(selected && key !== selected ? " sk-dim" : "") +
@@ -1036,12 +1179,15 @@
 	}
 
 	/**
-	 * One of the pane's two long fixed paragraphs, shown as a single line until clicked.
+	 * One of the pane's two long fixed paragraphs, shown in full and collapsible to a single
+	 * line with a click.
 	 *
-	 * WHY THESE TWO AND NOTHING ELSE: they are ~4 lines each and 82px of the pane's height
-	 * budget between them (measured), and they are the only blocks here whose text is FIXED
-	 * rather than a measurement. Clamping a data row would destroy a count; clamping these
-	 * hides a qualifier one click brings back. `main.css`'s `.sk-clamp` owns the visual side.
+	 * WHY ONLY THESE TWO MAY BE COLLAPSED AT ALL: they are ~4 lines each and 82px of the
+	 * pane's height budget between them (measured), and they are the only blocks here whose
+	 * text is FIXED rather than a measurement. Clamping a data row would destroy a count;
+	 * clamping these hides a qualifier one click brings back. They still START open (see
+	 * `openProse`) — the height is the reader's to reclaim, not this pane's to take on their
+	 * behalf. `main.css`'s `.sk-clamp` owns the visual side.
 	 *
 	 * TEXT ONLY, NEVER MARKUP. The whole string is repeated into `title` (so a pointer user
 	 * gets it without clicking) and `JD.esc` there would mangle any tags — so callers pass
@@ -1073,12 +1219,20 @@
 	}
 
 	function line(label, value, swatch) {
+		/* `title="value"` on the span: the value cell is `white-space: nowrap` + `overflow:
+		   hidden` in `.sk-facts` (see `main.css`), so a long value ("the agent and you" at
+		   100px in a 100px column) truncates without any way to read the full string —
+		   hover was the missing recovery. Title is the same string the cell shows, so
+		   short values that fit still show their tooltip, matching every other truncatable
+		   row on this page. */
 		return (
 			'<div class="sk-line">' +
 			(swatch ? '<i style="background:' + swatch + '"></i>' : "") +
 			"<b>" +
 			JD.esc(label) +
-			"</b><span>" +
+			'</b><span title="' +
+			JD.esc(value) +
+			'">' +
 			JD.esc(value) +
 			"</span></div>"
 		);
@@ -1107,7 +1261,7 @@
 	/**
 	 * The window's local days, taken from the BAND'S OWN series.
 	 *
-	 * Not recomputed from the range: `buildSkillDays` walks the window with
+	 * Not recomputed from the range: `buildDayPoints` walks the window with
 	 * `addLocalDays` precisely because a fixed 86,400,000 skips or repeats a bucket on
 	 * a DST day, and a client-side second implementation of that would disagree with
 	 * the band exactly on those days, silently. Reading its keys makes the three charts
@@ -1169,7 +1323,7 @@
 		var counts = buckets.map(() => 0);
 		points.forEach((point) => {
 			/* A point outside the window is dropped, never clamped onto an edge bucket —
-			   `buildSkillDays` states the same rule for the same reason: the SQL filters on
+			   `buildDayPoints` states the same rule for the same reason: the SQL filters on
 			   epoch bounds while these buckets are local day keys, so the only points this
 			   can reject are the boundary's own rounding, and filing one under a day it did
 			   not happen on would be worse than leaving it out. */
@@ -1451,6 +1605,12 @@
 		Array.prototype.forEach.call(app.querySelectorAll("[data-skill]"), (element) => {
 			element.onclick = () => {
 				var name = element.getAttribute("data-skill");
+				var focusedLegendName =
+					document.activeElement === element &&
+					element.classList &&
+					element.classList.contains("sk-legend")
+						? name
+						: null;
 				var next = state.paneName === name ? null : name;
 				/* The reader has now answered "which skill" themselves, so the default pick
 				   must not run again — otherwise the click that closes the pane re-opens the
@@ -1460,7 +1620,14 @@
 				state.paneName = next;
 				state.pane = null;
 				state.paneError = null;
-				renderSkills(model);
+				/* Targeted repaint plus the detail refetch — NOT `renderSkills(model)`,
+				   which would tear down the whole `.browser-page` section on every click
+				   (the visible flicker readers reported, plus the loss of the nav column's
+				   scroll position). `updateSelection` walks the band, list highlights and
+				   pane; `fetchDetail` starts the new detail request whose `.then` calls
+				   `drawPane` a second time when it lands. */
+				updateSelection(app, model, focusedLegendName);
+				fetchDetail(app, model);
 			};
 		});
 	}

--- a/cli/src/dashboard/assets/js/stats.js
+++ b/cli/src/dashboard/assets/js/stats.js
@@ -788,18 +788,32 @@ window.JD = window.JD || {};
 			   that gives (the name, which truncates). A bare string was falsy here and
 			   so emitted no slot at all; this keeps that. */
 			var kind = kindOf ? kindOf(row) : null;
-			/* Only the Skills list opens a detail view, so only its rows carry the
-			   affordance. The MCP lists would need their own endpoint and their own
-			   answer to "what is a server's detail", and a row that looks clickable
-			   and does nothing is worse than a row that does not. */
-			var clickable =
-				list === "skill"
-					? ' class="rl-click" tabindex="0" role="button" data-skill="' +
-						JD.esc(row.name) +
-						'" title="Open detail for ' +
-						JD.esc(row.name) +
-						'"'
-					: "";
+			/* TWO of the three lists open a detail view, and the third deliberately does
+			   not: `skill` links into the Skills page and `server` into the MCPs page,
+			   while the MCP TOOL list has no page of its own — a server is what
+			   `/api/mcp-detail` answers about, and a row that looks clickable and does
+			   nothing is worse than a row that does not.
+			 *
+			 * The attribute names the page's own selection parameter (`data-skill` →
+			   `?skill=`, `data-mcp` → `?mcp=`), which is what the binder at the foot of
+			   this file reads back. The server row's own identity is `row.server`, not
+			   `row.name` — `McpServerRow` has no `name` field. */
+			var clickable = "";
+			if (list === "skill") {
+				clickable =
+					' class="rl-click" tabindex="0" role="button" data-skill="' +
+					JD.esc(row.name) +
+					'" title="Open detail for ' +
+					JD.esc(row.name) +
+					'"';
+			} else if (list === "server") {
+				clickable =
+					' class="rl-click" tabindex="0" role="button" data-mcp="' +
+					JD.esc(row.server) +
+					'" title="Open detail for ' +
+					JD.esc(row.server) +
+					'"';
+			}
 			html +=
 				"<li" +
 				clickable +
@@ -1317,7 +1331,13 @@ window.JD = window.JD || {};
 		state.loading = true;
 		state.error = false;
 		JD.renderPage(model);
-		JD.getJson(JD.withParams("/api/tool-usage" + JD.query(model, {}), { list: list, offset: String(rows.length) }))
+		JD.getJson(
+			JD.withParams("/api/tool-usage" + JD.query(model, {}), {
+				list: list,
+				offset: String(rows.length),
+				nowMs: model.generatedAtMs,
+			}),
+		)
 			.then((page) => {
 				/* A 30 s model refresh can finish while this page is in flight. That
 				   refresh replaces the global model and deliberately resets every tool
@@ -1439,7 +1459,12 @@ window.JD = window.JD || {};
 		var spec = TOOL_LISTS[list];
 		var usage = model.stats.toolUsage;
 		return JD.getJson(
-			JD.withParams("/api/tool-usage" + JD.query(model, {}), { list: list, offset: "0", limit: String(width) }),
+			JD.withParams("/api/tool-usage" + JD.query(model, {}), {
+				list: list,
+				offset: "0",
+				limit: String(width),
+				nowMs: model.generatedAtMs,
+			}),
 		)
 			.then((page) => {
 				/* Superseded — a later poll already replaced the model this answer was
@@ -2020,33 +2045,43 @@ window.JD = window.JD || {};
 			button.onclick = () => loadMoreToolRows(model, button.getAttribute("data-toolmore"));
 		});
 
-		/* The Skills rows LINK INTO the Skills page, which has a reading pane of its
-		   own. They used to open a modal over this card — a second renderer of the same
-		   figures, and one that could not be shared or reloaded. `?skill=` is that
-		   page's own selection state, so this navigation and a click over there land on
-		   the identical view.
+		/* The Skills and MCP-server rows LINK INTO their own pages, each of which has a
+		   reading pane. They used to open a modal over this card — a second renderer of
+		   the same figures, and one that could not be shared or reloaded. `?skill=` and
+		   `?mcp=` are those pages' own selection state, so this navigation and a click
+		   over there land on the identical view.
 
 		   Re-bound on every repaint like the button above, because a repaint replaces
 		   the whole of `#app` and takes the old rows' handlers with it.
 
 		   Keyboard as well as pointer: the row carries `role="button"` and a tabindex,
 		   so leaving it click-only would put a focusable control on the page that the
-		   keyboard cannot activate. */
-		document.querySelectorAll("[data-skill]").forEach((row) => {
-			var open = () => {
-				/* Through `JD.viewPath`, never a literal "/skills": that table is the one
-				   place a view's URL is spelled, so the nav row and this link cannot end up
-				   disagreeing about where the page lives. */
-				var query = JD.withParams(JD.query(model, {}), { skill: row.getAttribute("data-skill") });
-				window.location.href = JD.viewPath("skills") + query;
-			};
-			row.onclick = open;
-			row.onkeydown = (event) => {
-				if (event.key === "Enter" || event.key === " ") {
-					event.preventDefault();
-					open();
-				}
-			};
+		   keyboard cannot activate.
+
+		   ONE BINDER, TABLE-DRIVEN, because the two differ only in which attribute
+		   carries the identity and which view receives it — and a second copy of this
+		   loop is a second place for the `JD.viewPath` rule below to be forgotten. */
+		[
+			{ attribute: "data-skill", param: "skill", view: "skills" },
+			{ attribute: "data-mcp", param: "mcp", view: "mcps" },
+		].forEach((link) => {
+			document.querySelectorAll("[" + link.attribute + "]").forEach((row) => {
+				var open = () => {
+					/* Through `JD.viewPath`, never a literal "/skills": that table is the one
+					   place a view's URL is spelled, so the nav row and this link cannot end up
+					   disagreeing about where the page lives. */
+					var params = {};
+					params[link.param] = row.getAttribute(link.attribute);
+					window.location.href = JD.viewPath(link.view) + JD.withParams(JD.query(model, {}), params);
+				};
+				row.onclick = open;
+				row.onkeydown = (event) => {
+					if (event.key === "Enter" || event.key === " ") {
+						event.preventDefault();
+						open();
+					}
+				};
+			});
 		});
 	};
 

--- a/cli/src/dashboard/assets/styles/main.css
+++ b/cli/src/dashboard/assets/styles/main.css
@@ -1867,10 +1867,28 @@ body {
 .jd .wiki-freshness .wiki-dismiss:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
 
-/* ══ Skills page ══════════════════════════════════════════════════════════════
+/* ══ Skills and MCPs pages ════════════════════════════════════════════════════
    A chart band across the top, then a chooser column and a reading pane — the
    same grammar Memories uses, so the two pages are navigated the same way.
    `.mem-*` above is the reference for every chrome value here.
+
+   TWO PAGES, ONE BLOCK, and `.browser-page` is what says so. Skills and MCPs are the
+   same frame around the same three regions, differing only in what their rows and
+   sections hold (`assets/js/skills.js` and `assets/js/mcps.js`), so the frame class is
+   named after the SHAPE rather than after either page. The `.sk-*` prefix below is
+   shared for the same reason and keeps its name: it predates the second page, and
+   renaming forty classes to say what this one line already says would be churn.
+   Only the two page-specific hooks are separate — `.mcp-page` narrows the third
+   column and adds the tool list, both at the end of this block.
+
+   Every height budget below was derived against the SKILLS pane, and the MCPs pane is
+   held inside it by a cap of its OWN rather than by being smaller in general. Most of it
+   is a subset — no cost figures, no outcome strip, no inferred caveat — but its tool
+   list is the one section whose length belongs to the SERVER, and a real 12-tool
+   registration overran the pane by 10px before it was capped. So `MCP_DETAIL_TOOL_LIMIT`
+   is a height budget in disguise and carries that measurement; at the top end the two
+   panes are within a few pixels of each other rather than one sitting comfortably inside
+   the other. Re-derive both if either pane grows a section.
 
    THE WRAP'S 1200px CAP STAYS HERE, which is where this page parts from
    `.memories-page`. Releasing it is what a full-bleed browser needs, and this page
@@ -1949,13 +1967,13 @@ body {
    nothing) — and the chart already reaches ~900px inside the cap, because the band spans
    BOTH columns and never shared the width with the list. Not enough to trade the page's
    alignment with every other view for. Revisit it if the pane's own caps ever come off. */
-/* `#app`, NOT `.grid`: main.js sets `#app.className = view.grid ? "grid" : ""`, and
-   `skills` is declared `grid: false` in shell.js — so `#app` carries NO class here and
-   the `.grid:has(.skills-page)` rule this replaces never matched anything. It was inert
-   for as long as it shipped (harmless while the page was `display: block` by default,
-   and a silent no-op the moment the flex chain below started depending on it). */
-.jd:has(.skills-page) { height: 100vh; overflow: hidden; }
-.jd .main:has(.skills-page) {
+/* `#app`, NOT `.grid`: main.js sets `#app.className = view.grid ? "grid" : ""`, and both
+   `skills` and `mcps` are declared `grid: false` there — so `#app` carries NO class here
+   and the `.grid:has(…)` rule this replaces never matched anything. It was inert for as
+   long as it shipped (harmless while the page was `display: block` by default, and a
+   silent no-op the moment the flex chain below started depending on it). */
+.jd:has(.browser-page) { height: 100vh; overflow: hidden; }
+.jd .main:has(.browser-page) {
 	padding-bottom: 0; display: flex; flex-direction: column; height: 100vh; min-height: 0;
 }
 /* Deliberately NOT hidden the way Knowledge hides its own: this note is empty on this
@@ -1967,12 +1985,26 @@ body {
    below it, and this frame has nothing. It comes out of the SAME vertical budget as
    everything else (see the chart's `clamp()`), so the 12px is 33px of chart width; that
    trade is why it is 12 and not the 20 that would mirror the padding above. */
-.jd .wrap:has(.skills-page) {
+/* `width: 100%` is what pins the layout at every pane state — MEASURED THE HARD
+   WAY. `.wrap` is a flex item in `.main`'s flex column with `margin: 0 auto`,
+   so with no explicit width it takes its `max-content` inline size. That size
+   is the grid inside — `344px + 6px + max-content of .sk-pane` — so an EMPTY
+   pane (the "Select a skill…" state) demands only ~430px, an OPEN pane demands
+   ~800px, and the whole page shrinks and re-centres by ~350px between the two.
+   `minmax(0, 1fr)` on the pane's grid track sets a MIN of 0 but does not force
+   growth; the container has to be sized first for `1fr` to have anything to
+   distribute. Pinning `.wrap` to `100%` (capped by its `max-width: 1200px`)
+   fixes the container width first, and `1fr` then hands the pane whatever the
+   nav column did not take — same 800-odd px whether the pane is empty or full.
+   Auto margins keep centering the wrap between the 1200px cap and the window
+   because `width: 100%` still yields to `max-width`. */
+.jd .wrap:has(.browser-page) {
+	width: 100%;
 	flex: 1; min-height: 0; display: flex; flex-direction: column; padding-bottom: 12px;
 }
-.jd #app:has(.skills-page) { display: flex; flex-direction: column; flex: 1; min-height: 0; }
+.jd #app:has(.browser-page) { display: flex; flex-direction: column; flex: 1; min-height: 0; }
 
-.jd .skills-page {
+.jd .browser-page {
 	display: grid; grid-template-columns: 344px minmax(0, 1fr); gap: 6px;
 	/* The band takes its own height; the columns take everything left. `minmax(0, 1fr)`
 	   rather than `1fr` so the row can be SHORTER than its content — a bare `1fr` floors
@@ -2070,6 +2102,16 @@ body {
 /* `display: block` drops the inline baseline gap under the SVG; the pinned height is the
    whole point of the change above. */
 .jd .sk-bandbars { display: block; width: 100%; height: var(--sk-band-plot-h); }
+/* HIGHLIGHT ON THE CHART, keyed off `data-selected` on `.sk-band`. When a row in the
+   chooser column is selected, every rect fades to a recessed ~.22, and the ones tagged
+   `data-active` (added by JS after render, matching the selection) come back to full
+   opacity. Two rules rather than a JS repaint of the SVG: the bars stay in place across
+   selection changes, so the transition below actually reads as an animation instead of a
+   flash of the whole chart being torn down. Same recessed rule the legend's `.sk-dim`
+   uses, one level up in the DOM. */
+.jd .sk-bandbars rect[data-series] { transition: opacity .18s ease; }
+.jd .sk-band[data-selected]:not([data-selected=""]) .sk-bandbars rect[data-series] { opacity: .22; }
+.jd .sk-band[data-selected]:not([data-selected=""]) .sk-bandbars rect[data-active] { opacity: 1; }
 /* The key, stacked in that spare width. INSIDE THIS BAND THE RAMP MEANS SKILL,
    while everywhere else on the dashboard it means agent — which is why the key sits
    against the chart rather than at the page edge. A colour may not be read across
@@ -2145,9 +2187,15 @@ body {
  * to know this region scrolls before the footnote at its end is reachable at all. It is
  * on `.sk-list` itself now precisely because there is no longer an uncapped state for it
  * to be absent in. */
+/* `scrollbar-gutter: stable` reserves the scrollbar's width even when the list
+   fits without scrolling, so the rows do not shift by ~10px when the tail of
+   the list arrives (or when the reader switches to the MCPs page, whose list
+   is usually much shorter than Skills'). Without it the row column's inner
+   edge jitters between the two pages, and against a fixed 344px outer width
+   that shift also moves every row's ellipsis in and out. */
 .jd .sk-list {
 	min-width: 0; min-height: 0; flex: 1; padding: 8px 14px;
-	overflow-y: auto;
+	overflow-y: auto; scrollbar-gutter: stable;
 	scrollbar-width: thin; scrollbar-color: color-mix(in srgb, var(--muted) 42%, transparent) transparent;
 }
 .jd .sk-list::-webkit-scrollbar { width: 10px; }
@@ -2223,8 +2271,13 @@ body {
    overflow at 1280x817. Trimming 20/28 to 16/20 buys 12px and covers every width; the
    alternative was raising the height constant, which would have cost EVERY window 22px of
    chart to fix one width. */
+/* `scrollbar-gutter: stable` reserves the scrollbar's space at every state, so
+   the two-column reading in `.sk-panebody` does not reflow when the pane goes
+   from empty ("Select a skill…") to full detail — the width the reader is
+   halfway through would otherwise shift by ~10px the instant the fetch lands.
+   Same rule as `.sk-list` above; both are the fallback for the same reason. */
 .jd .sk-pane {
-	min-width: 0; min-height: 0; overflow-y: auto;
+	min-width: 0; min-height: 0; overflow-y: auto; scrollbar-gutter: stable;
 	border: 1px solid var(--border); border-radius: 10px; padding: 16px 24px 20px; background: var(--page);
 }
 /* TWO COLUMNS, PINNED — not `repeat(auto-fit, minmax(300px, 1fr))`, which made the pane's
@@ -2272,6 +2325,14 @@ body {
 .jd .sk-facts { display: grid; grid-template-columns: 1fr 1fr; gap: 0 18px; }
 .jd .sk-facts .sk-line { min-width: 0; }
 .jd .sk-facts .sk-line span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* `nowrap` + `flex: none` on the LABEL, so a wide value cannot squeeze `Entered by`
+   or `First used` into two lines — the value has `overflow: hidden` + ellipsis and
+   is the side that CAN give (its truncation now recovers on hover via `title`).
+   Before this rule, in a 171px flex row, a 102px value left the 63px label 61px of
+   room and it wrapped to "Entered\nby". `.sk-line b` is `<b>`, whose default is
+   `inline`, so the flex-item defaults apply the moment `.sk-line` becomes a flex
+   parent — no display change needed for either rule to take effect. */
+.jd .sk-facts .sk-line b { white-space: nowrap; flex: none; }
 
 /* The pane's two bar charts. Bars rather than `JD.spark`: a polyline interpolates
    BETWEEN points and every series here is discrete, so bars claim exactly what the
@@ -2326,12 +2387,18 @@ body {
 	font-size: 11px; line-height: 1.5; color: var(--ink-2);
 }
 
-/* THE TWO LONG FIXED PARAGRAPHS, COLLAPSED TO ONE LINE. `.sk-caveat` and `.sk-basis` are
-   ~4 lines each and 82px of the pane's budget between them (measured) — the second largest
-   saving after the section chrome, and the cheapest, because these two are the only blocks
-   in the pane whose text is FIXED rather than a measurement. Clamping a data row would
+/* THE LONG FIXED PARAGRAPHS, COLLAPSIBLE TO ONE LINE. `.sk-caveat` and `.sk-basis` are
+   ~4 lines each and 82px of the skills pane's budget between them (measured) — the second
+   largest saving after the section chrome, and the cheapest, because these are the only
+   blocks in a pane whose text is FIXED rather than a measurement. Clamping a data row would
    destroy a count; clamping these hides a qualifier the reader can bring back with a click.
    Chosen over a `title` tooltip on its own, which no touch device can reach.
+ *
+ * THE RULES BELOW ARE THE COLLAPSED STATE, AND NEITHER PANE STARTS THERE. `openProse` in
+ * `skills.js` and `mcps.js` renders `aria-expanded="true"` on first paint, so a reader meets
+ * every one of these paragraphs whole; the clamp is what a click puts them into. Keep the
+ * bare selector as the collapsed half — the markup names the open state explicitly, so
+ * inverting these two rules would leave a pane with no way to spell "folded".
  *
  * `-webkit-line-clamp` needs `display: -webkit-box`, so the open state has to restore
  * `display: block` as well as releasing the clamp — dropping the clamp alone leaves the
@@ -2365,6 +2432,40 @@ body {
 	margin-top: 10px; max-width: 560px;
 	font-size: 11px; line-height: 1.5; color: var(--ink-2);
 }
+
+/* ── The MCPs page's own two hooks ───────────────────────────────────────────────────
+   Everything above is shared with Skills (see this block's header). These two are not,
+   and both are here because the MCPs page's columns carry a different KIND of number. */
+
+/* The third column is a TOOL COUNT, not a token figure. Skills gives it 76px because
+   `206.0k` has to fit; a server's tool count is one or two digits, so the width goes to
+   the name instead — which is where it is needed, since a server registered through a
+   plugin manifest carries a long prefix. Both selectors are overridden together, or the
+   header would drift from the rows it labels. */
+.jd .mcp-page .sk-cols,
+.jd .mcp-page .sk-row { grid-template-columns: minmax(0, 1fr) 52px 50px; }
+
+/* The pane's tool list. Its own grid rather than `.sk-line`, because a tool row carries
+   TWO figures (calls and sessions) where every `.sk-line` in this pane carries one — and
+   `.sk-line` pushes its single value to the far edge with `margin-left: auto`, which two
+   values cannot share. Baseline-aligned so the name and both numbers sit on one line
+   even when the name is in the mono face. */
+.jd .mcp-tools { display: grid; gap: 6px; margin-top: 4px; }
+.jd .mcp-tool {
+	display: grid; grid-template-columns: minmax(0, 1fr) 44px 56px; gap: 10px;
+	align-items: baseline; font-size: 12px;
+}
+/* `min-width: 0` is what lets the name truncate — a grid item's automatic minimum is its
+   content, so without it a long tool name widens the column and pushes the numbers off
+   (the same rule `.sk-name` carries). The full name stays reachable in its `title`. */
+.jd .mcp-tool b {
+	min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+	font-weight: 600; color: var(--ink);
+}
+.jd .mcp-tool span { text-align: right; color: var(--ink-2); font-variant-numeric: tabular-nums; }
+/* The session count is the quieter of the two figures: calls is what the list is ranked
+   by and what the row is read for, so the second number recedes rather than competing. */
+.jd .mcp-tool .mcp-tool-sess { font-size: 11px; }
 
 /* ── THE SHORT-WINDOW BUDGET ────────────────────────────────────────────────────────
    Two rules that only make sense together: on a window this short the band's chart has
@@ -2416,13 +2517,13 @@ body {
    while 0 reads as a card welded to the window's edge. */
 @media (max-height: 816px) {
 	.jd .sk-band { padding: 10px 20px 8px; }
-	.jd .wrap:has(.skills-page) { padding-bottom: 8px; }
+	.jd .wrap:has(.browser-page) { padding-bottom: 8px; }
 }
 
 /* No wrap-padding overrides at either breakpoint: the wrap keeps its own 24px and
    its cap is already inert below 1200px, so there is nothing left to reclaim. */
 @media (max-width: 1180px) {
-	.jd .skills-page { grid-template-columns: 320px minmax(0, 1fr); }
+	.jd .browser-page { grid-template-columns: 320px minmax(0, 1fr); }
 }
 @media (max-width: 899px) {
 	/* THE WHOLE FIXED FRAME COMES OFF HERE, not just the second column. Once the columns
@@ -2437,11 +2538,11 @@ body {
 	 * `.sk-list`'s cap needs no `!important` any more: it used to be an inline pixel value
 	   written by `listOpenTag`, which nothing but `!important` outranks, and the flex chain
 	   replaced it with a stylesheet rule this block can simply override. */
-	.jd:has(.skills-page) { height: auto; overflow: visible; }
-	.jd .main:has(.skills-page) { display: block; height: auto; padding-bottom: 48px; }
-	.jd .wrap:has(.skills-page) { display: block; flex: none; }
-	.jd #app:has(.skills-page) { display: block; flex: none; }
-	.jd .skills-page {
+	.jd:has(.browser-page) { height: auto; overflow: visible; }
+	.jd .main:has(.browser-page) { display: block; height: auto; padding-bottom: 48px; }
+	.jd .wrap:has(.browser-page) { display: block; flex: none; }
+	.jd #app:has(.browser-page) { display: block; flex: none; }
+	.jd .browser-page {
 		grid-template-columns: minmax(0, 1fr); grid-template-rows: none;
 		flex: none; align-items: start;
 	}

--- a/codex-plugin/scripts/_publish-lib.sh
+++ b/codex-plugin/scripts/_publish-lib.sh
@@ -43,6 +43,7 @@ PUBLISH_REQUIRED_DIST=(
 	dashboard-assets/js/shell.js
 	dashboard-assets/js/stats.js
 	dashboard-assets/js/skills.js
+	dashboard-assets/js/mcps.js
 	dashboard-assets/js/standup.js
 	dashboard-assets/js/memories.js
 	dashboard-assets/js/journeys.js

--- a/cursor-plugin/scripts/_publish-lib.sh
+++ b/cursor-plugin/scripts/_publish-lib.sh
@@ -38,6 +38,7 @@ PUBLISH_REQUIRED_DIST=(
 	dashboard-assets/js/shell.js
 	dashboard-assets/js/stats.js
 	dashboard-assets/js/skills.js
+	dashboard-assets/js/mcps.js
 	dashboard-assets/js/standup.js
 	dashboard-assets/js/memories.js
 	dashboard-assets/js/journeys.js


### PR DESCRIPTION
<!-- jollimemory-summary-start -->

## Context

- Skills used — 3 skills · some inferred

## Quick recap

The dashboard gained a full MCP servers page that lets users browse per-server usage details alongside the existing Skills page. Each server now has its own detail view showing total calls, sessions, called tools, contributing agents, and the repositories it ran in, with a daily adoption chart and a daily call-volume chart sharing the same timeline. Rows on the dashboard's existing MCP summary card now link directly into this new page.

Before building the page, an investigation confirmed that no database changes were required. Every figure the new page needed could be computed from data the dashboard was already recording. That investigation also clarified how repeated tool calls within a single session are stored, and it ruled out adding a list of configured-but-unused servers or a precise first-call timestamp.

A follow-up review of the new page uncovered four correctness issues before release. A trend chart was silently truncating older sessions for busy servers, a details view could return a wrong result right after midnight, dynamically named servers could collide with special property names built into JavaScript objects, and the page's tool count included tools that had no associated server. All four were fixed and covered with new automated tests.

---

## Topics (3)
<details>
<summary><strong>01 · Fixed four correctness bugs found in MCP dashboard code review</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The user asked for a full code review of the uncommitted MCP dashboard changes; the review surfaced four issues that existing tests would not have caught, and the user then asked for them to be fixed without introducing any new problems.

**💡 Decisions Behind the Code**

- **Day-level aggregation over session truncation**: bucketing by calendar day bounds the response size using the window's existing day cap without silently dropping data for high-traffic servers, avoiding a chart that misrepresents early activity as zero.
- **Anchoring "now" to the page's generation time**: passing the already-resolved timestamp into the detail request, rather than letting the server re-resolve "today" independently, guarantees the two related views can never disagree about which day range is current.
- **Keeping the old tool-count field unchanged**: rather than redefining the existing all-tools total, a new server-scoped field was added so a different part of the dashboard that intentionally includes serverless tool rows was not affected.

**✅ What Was Implemented**

- The server detail trend chart was silently dropping sessions past a 400-session cap, causing busy servers to show early dates as zero; this was replaced with a full-window day-by-day aggregation bounded instead by the existing 366-day window limit.
- The detail page re-resolved "now" using the live server clock instead of the time the page itself was generated, so a page left open past midnight and then clicked would 404; the fix passes the page's own generation timestamp into the detail request and validates it strictly.
- Server names come from live data and were stored in plain JavaScript objects, so a server literally named "Other" or named like a reserved property could silently disappear or get miscounted; this was fixed with collision-safe storage and a collision-avoiding rollup key.
- The page's total tool count included legacy tool records that had no server attached, misrepresenting the header figure; a new server-scoped tool total was added and kept separate from the existing all-tools total used elsewhere.

**📁 FILES**
- `cli/src/dashboard/DashboardQuery.ts`
- `cli/src/dashboard/DashboardModel.ts`
- `cli/src/dashboard/DashboardServer.ts`
- `cli/src/dashboard/assets/js/mcps.js`

</blockquote>
</details>
<details>
<summary><strong>02 · Built a new MCP servers usage page modeled on the existing Skills page</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Using a design mockup and the already-implemented Skills page as a reference, the user asked to implement a full MCP servers page so each server's usage could be browsed in detail, the same way skills already can be.

**💡 Decisions Behind the Code**

- **Daily buckets instead of the mockup's weekly buckets**: matching the day axis already shared by the page's other charts avoided reintroducing a previously-fixed bug where two charts on the same page disagreed about which day something happened.
- **A per-day calls chart instead of the mockup's one-bar-per-session chart**: the record only stores one timestamp per session, so a per-session axis would represent an ordering rather than real time; a per-day chart keeps every chart on the page aligned to the same timeline, with per-session average shown as a separate figure instead.
- **No detail table for individual calls**: the mockup explicitly states call arguments and results are not shown, and no such per-call data exists to display, so the page states that absence in words instead of leaving an empty-looking section.

**✅ What Was Implemented**

- Added a new dashboard page and route for MCP servers with a chooser column, a stacked adoption chart, and a detail reading pane, following the same structure and interaction patterns as the existing Skills page.
- Added a backend query returning one server's full detail — tool breakdown, per-day session/call trend, calling agents, repositories, and first/last-seen timestamps — by generalizing the shared day-bucketing helper the skill detail view already used.
- Made the MCP rows on the existing dashboard summary card clickable into the new detail page, generalizing a click handler that previously only supported skill rows into one shared, table-driven handler.

**📁 FILES**
- `cli/src/dashboard/assets/js/mcps.js`
- `cli/src/dashboard/DashboardQuery.ts`
- `cli/src/dashboard/DashboardModel.ts`
- `cli/src/dashboard/DashboardServer.ts`
- `cli/src/dashboard/assets/js/shell.js`

</blockquote>
</details>
<details>
<summary><strong>03 · Confirmed no database schema changes were needed for the MCP usage page</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Before implementation began, the user asked whether any database tables or fields needed to be added or changed to support the new MCP page, and wanted an explanation of what any new fields would mean and why they'd be needed.

**💡 Decisions Behind the Code**

- **Building the page from existing data rather than proposing schema changes**: real-database verification showed every needed figure was already captured completely, making a schema change unnecessary added risk and permanent commitment for no accuracy gain.
- **Declining to list "configured but never used" servers**: that information only exists in each individual tool's local configuration files, not in the shared database, and guessing at it from partial data risked wrongly telling someone to disable a server they actually rely on.
- **Declining to reintroduce a detailed per-call metadata column**: a similar column had previously been removed for having no reader or writer, and the mockup itself states that call payload data is intentionally not shown, so bringing it back was treated as a separate decision outside this page's scope.

**✅ What Was Implemented**

- Verified against the mockup and the live database that every figure the page needed — call counts, server/tool breakdown, session counts, and agent distribution — could already be computed from the existing tool-usage and session tables, requiring no new tables or columns.
- Clarified, in response to a follow-up question, that repeated calls to the same tool within one session collapse into a single stored row with a summed call count and only the timestamp of the last call, not one row per call.
- Identified that a "first seen" figure could only ever be an approximation (the earliest last-call time of any session) since no per-call timestamp is stored, and that this could not be improved by a schema change because historical rows could never be backfilled.

**📁 FILES**
- `cli/src/dashboard/DashboardModel.ts`
- `cli/src/dashboard/DashboardQuery.ts`
- `cli/src/dashboard/SotSchema.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 24, 2026 at 2:33 PM · via Local agent - Claude Code*
<!-- jollimemory-summary-end -->
