### PR TITLE
Handle keep-alive proxy responses and improve slow-query diagnostics

### DIFF
--- a/cli/src/commands/DoctorCommand.test.ts
+++ b/cli/src/commands/DoctorCommand.test.ts
@@ -974,7 +974,14 @@ describe("doctor --schema-log", () => {
 			expect(logs.join("\n")).toContain(
 				"Recorded here but unknown to this build: 2026-09-01-0000-from-another-branch",
 			);
-			expect(logs.join("\n")).toContain("not a fault");
+			// The report must name the CONSEQUENCE, not just the fact. The same
+			// predicate gates `buildRollupQuietly`, so an unknown name means the daily
+			// stats cache is never written and every render recomputes its full
+			// window — which is usually why someone is reading this list at all. It
+			// used to say only "not a fault", which is true of the data and wrong
+			// about the performance.
+			expect(logs.join("\n")).toContain("DAILY STATS CACHE IS OFF");
+			expect(logs.join("\n")).toContain("Reads and writes keep working");
 			// Put it back, so the repair assertions below see the log they expect.
 			await withRepairDashboardDb((db) => {
 				db.prepare("UPDATE schema_migrations SET name = ? WHERE name = ?").run(

--- a/cli/src/commands/DoctorCommand.ts
+++ b/cli/src/commands/DoctorCommand.ts
@@ -1123,10 +1123,22 @@ export async function runSchemaLog(action: { mark?: string }): Promise<void> {
 	const unknown = state.rows.filter((row) => !MIGRATIONS.some((m) => m.name === row.name));
 	if (unknown.length > 0) {
 		const names = [...new Set(unknown.map((r) => r.name))].join(", ");
+		// The consequence line is not decoration, and "this is a diagnostic, not a
+		// fault" — what this said before — was measurably too weak. The same
+		// predicate gates `buildRollupQuietly`, so an unknown name here means the
+		// daily stats cache is never written and every dashboard render recomputes
+		// its whole window, permanently. Measured on a real machine whose database
+		// had been opened by two released CLIs: `stats_daily` held 0 rows and the
+		// stats page cost seconds. Whoever reads this list is usually reading it
+		// because a page is slow, so the connection has to be stated here.
 		console.log(
 			`\n  ⚠ Recorded here but unknown to this build: ${names}\n` +
-				"    Another build — very likely from an unmerged branch — has opened this database.\n" +
-				"    It keeps working; this is a diagnostic, not a fault.",
+				"    Another build — very likely from an unmerged branch, or a released CLI this\n" +
+				"    one predates — has opened this database.\n" +
+				"    Reads and writes keep working, but the DAILY STATS CACHE IS OFF while this\n" +
+				"    holds: nothing settles into `stats_daily`, so every dashboard render\n" +
+				"    recomputes its full window. Running a build that knows every name above\n" +
+				"    turns it back on by itself.",
 		);
 	}
 }

--- a/cli/src/core/LlmClient.test.ts
+++ b/cli/src/core/LlmClient.test.ts
@@ -1085,6 +1085,61 @@ describe("LlmClient", () => {
 			);
 		});
 
+		it("parses a response body that the backend prefixed with keep-alive whitespace", async () => {
+			// The backend writes newlines while it waits on Anthropic so the load
+			// balancer does not drop the idle socket at 60s. A real Response is used
+			// here rather than a mocked `json()` — the whole point is that the actual
+			// parser tolerates the prefix, which a stubbed `json()` would not prove.
+			fetchSpy.mockResolvedValueOnce(
+				new Response('\n\n\n{"text":"kept alive","inputTokens":11,"outputTokens":22}', {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
+			);
+
+			const result = await callLlm({
+				action: "commit-message",
+				params: { branch: "main", fileList: "src/foo.ts", stagedDiff: "diff" },
+				jolliApiKey: "sk-jol-test.secret",
+			});
+
+			expect(result.text).toBe("kept alive");
+			expect(result.inputTokens).toBe(11);
+			expect(result.outputTokens).toBe(22);
+		});
+
+		it("reports a body that dies after the headers, instead of a bare transport error", async () => {
+			// Keep-alive splits the response in two: the status line can land tens of
+			// seconds before the body. So a backend that fails after committing to a
+			// 200 destroys the socket, and that surfaces on the body read — not on the
+			// fetch. The call must still reject (a truncated body has no completion in
+			// it), but with a log that names the phase.
+			const body = new ReadableStream({
+				start(controller) {
+					controller.enqueue(new TextEncoder().encode("\n\n"));
+					controller.error(Object.assign(new Error("terminated"), { code: "ERR_STREAM_PREMATURE_CLOSE" }));
+				},
+			});
+			fetchSpy.mockResolvedValueOnce(
+				new Response(body, { status: 200, headers: { "content-type": "application/json" } }),
+			);
+
+			await expect(
+				callLlm({
+					action: "commit-message",
+					params: { branch: "main", fileList: "src/foo.ts", stagedDiff: "diff" },
+					jolliApiKey: "sk-jol-test.secret",
+				}),
+			).rejects.toThrow();
+
+			// Match the format string only: asserting the argument list would break the
+			// moment a field is added to that log line.
+			const logged = mockLogError.mock.calls.some((call) =>
+				String(call[0]).includes("Proxy LLM body read failed"),
+			);
+			expect(logged).toBe(true);
+		});
+
 		it("throws when proxy returns error", async () => {
 			fetchSpy.mockResolvedValueOnce({
 				ok: false,

--- a/cli/src/core/LlmClient.ts
+++ b/cli/src/core/LlmClient.ts
@@ -91,14 +91,23 @@ const LLM_PROXY_PATH = "/api/push/llm/complete";
 
 /**
  * End-to-end timeout for proxy LLM calls (covers connect + headers + body).
- * The backend invokes Anthropic non-streaming inside this request, so 180s is
- * generous for a full LLM round-trip while bounding how long a stuck request
- * can hold the QueueWorker file lock. Historically moved in lockstep with
- * `DIRECT_FETCH_TIMEOUT_MS`, but that rationale no longer holds: the direct
- * path now streams by default and its non-streaming budget governs only
- * trivially-small calls, whereas this proxy budget governs ALL proxy calls
- * (which have no streaming escape). They happen to share 180s today but should
- * be evaluated independently. Exported so a regression test can pin the value.
+ *
+ * This is the ONLY wall-clock limit on a proxied call now. The backend streams
+ * from Anthropic and writes keep-alive whitespace while it waits, so the load
+ * balancer's 60s idle timeout — which used to cut every slow completion short
+ * with an unparseable HTML 504 — no longer applies. `AbortSignal.timeout` covers
+ * the whole exchange, so a response whose headers arrived early (keep-alive does
+ * exactly that) still dies here if the body never finishes.
+ *
+ * 180s also bounds how long a stuck request can hold the QueueWorker file lock,
+ * which is per-repo and held for the whole drain: raising this makes every other
+ * hook in that repo wait longer. Raise it only against measured backend latency,
+ * not on a hunch. Historically moved in lockstep with `DIRECT_FETCH_TIMEOUT_MS`,
+ * but that rationale no longer holds: the direct path now streams by default and
+ * its non-streaming budget governs only trivially-small calls, whereas this proxy
+ * budget governs ALL proxy calls (which have no streaming escape). They happen to
+ * share 180s today but should be evaluated independently. Exported so a
+ * regression test can pin the value.
  */
 export const PROXY_FETCH_TIMEOUT_MS = 180_000;
 
@@ -1143,7 +1152,10 @@ async function callProxy(
 		);
 		throw err;
 	}
-	const elapsed = Date.now() - startTime;
+	// Headers only. The backend may send them long before the body: while it waits
+	// on Anthropic it writes keep-alive whitespace, and the first frame flushes the
+	// status line. So this is "time to first byte", NOT the call's duration.
+	const headersMs = Date.now() - startTime;
 
 	if (!response.ok) {
 		const errorBody = await response.text();
@@ -1151,9 +1163,44 @@ async function callProxy(
 		throw new Error(`LLM proxy request failed with status ${response.status}: ${errorBody.substring(0, 200)}`);
 	}
 
-	const result = (await response.json()) as Record<string, unknown>;
+	// JSON.parse skips the keep-alive whitespace that may precede the object, so the
+	// body needs no special handling — but it does have to be read before the call
+	// counts as finished, and reading it is now its own failure surface.
+	let result: Record<string, unknown>;
+	try {
+		result = (await response.json()) as Record<string, unknown>;
+	} catch (err) {
+		// A failure mode that barely existed before the backend started writing
+		// keep-alive bytes: the status line can now arrive tens of seconds ahead of
+		// the body, so whatever goes wrong afterwards surfaces HERE and not on the
+		// fetch above. Two causes, told apart by the clocks: the backend hit its own
+		// deadline or upstream error after committing to a 200 and destroyed the
+		// socket (elapsed well under our timeout), or our own AbortSignal fired after
+		// the headers had landed (elapsed ≈ the timeout). Deliberately not recovered
+		// — a truncated body has no completion in it — but it must be diagnosable,
+		// otherwise the caller just sees a bare "terminated".
+		const elapsedMs = Date.now() - startTime;
+		const message = err instanceof Error ? err.message : String(err);
+		const cause = err instanceof Error ? formatCause((err as { cause?: unknown }).cause) : "(non-error)";
+		log.error(
+			"Proxy LLM body read failed: action=%s url=%s elapsedMs=%d headersMs=%d prematureClose=%s error=%s cause=%s",
+			options.action,
+			url,
+			elapsedMs,
+			headersMs,
+			String(isPrematureClose(err)),
+			message,
+			cause,
+		);
+		throw err;
+	}
+	const elapsed = Date.now() - startTime;
 
-	log.info("Proxy LLM response: action=%s latency=%dms", options.action, elapsed);
+	// Both numbers, because they answer different questions: `latency` is what the
+	// call actually cost, `headers` is when the backend committed to a 200. On a
+	// slow call `headers` pins to the backend's keep-alive delay, and a `latency`
+	// far above it is normal, not a stall.
+	log.info("Proxy LLM response: action=%s latency=%dms headers=%dms", options.action, elapsed, headersMs);
 
 	/* v8 ignore start -- defensive: proxy response always includes token counts, ?? 0 is a safety net */
 	return {

--- a/cli/src/dashboard/DashboardDb.ts
+++ b/cli/src/dashboard/DashboardDb.ts
@@ -32,6 +32,7 @@ import { classifyScanError } from "../core/SqliteHelpers.js";
 import { createLogger, errMsg, isEnoent } from "../Logger.js";
 import { MIGRATIONS } from "./migrations/index.js";
 import type { DbMigration } from "./migrations/MigrationHelpers.js";
+import { instrumentDashboardDb } from "./SlowQueryLog.js";
 
 const log = createLogger("DashboardDb");
 
@@ -178,7 +179,16 @@ export interface OpenDashboardDbOptions {
  */
 const WRITE_PRAGMAS = ["PRAGMA journal_mode = WAL", "PRAGMA foreign_keys = ON"] as const;
 
-/** Read-only connections cannot set `journal_mode`; the writer already did. */
+/**
+ * Read-only connections cannot set `journal_mode`; the writer already did.
+ *
+ * No `cache_size` here, and that is a measured decision rather than an omission.
+ * SQLite's page cache is per CONNECTION and every render opens its own, so a
+ * larger one looked like free speed. Measured on a real 194 MB database once the
+ * analytic queries were index-driven, `-32000` (32 MB) was not faster than the
+ * 2 MB default and trended slightly slower: median 283 ms against 252 ms for the
+ * stats build. Re-add it only with a measurement attached.
+ */
 const READ_PRAGMAS = ["PRAGMA foreign_keys = ON"] as const;
 
 /**
@@ -869,7 +879,16 @@ async function openDb(readOnly: boolean, opts: OpenDashboardDbOptions): Promise<
 			db.exec(`PRAGMA busy_timeout = ${opts.busyTimeoutMs ?? DEFAULT_BUSY_TIMEOUT_MS}`);
 			// After the open: the file exists only now (see restrictDbFilesToOwner).
 			if (!readOnly) restrictDbFilesToOwner(dbPath);
-			return db;
+			// Slow-statement logging goes on HERE rather than at each call site,
+			// because this is the one place every dashboard read and write passes
+			// through — the server's renders, the hooks' `StatsWriter` batches, the
+			// backfill sweep and the migrations alike. Wrapping after the pragmas is
+			// deliberate: those are the open's own cost, not a query anyone can act
+			// on, and timing them would put a `PRAGMA busy_timeout` line in the log
+			// of every contended open. On by default at 200 ms; a run with
+			// `JOLLI_SLOW_SQL_MS=off` gets the handle back unwrapped, so switching it
+			// off leaves no indirection at all.
+			return instrumentDashboardDb(db, { role: readOnly ? "ro" : "rw" });
 		} catch (err) {
 			// Close the half-open handle before retrying, or each attempt leaks a
 			// file descriptor and (on Windows) keeps the file locked against the
@@ -954,10 +973,17 @@ export async function withRepairDashboardDb<T>(
  * surfaces any real fault itself, whereas guessing `true` here would leave a database
  * unmigrated with nothing reporting it.
  *
- * ⚠ Deliberately does NOT read the `ddl` column. `defaultModelBuilder` calls
- * `ensureDashboardDbExists` on EVERY `/api/model` — once per page load and once per
- * 30 s poll for as long as the tab is open — and the first entry's SQL alone is
- * ~35 KB. `readAppliedMigrationNames` exists to keep this to two columns.
+ * ⚠ Deliberately does NOT read the `ddl` column, which stores each migration's
+ * entire source text — the first entry's SQL alone is ~35 KB — to answer a
+ * question about NAMES. `readAppliedMigrationNames` exists to keep this to two
+ * columns. That was written when this read was on the dashboard's hot path
+ * (`defaultModelBuilder` called {@link ensureDashboardDbExists} on every
+ * `/api/model`, so once per page load and once per 30 s poll per open tab); that
+ * call is gone — see `readWithRecovery` in `DashboardServer.ts`, which pays it
+ * only when a read-only open actually fails — so today the only callers are
+ * `jolli dashboard`'s startup and that recovery. The two-column SELECT stays
+ * regardless: it is the right read for the question, and it is the next caller,
+ * not this one, that would pay for widening it.
  */
 export function isSchemaCurrent(db: DashboardDbHandle): boolean {
 	const done = readAppliedMigrationNames(db);
@@ -972,11 +998,12 @@ export function isSchemaCurrent(db: DashboardDbHandle): boolean {
  * Its own SELECT rather than a projection over {@link readMigrationLogState},
  * and the reason is the `ddl` column: it stores each migration's entire source
  * text — the baseline entry alone is ~35 KB — while this answers a question
- * about NAMES. That read is on the dashboard's hot path, not a startup one:
- * `defaultModelBuilder` calls {@link ensureDashboardDbExists} on EVERY
- * `/api/model`, so once per page load and once per 30 s poll for as long as the
- * tab is open. Pulling every migration's DDL there moved tens of KB per request
- * to look at two columns.
+ * about NAMES. It was measured on the dashboard's hot path: `defaultModelBuilder`
+ * used to call {@link ensureDashboardDbExists} on EVERY `/api/model`, so once per
+ * page load and once per 30 s poll for as long as a tab was open, and pulling
+ * every migration's DDL there moved tens of KB per request to look at two
+ * columns. That call has since moved off the read path (see `readWithRecovery` in
+ * `DashboardServer.ts`), which changes who pays, not whether the read is right.
  *
  * Collapses `none` and `unreadable` into one `undefined`, which the full read
  * deliberately does not: this caller answers BOTH the same way — {@link

--- a/cli/src/dashboard/DashboardModel.ts
+++ b/cli/src/dashboard/DashboardModel.ts
@@ -213,14 +213,25 @@ export interface WorktreeStatusEvent {
 /**
  * Insight kinds mined from a commit's memory (the standup board's buckets).
  *
- * Only `decision` and `todo` are PRODUCIBLE: `TOPIC_INSIGHTS_CTE` in
- * `DashboardQuery.ts` derives insights from each memory topic's own
- * `decisions`/`todo` text and emits those two literals, so nothing can carry the
- * other three. They stay in the union because they are what a summarizer taught
- * to record risks would emit, and because `StandupAsset.test.ts` builds them to
- * assert the UI renders nothing for them — the standup board's Risks column was
- * removed for exactly this reason. Anything reading a `blocker`/`question`/
- * `gotcha` off a live model is reading a value the pipeline cannot produce yet.
+ * NONE of these is producible today, and `decision` is the only one that ever
+ * was on this path. `TOPIC_DECISIONS_CTE` in `DashboardQuery.ts` derives rows
+ * from each memory topic's own `decisions` text, and it feeds the Decisions
+ * card — which carries the text directly and has no `kind` at all. So no live
+ * model has ever carried a `blocker` / `question` / `gotcha`, and none carries a
+ * `todo` any more either.
+ *
+ * `todo` was real once: it was the second arm of that CTE, filling the standup
+ * board's Risks/Blockers/Questions column. The column was removed in
+ * JOLLI-2200/2201 because nothing produces the other kinds, the server then
+ * stopped SENDING the rows, and the derivation was finally dropped when it was
+ * measured still costing a full `memories` scan per call for rows both consumers
+ * discarded (see that CTE's docstring).
+ *
+ * The union keeps all five deliberately. They are what a summarizer taught to
+ * record risks would emit, `StandupAsset.test.ts` builds them to assert the UI
+ * renders nothing for them, and {@link StandupInsight} is kept for the same
+ * reason — so an insight column can return without a wire change. Restoring a
+ * derivation is a new CTE; restoring a deleted wire type is not.
  */
 export type CommitInsightKind = "decision" | "blocker" | "question" | "todo" | "gotcha";
 

--- a/cli/src/dashboard/DashboardQuery.ts
+++ b/cli/src/dashboard/DashboardQuery.ts
@@ -456,47 +456,65 @@ function commitsInRange(
 }
 
 /**
- * Insights derived at query time from the memory's own topics — the summary
+ * Decisions derived at query time from the memory's own topics — the summary
  * schema has no `insights` field; what the retired commit_insights rows held
- * was ALWAYS this derivation (each topic's `decisions` and `todo`, in topic
- * order), performed at event-build time. Doing it in SQL keeps the rule in
- * one place and means a regenerated memory can never leave stale insights
- * behind. `ord` preserves the old idx ordering: topic position x2, decisions
- * before todo. addressed_to was never populated by the live deriver and stays
- * NULL. Legacy v3 memories whose root carries no topics degrade to no
- * insights — same as the old event path when the root display set was empty.
+ * was ALWAYS this derivation (each topic's `decisions`, in topic order),
+ * performed at event-build time. Doing it in SQL keeps the rule in one place and
+ * means a regenerated memory can never leave stale insights behind. `ord`
+ * preserves the old idx ordering, topic position x2. Legacy v3 memories whose
+ * root carries no topics degrade to no decisions — same as the old event path
+ * when the root display set was empty.
  *
- * `topic_title` carries the OWNING topic's title alongside the insight text.
+ * `topic_title` carries the OWNING topic's title alongside the decision text.
  * The Decisions card renders that title and nothing else (see
  * {@link buildDecisionsCard}), so it has to travel with the row: the `text` a
- * decision row holds is the whole `decisions` block, which is prose and has no
- * title in it to recover. Both branches select it so the column exists whatever
- * `kind` a consumer filters to.
+ * row holds is the whole `decisions` block, which is prose and has no title in
+ * it to recover.
  *
- * **Both branches filter `m.parent_hash IS NULL`** — the same "current
- * generation" rule {@link buildSeries} states at length, for the same reason and
- * with the same trap. `memories` holds one row per GENERATION, so a branch
- * amended or squashed four times keeps its predecessors' topics, and every
- * consumer of this CTE joins `commits`, which retains the predecessors' rows.
- * Unfiltered, one decision is counted once per rewrite — directly beside
- * `memoriesCreated`, which filters the same history out via `isReachable`.
+ * **`m.parent_hash IS NULL`** — the same "current generation" rule
+ * {@link buildSeries} states at length, for the same reason and with the same
+ * trap. `memories` holds one row per GENERATION, so a branch amended or squashed
+ * four times keeps its predecessors' topics, and every consumer of this CTE
+ * joins `commits`, which retains the predecessors' rows. Unfiltered, one
+ * decision is counted once per rewrite — directly beside `memoriesCreated`,
+ * which filters the same history out via `isReachable`.
+ *
+ * ## Why there is no `todo` branch, and no `kind` column
+ *
+ * There was, and it was dead work on EVERY call. This CTE emitted a second
+ * `UNION ALL` arm deriving each topic's `todo` text, and both of its two
+ * consumers then wrote `WHERE i.kind = 'decision'` — so the arm cost a full scan
+ * of `memories` plus a `json_each` parse of every `summary_json` (194 rows /
+ * 3.3 MB on a real database), produced rows, and had them thrown away.
+ *
+ * The `todo` rows fed the standup board's Risks/Blockers/Questions column, which
+ * was removed in JOLLI-2200/2201 because nothing produces the other kinds (see
+ * {@link ./DashboardModel.ts}'s `CommitInsightKind`). That removal stopped the
+ * SERVER sending them — `standup.insights` survives as a memory-tier flag whose
+ * presence alone is read — but stopped one layer short of the derivation, which
+ * kept running. Measured on a real database, dropping the arm takes
+ * `buildDecisionsCard` from **113 ms to 5 ms** for a byte-identical 219-row
+ * result, and `decisionCountsFor` from 2 ms to under 1 ms.
+ *
+ * `kind` went with it: a column that can only hold `'decision'` invites a filter
+ * that reads like a choice and is not one. Both consumers now select decisions
+ * because that is all this derivation makes.
+ *
+ * ⚠ `CommitInsightKind` and `StandupInsight` are deliberately NOT narrowed to
+ * match. They are kept so a real insight column "can return here without a wire
+ * change" (their own docstrings), and restoring a derivation arm here is far
+ * cheaper than restoring a deleted wire type. Adding one back means a second
+ * CTE, not a `kind` column on this one — a consumer that needs both should say
+ * which it wants at the point it asks.
  */
-const TOPIC_INSIGHTS_CTE = `WITH topic_insights AS (
-	SELECT m.repo_id, m.commit_hash, 'decision' AS kind,
+const TOPIC_DECISIONS_CTE = `WITH topic_decisions AS (
+	SELECT m.repo_id, m.commit_hash,
 	       TRIM(json_extract(t.value, '$.decisions')) AS text,
 	       TRIM(COALESCE(json_extract(t.value, '$.title'), '')) AS topic_title,
-	       NULL AS addressed_to, t.key * 2 AS ord
+	       t.key * 2 AS ord
 	  FROM memories m, json_each(m.summary_json, '$.topics') t
 	 WHERE m.parent_hash IS NULL
 	   AND TRIM(COALESCE(json_extract(t.value, '$.decisions'), '')) <> ''
-	UNION ALL
-	SELECT m.repo_id, m.commit_hash, 'todo' AS kind,
-	       TRIM(json_extract(t.value, '$.todo')) AS text,
-	       TRIM(COALESCE(json_extract(t.value, '$.title'), '')) AS topic_title,
-	       NULL AS addressed_to, t.key * 2 + 1 AS ord
-	  FROM memories m, json_each(m.summary_json, '$.topics') t
-	 WHERE m.parent_hash IS NULL
-	   AND TRIM(COALESCE(json_extract(t.value, '$.todo'), '')) <> ''
 )`;
 
 const totalTokens = (row: SessionRow): number => row.input_tokens + row.output_tokens + row.cached_tokens;
@@ -775,8 +793,7 @@ function decisionTitle(topicTitle: string | null, text: string): string {
 
 /**
  * Decisions mined from commit memories in the window — the standalone
- * Decisions card. Reuses {@link TOPIC_INSIGHTS_CTE}'s `decision` rows (the same
- * source the Standup page's insight list reads) rather than re-deriving the
+ * Decisions card. Reuses {@link TOPIC_DECISIONS_CTE} rather than re-deriving the
  * `json_each` walk a second time.
  *
  * `latest` carries the topic TITLE, not the decision text: the card shows one
@@ -805,15 +822,15 @@ function buildDecisionsCard(
 	const filter = scopeFilter(scopeToRepoIds(db, scope), "c.repo_id");
 	const rows = db
 		.prepare(
-			`${TOPIC_INSIGHTS_CTE}
+			`${TOPIC_DECISIONS_CTE}
 			 SELECT i.text, i.topic_title, i.commit_hash, c.committed_at_ms, r.repo_name, r.repo_identity
 			   FROM commits c
 			   JOIN repos r ON r.id = c.repo_id
 			   LEFT JOIN commit_aliases al ON al.repo_id = c.repo_id AND al.old_hash = c.hash
 			   -- See commitsInRange: a rewritten commit's decisions are still filed
 			   -- under the pre-rewrite hash, reachable only through the alias.
-			   JOIN topic_insights i ON i.repo_id = c.repo_id AND (i.commit_hash = c.hash OR i.commit_hash = al.target_hash)
-			  WHERE i.kind = 'decision' AND c.committed_at_ms >= ? AND c.committed_at_ms < ?${filter.sql}
+			   JOIN topic_decisions i ON i.repo_id = c.repo_id AND (i.commit_hash = c.hash OR i.commit_hash = al.target_hash)
+			  WHERE c.committed_at_ms >= ? AND c.committed_at_ms < ?${filter.sql}
 			  -- i.ord because one commit contributes several decision rows sharing its
 			  -- timestamp, so the date alone does not pick a first row — and rows[0]
 			  -- here IS the card (its one line and its one deep link).
@@ -1467,7 +1484,7 @@ function buildMemoryCards(db: DashboardDbHandle, scope: DashboardScope, window: 
 /**
  * Decisions recorded per memory card, keyed `repoIdentity\0commitHash`.
  *
- * Counts {@link TOPIC_INSIGHTS_CTE} rows — one per topic that recorded any
+ * Counts {@link TOPIC_DECISIONS_CTE} rows — one per topic that recorded any
  * decision — which is EXACTLY what `buildDecisionsCard`'s `keptCount` counts,
  * and that figure is rendered as "N decisions" directly above this list. A
  * per-bullet count (`splitDecisionBullets`) would be defensible on its own and
@@ -1479,7 +1496,7 @@ function buildMemoryCards(db: DashboardDbHandle, scope: DashboardScope, window: 
  *
  * No `commit_aliases` join, unlike the Decisions card: that one enters from the
  * `commits` side, where a rewritten commit's insights are filed under the
- * pre-rewrite hash. `topic_insights` is derived FROM `memories`, and these cards
+ * pre-rewrite hash. `topic_decisions` is derived FROM `memories`, and these cards
  * are selected from `memories` too, so both sides already name the same hash.
  */
 function decisionCountsFor(
@@ -1491,11 +1508,11 @@ function decisionCountsFor(
 	const holes = page.map(() => "?").join(",");
 	const rows = db
 		.prepare(
-			`${TOPIC_INSIGHTS_CTE}
+			`${TOPIC_DECISIONS_CTE}
 			 SELECT r.repo_identity, i.commit_hash, COUNT(*) AS n
-			   FROM topic_insights i
+			   FROM topic_decisions i
 			   JOIN repos r ON r.id = i.repo_id
-			  WHERE i.kind = 'decision' AND i.commit_hash IN (${holes})${filter.sql}
+			  WHERE i.commit_hash IN (${holes})${filter.sql}
 			  GROUP BY r.repo_identity, i.commit_hash`,
 		)
 		.all(...page.map((k) => k.commit_hash), ...filter.params) as ReadonlyArray<{

--- a/cli/src/dashboard/DashboardServer.test.ts
+++ b/cli/src/dashboard/DashboardServer.test.ts
@@ -143,7 +143,7 @@ import { getAggregateWikiFreshness } from "../core/WikiFreshness.js";
 import { resolveAssetsDir as resolveGraphAssetsDir } from "../graph/GraphExport.js";
 import * as installer from "../install/Installer.js";
 import { withIsolatedHome } from "../testUtils/isolatedHome.js";
-import { withDashboardDb } from "./DashboardDb.js";
+import { withDashboardDb, withReadonlyDashboardDb } from "./DashboardDb.js";
 import { type DashboardModel, type DashboardScope, type DashboardView, TOOL_ROWS_LIMIT } from "./DashboardModel.js";
 import {
 	assembleDashboardHtml,
@@ -404,7 +404,14 @@ describe("navigation", () => {
 		expect(res.status).toBe(200);
 		const html = await res.text();
 		expect(html).toContain("window.__JOLLI_DASHBOARD__");
-		expect(html).toContain("body{color:red}"); // inlined CSS
+		// The stylesheet is LINKED, not inlined — and the link resolves. Asserting
+		// the tag alone would pass for a URL nothing serves, which is the one way
+		// this can break: the page would render unstyled with a 404 in the console.
+		const href = /<link rel="stylesheet" href="([^"]+)"/.exec(html)?.[1];
+		expect(href).toMatch(/^\/assets\/main-[0-9a-f]{8}\.css$/);
+		const css = await get(port, href as string);
+		expect(css.status).toBe(200);
+		expect(await css.text()).toContain("body{color:red}");
 		// Nothing is set on the client: no cookie, so nothing to go stale.
 		expect(res.headers.get("set-cookie")).toBeNull();
 	});
@@ -1236,6 +1243,20 @@ describe("routes", () => {
 	});
 });
 
+/**
+ * Where `main.js`'s tag starts — the "app scripts begin here" marker the inline
+ * data blocks must precede.
+ *
+ * ⚠ Not `indexOf("/assets/main-")`: the stylesheet is `main-<hash>.css` and it
+ * sits in the `<head>`, so the loose match finds it first and every ordering
+ * assertion silently compares against the wrong element.
+ */
+function mainScriptAt(html: string): number {
+	const at = html.search(/<script src="\/assets\/main-[0-9a-f]{8}\.js"/);
+	expect(at, "main.js script tag").toBeGreaterThan(-1);
+	return at;
+}
+
 describe("assembleDashboardHtml", () => {
 	it("throws on a template missing its markers", () => {
 		writeFileSync(join(assetsDir, "index.html"), "<html><body>no markers</body></html>");
@@ -1257,8 +1278,10 @@ describe("assembleDashboardHtml", () => {
 		const html = assembleDashboardHtml(assetsDir, JSON.stringify({ title: "<!--<script>" }));
 		expect(html).not.toContain("<!--");
 		// The model block still closes: the app scripts after it stay real tags.
-		expect(html).toContain("/* main.js */");
-		expect(html.indexOf("window.__JOLLI_DASHBOARD__")).toBeLessThan(html.indexOf("/* main.js */"));
+		// Asserted against the LINKED script now that the bodies are external — the
+		// property under test is the tokenizer state, not where the code lives.
+		expect(html).toMatch(/<script src="\/assets\/main-[0-9a-f]{8}\.js"><\/script>/);
+		expect(html.indexOf("window.__JOLLI_DASHBOARD__")).toBeLessThan(mainScriptAt(html));
 	});
 
 	// The agent-name half of `JD.sourceBadge`. Inlined from the CLI's own map so
@@ -1268,7 +1291,7 @@ describe("assembleDashboardHtml", () => {
 	it("inlines the transcript source labels ahead of the app scripts", () => {
 		const html = assembleDashboardHtml(assetsDir, "{}");
 		expect(html).toContain(`window.__JOLLI_SOURCE_LABELS__ = ${JSON.stringify(TRANSCRIPT_SOURCE_LABELS)}`);
-		expect(html.indexOf("__JOLLI_SOURCE_LABELS__")).toBeLessThan(html.indexOf("/* main.js */"));
+		expect(html.indexOf("__JOLLI_SOURCE_LABELS__")).toBeLessThan(mainScriptAt(html));
 	});
 
 	// Unlike the token, which is omitted when absent: a page without the labels
@@ -1289,7 +1312,138 @@ describe("assembleDashboardHtml", () => {
 		expect(html).toContain(
 			`window.__JOLLI_SOURCE_META__ = ${JSON.stringify({ meta: SOURCE_META, neutral: NEUTRAL_SOURCE_COLOR })}`,
 		);
-		expect(html.indexOf("__JOLLI_SOURCE_META__")).toBeLessThan(html.indexOf("/* main.js */"));
+		expect(html.indexOf("__JOLLI_SOURCE_META__")).toBeLessThan(mainScriptAt(html));
+	});
+});
+
+describe("hashed asset routes", () => {
+	/** The CSS URL the page links, which is also a key in the served map. */
+	const cssUrlFrom = (html: string): string => {
+		const href = /<link rel="stylesheet" href="([^"]+)"/.exec(html)?.[1];
+		expect(href, "stylesheet link").toBeTruthy();
+		return href as string;
+	};
+
+	it("serves every URL the page links, and 404s anything else under /assets/", async () => {
+		// The page is only as good as its links. Asserting the tags without
+		// fetching them would pass for a bundle that renders a document full of
+		// 404s — unstyled, and with no JavaScript at all.
+		const port = await listen(testServer());
+		const html = await (await get(port, "/dashboard")).text();
+		const urls = [cssUrlFrom(html), ...[...html.matchAll(/<script src="([^"]+)"/g)].map((m) => m[1] as string)];
+		expect(urls.length).toBe(DASHBOARD_SCRIPT_FILES.length + 1);
+		for (const url of urls) {
+			expect((await get(port, url)).status, url).toBe(200);
+		}
+		expect((await get(port, "/assets/nope-00000000.js")).status).toBe(404);
+	});
+
+	it("answers by exact path, so a traversal is just a miss", async () => {
+		// There is no filesystem join on this route at all — the map built at
+		// startup IS the allowlist — so these are 404s rather than reads. Asserted
+		// because the absence of a join is exactly the kind of thing a later
+		// "improvement" re-introduces.
+		const port = await listen(testServer());
+		for (const path of [
+			"/assets/../../../../etc/passwd",
+			"/assets/..%2f..%2fetc%2fpasswd",
+			"/assets/js/main.js",
+			"/assets/",
+		]) {
+			expect((await get(port, path)).status, path).toBe(404);
+		}
+	});
+
+	it("caches immutably and revalidates on a strong validator", async () => {
+		// `immutable` for a year is only correct because the URL names the content:
+		// an upgrade changes the bytes, so it changes the URL, so a cached copy can
+		// never be served for new content.
+		const port = await listen(testServer());
+		const html = await (await get(port, "/dashboard")).text();
+		const url = cssUrlFrom(html);
+
+		const first = await get(port, url);
+		expect(first.headers.get("cache-control")).toBe("public, max-age=31536000, immutable");
+		const etag = first.headers.get("etag");
+		expect(etag).toMatch(/^"[0-9a-f]{8}"$/);
+
+		const revalidated = await get(port, url, { "If-None-Match": etag as string });
+		expect(revalidated.status).toBe(304);
+		expect(await revalidated.text()).toBe("");
+	});
+
+	it("gzips an asset for a client that takes it, and not for one that does not", async () => {
+		const port = await listen(testServer());
+		const html = await (await get(port, "/dashboard")).text();
+		const url = cssUrlFrom(html);
+
+		const zipped = await get(port, url, { "Accept-Encoding": "gzip" });
+		// `fetch` decodes transparently, so the header is what proves it — and the
+		// body must still come out identical after decoding.
+		expect(zipped.headers.get("content-encoding")).toBe("gzip");
+		expect(zipped.headers.get("vary")).toBe("Accept-Encoding");
+		expect(await zipped.text()).toContain("body{color:red}");
+
+		const plain = await get(port, url, { "Accept-Encoding": "identity" });
+		expect(plain.headers.get("content-encoding")).toBeNull();
+		expect(await plain.text()).toContain("body{color:red}");
+	});
+
+	it("reads the q-values, so `gzip;q=0` is a refusal and `*` is a yes", async () => {
+		// The substring test this replaced answered yes to both `gzip` and
+		// `gzip;q=0` — and the second is a client saying it CANNOT decode gzip
+		// (RFC 9110 §12.5.3), so it got a body it had refused. No browser sends
+		// either form; the clients that do are curl, proxies and health checkers.
+		const port = await listen(testServer());
+		const url = cssUrlFrom(await (await get(port, "/dashboard")).text());
+
+		for (const [accept, encoded] of [
+			["gzip;q=0", false],
+			["gzip;q=0.0", false],
+			["gzip;q=0.5", true],
+			["*", true],
+			["*;q=0", false],
+			// An explicit entry outranks the wildcard, whichever way each points.
+			["*;q=0, gzip", true],
+			["gzip;q=0, *", false],
+			["deflate, gzip;q=0", false],
+		] as ReadonlyArray<[string, boolean]>) {
+			const res = await get(port, url, { "Accept-Encoding": accept });
+			expect(res.headers.get("content-encoding"), accept).toBe(encoded ? "gzip" : null);
+			expect(await res.text(), accept).toContain("body{color:red}");
+		}
+	});
+
+	it("keeps the document out of the cache while its assets stay in it", async () => {
+		// The document carries the model and the mutation token, both per request;
+		// the assets carry neither. Serving them under one policy is what the split
+		// exists to avoid.
+		const port = await listen(testServer());
+		const page = await get(port, "/dashboard");
+		expect(page.headers.get("cache-control")).toBe("no-store");
+		const url = cssUrlFrom(await page.text());
+		expect((await get(port, url)).headers.get("cache-control")).toContain("immutable");
+	});
+
+	it("gzips /api/model, which the stats page re-fetches every 30s", async () => {
+		const port = await listen(
+			testServer({
+				// Big enough to clear the compress-it-at-all floor.
+				buildModel: async (req) => ({ ...model(req.view), filler: "x".repeat(4096) }) as never,
+			}),
+		);
+		const res = await get(port, "/api/model?view=stats", { "Accept-Encoding": "gzip" });
+		expect(res.headers.get("content-encoding")).toBe("gzip");
+		expect(((await res.json()) as DashboardModel).view).toBe("stats");
+	});
+
+	it("leaves a small payload uncompressed", async () => {
+		// Below the floor gzip's framing plus the CPU cost buys nothing, and most
+		// JSON this server sends is a small view model.
+		const port = await listen(testServer());
+		const res = await get(port, "/api/model?view=standup", { "Accept-Encoding": "gzip" });
+		expect(res.headers.get("content-encoding")).toBeNull();
+		expect(((await res.json()) as DashboardModel).view).toBe("standup");
 	});
 });
 
@@ -1968,6 +2122,95 @@ describe("defaultModelBuilder (no injected buildModel)", () => {
 		const retired = await get(port, "/api/model?view=repositories");
 		expect(retired.status).toBe(200);
 		expect(((await retired.json()) as DashboardModel).view).toBe("stats");
+	});
+
+	it("recreates a database that is missing at request time, and still renders", async () => {
+		// The render path no longer runs `ensureDashboardDbExists` ahead of every
+		// read — that was a WRITABLE open on every 30 s poll, to pre-empt a case
+		// that happens approximately never. The recovery it bought is kept, moved
+		// to the moment the read-only open actually fails: without it the request
+		// 500s as plain text, and a page with no scripts on it never polls again,
+		// so the browser cannot come back on its own.
+		//
+		// Asserted on a path that was never created, which is also the shape of a
+		// database wiped under a running server.
+		const dbPath = join(dir, "vanished", "dashboard.db");
+		const configDir = join(dir, "vanished-config");
+		expect(existsSync(dbPath)).toBe(false);
+
+		const port = await listen(createDashboardServer({ port: 0, assetsDir, dbPath, configDir }));
+		const res = await get(port, "/api/model?view=stats");
+
+		expect(res.status).toBe(200);
+		expect(((await res.json()) as DashboardModel).view).toBe("stats");
+		expect(existsSync(dbPath)).toBe(true);
+	});
+
+	it("recreates a schema for a database file that has none", async () => {
+		// The same recovery, arriving under a different error code. SQLite opens a
+		// zero-length file as a valid EMPTY database, so this one gets past the open
+		// and fails at the first query with `no such table` — `classifyScanError`
+		// calls that `schema`, not `permission`. It is the second half of the case the
+		// test above covers (a wipe or a `doctor` mid-restore), so narrowing the
+		// recovery to `permission` alone left exactly this shape answering the
+		// scriptless 500 the recovery exists to prevent.
+		const dbPath = join(dir, "empty.db");
+		const configDir = join(dir, "empty-config");
+		writeFileSync(dbPath, "");
+
+		const port = await listen(createDashboardServer({ port: 0, assetsDir, dbPath, configDir }));
+		const res = await get(port, "/api/model?view=stats");
+
+		expect(res.status).toBe(200);
+		expect(((await res.json()) as DashboardModel).view).toBe("stats");
+		expect(readFileSync(dbPath).length).toBeGreaterThan(0);
+	});
+
+	it("does not answer a broken query by re-running migrations", async () => {
+		// The `catch` covers the whole read, not just the open, so `classifyScanError`
+		// answers `schema` both for a database with no tables and for a query naming a
+		// table THIS BUILD got wrong. A complete migration log with a table missing
+		// under it is the second shape, and what this pins is the outcome: the real
+		// failure reaches the caller and the file is left exactly as it was.
+		//
+		// ⚠ It does NOT pin `readWithRecovery`'s `schemaIsComplete` guard, and that is
+		// worth knowing before trusting it as one. Without the guard the recovery still
+		// writes nothing here — `ensureDashboardDbExists` finds the log complete and
+		// short-circuits before its writable open — so both paths end in this same 500
+		// with the table still gone. What the guard buys is not visible from out here:
+		// an honest log line, and not rebuilding the whole model a second time to fail
+		// the same way. Measured by removing it: this case stays green.
+		const dbPath = join(dir, "dropped.db");
+		const configDir = join(dir, "dropped-config");
+		await withDashboardDb((db) => db.exec("DROP TABLE sessions"), { dbPath });
+
+		const port = await listen(createDashboardServer({ port: 0, assetsDir, dbPath, configDir }));
+		const res = await get(port, "/api/model?view=stats");
+
+		expect(res.status).toBe(500);
+		// Read-only on purpose: a writable open here would migrate and recreate the
+		// table itself, and the assertion would pass whatever the server had done.
+		const tables = await withReadonlyDashboardDb(
+			(db) => db.prepare("SELECT name FROM sqlite_master WHERE name = 'sessions'").all(),
+			{ dbPath },
+		);
+		expect(tables).toEqual([]);
+	});
+
+	it("does not answer a corrupt database by writing a schema over it", async () => {
+		// The recovery covers `permission` (SQLITE_CANTOPEN) and `schema` (a file with
+		// no tables in it). A `corrupt` or `locked` file is a different problem, and
+		// creating a schema on top of one would be destructive — so it must surface as
+		// the 500 it is.
+		const dbPath = join(dir, "corrupt.db");
+		const configDir = join(dir, "corrupt-config");
+		writeFileSync(dbPath, "this is not a sqlite database, not even close");
+
+		const port = await listen(createDashboardServer({ port: 0, assetsDir, dbPath, configDir }));
+		const res = await get(port, "/api/model?view=stats");
+
+		expect(res.status).toBe(500);
+		expect(readFileSync(dbPath, "utf8")).toBe("this is not a sqlite database, not even close");
 	});
 
 	// The optional sidebar rows come from config, and they are read on EVERY view
@@ -3664,10 +3907,14 @@ describe("read routes carry a detail-repo scope token", () => {
 });
 
 describe("outer request-handler error paths", () => {
-	it("ends the response cleanly when serialization throws after the headers are sent", async () => {
-		// sendJson writes the 200 header, then JSON.stringify throws on the BigInt —
-		// the outer catch sees headersSent and just ends the response rather than
-		// trying to write a second header.
+	it("500s when serialization throws, and survives it", async () => {
+		// This used to answer 200-then-nothing: `sendJson` wrote the header first and
+		// `JSON.stringify` threw on the BigInt afterwards, so the outer catch saw
+		// `headersSent` and could only end a response it had already promised was a
+		// success. `/api/model` now serialises BEFORE writing the header (it has to —
+		// gzip needs the bytes to know the length), so the throw arrives while a real
+		// status can still be sent. A client that asked for JSON and got half a 200
+		// has no way to tell that from an empty model.
 		const port = await listen(
 			testServer({
 				buildModel: async (req) =>
@@ -3675,7 +3922,7 @@ describe("outer request-handler error paths", () => {
 			}),
 		);
 		const res = await get(port, "/api/model?view=stats");
-		expect(res.status).toBe(200);
+		expect(res.status).toBe(500);
 		// The server survives and answers the next request normally.
 		expect((await get(port, "/memories")).status).toBe(200);
 	});

--- a/cli/src/dashboard/DashboardServer.ts
+++ b/cli/src/dashboard/DashboardServer.ts
@@ -84,12 +84,13 @@
  *      on a GET needs it back — cross-site reachability here is unchanged.
  */
 
-import { randomBytes, timingSafeEqual } from "node:crypto";
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { hostname } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath, URL } from "node:url";
+import { gzipSync } from "node:zlib";
 import { clearAuthCredentials, getJolliUrl } from "../auth/AuthConfig.js";
 import { browserLogin } from "../auth/Login.js";
 import { getProjectRootDir, readLocalGitIdentity } from "../core/GitOps.js";
@@ -98,6 +99,7 @@ import { isLocalAgentUsable } from "../core/localagent/DetectAgents.js";
 import { listPushControlRepos, setRepoPushDisabledByIdentity, triggerReenableDrain } from "../core/PushControl.js";
 import { NEUTRAL_SOURCE_COLOR, SOURCE_META } from "../core/references/SourceLabels.js";
 import { getGlobalConfigDir, loadConfigFromDir } from "../core/SessionTracker.js";
+import { classifyScanError } from "../core/SqliteHelpers.js";
 import { trackAs } from "../core/Telemetry.js";
 import { isTelemetryEventName, type TelemetryEventName } from "../core/TelemetryEvents.js";
 import { TRANSCRIPT_SOURCE_LABELS } from "../core/TranscriptSourceLabel.js";
@@ -107,8 +109,10 @@ import { install } from "../install/Installer.js";
 import { createLogger, errMsg } from "../Logger.js";
 import type { LocalAgentToolId } from "../Types.js";
 import {
+	type DashboardDbHandle,
 	ensureDashboardDbExists,
 	getDashboardDbPath,
+	isSchemaCurrent,
 	withDashboardDb,
 	withReadonlyDashboardDb,
 } from "./DashboardDb.js";
@@ -276,12 +280,17 @@ export function resolveDashboardAssetsDir(baseDir: string = HERE): string {
  * Sentry issue all rendered as one identical amber `R` while the editor showed
  * three distinct badges for the same memory.
  */
-export function assembleDashboardHtml(assetsDir: string, modelJson: string, token?: string): string {
-	const read = (...p: string[]) => readFileSync(join(assetsDir, ...p), "utf8");
-	let html = read("index.html");
+export function assembleDashboardHtml(
+	assetsDir: string,
+	modelJson: string,
+	token?: string,
+	assets?: DashboardAssets,
+): string {
+	const bundle = assets ?? buildDashboardAssets(assetsDir);
+	let html = readFileSync(join(assetsDir, "index.html"), "utf8");
 	const cssMarker = '<link rel="stylesheet" href="styles/main.css" />';
 	if (!html.includes(cssMarker)) throw new Error("dashboard template missing stylesheet marker");
-	html = html.replace(cssMarker, () => `<style>\n${read("styles", "main.css")}\n</style>`);
+	html = html.replace(cssMarker, () => `<link rel="stylesheet" href="${bundle.cssUrl}" />`);
 	const tokenScript = token
 		? `<script>window.__JOLLI_DASHBOARD_TOKEN__ = ${escapeForInlineScript(JSON.stringify(token))};</script>\n`
 		: "";
@@ -292,10 +301,138 @@ export function assembleDashboardHtml(assetsDir: string, modelJson: string, toke
 			JSON.stringify({ meta: SOURCE_META, neutral: NEUTRAL_SOURCE_COLOR }),
 		)};</script>\n` +
 		`<script>window.__JOLLI_DASHBOARD__ = ${escapeForInlineScript(modelJson)};</script>\n` +
-		DASHBOARD_SCRIPT_FILES.map((f) => `<script>\n${read("js", f)}\n</script>`).join("\n");
+		bundle.scriptUrls.map((url) => `<script src="${url}"></script>`).join("\n");
 	const marker = /<!-- scripts:start -->[\s\S]*?<!-- scripts:end -->/;
 	if (!marker.test(html)) throw new Error("dashboard template missing scripts block");
 	return html.replace(marker, () => scripts);
+}
+
+// ── Static asset bundle ─────────────────────────────────────────────────────
+
+/**
+ * One servable file: its bytes, a precomputed gzip of them, and the strong
+ * validator both are served under.
+ */
+interface DashboardAsset {
+	readonly contentType: string;
+	readonly body: Buffer;
+	readonly gzip: Buffer;
+	readonly etag: string;
+}
+
+export interface DashboardAssets {
+	/** URL for the stylesheet link, content-hashed. */
+	readonly cssUrl: string;
+	/** URLs for the app scripts, in `DASHBOARD_SCRIPT_FILES` order — which is a dependency order. */
+	readonly scriptUrls: ReadonlyArray<string>;
+	/** Everything servable, keyed by the exact URL path. */
+	readonly byPath: ReadonlyMap<string, DashboardAsset>;
+}
+
+/** URL prefix for the hashed asset routes. Its own constant so the route and the builder cannot drift. */
+const ASSET_URL_PREFIX = "/assets/";
+
+/**
+ * Reads the stylesheet and the app scripts once, and gives each a content-hashed
+ * URL.
+ *
+ * These used to be INLINED into every page — 181 KB of CSS and 496 KB of
+ * JavaScript, in a document served `no-store`, regardless of view. Navigation is
+ * a full page load (`window.location.href` on every repo / range / dimension /
+ * view change, see `shell.js`), so each click re-sent ~694 KB and the browser
+ * re-parsed half a megabyte of JavaScript it had already compiled a moment
+ * before. Externalising them makes the document ~15 KB and lets the HTTP cache
+ * and V8's code cache do their jobs across navigations.
+ *
+ * The hash in the URL is what makes `immutable` safe: assets change only when
+ * the CLI is upgraded, and an upgrade changes the bytes and therefore the URL,
+ * so a stale cached copy can never be served for new content. Computed once at
+ * server start rather than per request — the files cannot change under a running
+ * server (a `jolli` upgrade replaces the dist and the next command starts a new
+ * one), and re-hashing 680 KB per page load would trade one waste for another.
+ *
+ * ⚠ The map is the ALLOWLIST. Requests are answered by exact-path lookup, never
+ * by joining a path segment onto `assetsDir` — there is no traversal to defend
+ * against because no request string ever reaches the filesystem.
+ *
+ * gzip is precomputed here, once, for the same reason: it is the same bytes for
+ * every request, and compressing 680 KB per response would be a new per-request
+ * cost on the path this change exists to make cheap.
+ */
+export function buildDashboardAssets(assetsDir: string): DashboardAssets {
+	const byPath = new Map<string, DashboardAsset>();
+	const add = (name: string, contentType: string, ...parts: string[]): string => {
+		const body = readFileSync(join(assetsDir, ...parts));
+		const hash = createHash("sha256").update(body).digest("hex").slice(0, 8);
+		const dot = name.lastIndexOf(".");
+		const url = `${ASSET_URL_PREFIX}${name.slice(0, dot)}-${hash}${name.slice(dot)}`;
+		byPath.set(url, { contentType, body, gzip: gzipSync(body, { level: 6 }), etag: `"${hash}"` });
+		return url;
+	};
+	const cssUrl = add("main.css", "text/css; charset=utf-8", "styles", "main.css");
+	const scriptUrls = DASHBOARD_SCRIPT_FILES.map((f) => add(f, "text/javascript; charset=utf-8", "js", f));
+	return { cssUrl, scriptUrls, byPath };
+}
+
+/**
+ * Whether the client said it can take gzip.
+ *
+ * ⚠ Reads the q-values rather than testing for the substring, because the two
+ * disagree in exactly the case that matters: `Accept-Encoding: gzip;q=0` is a
+ * client REFUSING gzip (RFC 9110 §12.5.3), and a `\bgzip\b` match would answer
+ * yes and then send it a body it said it cannot decode — a hard failure, not a
+ * missed optimisation. `*` is honoured for the same reason in the other
+ * direction: it means "anything", which a substring test could never see. An
+ * explicit `gzip` entry always wins over `*`, whichever way each points.
+ *
+ * No real browser sends either form, so this is about the clients that are not
+ * browsers — curl invocations, proxies, and the odd health checker.
+ */
+function acceptsGzip(req: IncomingMessage): boolean {
+	const header = req.headers["accept-encoding"];
+	const value = Array.isArray(header) ? header.join(",") : (header ?? "");
+	let wildcard: boolean | undefined;
+	for (const part of value.split(",")) {
+		const [rawName, ...params] = part.split(";");
+		const name = rawName.trim().toLowerCase();
+		if (name !== "gzip" && name !== "*") continue;
+		// A malformed or absent q defaults to 1 — the spec's default, and the safe
+		// reading of a header we could not parse.
+		const q = params.map((p) => /^\s*q\s*=\s*([\d.]+)\s*$/i.exec(p)).find((m) => m !== null)?.[1];
+		const acceptable = q === undefined || Number.parseFloat(q) > 0;
+		if (name === "gzip") return acceptable;
+		wildcard = acceptable;
+	}
+	return wildcard ?? false;
+}
+
+/**
+ * Serves one hashed asset, or 404s.
+ *
+ * `immutable` plus a year is the strongest caching statement there is, and it is
+ * correct here only because of the hash: the URL names the content. A 304 path
+ * is kept beside it for the case `immutable` does not cover — a browser told to
+ * revalidate (a hard reload), and any client that ignores the directive.
+ */
+function serveAsset(req: IncomingMessage, res: ServerResponse, asset: DashboardAsset): void {
+	if (req.headers["if-none-match"] === asset.etag) {
+		res.writeHead(304, { ETag: asset.etag, "Cache-Control": "public, max-age=31536000, immutable" });
+		res.end();
+		return;
+	}
+	const gzip = acceptsGzip(req);
+	res.writeHead(200, {
+		"Content-Type": asset.contentType,
+		"Cache-Control": "public, max-age=31536000, immutable",
+		ETag: asset.etag,
+		"Content-Length": String(gzip ? asset.gzip.length : asset.body.length),
+		// Vary, even though the only thing that changes is the encoding: an
+		// intermediary that cached the gzip copy would otherwise hand it to a client
+		// that never asked for one.
+		Vary: "Accept-Encoding",
+		...(gzip ? { "Content-Encoding": "gzip" } : {}),
+	});
+	res.end(gzip ? asset.gzip : asset.body);
 }
 
 // ── Framed viewer documents (Knowledge / Graph iframes) ─────────────────────
@@ -611,6 +748,28 @@ async function readLocalAuthorIdentity(
 }
 
 /**
+ * The read failures `defaultModelBuilder`'s `readWithRecovery` answers by creating
+ * a schema. See the ⚠ note there for why it is these two and no others.
+ */
+const RECOVERABLE_OPEN_FAILURES: ReadonlySet<string> = new Set(["permission", "schema"]);
+
+/**
+ * Whether the database already carries every migration this build knows.
+ *
+ * The discriminator between "there is no schema here" and "this build's SQL is
+ * wrong" — the two states `classifyScanError` spells with the same `schema` kind.
+ * Answers `false` for a database it cannot open at all, which is the recoverable
+ * direction: a reader that cannot get in has nothing to say about the schema.
+ */
+async function schemaIsComplete(dbPath: string | undefined): Promise<boolean> {
+	try {
+		return await withReadonlyDashboardDb(isSchemaCurrent, { dbPath });
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Builds only data for routes that are part of the released dashboard surface.
  */
 async function defaultModelBuilder(
@@ -621,14 +780,13 @@ async function defaultModelBuilder(
 	now: () => number,
 	launchCwd: string,
 ): Promise<DashboardModel> {
-	// The command creates the file before it binds, so this only
-	// covers the case where it disappears under a running server (a wiped
-	// `~/.jolli/jollimemory`, a `doctor` mid-restore). Recreating an empty
-	// schema beats the alternative: a read-only open raises SQLITE_CANTOPEN,
-	// which the request handler turns into a plain-text 500 — a page with no
-	// scripts on it, so nothing polls `/api/model` and the browser never comes
-	// back on its own. An empty database renders the normal "no data yet" page.
-	await ensureDashboardDbExists(dbPath ? { dbPath } : {});
+	// NOTE: the file is NOT checked here any more — see `readWithRecovery` at the
+	// bottom of this builder. `ensureDashboardDbExists` opens a WRITABLE handle
+	// and walks the migration log, and it ran on every `/api/model` — a poll every
+	// 30 s per open tab, plus every navigation — to cover a case that happens
+	// approximately never (the file disappearing under a running server). Paying a
+	// writable open on every read to pre-empt a rare failure is backwards when the
+	// failure is detectable and recoverable at the moment it occurs.
 	// Settings is built off config + a cheap folder-state peek, not the DB. Built
 	// here (before the read-only DB open) and threaded through `QueryOptions`. The
 	// launch cwd — `process.cwd()`, set to the git root by `DashboardCommand` when
@@ -658,60 +816,105 @@ async function defaultModelBuilder(
 		knowledge: menuConfig.dashboardKnowledgeMenuEnabled === true,
 		graph: menuConfig.dashboardGraphMenuEnabled === true,
 	};
-	return withReadonlyDashboardDb(
-		async (db) => {
-			// A rebase/reset/squash that rewrites history away leaves the old commits'
-			// rows in `commits` and `memories` forever. Reachability used to be asked
-			// of git here (a `rev-list --branches` per repo, on every load), and is now
-			// a materialised `memories.reachable` / `commits.reachable` column the feeds
-			// filter in SQL — maintained asynchronously by the backfill sweep and the
-			// daemon reconcile task (see MEMORY_REACHABLE_DDL / COMMIT_REACHABLE_DDL).
-			// So no view pays git on the read path.
-			//
-			// Standup is a FIRST-PERSON report, unlike every other view: its columns
-			// feed a Copy-as-standup draft the user posts as their own work, so a
-			// shared branch's teammate commits are a false claim rather than noise.
-			const authorIdentity =
-				request.view === "standup"
-					? await readLocalAuthorIdentity(
-							db
-								.prepare("SELECT worktree_root FROM repos WHERE disabled_at IS NULL")
-								.all() as ReadonlyArray<{ worktree_root: string }>,
-							identityCache,
-							now,
-						)
-					: undefined;
-			// Which of spec §9's three sentences the memory detail's EMPTY
-			// conversations list prints. Async — it reads the machine-global Claude
-			// owners ledger and stats the transcripts it names — so it is computed
-			// here and threaded through `QueryOptions`, exactly like the reachability
-			// sets above. Without this the page would fall through to the plainest
-			// wording forever, with nothing failing to say so.
-			//
-			// Only the memories view, and only when a memory is actually selected: a
-			// tree render with no `?hash=` has no detail pane to word.
-			const transcriptRepairState =
-				request.view === "memories" && request.hash
-					? await readMemoryTranscriptRepairState(db, request.scope, request.hash, request.detailRepoIdentity)
-					: undefined;
-			// Every view is now served straight from the database. The stats view
-			// used to get one more step here — a display-time LLM call compressing
-			// the Decisions card's text — which is what made this builder async and
-			// gave a GET a way to spend money. The card shows a stored topic title
-			// now, so the call is retired (JOLLI-2209).
-			return buildDashboardModel(db, {
-				...request,
-				registryRoots,
-				menus,
-				...(settingsModel ? { settingsModel } : {}),
-				...(knowledgeModel ? { knowledgeModel } : {}),
-				...(graphModel ? { graphModel } : {}),
-				...(authorIdentity ? { authorIdentity } : {}),
-				...(transcriptRepairState ? { transcriptRepairState } : {}),
-			});
-		},
-		{ dbPath },
-	);
+	/**
+	 * The read, with the one recovery the removed pre-flight used to buy.
+	 *
+	 * `ensureDashboardDbExists` ran ahead of every render to cover a file that
+	 * vanished under a running server (a wiped `~/.jolli/jollimemory`, a `doctor`
+	 * mid-restore). Recreating an empty schema really is better than the
+	 * alternative — a read-only open raises `SQLITE_CANTOPEN`, which the request
+	 * handler turns into a plain-text 500, and that page has no scripts on it, so
+	 * nothing polls `/api/model` and the browser never comes back on its own.
+	 *
+	 * So the recovery stays; only its trigger moves. Pay it when the open actually
+	 * fails that way, not on every poll. Exactly one retry: if creating the schema
+	 * did not make the file openable, the second failure is the real one and
+	 * belongs to the caller.
+	 *
+	 * ⚠ Two kinds, and both halves of that are deliberate. `permission` is what
+	 * `classifyScanError` calls SQLITE_CANTOPEN, i.e. the file is not there at all.
+	 * `schema` is the SAME situation one step further along and is the reason the
+	 * set is not just `permission`: SQLite opens a zero-length file as a valid empty
+	 * database, so a `doctor` caught mid-restore fails at the first query with `no
+	 * such table` rather than at the open — the very case named above, arriving
+	 * under a different code. `ensureDashboardDbExists` handles it correctly
+	 * (`isSchemaCurrent` reads the missing log as "not current" and migrates), and
+	 * without this it produced exactly the scriptless 500 this recovery exists to
+	 * prevent. A `locked` or `corrupt` database must NOT be met by writing a schema
+	 * over it, and `unknown` stays out for the same reason: creating a schema is
+	 * only safe where there demonstrably is not one.
+	 *
+	 * ⚠ This `catch` covers the whole read, not just the open — so `schema` also
+	 * arrives for a query naming a table or column THIS BUILD got wrong, which is a
+	 * bug and not a recoverable state. {@link schemaIsComplete} is what tells the
+	 * two apart, and it is asked only here, on a path that has already failed.
+	 * Without it a plain SQL mistake spent a redundant migrate and a doomed retry
+	 * and logged "creating the schema" while doing nothing of the kind — the wrong
+	 * answer to look at while debugging the real error underneath.
+	 */
+	const readWithRecovery = async <T>(read: (db: DashboardDbHandle) => Promise<T>): Promise<T> => {
+		try {
+			return await withReadonlyDashboardDb(read, { dbPath });
+		} catch (err) {
+			const kind = classifyScanError(err)?.kind;
+			if (kind === undefined || !RECOVERABLE_OPEN_FAILURES.has(kind)) throw err;
+			if (kind === "schema" && (await schemaIsComplete(dbPath))) throw err;
+			log.info("dashboard read failed (%s); creating the missing schema and retrying", kind);
+			await ensureDashboardDbExists(dbPath ? { dbPath } : {});
+			return withReadonlyDashboardDb(read, { dbPath });
+		}
+	};
+	return readWithRecovery(async (db) => {
+		// A rebase/reset/squash that rewrites history away leaves the old commits'
+		// rows in `commits` and `memories` forever. Reachability used to be asked
+		// of git here (a `rev-list --branches` per repo, on every load), and is now
+		// a materialised `memories.reachable` / `commits.reachable` column the feeds
+		// filter in SQL — maintained asynchronously by the backfill sweep and the
+		// daemon reconcile task (see MEMORY_REACHABLE_DDL / COMMIT_REACHABLE_DDL).
+		// So no view pays git on the read path.
+		//
+		// Standup is a FIRST-PERSON report, unlike every other view: its columns
+		// feed a Copy-as-standup draft the user posts as their own work, so a
+		// shared branch's teammate commits are a false claim rather than noise.
+		const authorIdentity =
+			request.view === "standup"
+				? await readLocalAuthorIdentity(
+						db.prepare("SELECT worktree_root FROM repos WHERE disabled_at IS NULL").all() as ReadonlyArray<{
+							worktree_root: string;
+						}>,
+						identityCache,
+						now,
+					)
+				: undefined;
+		// Which of spec §9's three sentences the memory detail's EMPTY
+		// conversations list prints. Async — it reads the machine-global Claude
+		// owners ledger and stats the transcripts it names — so it is computed
+		// here and threaded through `QueryOptions`, exactly like the reachability
+		// sets above. Without this the page would fall through to the plainest
+		// wording forever, with nothing failing to say so.
+		//
+		// Only the memories view, and only when a memory is actually selected: a
+		// tree render with no `?hash=` has no detail pane to word.
+		const transcriptRepairState =
+			request.view === "memories" && request.hash
+				? await readMemoryTranscriptRepairState(db, request.scope, request.hash, request.detailRepoIdentity)
+				: undefined;
+		// Every view is now served straight from the database. The stats view
+		// used to get one more step here — a display-time LLM call compressing
+		// the Decisions card's text — which is what made this builder async and
+		// gave a GET a way to spend money. The card shows a stored topic title
+		// now, so the call is retired (JOLLI-2209).
+		return buildDashboardModel(db, {
+			...request,
+			registryRoots,
+			menus,
+			...(settingsModel ? { settingsModel } : {}),
+			...(knowledgeModel ? { knowledgeModel } : {}),
+			...(graphModel ? { graphModel } : {}),
+			...(authorIdentity ? { authorIdentity } : {}),
+			...(transcriptRepairState ? { transcriptRepairState } : {}),
+		});
+	});
 }
 
 export interface DashboardServerOptions {
@@ -767,6 +970,63 @@ export function hasForeignOrigin(originHeader: string | undefined, port: number)
 	} catch {
 		return true;
 	}
+}
+
+/**
+ * Smallest payload worth compressing. Below it gzip's own framing plus the CPU
+ * cost buys nothing — and most JSON this server sends is a small view model.
+ */
+const GZIP_MIN_BYTES = 1024;
+
+/**
+ * Compresses a per-request body when the client takes gzip and it is big enough
+ * to be worth it.
+ *
+ * Per REQUEST, so unlike the asset bundle it cannot be precomputed — which is
+ * also why it is worth being careful about: `gzipSync` blocks the event loop,
+ * and this process serves everything on one thread. Level 6 on the largest
+ * payload here (a ~38 KB stats model) is well under a millisecond, and it
+ * replaces a transfer that is otherwise the biggest thing on the wire.
+ *
+ * `no-store` is kept on everything that goes through here. These bodies are the
+ * model and the token; the caching win of this change lives entirely in the
+ * hashed asset routes.
+ */
+function sendMaybeGzipped(
+	req: IncomingMessage,
+	res: ServerResponse,
+	status: number,
+	contentType: string,
+	body: string,
+): void {
+	const raw = Buffer.from(body, "utf8");
+	const gzip = raw.length >= GZIP_MIN_BYTES && acceptsGzip(req) ? gzipSync(raw, { level: 6 }) : undefined;
+	res.writeHead(status, {
+		"Content-Type": contentType,
+		"Cache-Control": "no-store",
+		"Content-Length": String((gzip ?? raw).length),
+		Vary: "Accept-Encoding",
+		...(gzip ? { "Content-Encoding": "gzip" } : {}),
+	});
+	res.end(gzip ?? raw);
+}
+
+/**
+ * The page document, compressed on the same terms.
+ *
+ * ⚠ This document is the one response that carries BOTH the mutation token and
+ * request-derived content (`?repo=` reaches the model verbatim through
+ * `parseScope`), so compressing it is the BREACH shape: a length oracle over a
+ * body that mixes a secret with attacker-chosen text. Accepted, deliberately.
+ * Reading a compressed length cross-origin needs a network observer, and this
+ * listener is loopback-only behind the host allowlist and the Origin check — an
+ * attacker positioned to measure it is already on the machine, where the token is
+ * reachable more directly. If that calculus ever changes, the fix is to drop this
+ * helper and send the document uncompressed: the win this change exists for is
+ * the hashed asset routes plus `/api/model`, and neither carries the token.
+ */
+function sendHtmlMaybeGzipped(req: IncomingMessage, res: ServerResponse, html: string): void {
+	sendMaybeGzipped(req, res, 200, "text/html", html);
 }
 
 function sendJson(res: ServerResponse, status: number, body: unknown): void {
@@ -1209,7 +1469,27 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 	const configDir = options.configDir;
 	const serverCwd = options.serverCwd ?? process.cwd();
 	const token = options.token ?? randomBytes(32).toString("hex");
+	/**
+	 * The dashboard's own asset directory, and the hashed CSS/JS bundle built out of
+	 * it — both resolved on first use and then reused for the life of the server.
+	 * Lazily, so that constructing a server still touches no filesystem (several
+	 * tests build one and never serve a page).
+	 *
+	 * One resolution site on purpose: three routes need the directory (the page, the
+	 * bundle, the context viewer's `marked`), and three copies of
+	 * `options.assetsDir ?? resolveDashboardAssetsDir()` are three chances for a
+	 * route to end up reading a different tree than the one it links to.
+	 */
 	let assetsDir: string | undefined;
+	let assets: DashboardAssets | undefined;
+	const dashboardAssetsDir = (): string => {
+		assetsDir ??= options.assetsDir ?? resolveDashboardAssetsDir();
+		return assetsDir;
+	};
+	const dashboardAssets = (): DashboardAssets => {
+		assets ??= buildDashboardAssets(dashboardAssetsDir());
+		return assets;
+	};
 	/** Lazily-resolved knowledge-graph viz assets (`<dist>/graph-assets/`) — reused by both iframe routes. */
 	let graphAssetsDir: string | undefined;
 	let boundPort = options.port;
@@ -1356,6 +1636,22 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 			return;
 		}
 
+		// The hashed CSS/JS bundle. Answered by exact-path lookup against the map
+		// built at first render — a request string never reaches the filesystem, so
+		// there is no traversal to defend against and no allowlist to keep in sync
+		// with one. Ungated like every other read here: these are the same product
+		// assets anyone can read out of the npm package, and the page cannot render
+		// without them.
+		if (url.pathname.startsWith(ASSET_URL_PREFIX)) {
+			const asset = dashboardAssets().byPath.get(url.pathname);
+			if (!asset) {
+				sendText(res, 404, "Not found");
+				return;
+			}
+			serveAsset(req, res, asset);
+			return;
+		}
+
 		if (url.pathname === "/") {
 			// Unconditional now. This used to build a whole `repositories` model
 			// just to choose between two destinations — the LANDING page depended
@@ -1386,10 +1682,13 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 				scope: parseScope(url),
 				...parseWindow(url),
 			});
-			assetsDir ??= options.assetsDir ?? resolveDashboardAssetsDir();
-			const html = assembleDashboardHtml(assetsDir, JSON.stringify(model), token);
-			res.writeHead(200, { "Content-Type": "text/html", "Cache-Control": "no-store" });
-			res.end(html);
+			const html = assembleDashboardHtml(dashboardAssetsDir(), JSON.stringify(model), token, dashboardAssets());
+			// The document itself stays `no-store` — it carries the model and the
+			// mutation token, both per request. What it no longer carries is the
+			// 680 KB of CSS and JS that used to be inlined into it; those are hashed
+			// URLs served `immutable` by the route above, so a navigation re-fetches
+			// only this ~15 KB.
+			sendHtmlMaybeGzipped(req, res, html);
 			return;
 		}
 
@@ -1438,8 +1737,7 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 				sendViewerHtml(res, 404, viewerMessageHtml("This document could not be found."));
 				return;
 			}
-			assetsDir ??= options.assetsDir ?? resolveDashboardAssetsDir();
-			const markedJs = resolveMarkedJs(assetsDir);
+			const markedJs = resolveMarkedJs(dashboardAssetsDir());
 			if (markedJs === undefined) {
 				// A 200 with guidance, not a 500: the document was found and the rest of
 				// the dashboard is fine — only this renderer is missing from the install.
@@ -1582,14 +1880,21 @@ export function createDashboardServer(options: DashboardServerOptions): Server {
 			// here is a free public read, and `trusted` decides nothing beyond the
 			// settings gate above. (It used to also gate the Decisions gist's LLM
 			// call — the one paid path a GET had, now retired.)
-			sendJson(
+			// Gzipped when the client takes it. This is the biggest per-request body
+			// the server sends — the stats model measures ~38 KB — and the page
+			// re-fetches it every 30 s for as long as a stats tab is open.
+			sendMaybeGzipped(
+				req,
 				res,
 				200,
-				await buildModel({
-					view,
-					scope: parseScope(url),
-					...parseWindow(url),
-				}),
+				"application/json",
+				JSON.stringify(
+					await buildModel({
+						view,
+						scope: parseScope(url),
+						...parseWindow(url),
+					}),
+				),
 			);
 			return;
 		}

--- a/cli/src/dashboard/LocalDays.test.ts
+++ b/cli/src/dashboard/LocalDays.test.ts
@@ -177,3 +177,58 @@ describe("local-day engine — zones whose local midnight is skipped", () => {
 		);
 	}
 });
+
+/**
+ * `localDayKey` answers from a one-entry-per-zone memo whose stored interval is
+ * derived by `localMidnight` / `addLocalDays`. The dangerous failure mode is an
+ * interval that is too WIDE, because that returns the previous day's key for an
+ * instant belonging to the next one — and it is already caught above: writing
+ * `fromMs + 86_400_000` instead of `addLocalDays(fromMs, 1, …)` reds the
+ * 23-hour-day case and both gap-midnight walks (measured). These cases exist to
+ * name the memo directly and to cover the two things those do not: the access
+ * pattern a single slot is WORST at, and every instant of a 25-hour day rather
+ * than just its boundaries.
+ *
+ * The oracle is a second, independent `Intl` formatter using `format` rather than
+ * `formatToParts`, so it shares no code with the implementation under test.
+ */
+describe("localDayKey memoisation", () => {
+	const oracle = (ms: number, timeZone: string) =>
+		new Intl.DateTimeFormat("en-CA", { timeZone, year: "numeric", month: "2-digit", day: "2-digit" }).format(ms);
+
+	const spans = [
+		// 23-hour day (DST starts 02:00 → 03:00).
+		{ zone: LA, label: "spring-forward", from: "2026-03-07T00:00:00Z" },
+		// 25-hour day, whose repeated hour must land inside the interval it belongs to.
+		{ zone: LA, label: "fall-back", from: "2026-10-31T00:00:00Z" },
+		// A day whose local midnight does not exist at all, so `fromMs` comes from
+		// `firstInstantOfLocalDay` rather than from the arithmetic.
+		{ zone: "Africa/Cairo", label: "skipped midnight", from: "2027-04-24T00:00:00Z" },
+	];
+
+	const QUARTER_HOUR = 900_000;
+	const STEPS = 3 * 96; // three local days at 15-minute resolution
+
+	for (const { zone, label, from } of spans) {
+		const start = Date.parse(from);
+		const instants = Array.from({ length: STEPS }, (_, i) => start + i * QUARTER_HOUR);
+
+		it(`${zone} (${label}): every instant matches an independent formatter, walking forward`, () => {
+			// Forward order is the hit-heavy path: one miss per day boundary, then ~96
+			// hits off the stored interval.
+			for (const ms of instants) expect(localDayKey(ms, zone), new Date(ms).toISOString()).toBe(oracle(ms, zone));
+		});
+
+		it(`${zone} (${label}): every instant matches when the order defeats the single slot`, () => {
+			// Alternating between the ends of the span makes almost every call a miss —
+			// the pattern the memo's docstring warns is ~9x slower than no memo. It must
+			// still be exactly right, since a wrong answer here would be a wrong day on
+			// a chart rather than a slow one.
+			for (let i = 0; i < instants.length / 2; i++) {
+				for (const ms of [instants[i], instants[instants.length - 1 - i]] as ReadonlyArray<number>) {
+					expect(localDayKey(ms, zone), new Date(ms).toISOString()).toBe(oracle(ms, zone));
+				}
+			}
+		});
+	}
+});

--- a/cli/src/dashboard/LocalDays.ts
+++ b/cli/src/dashboard/LocalDays.ts
@@ -56,10 +56,65 @@ function zonedParts(ms: number, timeZone: string): ZonedParts {
 	return { year: get("year"), month: get("month"), day: get("day"), hour: get("hour"), minute: get("minute") };
 }
 
-/** Local calendar day of `ms` as `YYYY-MM-DD`. */
-export function localDayKey(ms: number, timeZone: string): string {
+/**
+ * The last day {@link localDayKey} resolved, per zone, as the half-open interval
+ * it covers — so a run of instants inside one day answers from arithmetic
+ * instead of `Intl`.
+ *
+ * `formatToParts` allocates an array of part objects and `parts.find` walks it
+ * five times per call, and the callers here are per-ROW: bucketing a 30-day
+ * window's 12,000 usage rows called it 12,000 times. Measured at 86 ms of a
+ * ~330 ms stats render — the largest pure-JS cost left once the SQL was fixed.
+ *
+ * ⚠ ONE entry per zone, not an LRU, and that is a deliberate fit to the access
+ * pattern rather than a simplification: every caller walks instants in an order
+ * that is at least loosely time-sorted (a day series, a window scan), so the
+ * hit rate is what matters and a single slot already captures it.
+ *
+ * ⚠ A miss costs MORE than the uncached path did, which is what makes that
+ * ordering load-bearing rather than merely convenient. Filling the slot has to
+ * derive the interval: `localMidnight` (~2 `formatToParts`) plus `addLocalDays`
+ * (~6 — it re-snaps `fromMs` to its own midnight before stepping) on top of this
+ * call's own one, so ~9 where the uncached path spent 1. Two consequences before
+ * calling this from somewhere new. The per-day loops that seed a bucket map
+ * before walking rows (`DashboardQuery`'s heatmap / per-day maps, `StatsRollup`'s
+ * day walks) are 100% misses by construction — fine, since that is ~9 × the
+ * window length, well under a millisecond for 30 days. But a caller that
+ * ALTERNATES between two days row by row would be ~9x slower than with no memo
+ * at all; the fix there is a second slot or sorted rows, not a wider interval.
+ *
+ * ⚠ The interval is computed by {@link startOfLocalDay} / {@link addLocalDays},
+ * never by adding 86,400,000 — the whole reason this module exists is that a
+ * local day is not always 24 hours. Two DST properties make the memo safe: the
+ * interval really is the set of instants sharing that key (its bounds come from
+ * the same zone arithmetic the uncached path uses), and a fall-back repeated
+ * hour lies inside the interval it belongs to, so it hits with the right key.
+ */
+const dayKeyMemo = new Map<string, { fromMs: number; toMs: number; key: string }>();
+
+/**
+ * The uncached answer — and the one every boundary helper below must call.
+ *
+ * ⚠ `localMidnight` → `firstInstantOfLocalDay` bisects on the day key, so it
+ * asks this question thousands of times while ANSWERING it. Routing that through
+ * the memoised entry point makes `localDayKey` recursive through its own cache
+ * fill (measured: `RangeError: Maximum call stack size exceeded` on the first
+ * gap-date input). Callers below therefore take this function, never the export.
+ */
+function computeDayKey(ms: number, timeZone: string): string {
 	const p = zonedParts(ms, timeZone);
 	return `${p.year}-${String(p.month).padStart(2, "0")}-${String(p.day).padStart(2, "0")}`;
+}
+
+/** Local calendar day of `ms` as `YYYY-MM-DD`. */
+export function localDayKey(ms: number, timeZone: string): string {
+	const hit = dayKeyMemo.get(timeZone);
+	if (hit && ms >= hit.fromMs && ms < hit.toMs) return hit.key;
+	const p = zonedParts(ms, timeZone);
+	const key = `${p.year}-${String(p.month).padStart(2, "0")}-${String(p.day).padStart(2, "0")}`;
+	const fromMs = localMidnight(p.year, p.month, p.day, timeZone);
+	dayKeyMemo.set(timeZone, { fromMs, toMs: addLocalDays(fromMs, 1, timeZone), key });
+	return key;
 }
 
 /**
@@ -132,7 +187,7 @@ function firstInstantOfLocalDay(year: number, month: number, day: number, timeZo
 	let hiMin = Math.ceil((naive + 14 * 3_600_000) / 60_000);
 	while (hiMin - loMin > 1) {
 		const midMin = Math.floor((loMin + hiMin) / 2);
-		if (localDayKey(midMin * 60_000, timeZone) < targetKey) loMin = midMin;
+		if (computeDayKey(midMin * 60_000, timeZone) < targetKey) loMin = midMin;
 		else hiMin = midMin;
 	}
 	return hiMin * 60_000;

--- a/cli/src/dashboard/SlowQueryLog.test.ts
+++ b/cli/src/dashboard/SlowQueryLog.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import {
+	condenseSql,
+	DEFAULT_SLOW_QUERY_MS,
+	instrumentDashboardDb,
+	resolveSlowQueryThresholdMs,
+	type SlowQueryEntry,
+} from "./SlowQueryLog.js";
+
+/**
+ * A handle whose statements take exactly the time the test dictates, driven by a
+ * clock the test also owns — so no case here depends on real timing.
+ */
+function fakeDb(plan: { costMs?: number; rows?: number; throws?: Error } = {}) {
+	const calls: string[] = [];
+	let clock = 0;
+	const cost = plan.costMs ?? 0;
+	const advance = () => {
+		clock += cost;
+	};
+	const db = {
+		exec(sql: string) {
+			calls.push(`exec:${sql}`);
+			advance();
+		},
+		prepare(sql: string) {
+			calls.push(`prepare:${sql}`);
+			return {
+				all: (...p: ReadonlyArray<unknown>) => {
+					calls.push(`all:${p.length}`);
+					advance();
+					if (plan.throws) throw plan.throws;
+					return Array.from({ length: plan.rows ?? 0 }, (_, i) => i);
+				},
+				get: (...p: ReadonlyArray<unknown>) => {
+					calls.push(`get:${p.length}`);
+					advance();
+					if (plan.throws) throw plan.throws;
+					return { n: 1 };
+				},
+				run: (...p: ReadonlyArray<unknown>) => {
+					calls.push(`run:${p.length}`);
+					advance();
+					if (plan.throws) throw plan.throws;
+					return { changes: 1 };
+				},
+			};
+		},
+		close() {
+			calls.push("close");
+		},
+	};
+	return { db, calls, now: () => clock };
+}
+
+describe("resolveSlowQueryThresholdMs", () => {
+	it("defaults when the variable is unset or empty", () => {
+		expect(resolveSlowQueryThresholdMs({})).toBe(DEFAULT_SLOW_QUERY_MS);
+		expect(resolveSlowQueryThresholdMs({ JOLLI_SLOW_SQL_MS: "   " })).toBe(DEFAULT_SLOW_QUERY_MS);
+	});
+
+	it("takes a numeric override, including 0 for log-everything", () => {
+		expect(resolveSlowQueryThresholdMs({ JOLLI_SLOW_SQL_MS: "50" })).toBe(50);
+		expect(resolveSlowQueryThresholdMs({ JOLLI_SLOW_SQL_MS: "0" })).toBe(0);
+	});
+
+	it("disables on `off`, case-insensitively", () => {
+		expect(resolveSlowQueryThresholdMs({ JOLLI_SLOW_SQL_MS: "off" })).toBeNull();
+		expect(resolveSlowQueryThresholdMs({ JOLLI_SLOW_SQL_MS: "OFF" })).toBeNull();
+	});
+
+	it("falls back to the default on garbage rather than disabling", () => {
+		// A typo in a debugging variable must not silently switch off the thing
+		// being debugged — that is the one failure nobody would notice.
+		expect(resolveSlowQueryThresholdMs({ JOLLI_SLOW_SQL_MS: "fast" })).toBe(DEFAULT_SLOW_QUERY_MS);
+		expect(resolveSlowQueryThresholdMs({ JOLLI_SLOW_SQL_MS: "-5" })).toBe(DEFAULT_SLOW_QUERY_MS);
+	});
+});
+
+describe("condenseSql", () => {
+	it("collapses the multi-line template literals these statements are written as", () => {
+		expect(condenseSql("SELECT a,\n\t\tb\n\t  FROM t")).toBe("SELECT a, b FROM t");
+	});
+
+	it("keeps the prefix when truncating, since that is what identifies the statement", () => {
+		const long = `SELECT ${"x".repeat(400)}`;
+		const out = condenseSql(long);
+		expect(out.startsWith("SELECT xxx")).toBe(true);
+		expect(out.endsWith("…")).toBe(true);
+		expect(out.length).toBeLessThan(long.length);
+	});
+});
+
+describe("instrumentDashboardDb", () => {
+	it("returns the handle untouched when logging is disabled", () => {
+		const { db } = fakeDb();
+		expect(instrumentDashboardDb(db, { thresholdMs: null })).toBe(db);
+	});
+
+	it("stays silent for a statement under the threshold", () => {
+		const seen: SlowQueryEntry[] = [];
+		const { db, now } = fakeDb({ costMs: 10 });
+		const wrapped = instrumentDashboardDb(db, { thresholdMs: 200, now, onSlow: (e) => seen.push(e) });
+		wrapped.prepare("SELECT 1").all();
+		expect(seen).toEqual([]);
+	});
+
+	it("reports a slow `all` with its row count and parameter count", () => {
+		const seen: SlowQueryEntry[] = [];
+		const { db, now } = fakeDb({ costMs: 500, rows: 3 });
+		const wrapped = instrumentDashboardDb(db, { thresholdMs: 200, now, role: "ro", onSlow: (e) => seen.push(e) });
+		wrapped.prepare("SELECT  a\n  FROM t WHERE x = ?").all(1);
+		expect(seen).toHaveLength(1);
+		expect(seen[0]).toMatchObject({
+			ms: 500,
+			method: "all",
+			role: "ro",
+			params: 1,
+			rows: 3,
+			sql: "SELECT a FROM t WHERE x = ?",
+		});
+	});
+
+	it("reports `get`, `run` and `exec` too, without a row count", () => {
+		const seen: SlowQueryEntry[] = [];
+		const { db, now } = fakeDb({ costMs: 500 });
+		const wrapped = instrumentDashboardDb(db, { thresholdMs: 200, now, onSlow: (e) => seen.push(e) });
+		wrapped.prepare("SELECT 1").get();
+		wrapped.prepare("DELETE FROM t").run(7, 8);
+		wrapped.exec("VACUUM");
+		expect(seen.map((e) => [e.method, e.params, e.rows])).toEqual([
+			["get", 0, undefined],
+			["run", 2, undefined],
+			["exec", 0, undefined],
+		]);
+	});
+
+	it("times a statement that throws, and lets the error through", () => {
+		// A statement that spends four seconds and then fails is worth exactly as
+		// much as one that spends four seconds and succeeds; the error alone does
+		// not carry the duration.
+		const seen: SlowQueryEntry[] = [];
+		const boom = new Error("no such table: t");
+		const { db, now } = fakeDb({ costMs: 500, throws: boom });
+		const wrapped = instrumentDashboardDb(db, { thresholdMs: 200, now, onSlow: (e) => seen.push(e) });
+		expect(() => wrapped.prepare("SELECT * FROM t").all()).toThrow(boom);
+		expect(seen).toHaveLength(1);
+		expect(seen[0]?.ms).toBe(500);
+		expect(seen[0]?.rows).toBeUndefined();
+	});
+
+	it("logs every occurrence rather than deduplicating", () => {
+		// Repetition is the finding, not noise: coaching ran one slow read twice
+		// per render and `forgetRollupDays` reached its zone seek once per session.
+		const seen: SlowQueryEntry[] = [];
+		const { db, now } = fakeDb({ costMs: 500 });
+		const wrapped = instrumentDashboardDb(db, { thresholdMs: 200, now, onSlow: (e) => seen.push(e) });
+		const stmt = wrapped.prepare("SELECT 1");
+		stmt.all();
+		stmt.all();
+		stmt.all();
+		expect(seen).toHaveLength(3);
+	});
+
+	it("passes parameters and results through unchanged", () => {
+		const { db, calls, now } = fakeDb({ costMs: 0, rows: 2 });
+		const wrapped = instrumentDashboardDb(db, { thresholdMs: 0, now, onSlow: () => {} });
+		expect(wrapped.prepare("SELECT ?").all("a", "b")).toEqual([0, 1]);
+		expect(wrapped.prepare("SELECT 1").get()).toEqual({ n: 1 });
+		expect(wrapped.prepare("DELETE FROM t").run()).toEqual({ changes: 1 });
+		wrapped.close();
+		expect(calls).toContain("all:2");
+		expect(calls).toContain("close");
+	});
+
+	it("prepares the underlying statement exactly once per prepare", () => {
+		// The wrapper must not re-prepare per execution: several readers prepare
+		// once and run in a loop, and re-preparing would add the parse cost back
+		// to every iteration — the opposite of what this module is for.
+		const { db, calls, now } = fakeDb({ costMs: 0 });
+		const wrapped = instrumentDashboardDb(db, { thresholdMs: 0, now, onSlow: () => {} });
+		const stmt = wrapped.prepare("SELECT 1");
+		stmt.all();
+		stmt.all();
+		expect(calls.filter((c) => c.startsWith("prepare:"))).toHaveLength(1);
+	});
+});

--- a/cli/src/dashboard/SlowQueryLog.ts
+++ b/cli/src/dashboard/SlowQueryLog.ts
@@ -1,0 +1,191 @@
+/**
+ * Slow-query logging for the dashboard database.
+ *
+ * `node:sqlite` is SYNCHRONOUS, so a slow statement is not a slow I/O wait that
+ * something else can fill — it is the whole process stopped. On the dashboard
+ * server that is the request; inside a git hook it is the commit. Nothing in the
+ * product could say which statement it was, so every investigation started by
+ * re-deriving it with an ad-hoc harness against a copy of a real database. This
+ * makes the database say so itself.
+ *
+ * It exists because the answer is never guessable from the SQL. Two measured
+ * examples from this schema, both a single expression away from their fast form
+ * and neither visibly suspicious:
+ *
+ *   - the spend axes' `EXISTS (…) AND (SELECT SUM(…) …)` cover test — a
+ *     correlated AGGREGATE, re-run per candidate row: **1008 ms**, against 23 ms
+ *     for the same question asked as a grouped CTE.
+ *   - `readSessionAggregates`' two-table join, whose index covered the join
+ *     columns but not the column it SELECTs, so the planner fell back to a
+ *     whole-repo scan: **~2.1 s**, against 30 ms with a covering index.
+ *
+ * ## The four decisions in here
+ *
+ * **`info`, not `warn`.** This wraps EVERY dashboard open, and most of them are
+ * not the dashboard: `StatsWriter` runs from `post-commit`, `SessionStart` and
+ * the editor tick. `warn` goes to stderr even in CLI mode (see `createLogger`),
+ * so a slow write would print SQL into the terminal of someone running `git
+ * commit`. `info` reaches `debug.log` and stops there — recorded, not shown,
+ * the same call `buildRollupQuietly` makes for the same reason.
+ *
+ * **Parameters are never logged.** They carry worktree paths, commit hashes and
+ * branch names; the SQL alone identifies the statement, which is the whole job.
+ * The parameter COUNT is logged, because a mismatch there is a real bug shape
+ * and the count is not itself content.
+ *
+ * **Every occurrence is logged, with no per-statement throttle.** Repetition is
+ * not noise here, it is the finding: coaching ran one 1.4 s read twice per
+ * render, and `forgetRollupDays` reached `cachedZones` once per session in a
+ * backfill — both are invisible in a deduplicated log and obvious in a raw one.
+ * A statement over the threshold is already rare by construction; if it is not,
+ * that is the thing to fix.
+ *
+ * **A throw is timed too** (`finally`, not a trailing call). A statement that
+ * spends four seconds and then fails is worth exactly as much as one that
+ * spends four seconds and succeeds, and the error alone does not carry the
+ * duration.
+ */
+
+import { createLogger } from "../Logger.js";
+// Type-only, so this closes no runtime cycle with `DashboardDb.ts` (which imports
+// this module for real) — and it is what makes the guarantee below a compile
+// error rather than a comment. A local structural restatement of these two
+// interfaces cannot notice the day one of them grows a member.
+import type { DashboardDbHandle, DashboardStatement } from "./DashboardDb.js";
+
+const log = createLogger("SlowQuery");
+
+/**
+ * Default threshold. 200 ms is chosen against what this schema's reads actually
+ * cost: the whole stats model builds in ~260 ms when nothing is pathological and
+ * its individual statements are single-digit to low-tens of ms, so 200 ms cannot
+ * fire for a healthy query while every regression measured on this database
+ * (1008 ms, 1345 ms, 2.1 s) clears it by 5x or more.
+ */
+export const DEFAULT_SLOW_QUERY_MS = 200;
+
+/** How much of the statement text reaches the log. */
+const SQL_LOG_LIMIT = 240;
+
+/**
+ * Threshold in milliseconds, or `null` to disable logging entirely.
+ *
+ * `JOLLI_SLOW_SQL_MS` overrides it for one run — `0` logs every statement (what
+ * you want while profiling a single command), `off` silences it. An
+ * unparseable value falls back to the default rather than disabling: a typo in
+ * a debugging env var must not silently switch off the thing being debugged.
+ */
+export function resolveSlowQueryThresholdMs(env: NodeJS.ProcessEnv = process.env): number | null {
+	const raw = env.JOLLI_SLOW_SQL_MS?.trim();
+	if (raw === undefined || raw === "") return DEFAULT_SLOW_QUERY_MS;
+	if (raw.toLowerCase() === "off") return null;
+	const parsed = Number(raw);
+	return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_SLOW_QUERY_MS;
+}
+
+/**
+ * One line's worth of SQL: whitespace collapsed, truncated.
+ *
+ * These statements are written as indented multi-line template literals, so the
+ * raw text would spread one log entry over twenty lines and bury the timing.
+ * Truncation keeps the PREFIX because that is what identifies the statement —
+ * `SELECT s.repo_id, e.responded_at_ms …` is already unambiguous among the
+ * handful of readers here.
+ */
+export function condenseSql(sql: string): string {
+	const flat = sql.replace(/\s+/g, " ").trim();
+	return flat.length > SQL_LOG_LIMIT ? `${flat.slice(0, SQL_LOG_LIMIT)}…` : flat;
+}
+
+export interface SlowQueryOptions {
+	/** Milliseconds, or `null` to return the handle unwrapped. */
+	readonly thresholdMs?: number | null;
+	/** `ro` / `rw` — which kind of open this was, so a hook write is legible beside a page read. */
+	readonly role?: string;
+	/** Injectable for tests; `performance.now` in production. */
+	readonly now?: () => number;
+	/** Injectable for tests. */
+	readonly onSlow?: (entry: SlowQueryEntry) => void;
+}
+
+export interface SlowQueryEntry {
+	readonly ms: number;
+	readonly method: "all" | "get" | "run" | "exec";
+	readonly sql: string;
+	readonly params: number;
+	readonly role: string;
+	/** Rows returned by `all`; absent for the other methods. */
+	readonly rows?: number;
+}
+
+function defaultSink(entry: SlowQueryEntry): void {
+	const rows = entry.rows === undefined ? "" : ` rows=${entry.rows}`;
+	log.info(
+		"%dms %s [%s] params=%d%s :: %s",
+		Math.round(entry.ms),
+		entry.method,
+		entry.role,
+		entry.params,
+		rows,
+		entry.sql,
+	);
+}
+
+/**
+ * Wraps a database handle so statements slower than the threshold are logged.
+ *
+ * Returns the handle UNCHANGED when logging is off, so the disabled path costs
+ * nothing at all — not even a property lookup through a wrapper. When it is on,
+ * the cost of a fast statement is two `performance.now()` calls and one
+ * comparison, which is beneath the resolution of anything this measures.
+ *
+ * ⚠ The wrapper is structural, not a subclass, and it exposes exactly the three
+ * members `DashboardDbHandle` declares. If that interface ever grows one
+ * (`iterate`, `backup`, `function`), it must be added here in the same change or
+ * callers reach a handle that silently lacks it — so the object below is
+ * annotated with the REAL interface and returned without a cast, which turns
+ * that omission into a compile error here. The earlier shape — a
+ * `<T extends Handle>` generic returning `wrapped as T` against a local copy of
+ * the interface — could not deliver that: `as T` is a downcast assertion TypeScript
+ * always permits, so a new member type-checked clean and failed at runtime, which
+ * is the one outcome this note promised it would not.
+ */
+export function instrumentDashboardDb(db: DashboardDbHandle, options: SlowQueryOptions = {}): DashboardDbHandle {
+	// `in`, not `??`: `null` is the caller's way of saying "off", and `??` treats
+	// it as absent — so `{ thresholdMs: null }` would resolve the env default and
+	// instrument the handle, which is the exact opposite of what was asked.
+	const thresholdMs = "thresholdMs" in options ? options.thresholdMs : resolveSlowQueryThresholdMs();
+	if (thresholdMs === null || thresholdMs === undefined) return db;
+	const now = options.now ?? (() => performance.now());
+	const sink = options.onSlow ?? defaultSink;
+	const role = options.role ?? "rw";
+
+	const timed = <R>(method: SlowQueryEntry["method"], sql: string, params: number, call: () => R): R => {
+		const started = now();
+		let rows: number | undefined;
+		try {
+			const result = call();
+			if (method === "all" && Array.isArray(result)) rows = result.length;
+			return result;
+		} finally {
+			const ms = now() - started;
+			if (ms >= thresholdMs) {
+				sink({ ms, method, sql: condenseSql(sql), params, role, ...(rows === undefined ? {} : { rows }) });
+			}
+		}
+	};
+
+	const wrapped: DashboardDbHandle = {
+		exec: (sql: string) => timed("exec", sql, 0, () => db.exec(sql)),
+		close: () => db.close(),
+		prepare: (sql: string): DashboardStatement => {
+			const stmt = db.prepare(sql);
+			return {
+				all: (...params) => timed("all", sql, params.length, () => stmt.all(...params)),
+				get: (...params) => timed("get", sql, params.length, () => stmt.get(...params)),
+				run: (...params) => timed("run", sql, params.length, () => stmt.run(...params)),
+			};
+		},
+	};
+	return wrapped;
+}

--- a/cli/src/dashboard/StatsRollup.test.ts
+++ b/cli/src/dashboard/StatsRollup.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { withDashboardDb } from "./DashboardDb.js";
 import type { SeriesDimension, StatsEventEnvelope } from "./DashboardModel.js";
 import { buildDashboardModel } from "./DashboardQuery.js";
@@ -173,6 +173,41 @@ describe("stats rollup", () => {
 			{ dbPath },
 		);
 		expect((await rollupRows()).length).toBeGreaterThan(0);
+	});
+
+	it("reports the cache being off without writing to a terminal", async () => {
+		// The `quietly` in the name is load-bearing, and `info` is what keeps it
+		// true: `warn` reaches stderr regardless of `setSilentConsole`, and this
+		// branch is NOT dashboard-only — `ProducerHooks.safeApply` passes no
+		// `skipRollup`, so every producer arrives here. A `warn` would therefore
+		// print on every `jolli recall`, onto the MCP server's stderr and into an
+		// agent's tool output, for as long as the database carries one name this
+		// build lacks — which a machine running mixed surface versions does
+		// routinely. The state is meant to be visible from `jolli doctor
+		// --schema-log`, which asks for it.
+		const spoke: string[] = [];
+		const record = (line: unknown) => {
+			spoke.push(String(line));
+		};
+		const warn = vi.spyOn(console, "warn").mockImplementation(record);
+		const error = vi.spyOn(console, "error").mockImplementation(record);
+		try {
+			await withDashboardDb(
+				(db) => {
+					db.prepare(
+						`INSERT INTO schema_migrations (slot, name, outcome, applied_by, applied_at_ms, duration_ms, ddl)
+						 VALUES (99, '2099-01-01-0000-from-the-future', 'applied', 'cli/99.0.0', 0, 0, '')`,
+					).run();
+					buildRollupQuietly(db, { now: () => NOW, timeZone: UTC });
+					buildRollupQuietly(db, { now: () => NOW, timeZone: UTC });
+				},
+				{ dbPath },
+			);
+		} finally {
+			warn.mockRestore();
+			error.mockRestore();
+		}
+		expect(spoke.filter((line) => line.includes("stats rollup"))).toEqual([]);
 	});
 
 	it("never settles today, however many times it runs", async () => {

--- a/cli/src/dashboard/StatsRollup.ts
+++ b/cli/src/dashboard/StatsRollup.ts
@@ -568,7 +568,28 @@ export function buildRollupQuietly(db: DashboardDbHandle, opts: BuildRollupOptio
 		// added no columns, and fired for one whose additions this build can read
 		// perfectly well.
 		if (dbHasUnknownMigrations(db)) {
-			log.info("stats rollup skipped: the database carries migrations this build does not know");
+			// The wording is strong because the state is not the rare one the old
+			// sentence implied: a database that has ever been opened by a RELEASED
+			// build carries migration names a development line may not have — and a
+			// machine running mixed surface versions (the whole point of the
+			// `dist-paths` version race) reaches that state routinely. While it holds,
+			// nothing settles into `stats_daily` and every dashboard render recomputes
+			// its full window.
+			//
+			// ⚠ `info`, never `warn`, and that is the same rule `SlowQueryLog`
+			// documents at length. `warn` goes to stderr regardless of
+			// `setSilentConsole` (see `Logger.createLogger`), and this line is NOT on a
+			// dashboard path: `applyStatsEvents` reaches it from every producer —
+			// `ProducerHooks.safeApply` passes no `skipRollup` — so a `warn` here
+			// prints to the terminal of `jolli recall`, onto the MCP server's stderr
+			// (and thereby into an agent's context), and out of the StopHook. Those
+			// processes are short-lived, so "once per process" would have been once per
+			// invocation. A warning that fires on every recall for a version-mixed
+			// install is not a signal. Visibility belongs to the surface that asked:
+			// `jolli doctor --schema-log` names the migrations and says what is off.
+			log.info(
+				"stats rollup is OFF: the database carries migrations this build does not know, so cached daily stats are never written and every dashboard render recomputes its full window. `jolli doctor --schema-log` lists the unknown names.",
+			);
 			return;
 		}
 		buildRollup(db, opts);

--- a/cli/src/dashboard/StatsSeries.test.ts
+++ b/cli/src/dashboard/StatsSeries.test.ts
@@ -1,0 +1,205 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { withDashboardDb } from "./DashboardDb.js";
+import type { DashboardScope, SeriesDimension, StatsEventEnvelope } from "./DashboardModel.js";
+import { readAxisRows, readDatedUsage } from "./StatsSeries.js";
+import { applyStatsEvents } from "./StatsWriter.js";
+
+/**
+ * The cover test's PARTITION property, asserted directly.
+ *
+ * `readDatedUsage` and `readAxisRows` each union two arms — sessions whose
+ * per-response rows account for all their tokens, and every other session — and
+ * the whole correctness of the spend numbers rests on those two arms being
+ * complements: overlap double-counts a session's spend, a gap loses it. The
+ * arms are now a CTE join and its outer counterpart rather than a predicate and
+ * `NOT` of it, so "they are complements" is no longer visible from the SQL's
+ * shape and has to be measured.
+ *
+ * Every case below therefore builds a database holding one session of each shape
+ * the rule distinguishes, and checks the union against the session-level totals.
+ */
+
+const NOW = Date.parse("2026-07-30T12:00:00Z");
+const day = (key: string, hour = 10) => Date.parse(`${key}T${String(hour).padStart(2, "0")}:00:00Z`);
+const ALL: DashboardScope = { kind: "all" };
+const WINDOW = [0, Date.parse("2027-01-01T00:00:00Z")] as const;
+
+/**
+ * One session, with explicit control over the two things the cover test compares:
+ * the session-level total and the per-response rows that may or may not add up to it.
+ *
+ * `models` mirrors the session total on purpose, because that is what a real
+ * producer writes — and the `model` axis needs it. That axis is the one whose
+ * FALLBACK arm reads `session_model_usage` rather than `sessions` (the other two
+ * take the session row itself), so a fixture that supplied only `usageEvents`
+ * would make an uncovered session contribute to `agent` and `project` and vanish
+ * from `model`. That asymmetry is the production shape, not a defect: the model
+ * name is not a column on `sessions`, so there is nowhere else for it to come
+ * from.
+ */
+function session(
+	id: string,
+	atMs: number,
+	total: { input: number; output: number; cached?: number },
+	usage: ReadonlyArray<{ respondedAtMs: number; model: string; input: number; output: number }> = [],
+): StatsEventEnvelope {
+	return {
+		event: {
+			type: "session.upserted",
+			repoIdentity: "repo-1",
+			source: "claude",
+			sessionId: id,
+			updatedAtMs: atMs,
+			messageCount: 2,
+			inputTokens: total.input,
+			outputTokens: total.output,
+			cachedTokens: total.cached ?? 0,
+			models: [
+				{
+					model: "m1",
+					inputTokens: total.input,
+					outputTokens: total.output,
+					cachedTokens: total.cached ?? 0,
+					estCostUsd: 0,
+				},
+			],
+			usageEvents: usage.map((u) => ({
+				...u,
+				cached: 0,
+				estCostUsd: 0,
+				dedupKey: `${id}:${u.respondedAtMs}`,
+			})),
+		},
+		producerKind: "cli",
+	} as StatsEventEnvelope;
+}
+
+describe("StatsSeries cover test", () => {
+	let dir: string;
+	let dbPath: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "jolli-series-"));
+		dbPath = join(dir, "dashboard.db");
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	/**
+	 * The four shapes the rule distinguishes, in one database:
+	 *
+	 *  - `covered`   — rows sum to the session total: counted by its events.
+	 *  - `partial`   — rows exist but fall short (the measured 97.5%-loss shape):
+	 *                  counted by its session total, NOT by its rows.
+	 *  - `bare`      — no rows at all: counted by its session total.
+	 *  - `zero-bare` — no rows and no tokens. `0 >= 0` makes the sum comparison
+	 *                  alone call this "covered", which is why the existence half
+	 *                  is not redundant; it must land in the fallback arm so its
+	 *                  series key still registers.
+	 */
+	const seed = async () => {
+		await applyStatsEvents(
+			[
+				session("covered", day("2026-07-28", 23), { input: 100, output: 10 }, [
+					{ respondedAtMs: day("2026-07-28", 9), model: "m1", input: 60, output: 6 },
+					{ respondedAtMs: day("2026-07-28", 21), model: "m1", input: 40, output: 4 },
+				]),
+				session("partial", day("2026-07-29", 23), { input: 1000, output: 100 }, [
+					{ respondedAtMs: day("2026-07-29", 9), model: "m1", input: 10, output: 1 },
+				]),
+				session("bare", day("2026-07-29", 12), { input: 500, output: 50 }),
+				session("zero-bare", day("2026-07-29", 13), { input: 0, output: 0 }),
+			],
+			{ producerKind: "cli", dbPath, now: () => NOW },
+		);
+	};
+
+	/** Session-level totals straight from `sessions`, the figure the union must reproduce. */
+	const sessionTotals = async () =>
+		withDashboardDb(
+			(db) =>
+				db
+					.prepare(
+						`SELECT session_id, input_tokens + output_tokens + cached_tokens AS total
+						   FROM sessions ORDER BY session_id`,
+					)
+					.all() as ReadonlyArray<{ session_id: string; total: number }>,
+			{ dbPath },
+		);
+
+	it("counts every session exactly once across the two arms", async () => {
+		// The property the arms exist to have. A third spelling on either side —
+		// or a LEFT JOIN filter that forgets `cov.id IS NULL` — breaks it in one of
+		// two directions, and both are silent: a gap loses a session's whole spend,
+		// an overlap doubles it.
+		await seed();
+		const totals = await sessionTotals();
+		const expected = totals.reduce((sum, r) => sum + r.total, 0);
+		const rows = await withDashboardDb((db) => readDatedUsage(db, ALL, WINDOW[0], WINDOW[1]), { dbPath });
+		const actual = rows.reduce((sum, r) => sum + r.input + r.output + r.cached, 0);
+		expect(actual).toBe(expected);
+	});
+
+	it("dates a covered session by its responses and an uncovered one by its session stamp", async () => {
+		// The reason the split exists at all: a conversation spanning days should
+		// contribute to each of them, which only its per-response rows can express.
+		await seed();
+		const rows = await withDashboardDb((db) => readDatedUsage(db, ALL, WINDOW[0], WINDOW[1]), { dbPath });
+		const stamps = rows.map((r) => r.bucket_at_ms).sort((a, b) => a - b);
+		// `covered`'s two responses land on their own instants, not on its 23:00 stamp.
+		expect(stamps).toContain(day("2026-07-28", 9));
+		expect(stamps).toContain(day("2026-07-28", 21));
+		expect(stamps).not.toContain(day("2026-07-28", 23));
+		// `partial` is counted by its session stamp, and its lone response is NOT
+		// counted separately — that is the double-count the negation prevents.
+		expect(stamps).toContain(day("2026-07-29", 23));
+		expect(stamps).not.toContain(day("2026-07-29", 9));
+	});
+
+	it("keeps a zero-token session with no rows on the axis", async () => {
+		// `0 >= 0` reads as "covered" to the sum comparison alone, and an events arm
+		// has nothing to contribute for it — so without the existence half this
+		// session disappears from the legend entirely.
+		await seed();
+		const rows = await withDashboardDb((db) => readAxisRows(db, ALL, "agent", WINDOW[0], WINDOW[1]), { dbPath });
+		expect(rows.some((r) => r.bucket_at_ms === day("2026-07-29", 13))).toBe(true);
+	});
+
+	it("reproduces the session totals on every axis that reads the cover test", async () => {
+		// model / agent / project all union the same two arms. An axis whose join
+		// drifted would still draw a plausible chart — it just would not add up.
+		await seed();
+		const totals = await sessionTotals();
+		const expected = totals.reduce((sum, r) => sum + r.total, 0);
+		for (const dimension of ["model", "agent", "project"] as ReadonlyArray<SeriesDimension>) {
+			const rows = await withDashboardDb((db) => readAxisRows(db, ALL, dimension, WINDOW[0], WINDOW[1]), {
+				dbPath,
+			});
+			expect(
+				rows.reduce((sum, r) => sum + r.tokens, 0),
+				`axis ${dimension}`,
+			).toBe(expected);
+		}
+	});
+
+	it("counts nothing twice when a session's rows exceed its stored total", async () => {
+		// `>=`, not `=`: rows that overshoot are the more detailed record and are
+		// trusted — but the session must still be counted once, by the events arm.
+		await applyStatsEvents(
+			[
+				session("over", day("2026-07-28", 23), { input: 10, output: 1 }, [
+					{ respondedAtMs: day("2026-07-28", 9), model: "m1", input: 100, output: 10 },
+				]),
+			],
+			{ producerKind: "cli", dbPath, now: () => NOW },
+		);
+		const rows = await withDashboardDb((db) => readDatedUsage(db, ALL, WINDOW[0], WINDOW[1]), { dbPath });
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.bucket_at_ms).toBe(day("2026-07-28", 9));
+	});
+});

--- a/cli/src/dashboard/StatsSeries.ts
+++ b/cli/src/dashboard/StatsSeries.ts
@@ -68,19 +68,71 @@ import { scopeFilter, scopeToRepoIds } from "./DashboardScopeUtil.js";
  * ⚠ The two arms must use EXACTLY this predicate and its negation. They are
  * complements, which is what makes the union neither double-count nor drop: a
  * third spelling on either side re-opens one of the two failures.
+ *
+ * ## Why this is a CTE join and not the correlated subquery it reads as
+ *
+ * The rule above was first written literally — `EXISTS (…) AND (SELECT SUM(…) …)
+ * >= …`, both correlated on `s.event_id`. That is one correlated AGGREGATE per
+ * candidate row, and SQLite cannot cache it across rows, so the SUM is re-run
+ * once for every row the window admits. Measured on a real 194 MB database over
+ * a 30-day window (11,380 rows out of a 12,306-row table):
+ *
+ *   - plain join, no cover test ......................  19 ms
+ *   - + the `EXISTS` half only .......................  23 ms
+ *   - + the correlated `SUM(…) >= …` half ............ 1008 ms   ← the whole cost
+ *   - the CTE below, byte-identical result set .......  23 ms
+ *
+ * Both readers here run the test, so a stats render paid it twice: ~2.6 s of a
+ * ~3.4 s build. `GROUP BY session_event_id` computes every session's total ONCE
+ * and the arms join it — the same question, asked in the order the planner can
+ * answer cheaply.
+ *
+ * The equivalence is exact, for a reason worth stating rather than checking case
+ * by case: a `GROUP BY` emits a row for a session **iff** that session has at
+ * least one event row, which is precisely the `EXISTS` half, and that row's
+ * `tot` is precisely the SUM half. So the covered arm is an INNER join (no row ⇒
+ * no match ⇒ not covered, so the zero-token session the `EXISTS` half was added
+ * for still falls to the fallback), and the uncovered arm is the LEFT join plus
+ * `cov.id IS NULL OR cov.tot < …` — De Morgan on the same two terms. The
+ * `COALESCE(…, 0)` is dropped deliberately: it existed to turn "no rows" into 0,
+ * and "no rows" is now `cov.id IS NULL`; the columns are NOT NULL, so a grouped
+ * SUM over ≥1 row can never be NULL.
+ *
+ * ⚠ The three fragments below are a MATCHED SET derived from one CTE. Spelling
+ * either arm's join by hand is the hazard this docstring already warns about,
+ * one layer down: an `INNER JOIN` with the comparison moved to `WHERE` still
+ * reads right and still partitions correctly, but a `LEFT JOIN` whose filter
+ * forgets `cov.id IS NULL` silently drops every session with no event rows at
+ * all — which, for every non-Claude source, is all of them.
+ *
+ * `MATERIALIZED` is not decoration: without it the planner may inline the CTE
+ * into each arm of the `UNION ALL` and re-run the aggregate per arm.
  */
-const EVENTS_COVER_SESSION = `EXISTS (SELECT 1 FROM session_usage_events e0
-	                                   WHERE e0.session_event_id = s.event_id)
-	                         AND (SELECT COALESCE(SUM(e2.input_tokens + e2.output_tokens + e2.cached_tokens), 0)
-	                                FROM session_usage_events e2
-	                               WHERE e2.session_event_id = s.event_id)
-	                             >= s.input_tokens + s.output_tokens + s.cached_tokens`;
+const SESSION_USAGE_COVER_CTE = `WITH session_usage_cover AS MATERIALIZED (
+	         SELECT session_event_id AS id,
+	                SUM(input_tokens + output_tokens + cached_tokens) AS tot
+	           FROM session_usage_events
+	          GROUP BY session_event_id
+	     )`;
 
-/** The events arm's guard: count these rows only when they are the whole story. */
-const HAS_DATED_USAGE = `(${EVENTS_COVER_SESSION})`;
+/**
+ * The events arm's guard: count these rows only when they are the whole story.
+ * A FROM-clause fragment, not a WHERE predicate — it must sit with the joins.
+ */
+const HAS_DATED_USAGE = `JOIN session_usage_cover cov
+	                          ON cov.id = s.event_id
+	                         AND cov.tot >= s.input_tokens + s.output_tokens + s.cached_tokens`;
+
+/**
+ * The fallback arm's join — the outer half of the same pair. Pairs with
+ * {@link NO_DATED_USAGE_FILTER}, which carries the negation; both are required,
+ * and the filter belongs in that arm's `WHERE`.
+ */
+const NO_DATED_USAGE_JOIN = `LEFT JOIN session_usage_cover cov ON cov.id = s.event_id`;
 
 /** The fallback arm's guard — the exact negation, never a separate spelling. */
-const NO_DATED_USAGE = `NOT (${EVENTS_COVER_SESSION})`;
+const NO_DATED_USAGE_FILTER = `(cov.id IS NULL
+	                            OR cov.tot < s.input_tokens + s.output_tokens + s.cached_tokens)`;
 
 /**
  * The two joins the landing rule needs, for a query whose `memories` is aliased
@@ -200,7 +252,7 @@ const MEMORY_FOR_COMMIT = `m.commit_hash = c.hash
  * Token segments placed on the day they were actually spent.
  *
  * The same UNION the spend axes use, kept in one place because the guard on the
- * fallback side is the easy half to forget: without {@link NO_DATED_USAGE}
+ * fallback side is the easy half to forget: without {@link NO_DATED_USAGE_FILTER}
  * every Claude session is counted twice, once as its responses and once as its
  * total.
  */
@@ -221,15 +273,18 @@ export function readDatedUsage(
 	const filter = scopeFilter(scopeToRepoIds(db, scope), "s.repo_id");
 	return db
 		.prepare(
-			`SELECT s.repo_id, e.responded_at_ms AS bucket_at_ms, e.input_tokens AS input,
+			`${SESSION_USAGE_COVER_CTE}
+			SELECT s.repo_id, e.responded_at_ms AS bucket_at_ms, e.input_tokens AS input,
 			        e.output_tokens AS output, e.cached_tokens AS cached
 			   FROM session_usage_events e JOIN sessions s ON s.event_id = e.session_event_id
-			  WHERE e.responded_at_ms >= ? AND e.responded_at_ms < ?${filter.sql} AND ${HAS_DATED_USAGE}
+			   ${HAS_DATED_USAGE}
+			  WHERE e.responded_at_ms >= ? AND e.responded_at_ms < ?${filter.sql}
 			 UNION ALL
 			SELECT s.repo_id, s.updated_at_ms AS bucket_at_ms, s.input_tokens AS input,
 			        s.output_tokens AS output, s.cached_tokens AS cached
 			   FROM sessions s
-			  WHERE s.updated_at_ms >= ? AND s.updated_at_ms < ?${filter.sql} AND ${NO_DATED_USAGE}`,
+			   ${NO_DATED_USAGE_JOIN}
+			  WHERE s.updated_at_ms >= ? AND s.updated_at_ms < ?${filter.sql} AND ${NO_DATED_USAGE_FILTER}`,
 		)
 		.all(fromMs, toMs, ...filter.params, fromMs, toMs, ...filter.params) as DatedUsageRow[];
 }
@@ -262,17 +317,20 @@ export function readAxisRows(
 		const filter = scopeFilter(scopeToRepoIds(db, scope), "s.repo_id");
 		return db
 			.prepare(
-				`SELECT s.repo_id, e.responded_at_ms AS bucket_at_ms, e.model AS key,
+				`${SESSION_USAGE_COVER_CTE}
+				SELECT s.repo_id, e.responded_at_ms AS bucket_at_ms, e.model AS key,
 				        e.input_tokens + e.output_tokens + e.cached_tokens AS tokens,
 				        COALESCE(e.est_cost_usd, 0) AS cost
 				   FROM session_usage_events e JOIN sessions s ON s.event_id = e.session_event_id
-				  WHERE e.responded_at_ms >= ? AND e.responded_at_ms < ?${filter.sql} AND ${HAS_DATED_USAGE}
+				   ${HAS_DATED_USAGE}
+				  WHERE e.responded_at_ms >= ? AND e.responded_at_ms < ?${filter.sql}
 				 UNION ALL
 				SELECT s.repo_id, s.updated_at_ms AS bucket_at_ms, u.model AS key,
 				        u.input_tokens + u.output_tokens + u.cached_tokens AS tokens,
 				        COALESCE(u.est_cost_usd, 0) AS cost
 				   FROM session_model_usage u JOIN sessions s ON s.event_id = u.session_event_id
-				  WHERE s.updated_at_ms >= ? AND s.updated_at_ms < ?${filter.sql} AND ${NO_DATED_USAGE}`,
+				   ${NO_DATED_USAGE_JOIN}
+				  WHERE s.updated_at_ms >= ? AND s.updated_at_ms < ?${filter.sql} AND ${NO_DATED_USAGE_FILTER}`,
 			)
 			.all(fromMs, toMs, ...filter.params, fromMs, toMs, ...filter.params) as AxisRow[];
 	}
@@ -280,17 +338,20 @@ export function readAxisRows(
 		const filter = scopeFilter(scopeToRepoIds(db, scope), "s.repo_id");
 		return db
 			.prepare(
-				`SELECT s.repo_id, e.responded_at_ms AS bucket_at_ms, s.source AS key,
+				`${SESSION_USAGE_COVER_CTE}
+				SELECT s.repo_id, e.responded_at_ms AS bucket_at_ms, s.source AS key,
 				        e.input_tokens + e.output_tokens + e.cached_tokens AS tokens,
 				        COALESCE(e.est_cost_usd, 0) AS cost
 				   FROM session_usage_events e JOIN sessions s ON s.event_id = e.session_event_id
-				  WHERE e.responded_at_ms >= ? AND e.responded_at_ms < ?${filter.sql} AND ${HAS_DATED_USAGE}
+				   ${HAS_DATED_USAGE}
+				  WHERE e.responded_at_ms >= ? AND e.responded_at_ms < ?${filter.sql}
 				 UNION ALL
 				SELECT s.repo_id, s.updated_at_ms AS bucket_at_ms, s.source AS key,
 				        s.input_tokens + s.output_tokens + s.cached_tokens AS tokens,
 				        COALESCE(s.est_cost_usd, 0) AS cost
 				   FROM sessions s
-				  WHERE s.updated_at_ms >= ? AND s.updated_at_ms < ?${filter.sql} AND ${NO_DATED_USAGE}`,
+				   ${NO_DATED_USAGE_JOIN}
+				  WHERE s.updated_at_ms >= ? AND s.updated_at_ms < ?${filter.sql} AND ${NO_DATED_USAGE_FILTER}`,
 			)
 			.all(fromMs, toMs, ...filter.params, fromMs, toMs, ...filter.params) as AxisRow[];
 	}
@@ -298,19 +359,22 @@ export function readAxisRows(
 		const filter = scopeFilter(scopeToRepoIds(db, scope), "s.repo_id");
 		return db
 			.prepare(
-				`SELECT s.repo_id, e.responded_at_ms AS bucket_at_ms, r.repo_name AS key,
+				`${SESSION_USAGE_COVER_CTE}
+				SELECT s.repo_id, e.responded_at_ms AS bucket_at_ms, r.repo_name AS key,
 				        e.input_tokens + e.output_tokens + e.cached_tokens AS tokens,
 				        COALESCE(e.est_cost_usd, 0) AS cost
 				   FROM session_usage_events e
 				   JOIN sessions s ON s.event_id = e.session_event_id
 				   JOIN repos r ON r.id = s.repo_id
-				  WHERE e.responded_at_ms >= ? AND e.responded_at_ms < ?${filter.sql} AND ${HAS_DATED_USAGE}
+				   ${HAS_DATED_USAGE}
+				  WHERE e.responded_at_ms >= ? AND e.responded_at_ms < ?${filter.sql}
 				 UNION ALL
 				SELECT s.repo_id, s.updated_at_ms AS bucket_at_ms, r.repo_name AS key,
 				        s.input_tokens + s.output_tokens + s.cached_tokens AS tokens,
 				        COALESCE(s.est_cost_usd, 0) AS cost
 				   FROM sessions s JOIN repos r ON r.id = s.repo_id
-				  WHERE s.updated_at_ms >= ? AND s.updated_at_ms < ?${filter.sql} AND ${NO_DATED_USAGE}`,
+				   ${NO_DATED_USAGE_JOIN}
+				  WHERE s.updated_at_ms >= ? AND s.updated_at_ms < ?${filter.sql} AND ${NO_DATED_USAGE_FILTER}`,
 			)
 			.all(fromMs, toMs, ...filter.params, fromMs, toMs, ...filter.params) as AxisRow[];
 	}


### PR DESCRIPTION
<!-- jollimemory-summary-start -->


## Quick recap

The dashboard stats page dropped from roughly two seconds to under 300 milliseconds on a real 194 MB database. The largest single gain came from rewriting the SQL that attributes token spend to individual AI responses: the original query re-ran an expensive aggregation once for every candidate row, and the rewrite computes each session's total once and joins it across both arms of the query. Four queries were affected, and new tests assert the structural property that makes the numbers correct — every session appears in exactly one counting arm — so a future change that breaks the partition fails loudly rather than producing subtly wrong spend figures.

The dashboard's static assets — roughly 680 KB of CSS and JavaScript — are now served as separately cacheable files with content-hashed URLs rather than being inlined into every page response. Navigation between views, repos, and date ranges now re-fetches only a small HTML document carrying the current data, while scripts and styles are served from the browser cache. The stats model endpoint also gained gzip compression, which matters for the 30-second polling that keeps the stats page current.

A new slow-query log was added to the database layer: any statement taking longer than 200 milliseconds now records itself automatically, naming the query, its timing, and how many rows it returned. This log was what identified the remaining slow query during the optimization work. The instrumentation wrapper was also hardened so that any future gap between the wrapper and the database interface produces a compile error rather than a silent runtime failure.

The backend started writing newline characters while waiting on the AI provider to keep the load balancer's connection alive, which broke response parsing and made body-read failures invisible. The client now separates header-arrival timing from total call duration and emits a structured diagnostic log when the body read fails, naming both elapsed times and whether the socket closed prematurely. Two new tests cover the keep-alive prefix case and the mid-body stream failure case.

The daily stats cache had been silently disabled on any machine that had previously run a released version of the tool. The dedicated schema diagnostic command now explicitly states that the cache is off and explains what that means for page speed. A diagnostic message about this condition that had been briefly promoted to a noisier log level — where it was reaching agent tool output and user terminals on every invocation — was returned to the appropriate background log level, with visibility delegated entirely to the diagnostic command.

---

## E2E Test (4)
<details>
<summary><strong>1. Dashboard stats page loads quickly</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Jolli dashboard with a real database that has recorded activity (ideally one that previously felt slow to load).

**Steps:**
1. Open the Jolli dashboard in your browser.
2. Click on the "Stats" view in the navigation.
3. Watch the page and note roughly how long it takes to finish loading the stats content.
4. Click away to another view (such as "Standup" or "Memories"), then click back to "Stats".
5. Check that the stats data appears fully and correctly — numbers, charts, or summaries as expected.

**Expected Results:**
- The stats page should load noticeably faster than before (target: under a second on a real database, not several seconds).
- All stats data should display correctly with no missing or blank sections.
- Navigating away and back should also feel fast.

</blockquote>
</details>
<details>
<summary><strong>2. Dashboard CSS and scripts load as separate files with caching</strong></summary>
<br>
<blockquote>

**Steps:**
1. Open the Jolli dashboard in your browser.
2. Open your browser's developer tools (press F12), go to the "Network" tab, and reload the page.
3. Look at the list of files the page downloaded — find the stylesheet (a ".css" file) and the JavaScript file (a ".js" file).
4. Check the "Cache-Control" header on the CSS and JS files in the network panel.
5. Reload the page a second time and check whether the browser reuses the cached CSS and JS files (they should show as "304 Not Modified" or served from cache).
6. Check the main HTML document's cache header — it should say "no-store".

**Expected Results:**
- The CSS and JavaScript are loaded as separate linked files, not embedded inside the HTML.
- The CSS and JS files show a cache header of "public, max-age=31536000, immutable" — meaning the browser can cache them for a year.
- On the second load, the browser reuses the cached assets rather than re-downloading them.
- The HTML document itself is marked "no-store" so it is always freshly fetched.

</blockquote>
</details>
<details>
<summary><strong>3. Doctor command explains that the daily stats cache is off</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Jolli database that has been opened by more than one version of the tool (for example, one that was previously used with a released CLI and is now being used with a newer build).

**Steps:**
1. Open a terminal.
2. Run the Jolli doctor command with the schema log option (for example: `jolli doctor --schema-log`).
3. Read the output carefully, looking for any warning about unknown migration names.
4. Check whether the output mentions the daily stats cache being off and what that means for performance.

**Expected Results:**
- If the database has been touched by a different version, the output should include a clear warning that says "DAILY STATS CACHE IS OFF".
- The message should explain that reads and writes keep working, but that every dashboard render is recomputing its full window because the cache is not being written.
- The output should no longer say only "not a fault" — it should name the performance consequence.

</blockquote>
</details>
<details>
<summary><strong>4. Dashboard recovers from a missing or empty database file</strong></summary>
<br>
<blockquote>

**Preconditions:** Have a Jolli dashboard server you can start fresh, and be able to delete or empty the database file it uses.

**Steps:**
1. Delete the Jolli database file entirely (or replace it with a completely empty file — zero bytes).
2. Start the Jolli dashboard server.
3. Open the dashboard in your browser and navigate to the Stats view.
4. Check whether the page loads successfully or shows an error.
5. Check that the database file now exists on disk and is no longer empty.

**Expected Results:**
- The dashboard should load successfully and show a valid Stats page (status 200), even though the database was missing or empty when the server started.
- The database file should now exist on disk and contain data (it should not be zero bytes).
- The page should not show a plain-text error or a broken layout with no scripts.

</blockquote>
</details>

---

## Topics (12)
<details>
<summary><strong>01 · Fix warning noise from stats cache reaching agent terminals and shells</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A diagnostic message about the daily stats cache being disabled was logged at a level that caused it to appear in agent tool output, MCP server stderr, and the terminals of short-lived commands. On machines running a mix of software versions, this fired on every single invocation.

**💡 Decisions Behind the Code**

- **Visibility through the right surface, not log level**: Raising the level to `warn` was intended to make a slow-dashboard condition visible, but `warn` bypasses the silent-console flag and reaches stderr unconditionally. The correct visibility surface for this diagnostic is the dedicated schema diagnostic command, which already names the unknown migrations and explains what is off. Keeping the message at `info` means it lands only in the rotating debug log, which is appropriate for a condition that fires on every write from every producer.
- **Remove deduplication along with the level change**: The once-per-process guard existed solely to suppress the noise a `warn` would produce when triggered on every producer invocation. Removing it alongside the level change keeps the code honest — suppression is no longer needed, and the guard's only purpose was suppression.

**✅ What Was Implemented**

- In `StatsRollup.ts`, downgraded the "stats rollup is OFF" notification from `warn` to `info` and removed the per-process deduplication flag and its exported test reset function. The message text and its pointer to `jolli doctor --schema-log` were preserved.
- In `StatsRollup.test.ts`, replaced the test asserting "warn fires exactly once" with one asserting that neither `console.warn` nor `console.error` receives any stats-rollup output — a direct regression test for the original bug.

**📁 FILES**
- `cli/src/dashboard/StatsRollup.ts`

</blockquote>
</details>
<details>
<summary><strong>02 · Fix proxy responses prefixed with keep-alive whitespace and improve body-read error diagnostics</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The backend started writing newline characters while waiting on the AI provider, keeping the load balancer's connection alive. This broke response parsing and made failures after the headers arrived invisible — callers only saw a bare "terminated" error with no timing or context.

**💡 Decisions Behind the Code**

- **Real Response object in the keep-alive test**: The test uses an actual `Response` rather than a mocked `json()` method. A stub would prove only that the mock works; the real parser is what must tolerate the whitespace prefix, and only a real `Response` exercises that path.
- **Separate header and body timing**: Two timestamps are now logged on success and on failure, answering different diagnostic questions: how long the whole call took versus when the backend committed to a 200. The old single elapsed variable measured only time-to-first-byte, not call duration.
- **No parameter logging on body failure**: Parameters carry worktree paths, commit hashes, and branch names. The action name and URL are sufficient to identify the call; logging parameters would expose user data in a log that is already capturing an unexpected failure path.

**✅ What Was Implemented**

- Updated `LlmClient.ts` to separate header-arrival timing from total call duration, adding a dedicated `try/catch` around the body-read phase. When the body read fails, a structured error log is emitted naming the action, both elapsed times, whether the socket closed prematurely, and the error message — without logging any request parameters.
- Added two new tests in `LlmClient.test.ts`: one verifying that a response body prefixed with newlines parses correctly using a real `Response` object (not a stubbed `json()`), and one verifying that a stream that dies mid-body rejects the call and produces the new diagnostic log entry.

**📁 FILES**
- `cli/src/core/LlmClient.ts`

</blockquote>
</details>
<details>
<summary><strong>03 · Extend database recovery to handle empty schema files alongside missing files</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The dashboard server's error-recovery path only handled the case where a database file was completely absent. A zero-length file left behind by an interrupted restore operation would open without error but fail at the first query, producing an unrecoverable error page with no way for the browser to retry.

**💡 Decisions Behind the Code**

- **Treat empty file and missing file as the same recoverable case**: SQLite opens a zero-length file as a valid empty database, so the failure arrives one step later — at the first query, as a missing-table error — rather than at the open. The underlying situation is identical: there is no schema to protect, so writing one is safe. Corrupt and locked files are excluded because writing a schema over them would be destructive.
- **Named set over inline string check**: Collecting the recoverable kinds into a single named constant makes the boundary explicit and auditable in one place. The comment on that constant carries the full rationale for why each kind is included or excluded, making future additions deliberate rather than accidental.

**✅ What Was Implemented**

- In `DashboardServer.ts`, introduced a named constant collecting both recoverable failure kinds and updated `readWithRecovery` to check membership rather than a single string equality. The log message now includes the error kind. Corrupt and locked databases remain excluded.
- In `DashboardServer.test.ts`, added a test that writes a zero-length file as the database path, makes a request, and asserts a 200 response with a valid model and a non-empty file on disk afterward. The existing corrupt-database test's comment was updated to reflect the expanded recovery set.

**📁 FILES**
- `cli/src/dashboard/DashboardServer.ts`

</blockquote>
</details>
<details>
<summary><strong>04 · Replace correlated aggregate subquery with materialized CTE for spend axis queries</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The dashboard stats page was taking nearly two seconds to load on a real database. Profiling showed that the SQL responsible for attributing token spend to individual responses was re-running an expensive aggregation once per candidate row, making the cost grow linearly with the number of usage events.

**💡 Decisions Behind the Code**

- **Materialized CTE instead of inline subquery**: Without the `MATERIALIZED` keyword, the query planner may inline the CTE into each arm of the union and re-run the aggregate per arm, defeating the optimization entirely. The keyword is load-bearing, not decorative, and is documented as such in the code.
- **Partition property tested directly, not by result comparison**: The correctness risk here is silent — a gap loses a session's entire spend, an overlap doubles it, and both produce a plausible-looking chart. The tests assert the structural invariant of mutual exclusion and full coverage rather than comparing against a reference output, so a future change that breaks the partition fails loudly rather than producing subtly wrong spend figures.

**✅ What Was Implemented**

- Rewrote the cover-test predicate in `StatsSeries.ts` from a correlated `EXISTS` + correlated `SUM` subquery into a `WITH … AS MATERIALIZED` CTE joined once, then referenced by both arms of the `UNION ALL`. The events arm uses an inner join on the CTE; the fallback arm uses a left join with a `NULL`-or-less-than filter. Measured on a real 194 MB database: 1008 ms → 23 ms per query, with four queries affected.
- Added `StatsSeries.test.ts` with five tests asserting the partition property directly: every session appears in exactly one arm, covered sessions are dated by their per-response timestamps, zero-token sessions without event rows still appear on the axis, all three axis dimensions reproduce session-level token totals, and sessions whose event rows exceed the stored total are counted once by the events arm.

**📁 FILES**
- `cli/src/dashboard/StatsSeries.ts`

</blockquote>
</details>
<details>
<summary><strong>05 · Externalize dashboard CSS and JavaScript as content-hashed cacheable assets with gzip</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Every dashboard page navigation re-downloaded and re-parsed roughly 680 KB of CSS and JavaScript that was inlined directly into the HTML document, which was itself served with no caching. Clicking between views, repos, or date ranges always paid the full transfer cost.

**💡 Decisions Behind the Code**

- **Content-hashed URLs make `immutable` safe**: A year-long immutable cache directive is only correct when the URL names the content. An upgrade changes the bytes, which changes the hash, which changes the URL — a cached copy from before the upgrade is never served for new content. This is the only approach that avoids both stale assets and per-request revalidation.
- **Path traversal defense is the allowlist itself**: The asset map is built from a fixed list of known filenames at startup. Requests are answered by exact-path lookup against that map; no path segment is ever joined onto the filesystem. There is no traversal to sanitize because the filesystem is never consulted at request time.
- **Gzip precomputed at startup, not per request**: The asset bytes are the same for every request and cannot change under a running server. The model JSON endpoint is compressed per-request because its content varies, but only above a minimum size floor where the framing overhead is worth it.

**✅ What Was Implemented**

- Added `buildDashboardAssets` and `serveAsset` in `DashboardServer.ts` to read the stylesheet and app scripts once at server start, assign each a content-hashed URL, precompute gzip, and serve them under `Cache-Control: public, max-age=31536000, immutable` with ETag/304 support. The asset map is the allowlist — no request string ever reaches the filesystem.
- Updated `assembleDashboardHtml` to emit linked `<link>` and `<script src>` tags instead of inlining file contents. The HTML document itself remains `no-store`. Added `sendMaybeGzipped` for per-request gzip of the model JSON endpoint, which the stats page polls every 30 seconds.
- Added seven new tests in `DashboardServer.test.ts` covering: all linked URLs resolve to 200, path traversal attempts are 404s, immutable caching and ETag revalidation, gzip negotiation for assets and the model endpoint, and the document/asset cache-policy split.

**📁 FILES**
- `cli/src/dashboard/DashboardServer.ts`

</blockquote>
</details>
<details>
<summary><strong>06 · Add slow SQL logging to the dashboard database layer</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Diagnosing slow dashboard pages required manually reproducing the problem with an ad-hoc profiling harness against a copy of a real database. There was no way for the running server to identify which statement was slow during normal operation.

**💡 Decisions Behind the Code**

- **Logged at info level, not warn**: This instrumentation wraps every database open, including those from git hooks running during a commit. Warn-level output reaches the terminal even in CLI mode, so a slow write during a commit would print SQL into the user's terminal. Info level reaches only the debug log file.
- **Parameters never logged, only their count**: Statement parameters carry worktree paths, commit hashes, and branch names. The SQL text alone identifies which statement was slow; the parameter count is logged because a mismatch there is a real bug shape, but the values themselves are not content the log should hold.
- **Every occurrence logged, no deduplication**: Repetition is diagnostic signal here, not noise. A statement that runs twice per page render appears twice in the log, making the pattern visible. A deduplicated log would have hidden the coaching query that ran 1.4 seconds twice per render.

**✅ What Was Implemented**

- Added `SlowQueryLog.ts` with `instrumentDashboardDb`, which wraps a database handle's `exec`, `prepare`, `all`, `get`, and `run` methods to time every statement and log those exceeding a threshold. The threshold defaults to 200 ms and is overridable via environment variable. The handle is returned unwrapped when logging is disabled, adding no overhead on the fast path.
- Wired the instrumentation into `openDb` in `DashboardDb.ts`, the single entry point for all dashboard reads and writes. Wrapping happens after the connection pragmas to avoid logging the open's own setup cost.
- Added `SlowQueryLog.test.ts` with 10 tests covering threshold resolution, SQL condensing, per-method reporting, exception timing, repetition logging, and pass-through correctness. One test caught a real bug: a null-coalescing check treated an explicit "off" value as absent and re-enabled logging.

**📁 FILES**
- `cli/src/dashboard/SlowQueryLog.ts`
- `cli/src/dashboard/DashboardDb.ts`

</blockquote>
</details>
<details>
<summary><strong>07 · Make daily stats cache disabled state visible and diagnosable</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The dashboard's daily stats cache was silently never being written on any machine that had previously been opened by a released version of the tool. Every stats page render was recomputing its full window from scratch, but nothing in the logs or UI indicated this was happening.

**💡 Decisions Behind the Code**

**Consequence stated, not just the fact**: The previous message said "not a fault," which is true of data integrity but wrong about the performance impact. The new message names what the user actually experiences — a slow stats page — and points to the tool that explains why. The diagnostic command is the correct visibility surface for this condition; the log-level approach explored earlier was reverted after it caused noise in agent terminals and user shells.

**✅ What Was Implemented**

- Updated the `doctor --schema-log` output in `DoctorCommand.ts` to state that the daily stats cache is off and explain what that means for page performance, replacing the previous "not a fault" wording.
- Added a test in `DoctorCommand.test.ts` asserting the new consequence language appears in the schema log output.

**📁 FILES**
- `cli/src/commands/DoctorCommand.ts`

</blockquote>
</details>
<details>
<summary><strong>08 · Make slow-query wrapper catch missing interface members at compile time</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

The instrumentation wrapper around the database handle used a generic type parameter and a type assertion to return the wrapped object. If the database handle interface ever gained a new method, the wrapper would compile cleanly but fail at runtime — the opposite of what the code's own comment promised.

**💡 Decisions Behind the Code**

The previous generic-plus-cast pattern is a TypeScript downcast that the compiler always permits regardless of structural fit. Switching to a concrete return type means any future addition to the database handle interface produces a compile error at the wrapper's construction site rather than a silent runtime gap. The type-only import is the key enabler: it is erased before execution, introducing no circular module loading while still making the interface's shape available to the type checker.

**✅ What Was Implemented**

In `SlowQueryLog.ts`, removed the local structural copies of the `Statement` and `Handle` interfaces and replaced them with type-only imports of `DashboardDbHandle` and `DashboardStatement` from `DashboardDb.ts`. The function signature changed from a generic returning a downcast assertion to a concrete signature returning `DashboardDbHandle` directly, and the internal wrapped object is annotated with that type without any cast.

**📁 FILES**
- `cli/src/dashboard/SlowQueryLog.ts`

</blockquote>
</details>
<details>
<summary><strong>09 · Move database existence check out of the per-request read path</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Every dashboard page load and every 30-second stats poll was opening a writable database connection and walking the migration log, even though the scenario it guarded against — the database file disappearing under a running server — happens almost never.

**💡 Decisions Behind the Code**

Recovery narrowed to specific recoverable failure kinds only: the original recovery ran unconditionally to pre-empt a rare failure. The new path triggers only on the specific error classes that the recovery actually fixes. A corrupt or locked file must not be met by writing a fresh schema over it — that would be destructive — so those cases are intentionally left to surface as errors.

**✅ What Was Implemented**

- Removed the unconditional `ensureDashboardDbExists` call from `defaultModelBuilder` in `DashboardServer.ts`. Replaced it with a `readWithRecovery` wrapper that attempts the normal read-only open first, and only calls `ensureDashboardDbExists` if that open fails with a recoverable error. A corrupt or locked database is not recovered — it surfaces as a 500.
- Added two tests: one confirming a missing database is recreated and the request succeeds, one confirming a corrupt database is not overwritten and returns a 500.

**📁 FILES**
- `cli/src/dashboard/DashboardServer.ts`

</blockquote>
</details>
<details>
<summary><strong>10 · Memoize local calendar day computation to reduce per-row overhead</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Bucketing tens of thousands of usage events into calendar days was calling an expensive locale-aware date formatter once per row. On a real database this accounted for roughly 86 milliseconds of every stats page render.

**💡 Decisions Behind the Code**

- **Single slot per timezone, not an LRU cache**: The access pattern is time-sorted rows within a window scan, so the hit rate of a single slot is nearly identical to a larger cache for this workload. An LRU would add complexity with no measurable benefit. Callers that alternate between two days would be slower than having no cache at all and should use sorted input or a second slot.
- **Memo applies only to the day-key function**: The hour and week-key functions use the same underlying formatter but operate at different granularities. Sharing the day-level memo across them would produce wrong answers for those callers, so the optimization is deliberately scoped to the one function where it is correct.

**✅ What Was Implemented**

- Added a per-timezone memo slot in `LocalDays.ts` that caches the last resolved day's half-open millisecond interval. Subsequent calls for timestamps within the same day return immediately from arithmetic. A miss costs more than the uncached path due to additional intermediate calculations.
- Extracted `computeDayKey` as an internal function used by boundary helpers, preventing a stack overflow that occurred when the bisection helper called the memoized entry point during cache population.

**📁 FILES**
- `cli/src/dashboard/LocalDays.ts`

</blockquote>
</details>
<details>
<summary><strong>11 · Correct stale comments about database hot-path and asset directory resolution</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

Two sets of comments described a call pattern that had already been removed: one justified a narrow two-column database read by citing a high-frequency hot path that no longer existed, and another described asset directory resolution as happening in multiple places when it had been consolidated to one.

**💡 Decisions Behind the Code**

- **Single resolution site for asset directory**: Having three independent resolution calls meant three opportunities for a route to read from a different directory than the one it linked to — a subtle correctness risk if the options object or environment changed between calls. A single lazy accessor eliminates the divergence and makes the consolidation self-documenting.
- **Preserve the two-column read even after the hot path is gone**: The narrow read is still the right choice for a question about migration names regardless of call frequency. The updated comment explains both the historical reason and the current one, so a future reader cannot conclude the read is vestigial and widen it unnecessarily.

**✅ What Was Implemented**

- In `DashboardDb.ts`, updated two comment blocks on `isSchemaCurrent` and `readAppliedMigrationNames` to describe the historical context accurately — the hot-path call is gone, the two-column read is still correct for independent reasons, and the comments now say so.
- In `DashboardServer.ts`, introduced `dashboardAssetsDir()` as a single lazy resolution point for the asset directory path. Three routes that previously each resolved the path independently now all go through this one function, with the consolidation rationale co-located with the definition.
- Also corrected a comment on the slow-query threshold default (described as "default-off" when the actual default is on at 200 ms) and documented the trade-off for compressing the HTML document that carries the mutation token.

**📁 FILES**
- `cli/src/dashboard/DashboardDb.ts`
- `cli/src/dashboard/DashboardServer.ts`

</blockquote>
</details>
<details>
<summary><strong>12 · Correct cache miss cost documentation for timezone day lookup</strong></summary>
<br>
<blockquote>

**⚡ Why This Change**

A comment in the timezone day-boundary module claimed that a cache miss cost the same as the uncached path. In reality a miss triggers several additional intermediate calculations, making it meaningfully more expensive for callers that alternate between two days.

**💡 Decisions Behind the Code**

The comment is the only load-bearing documentation for why the single-slot design is safe for its known callers. An inaccurate cost claim would lead a future caller to assume the cache is always neutral, when it is only neutral for time-sorted access. No logic was changed.

**✅ What Was Implemented**

Updated the comment in `LocalDays.ts` to state the actual miss cost, explain where the extra work comes from, and note the two practical consequences: forward-walking loops remain acceptable, but a caller alternating between two days would be slower than having no cache at all and should use a second slot or sorted input instead.

**📁 FILES**
- `cli/src/dashboard/LocalDays.ts`

</blockquote>
</details>

---

*Generated by Jolli Memory · August 25, 2026 at 2:59 PM · via Anthropic*
<!-- jollimemory-summary-end -->