### PR TITLE
release: intellij 0.99.15

### DIFF
--- a/intellij/CHANGELOG.md
+++ b/intellij/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.99.15
+
+### Fixes & Improvements
+
+- Bug fixes.
+
+### Performance
+
+- Performance improvements.
+
 ## 0.99.14
 
 ### Fixes & Improvements

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = "ai.jolli"
-version = "0.99.14"
+version = "0.99.15"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Bump the IntelliJ plugin to 0.99.15, aligning it with the CLI and VS Code
extension, which are both already at 0.99.15.

This release carries no IntelliJ feature work of its own, so the change
notes record bug fixes and performance improvements only — the same shape
as the 0.99.14 release commit.

## Changes

- `intellij/build.gradle.kts` — `version` 0.99.14 → 0.99.15
- `intellij/CHANGELOG.md` — new `## 0.99.15` section

## Releasing

After this merges, run the **Publish to JetBrains Marketplace** workflow
manually against `main`. It resolves the version from
`intellij/build.gradle.kts`, so no tag or version input is needed.