### PR TITLE
refactor(skill): drop page-name arg and route table from jolli-dashboard

### DIFF
--- a/claude-plugin/plugins/jolli/skills/dashboard/SKILL.md
+++ b/claude-plugin/plugins/jolli/skills/dashboard/SKILL.md
@@ -31,7 +31,7 @@ security recipe and the dist resolver and will not produce valid output.
 
 ## Step 1: Read the argument, if there is one
 
-`<user-arg>` is optional. Recognise exactly three things in it and ignore the rest:
+`<user-arg>` is optional. Recognise exactly two things in it and ignore the rest:
 
 - **a port** — only when the argument contains a bare run of digits (e.g. `3000`).
   Pass it as `--port <digits>`. Never interpolate any other part of `<user-arg>`
@@ -39,8 +39,10 @@ security recipe and the dist resolver and will not produce valid output.
 - **"url only" / "don't open" / "no browser"** — add `--no-open`, and report the
   URL instead of opening it. Prefer this whenever you know the host has no desktop
   session.
-- **a page name** — `standup`, `memories`, `knowledge` or `graph`. This does not
-  change the command; it changes which path you report in Step 3.
+
+A page name (standup, memories, knowledge, graph) is **not** an argument here — the
+dashboard's own nav switches between those pages once it is open, so there is
+nothing to pass through and nothing extra to report.
 
 ## Step 2: Start it in the BACKGROUND, then wait for its URL
 
@@ -96,17 +98,8 @@ dashboard may still be up and give the PID to stop it — or offer to relaunch w
 
 **`READY <url>`** — the dashboard is up. Unless `--no-open` was used it has already
 opened the user's default browser itself; say so in one line and give the URL as
-well, so they can open it by hand if no window appeared. When the user named a page
-in Step 1, give them that page's URL instead of the bare one, keeping the port you
-just read:
-
-| page | path |
-| --- | --- |
-| stats (default) | `/dashboard` |
-| standup | `/dashboard/standup` |
-| memories | `/memories` |
-| knowledge | `/knowledge` |
-| graph | `/graph` |
+well, so they can open it by hand if no window appeared. Report the bare URL as
+printed — the dashboard's own nav reaches every page from there.
 
 Mention once that it keeps serving in the background after this turn, and that
 `kill <PID>` (the pid echoed above) stops it.

--- a/cli/src/install/PluginSkillText.ts
+++ b/cli/src/install/PluginSkillText.ts
@@ -199,7 +199,7 @@ ${SHELL_PREREQUISITE_BLOCK}
 
 ## Step 1 — read the argument, if there is one
 
