### PR TITLE
chore(plugins): ship the slimmed jolli-dashboard skill

### DIFF
--- a/claude-plugin/plugins/jolli/.claude-plugin/plugin.json
+++ b/claude-plugin/plugins/jolli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "jolli",
 	"displayName": "Jolli Memory",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"description": "Automatically captures and generates project memory from your development work — team-shareable and synced across devices, so you can recall and search past decisions and context across sessions and agents. Backed by the jolli CLI bundled as an MCP server.",
 	"author": { "name": "jolli.ai", "url": "https://jolli.ai" },
 	"homepage": "https://jolli.ai",

--- a/codex-plugin/plugins/jolli/.codex-plugin/plugin.json
+++ b/codex-plugin/plugins/jolli/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "jolli",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "Automatically captures and generates project memory from your development work — team-shareable and synced across devices, so you can recall and search past decisions and context across sessions and agents. Backed by the jolli CLI bundled with this plugin.",
 	"author": { "name": "jolli.ai", "url": "https://jolli.ai" },
 	"homepage": "https://jolli.ai",

--- a/cursor-plugin/plugins/jolli/.cursor-plugin/plugin.json
+++ b/cursor-plugin/plugins/jolli/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "jolli",
 	"displayName": "Jolli Memory",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Automatically captures and generates project memory from your development work — team-shareable and synced across devices, so you can recall and search past decisions and context across sessions and agents. Backed by the jolli CLI bundled with this plugin.",
 	"author": { "name": "jolli.ai", "email": "hello@jolli.ai" },
 	"homepage": "https://jolli.ai",


### PR DESCRIPTION
### Why the skill changed

The `jolli dashboard` command hard-codes the stats page and exposes only `--port` / `--no-open` / `--cwd`, so the browser always opens `/dashboard` and the skill can never deep-link. The dashboard's own nav already reaches every page from there, so the old page-name argument and its `page → path` table only changed which URL text got echoed into chat — at the cost of a hand-maintained, un-pinned duplicate of `VIEW_PATHS` that would silently report a 404 link if a route were ever renamed.

The refactor dropped that argument and table from all four copies (the shared `buildDashboardSkillTemplate` builder that feeds the regenerated Codex/Cursor bundles, plus the hand-written Claude copy); the skill now recognizes only `--port` / `--no-open` and reports the bare `/dashboard` URL.

Since the bundled skill copies only reach users on a version bump, this PR carries the release for all three plugins. Version-only diff — the marketplace manifests carry no version key, so nothing else needed updating.