-This skill takes one optional free-text argument. Recognise exactly three things in
+This skill takes one optional free-text argument. Recognise exactly two things in
 it and ignore the rest:
 
 - **a port** — only when the argument contains a bare run of digits (e.g. \`3000\`).
@@ -208,8 +208,10 @@ it and ignore the rest:
 - **"url only" / "don't open" / "no browser"** — add \`--no-open\`, and report the
   URL instead of opening it. Prefer this whenever you know the host has no desktop
   session.
-- **a page name** — \`standup\`, \`memories\`, \`knowledge\` or \`graph\`. This does not
-  change the command; it changes which path you report in Step 3.
+
+A page name (standup, memories, knowledge, graph) is **not** an argument here — the
+dashboard's own nav switches between those pages once it is open, so there is
+nothing to pass through and nothing extra to report.
 
 ## Step 2 — start it in the BACKGROUND, then wait for its URL
 
@@ -265,17 +267,8 @@ dashboard may still be up and give the PID to stop it — or offer to relaunch w
 
 **\`READY <url>\`** — the dashboard is up. Unless \`--no-open\` was used it has
 already opened the user's default browser itself; say so in one line and give the
-URL as well, so they can open it by hand if no window appeared. When the user named
-a page in Step 1, give them that page's URL instead of the bare one, keeping the
-port you just read:
-
-| page | path |
-| --- | --- |
-| stats (default) | \`/dashboard\` |
-| standup | \`/dashboard/standup\` |
-| memories | \`/memories\` |
-| knowledge | \`/knowledge\` |
-| graph | \`/graph\` |
+URL as well, so they can open it by hand if no window appeared. Report the bare URL
+as printed — the dashboard's own nav reaches every page from there.
 
 Mention once that it keeps serving in the background after this turn, and that
 \`kill <PID>\` (the pid echoed above) stops it.

--- a/codex-plugin/plugins/jolli/skills/dashboard/SKILL.md
+++ b/codex-plugin/plugins/jolli/skills/dashboard/SKILL.md
@@ -30,7 +30,7 @@ security recipe and the dist resolver and will not produce valid output.
 
 ## Step 1 — read the argument, if there is one
 
-This skill takes one optional free-text argument. Recognise exactly three things in
+This skill takes one optional free-text argument. Recognise exactly two things in
 it and ignore the rest:
 
 - **a port** — only when the argument contains a bare run of digits (e.g. `3000`).
@@ -39,8 +39,10 @@ it and ignore the rest:
 - **"url only" / "don't open" / "no browser"** — add `--no-open`, and report the
   URL instead of opening it. Prefer this whenever you know the host has no desktop
   session.
-- **a page name** — `standup`, `memories`, `knowledge` or `graph`. This does not
-  change the command; it changes which path you report in Step 3.
+
+A page name (standup, memories, knowledge, graph) is **not** an argument here — the
+dashboard's own nav switches between those pages once it is open, so there is
+nothing to pass through and nothing extra to report.
 
 ## Step 2 — start it in the BACKGROUND, then wait for its URL
 
@@ -96,17 +98,8 @@ dashboard may still be up and give the PID to stop it — or offer to relaunch w
 
 **`READY <url>`** — the dashboard is up. Unless `--no-open` was used it has
 already opened the user's default browser itself; say so in one line and give the
-URL as well, so they can open it by hand if no window appeared. When the user named
-a page in Step 1, give them that page's URL instead of the bare one, keeping the
-port you just read:
-
-| page | path |
-| --- | --- |
-| stats (default) | `/dashboard` |
-| standup | `/dashboard/standup` |
-| memories | `/memories` |
-| knowledge | `/knowledge` |
-| graph | `/graph` |
+URL as well, so they can open it by hand if no window appeared. Report the bare URL
+as printed — the dashboard's own nav reaches every page from there.
 
 Mention once that it keeps serving in the background after this turn, and that
 `kill <PID>` (the pid echoed above) stops it.

--- a/cursor-plugin/plugins/jolli/skills/jolli-dashboard/SKILL.md
+++ b/cursor-plugin/plugins/jolli/skills/jolli-dashboard/SKILL.md
@@ -30,7 +30,7 @@ security recipe and the dist resolver and will not produce valid output.
 
 ## Step 1 — read the argument, if there is one
 
-This skill takes one optional free-text argument. Recognise exactly three things in
+This skill takes one optional free-text argument. Recognise exactly two things in
 it and ignore the rest:
 
 - **a port** — only when the argument contains a bare run of digits (e.g. `3000`).
@@ -39,8 +39,10 @@ it and ignore the rest:
 - **"url only" / "don't open" / "no browser"** — add `--no-open`, and report the
   URL instead of opening it. Prefer this whenever you know the host has no desktop
   session.
-- **a page name** — `standup`, `memories`, `knowledge` or `graph`. This does not
-  change the command; it changes which path you report in Step 3.
+
+A page name (standup, memories, knowledge, graph) is **not** an argument here — the
+dashboard's own nav switches between those pages once it is open, so there is
+nothing to pass through and nothing extra to report.
 
 ## Step 2 — start it in the BACKGROUND, then wait for its URL
 
@@ -96,17 +98,8 @@ dashboard may still be up and give the PID to stop it — or offer to relaunch w
 
 **`READY <url>`** — the dashboard is up. Unless `--no-open` was used it has
 already opened the user's default browser itself; say so in one line and give the
-URL as well, so they can open it by hand if no window appeared. When the user named
-a page in Step 1, give them that page's URL instead of the bare one, keeping the
-port you just read:
-
-| page | path |
-| --- | --- |
-| stats (default) | `/dashboard` |
-| standup | `/dashboard/standup` |
-| memories | `/memories` |
-| knowledge | `/knowledge` |
-| graph | `/graph` |
+URL as well, so they can open it by hand if no window appeared. Report the bare URL
+as printed — the dashboard's own nav reaches every page from there.
 
 Mention once that it keeps serving in the background after this turn, and that
 `kill <PID>` (the pid echoed above) stops it.


### PR DESCRIPTION
## What

Removes the optional **page-name** argument (`standup` / `memories` / `knowledge` / `graph`) and its `page → path` route table from the `jolli-dashboard` skill.

## Why

- The `jolli dashboard` command hard-codes the stats page (`executeDashboard("stats", …)`) and exposes only `--port` / `--no-open` / `--cwd` — there is no `--page` flag and no positional page arg (the old `jolli stats` / `jolli standup` aliases are retired). So the browser **always** opens `/dashboard` and stdout only prints that one URL; the skill could never actually deep-link.
- The dashboard SPA already has its own nav that reaches every page from `/dashboard`, so the page-name feature only changed which URL *text* got typed back into chat — saving at most one nav click.
- That table was a hand-maintained, **un-pinned** duplicate of `VIEW_PATHS` in `DashboardServer.ts` (unlike this repo's other cross-file duplicates, no lockstep test guarded it). A route rename would have silently made the skill report a 404 link.

Net: eliminates a silent-drift 404 risk in exchange for a convenience the in-page nav already covers.

## Changes

All four copies of the skill body updated together:

- `cli/src/install/PluginSkillText.ts` — `buildDashboardSkillTemplate` (shared source for the Codex/Cursor bundles)
- `codex-plugin/plugins/jolli/skills/dashboard/SKILL.md` — regenerated
- `cursor-plugin/plugins/jolli/skills/jolli-dashboard/SKILL.md` — regenerated
- `claude-plugin/plugins/jolli/skills/dashboard/SKILL.md` — hand-edited (independent copy)

## Verification

- `npm run all` green (CLI 15599 passed, VS Code 4663 passed; coverage above thresholds)
- `CodexPluginSkills` / `CursorPluginSkills` drift tests pass (bundle copies match the generator)

Note: dashboard skill is not written by `jolli enable`, so there is no revision/fingerprint to bump.