### PR TITLE
vscode(dashboard): launch the dashboard as a detached background process

### DIFF
--- a/vscode/src/Extension.ts
+++ b/vscode/src/Extension.ts
@@ -4262,20 +4262,16 @@ export function activate(context: vscode.ExtensionContext): void {
 			},
 		),
 
-		// Dashboard — the branch footer button. Runs `jolli dashboard` in an
-		// integrated terminal rather than in this process, so the command's own
-		// output (including the history import, which runs after the page is up and
-		// can take minutes) is in front of the user. DashboardLauncher decides only
-		// which CLI entry to invoke, and keeps the remote-window gate.
-		//
-		// No stop command rides beside this one: the command is a FOREGROUND server
-		// and the terminal is what owns it, so Ctrl+C is the stop — the thing an
-		// extension-owned child process had to reinvent.
+		// Dashboard — the branch footer button. Spawns `jolli dashboard` as a
+		// detached background process (no terminal, no output channel). The CLI
+		// opens the browser itself, and its own port-reclaim logic replaces any
+		// dashboard already serving on 1818 / 18118, so a second click ends the
+		// first server and takes over. DashboardLauncher decides only which CLI
+		// entry to invoke, and keeps the remote-window gate.
 		vscode.commands.registerCommand("jollimemory.openDashboard", () => {
 			log.info("cmd", "openDashboard invoked");
-			// Not awaited: launchDashboard resolves once the line has been sent to
-			// the terminal and reports its own failures, so there is nothing to wait
-			// for here.
+			// Not awaited: launchDashboard resolves once the child has been
+			// spawned and reports its own failures via a message box.
 			void launchDashboard({
 				cwd: workspaceRoot,
 				distDir: join(context.extensionPath, "dist"),

--- a/vscode/src/services/DashboardLauncher.test.ts
+++ b/vscode/src/services/DashboardLauncher.test.ts
@@ -1,18 +1,16 @@
 /**
  * DashboardLauncher tests.
  *
- * The subject is the command line and the terminal, not the dashboard: nothing
- * here starts a process, and `executeDashboard` is not involved at all any more —
- * the launcher's job ends when a line has been sent to a terminal.
- *
- * What is worth pinning is what this module decides on its own: the remote gate,
- * that tier 0 is a version-gated global `jolli`, tier 1 is `run-cli` and tier 2 is
- * the bundled entry run by the host's Node, that tier 1 is skipped on a shell that
- * cannot execute a bash script, that each shell's quoting and the PowerShell call
- * operator are right (a wrong quote does not fail loudly — it passes a mangled path
- * to the CLI), that the repo directory reaches the CLI ONLY as the terminal's own
- * cwd and never as a command argument, and that every click opens a NEW terminal
- * rather than reusing or revealing an earlier one.
+ * The launcher's job is to pick an executable + argv from three tiers and
+ * spawn it as a detached background process. What is worth pinning: the remote
+ * gate, that tier 0 is a version-gated global `jolli`, tier 1 is `run-cli` and
+ * tier 2 is the winning registered dist's `Cli.js` — falling back to the
+ * bundled entry — run by the host's Node, that tier 1 is skipped on win32
+ * (bash-only shebang and no shell to interpret it in a detached child), that a
+ * win32 `.cmd` shim is spawned through a shell, that the repo directory
+ * reaches the CLI only as the spawn's own cwd and never as an argument, and
+ * that the child is detached + unref'd + stdio-ignored so it survives the
+ * extension host.
  */
 
 import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
@@ -20,21 +18,9 @@ import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// `createTerminal` returns a usable stub rather than `undefined` because one case
-// below omits the `host` seam entirely, so that it exercises the `?? defaultHost()`
-// fallback — the only line in this module that touches `vscode.window` directly.
-const { createTerminalMock } = vi.hoisted(() => ({
-	createTerminalMock: vi.fn((options: { name: string }) => ({
-		name: options.name,
-		show: vi.fn(),
-		sendText: vi.fn(),
-	})),
-}));
-
 vi.mock("vscode", () => ({
-	env: { remoteName: undefined, shell: "/bin/zsh" },
+	env: { remoteName: undefined },
 	window: {
-		createTerminal: createTerminalMock,
 		showInformationMessage: vi.fn(),
 		showErrorMessage: vi.fn(),
 	},
@@ -55,25 +41,29 @@ import {
 	BUNDLED_CLI_VERSION,
 	CLI_ENTRY_FILE,
 	type DashboardLauncherHost,
-	detectShellFlavor,
+	type DashboardSpawn,
 	findExecutableOnPath,
 	GLOBAL_BIN_NAME,
+	INVOKED_VIA_ENV_KEY,
+	INVOKED_VIA_VALUE,
+	isShellSafePath,
 	isRemoteWorkspace,
 	launchDashboard,
-	quoteArg,
 	readWinningGlobalCliVersion,
 	REMOTE_HINT,
 	resolveDashboardCommand,
 	resolveRunCliPath,
-	type ShellFlavor,
-	TERMINAL_NAME,
-	type TerminalLike,
+	resolveWinningDistCliPath,
+	RUN_AS_NODE_ENV_KEY,
+	SPAWN_FAILED_MESSAGE,
+	type SpawnedChild,
 	UNAVAILABLE_MESSAGE,
 } from "./DashboardLauncher.js";
 
 const REPO = "/repo/root";
 const EXEC = "/Applications/Code.app/Contents/MacOS/Electron";
 const RUN_CLI = "/home/u/.jolli/jollimemory/run-cli";
+const GLOBAL_JOLLI = "/usr/local/bin/jolli";
 
 /** A dist directory that really holds a real `Cli.js`, so `existsSync` passes. */
 function distWithCli(): string {
@@ -82,44 +72,69 @@ function distWithCli(): string {
 	return dir;
 }
 
-interface FakeTerminal extends TerminalLike {
-	readonly sent: Array<string>;
-	readonly shown: Array<boolean | undefined>;
+interface FakeSpawnCall {
+	readonly executable: string;
+	readonly args: ReadonlyArray<string>;
+	readonly cwd: unknown;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly detached: unknown;
+	readonly stdio: unknown;
+	readonly shell: unknown;
+	readonly child: SpawnedChild;
 }
 
-function fakeTerminal(name: string = TERMINAL_NAME): FakeTerminal {
-	const terminal: FakeTerminal = {
-		name,
-		sent: [],
-		shown: [],
-		show: (preserveFocus) => {
-			terminal.shown.push(preserveFocus);
+interface FakeSpawn {
+	readonly fn: DashboardSpawn;
+	readonly calls: Array<FakeSpawnCall>;
+	/** The most recent child's `error` listener, for tests that fire it. */
+	errorListener?: (err: Error) => void;
+	/** The most recent child's `exit` listener, for tests that fire it. */
+	exitListener?: (code: number | null, signal: NodeJS.Signals | null) => void;
+	throwNextWith?: Error;
+	nextPid?: number;
+}
+
+function fakeSpawn(): FakeSpawn {
+	const state: FakeSpawn = {
+		fn: (executable, args, options) => {
+			if (state.throwNextWith) {
+				const err = state.throwNextWith;
+				state.throwNextWith = undefined;
+				throw err;
+			}
+			const child: SpawnedChild = {
+				pid: state.nextPid ?? 12345,
+				unref: vi.fn(),
+				on: vi.fn((event: string, listener: unknown) => {
+					if (event === "error") state.errorListener = listener as (err: Error) => void;
+					if (event === "exit") state.exitListener = listener as (code: number | null, signal: NodeJS.Signals | null) => void;
+				}),
+			};
+			state.calls.push({
+				executable,
+				args,
+				cwd: options.cwd,
+				env: (options.env ?? {}) as Readonly<Record<string, string | undefined>>,
+				detached: options.detached,
+				stdio: options.stdio,
+				shell: options.shell,
+				child,
+			});
+			return child;
 		},
-		sendText: (text) => {
-			terminal.sent.push(text);
-		},
+		calls: [],
 	};
-	return terminal;
+	return state;
 }
 
 interface FakeHostCalls {
-	readonly created: Array<{ name: string; cwd: string; env: Readonly<Record<string, string>> }>;
 	readonly infos: Array<string>;
 	readonly errors: Array<string>;
-	/** Every terminal handed out, in creation order. */
-	readonly terminals: Array<FakeTerminal>;
 }
 
-/** A host that records what it was asked to do and hands back fake terminals. */
 function fakeHost(): { host: DashboardLauncherHost; calls: FakeHostCalls } {
-	const calls: FakeHostCalls = { created: [], infos: [], errors: [], terminals: [] };
+	const calls: FakeHostCalls = { infos: [], errors: [] };
 	const host: DashboardLauncherHost = {
-		createTerminal: (options) => {
-			calls.created.push({ ...options });
-			const created = fakeTerminal(options.name);
-			calls.terminals.push(created);
-			return created;
-		},
 		showInfo: async (message) => {
 			calls.infos.push(message);
 		},
@@ -131,30 +146,34 @@ function fakeHost(): { host: DashboardLauncherHost; calls: FakeHostCalls } {
 }
 
 /**
- * Options that resolve to tier 1 on a POSIX shell, with nothing left to the machine.
- *
- * `globalCliVersion: null` is the load-bearing part: without it the launcher reads
- * the REAL dist-paths registry, and a developer machine with a global CLI installed
- * would silently push every one of these cases up to tier 0.
+ * Options that resolve to tier 1 on a non-win32 host, with nothing left to the
+ * machine. `globalCliVersion: null` is load-bearing: without it the launcher
+ * reads the REAL dist-paths registry, and a developer machine with a global CLI
+ * installed would silently push every one of these cases up to tier 0.
  */
 function tierOneOptions(overrides: Partial<Parameters<typeof launchDashboard>[0]> = {}) {
+	const spawn = fakeSpawn();
 	return {
-		cwd: REPO,
-		distDir: "/ext/dist",
-		platform: "darwin" as NodeJS.Platform,
-		shell: "/bin/zsh",
-		execPath: EXEC,
-		runCliPath: RUN_CLI,
-		canExecute: (path: string) => path === RUN_CLI,
-		fileExists: () => true,
-		globalCliVersion: null,
-		...overrides,
+		options: {
+			cwd: REPO,
+			distDir: "/ext/dist",
+			platform: "darwin" as NodeJS.Platform,
+			execPath: EXEC,
+			runCliPath: RUN_CLI,
+			canExecute: (path: string) => path === RUN_CLI,
+			fileExists: () => true,
+			globalCliVersion: null,
+			globalCliPath: null,
+			winningDistCliPath: null,
+			spawn: spawn.fn,
+			...overrides,
+		},
+		spawn,
 	};
 }
 
 beforeEach(() => {
 	logCalls.length = 0;
-	createTerminalMock.mockClear();
 });
 
 describe("isRemoteWorkspace", () => {
@@ -166,53 +185,6 @@ describe("isRemoteWorkspace", () => {
 		for (const name of ["ssh-remote", "wsl", "dev-container", "attached-container", "codespaces"]) {
 			expect(isRemoteWorkspace(name)).toBe(true);
 		}
-	});
-});
-
-describe("detectShellFlavor", () => {
-	it("reads PowerShell off either of its two binary names, with or without .exe", () => {
-		for (const shell of [
-			"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
-			"C:\\Program Files\\PowerShell\\7\\pwsh.exe",
-			"/usr/local/bin/pwsh",
-		]) {
-			expect(detectShellFlavor(shell, "win32")).toBe("powershell");
-		}
-	});
-
-	it("recognises cmd only when the path actually names it", () => {
-		expect(detectShellFlavor("C:\\Windows\\System32\\cmd.exe", "win32")).toBe("cmd");
-	});
-
-	it("classifies every POSIX shell as posix, Git Bash on Windows included", () => {
-		for (const shell of ["/bin/bash", "/bin/sh", "/bin/zsh", "/usr/bin/fish", "/bin/dash", "/bin/ksh"]) {
-			expect(detectShellFlavor(shell, "darwin")).toBe("posix");
-		}
-		// The reason the classification keys off the shell rather than the platform:
-		// Git Bash as the Windows default can run tier 1, and gets to.
-		expect(detectShellFlavor("C:\\Program Files\\Git\\bin\\bash.exe", "win32")).toBe("posix");
-	});
-
-	it("falls back to the platform default when the shell is unknown or absent", () => {
-		expect(detectShellFlavor(undefined, "win32")).toBe("powershell");
-		expect(detectShellFlavor(undefined, "darwin")).toBe("posix");
-		expect(detectShellFlavor("C:\\tools\\nushell\\nu.exe", "win32")).toBe("powershell");
-		expect(detectShellFlavor("/opt/homebrew/bin/nu", "darwin")).toBe("posix");
-	});
-});
-
-describe("quoteArg", () => {
-	it("single-quotes for POSIX so $ and backticks in a path stay literal", () => {
-		expect(quoteArg("/a/b $HOME/`x`", "posix")).toBe(`'/a/b $HOME/\`x\`'`);
-	});
-
-	it("escapes a literal quote per shell, and the two shells disagree", () => {
-		expect(quoteArg("it's", "posix")).toBe(`'it'\\''s'`);
-		expect(quoteArg("it's", "powershell")).toBe("'it''s'");
-	});
-
-	it("double-quotes for cmd, which has no literal-quoting form", () => {
-		expect(quoteArg("C:\\Program Files\\x", "cmd")).toBe(`"C:\\Program Files\\x"`);
 	});
 });
 
@@ -244,15 +216,11 @@ describe("findExecutableOnPath", () => {
 		expect(findExecutableOnPath("jolli", { platform: "darwin" })).toBeNull();
 	});
 
-	// These two assert WINDOWS behaviour from a POSIX host, which only works because
-	// the function takes its separator and its join from the `platform` argument. A
-	// `C:\npm` PATH split on the host's `:` would come back as `["C", "\\npm"]`.
 	it("tries PATHEXT suffixes on win32, which is how a .cmd shim is found", () => {
 		const found = findExecutableOnPath("jolli", {
 			pathEnv: "C:\\npm;C:\\other",
 			pathExt: ".COM;.EXE;.BAT;.CMD",
 			platform: "win32",
-			// npm installs a cmd-shim, so only the .CMD candidate exists.
 			fileExists: (path) => path === "C:\\npm\\jolli.CMD",
 		});
 		expect(found).toBe("C:\\npm\\jolli.CMD");
@@ -281,27 +249,17 @@ describe("findExecutableOnPath", () => {
 	it("uses a real exec-bit probe when none is injected", () => {
 		const dir = distWithCli();
 		chmodSync(join(dir, CLI_ENTRY_FILE), 0o755);
-		// The host's own platform, since this one touches a real path on it.
 		expect(findExecutableOnPath(CLI_ENTRY_FILE, { pathEnv: dir, platform: process.platform })).toBe(
 			join(dir, CLI_ENTRY_FILE),
 		);
 	});
 
-	// The reason that default is the exec bit and not `existsSync`: a present but
-	// unrunnable file would clear tier 0's gate and hand the shell a `command not
-	// found`, where a miss falls safely through to tier 1. Skipped on Windows,
-	// which has no exec bit for `chmod` to clear — there libuv folds X_OK down to
-	// an existence check, which is the intended behaviour on that platform.
 	it.skipIf(process.platform === "win32")("does not match a present file with no exec bit", () => {
 		const dir = distWithCli();
 		chmodSync(join(dir, CLI_ENTRY_FILE), 0o644);
 		expect(findExecutableOnPath(CLI_ENTRY_FILE, { pathEnv: dir, platform: process.platform })).toBeNull();
 	});
 
-	// The other false positive `existsSync` let through: a DIRECTORY named `jolli`
-	// early on PATH. It has the exec (search) bit, so the probe alone cannot reject
-	// it — but a directory is not a regular file, which is what `isExecutableFile`
-	// now also requires.
 	it("does not match a directory that happens to carry the binary's name", () => {
 		const dir = mkdtempSync(join(tmpdir(), "jolli-dashboard-launcher-"));
 		mkdirSync(join(dir, "jolli"));
@@ -310,20 +268,6 @@ describe("findExecutableOnPath", () => {
 });
 
 describe("readWinningGlobalCliVersion", () => {
-	/** A global config dir holding the given dist-paths entries, all pointing at real dirs. */
-	function registryWith(entries: Record<string, string>): string {
-		const globalDir = mkdtempSync(join(tmpdir(), "jolli-dashboard-registry-"));
-		const distPaths = join(globalDir, "dist-paths");
-		mkdirSync(distPaths, { recursive: true });
-		for (const [source, version] of Object.entries(entries)) {
-			// `available` is just existsSync(distDir), so any real directory will do.
-			const distDir = join(globalDir, `${source}-dist`);
-			mkdirSync(distDir, { recursive: true });
-			writeFileSync(join(distPaths, source), `${version}\n${distDir}\n`);
-		}
-		return globalDir;
-	}
-
 	it("reports the global CLI's version when it wins the competition", () => {
 		expect(readWinningGlobalCliVersion(registryWith({ cli: "1.2.3", vscode: "0.99.12" }))).toBe("1.2.3");
 	});
@@ -345,10 +289,39 @@ describe("readWinningGlobalCliVersion", () => {
 	});
 });
 
+/** A temp dist-paths registry whose entries point at real (but Cli.js-less) dist dirs. */
+function registryWith(entries: Record<string, string>): string {
+	const globalDir = mkdtempSync(join(tmpdir(), "jolli-dashboard-registry-"));
+	const distPaths = join(globalDir, "dist-paths");
+	mkdirSync(distPaths, { recursive: true });
+	for (const [source, version] of Object.entries(entries)) {
+		const distDir = join(globalDir, `${source}-dist`);
+		mkdirSync(distDir, { recursive: true });
+		writeFileSync(join(distPaths, source), `${version}\n${distDir}\n`);
+	}
+	return globalDir;
+}
+
+describe("resolveWinningDistCliPath", () => {
+	it("names the winning registered dist's Cli.js — existence checked by the resolver", () => {
+		const globalDir = registryWith({ cli: "1.2.3", vscode: "0.99.12" });
+		expect(resolveWinningDistCliPath(globalDir)).toBe(join(globalDir, "cli-dist", CLI_ENTRY_FILE));
+	});
+
+	it("is undefined when nothing is registered", () => {
+		expect(resolveWinningDistCliPath(registryWith({}))).toBeUndefined();
+	});
+
+	it("is undefined when the only entry's dist dir is gone (unavailable)", () => {
+		const globalDir = mkdtempSync(join(tmpdir(), "jolli-dashboard-registry-"));
+		const distPaths = join(globalDir, "dist-paths");
+		mkdirSync(distPaths, { recursive: true });
+		writeFileSync(join(distPaths, "cli"), `1.2.3\n${join(globalDir, "ghost-dist")}\n`);
+		expect(resolveWinningDistCliPath(globalDir)).toBeUndefined();
+	});
+});
+
 describe("resolveDashboardCommand", () => {
-	// `fileExists` is stubbed true because `/ext/dist` is a fictional path; the
-	// two cases that exercise the real probes build a real directory instead.
-	// `globalCliVersion: null` keeps tier 0 out of the way of the tier-1/2 cases.
 	const base = {
 		cwd: REPO,
 		distDir: "/ext/dist",
@@ -356,47 +329,96 @@ describe("resolveDashboardCommand", () => {
 		runCliPath: RUN_CLI,
 		fileExists: () => true,
 		globalCliVersion: null,
+		globalCliPath: null,
+		winningDistCliPath: null,
 	};
 
-	/** Tier-0-eligible: a winning global CLI at the bundle's own version, on PATH. */
-	const withGlobalCli = { ...base, globalCliVersion: BUNDLED_CLI_VERSION, globalBinOnPath: true };
+	const withGlobalCli = {
+		...base,
+		globalCliVersion: BUNDLED_CLI_VERSION,
+		globalCliPath: GLOBAL_JOLLI,
+	};
 
 	it("prefers a global jolli over run-cli when it wins and is new enough", () => {
 		const resolved = resolveDashboardCommand({
 			...withGlobalCli,
-			flavor: "posix",
-			// run-cli is present and usable — tier 0 still wins.
+			platform: "darwin",
 			canExecute: (path) => path === RUN_CLI,
 		});
 		expect(resolved).toEqual({
 			tier: "global-jolli",
-			commandLine: `${GLOBAL_BIN_NAME} dashboard`,
+			executable: GLOBAL_JOLLI,
+			args: ["dashboard"],
+			runAsNode: false,
+			shell: false,
 		});
 	});
 
-	it("sends the bare name unquoted, with no call operator on any shell", () => {
-		for (const flavor of ["posix", "powershell", "cmd"] as Array<ShellFlavor>) {
-			const resolved = resolveDashboardCommand({ ...withGlobalCli, flavor });
-			// Tier 0 is the one tier that is not platform-gated: PowerShell and cmd
-			// resolve a bare name through PATHEXT themselves.
+	it("uses the absolute global path on every platform, tier 0 is not platform-gated", () => {
+		for (const platform of ["darwin", "linux", "win32"] as Array<NodeJS.Platform>) {
+			const resolved = resolveDashboardCommand({ ...withGlobalCli, platform });
 			expect(resolved?.tier).toBe("global-jolli");
-			expect(resolved?.commandLine.startsWith(`${GLOBAL_BIN_NAME} dashboard`)).toBe(true);
+			expect(resolved?.executable).toBe(GLOBAL_JOLLI);
+			expect(resolved?.runAsNode).toBe(false);
+			expect(resolved?.shell).toBe(false);
 		}
 	});
 
-	it("never puts the repo directory in the command, on any tier or shell", () => {
-		// The directory reaches the CLI only as the terminal's own working directory
-		// (`createTerminal({ cwd })` → `process.cwd()`). Pinned because the opposite —
-		// an explicit `--cwd` — is the obvious thing to add back, and was dropped on
-		// purpose. Every tier is covered: tier 0 by the global CLI, tier 1 by run-cli,
-		// tier 2 by canExecute answering false.
+	it("spawns a win32 `.cmd` shim through a shell — Node refuses `.cmd` without one", () => {
+		const resolved = resolveDashboardCommand({
+			...withGlobalCli,
+			platform: "win32",
+			globalCliPath: "C:\\Users\\u\\AppData\\Roaming\\npm\\jolli.cmd",
+		});
+		expect(resolved).toEqual({
+			tier: "global-jolli",
+			executable: "C:\\Users\\u\\AppData\\Roaming\\npm\\jolli.cmd",
+			args: ["dashboard"],
+			runAsNode: false,
+			shell: true,
+		});
+	});
+
+	it("does not shell a win32 `.exe` global CLI", () => {
+		const resolved = resolveDashboardCommand({
+			...withGlobalCli,
+			platform: "win32",
+			globalCliPath: "C:\\Tools\\jolli.exe",
+		});
+		expect(resolved?.tier).toBe("global-jolli");
+		expect(resolved?.shell).toBe(false);
+	});
+
+	it("refuses a win32 shim path with cmd metacharacters, falling through to the host's Node", () => {
+		const resolved = resolveDashboardCommand({
+			...withGlobalCli,
+			platform: "win32",
+			globalCliPath: "C:\\Users\\a&b\\npm\\jolli.cmd",
+			canExecute: () => false,
+		});
+		expect(resolved?.tier).toBe("host-node");
+		expect(resolved?.shell).toBe(false);
+	});
+
+	it("refuses a win32 shim path with spaces, falling through to the host's Node", () => {
+		const resolved = resolveDashboardCommand({
+			...withGlobalCli,
+			platform: "win32",
+			globalCliPath: "C:\\Users\\John Doe\\AppData\\Roaming\\npm\\jolli.cmd",
+			canExecute: () => false,
+		});
+		expect(resolved?.tier).toBe("host-node");
+		expect(resolved?.shell).toBe(false);
+	});
+
+	it("never puts the repo directory in the args, on any tier or platform", () => {
 		const cwd = "/some/repo/root";
-		for (const flavor of ["posix", "powershell", "cmd"] as Array<ShellFlavor>) {
+		for (const platform of ["darwin", "linux", "win32"] as Array<NodeJS.Platform>) {
 			for (const tierDeps of [withGlobalCli, { ...base, canExecute: () => true }, base]) {
-				const resolved = resolveDashboardCommand({ ...tierDeps, cwd, flavor });
-				expect(resolved?.commandLine).not.toContain(cwd);
-				expect(resolved?.commandLine).not.toContain("--cwd");
-				expect(resolved?.commandLine.endsWith("dashboard")).toBe(true);
+				const resolved = resolveDashboardCommand({ ...tierDeps, cwd, platform });
+				expect(resolved?.args).not.toContain(cwd);
+				expect(resolved?.args).not.toContain("--cwd");
+				expect(resolved?.args.at(-1)).toBe("dashboard");
 			}
 		}
 	});
@@ -404,359 +426,460 @@ describe("resolveDashboardCommand", () => {
 	it("refuses a global CLI older than the core this bundle carries", () => {
 		const resolved = resolveDashboardCommand({
 			...withGlobalCli,
-			flavor: "posix",
+			platform: "darwin",
 			globalCliVersion: "0.97.0",
 			minGlobalCliVersion: "0.99.12",
 			canExecute: (path) => path === RUN_CLI,
 		});
-		// The whole reason presence is not the gate: 0.97 has no `dashboard` command,
-		// so a bare `jolli` there answers `unknown command` where run-cli works.
 		expect(resolved?.tier).toBe("run-cli");
 	});
 
-	it("refuses a winning global CLI that is not on PATH", () => {
+	it("refuses a winning global CLI whose path was not found on PATH", () => {
 		const resolved = resolveDashboardCommand({
 			...withGlobalCli,
-			flavor: "posix",
-			globalBinOnPath: false,
+			platform: "darwin",
+			globalCliPath: null,
 			canExecute: (path) => path === RUN_CLI,
 		});
 		expect(resolved?.tier).toBe("run-cli");
 	});
 
-	it("prefers run-cli on a POSIX shell — never a bare `jolli`", () => {
+	it("prefers run-cli on a POSIX host — never a bare `jolli`", () => {
 		const resolved = resolveDashboardCommand({
 			...base,
-			flavor: "posix",
+			platform: "linux",
 			canExecute: (path) => path === RUN_CLI,
 		});
 		expect(resolved).toEqual({
 			tier: "run-cli",
-			commandLine: `'${RUN_CLI}' dashboard`,
+			executable: RUN_CLI,
+			args: ["dashboard"],
+			runAsNode: false,
+			shell: false,
 		});
-		// The point of tier 1 existing at all: it is the version-selecting entry,
-		// and a bare CLI name would bypass that selection.
-		expect(resolved?.commandLine.startsWith("jolli ")).toBe(false);
 	});
 
-	it("falls to the bundled entry when run-cli is not executable", () => {
-		const resolved = resolveDashboardCommand({ ...base, flavor: "posix", canExecute: () => false });
+	it("falls back to the bundled entry when run-cli is not executable and nothing is registered", () => {
+		const resolved = resolveDashboardCommand({ ...base, platform: "darwin", canExecute: () => false });
 		expect(resolved).toEqual({
-			tier: "bundled-node",
-			commandLine: `'${EXEC}' '${join("/ext/dist", CLI_ENTRY_FILE)}' dashboard`,
+			tier: "host-node",
+			executable: EXEC,
+			args: [join("/ext/dist", CLI_ENTRY_FILE), "dashboard"],
+			runAsNode: true,
+			shell: false,
 		});
 	});
 
-	it("never tries run-cli on a shell that cannot execute a bash script", () => {
-		for (const flavor of ["powershell", "cmd"] as Array<ShellFlavor>) {
-			const probed: Array<string> = [];
-			const resolved = resolveDashboardCommand({
-				...base,
-				flavor,
-				canExecute: (path) => {
-					probed.push(path);
-					return true;
-				},
-			});
-			// Not even probed: `run-cli` carries a #!/bin/bash shebang and has no
-			// .cmd / .ps1 sibling, so an executable bit would not make it runnable.
-			expect(probed).toEqual([]);
-			expect(resolved?.tier).toBe("bundled-node");
-		}
+	it("prefers the winning registered dist's Cli.js over the bundled entry", () => {
+		const resolved = resolveDashboardCommand({
+			...base,
+			platform: "darwin",
+			canExecute: () => false,
+			winningDistCliPath: "/registry/winning/Cli.js",
+		});
+		expect(resolved).toEqual({
+			tier: "host-node",
+			executable: EXEC,
+			args: ["/registry/winning/Cli.js", "dashboard"],
+			runAsNode: true,
+			shell: false,
+		});
 	});
 
-	it("prefixes the PowerShell form with the call operator, and no other form", () => {
-		const ps = resolveDashboardCommand({ ...base, flavor: "powershell", canExecute: () => false });
-		expect(ps?.commandLine).toBe(
-			`& '${EXEC}' '${join("/ext/dist", CLI_ENTRY_FILE)}' dashboard`,
-		);
-		const cmd = resolveDashboardCommand({ ...base, flavor: "cmd", canExecute: () => false });
-		expect(cmd?.commandLine).toBe(
-			`"${EXEC}" "${join("/ext/dist", CLI_ENTRY_FILE)}" dashboard`,
-		);
-		expect(cmd?.commandLine.startsWith("&")).toBe(false);
+	it("falls back to the bundled entry when the winning dist's Cli.js is missing", () => {
+		const resolved = resolveDashboardCommand({
+			...base,
+			platform: "darwin",
+			canExecute: () => false,
+			winningDistCliPath: "/registry/winning/Cli.js",
+			fileExists: (path: string) => path !== "/registry/winning/Cli.js",
+		});
+		expect(resolved).toEqual({
+			tier: "host-node",
+			executable: EXEC,
+			args: [join("/ext/dist", CLI_ENTRY_FILE), "dashboard"],
+			runAsNode: true,
+			shell: false,
+		});
 	});
 
-	it("is null when the bundled entry is missing, since tier 2 has no other precondition", () => {
+	it("never tries run-cli on win32 (its shebang is bash-only)", () => {
+		const probed: Array<string> = [];
+		const resolved = resolveDashboardCommand({
+			...base,
+			platform: "win32",
+			canExecute: (path) => {
+				probed.push(path);
+				return true;
+			},
+		});
+		expect(probed).toEqual([]);
+		expect(resolved?.tier).toBe("host-node");
+	});
+
+	it("marks tier 2 with runAsNode so the launcher adds ELECTRON_RUN_AS_NODE", () => {
+		const resolved = resolveDashboardCommand({ ...base, platform: "darwin", canExecute: () => false });
+		expect(resolved?.runAsNode).toBe(true);
+	});
+
+	it("is null when the bundled entry and the winning dist are both missing", () => {
 		expect(
-			resolveDashboardCommand({ ...base, flavor: "posix", canExecute: () => false, fileExists: () => false }),
+			resolveDashboardCommand({
+				...base,
+				platform: "darwin",
+				canExecute: () => false,
+				fileExists: () => false,
+			}),
 		).toBeNull();
 	});
 
 	it("uses real filesystem probes when none are injected", () => {
 		const dir = distWithCli();
-		// `runCliPath` names a file that does not exist, so the default X_OK probe
-		// must answer false and hand over to tier 2 — whose entry really is there,
-		// so the default `existsSync` must answer true.
 		const resolved = resolveDashboardCommand({
 			cwd: REPO,
 			distDir: dir,
 			execPath: EXEC,
-			flavor: "posix",
+			platform: "darwin",
 			runCliPath: join(dir, "definitely-absent-run-cli"),
 		});
-		expect(resolved?.tier).toBe("bundled-node");
-		expect(resolved?.commandLine).toContain(join(dir, CLI_ENTRY_FILE));
+		expect(resolved?.tier).toBe("host-node");
+		expect(resolved?.args).toContain(join(dir, CLI_ENTRY_FILE));
 	});
 
 	it("treats a real executable as tier 1 through the default probe", () => {
-		// `process.execPath` is the one file every platform guarantees is
-		// executable, so it stands in for an installed `run-cli`.
 		const resolved = resolveDashboardCommand({
 			cwd: REPO,
 			distDir: "/ext/dist",
 			execPath: EXEC,
-			flavor: "posix",
+			platform: "linux",
 			runCliPath: process.execPath,
 		});
 		expect(resolved?.tier).toBe("run-cli");
 	});
 
 	it("resolves run-cli under the real home when no path is given", () => {
-		// Only the shape is asserted: whether this machine has run-cli installed
-		// decides the tier, and a test must not depend on that.
-		const resolved = resolveDashboardCommand({ ...base, runCliPath: undefined, flavor: "posix" });
-		expect(resolved === null || resolved.tier === "run-cli" || resolved.tier === "bundled-node").toBe(true);
+		const resolved = resolveDashboardCommand({ ...base, runCliPath: undefined, platform: "darwin" });
+		expect(resolved === null || resolved.tier === "run-cli" || resolved.tier === "host-node").toBe(true);
+	});
+});
+
+describe("isShellSafePath", () => {
+	it("accepts an ordinary win32 npm prefix", () => {
+		expect(isShellSafePath("C:\\Users\\me\\AppData\\Roaming\\npm\\jolli.cmd")).toBe(true);
+	});
+
+	it("rejects a path with spaces — cmd.exe does not get a quoted file", () => {
+		expect(isShellSafePath("C:\\Program Files\\Git\\bin\\bash.exe")).toBe(false);
+		expect(isShellSafePath("C:\\Users\\John Doe\\AppData\\Roaming\\npm\\jolli.cmd")).toBe(false);
+	});
+
+	it("rejects cmd metacharacters", () => {
+		expect(isShellSafePath("C:\\Users\\a&b\\npm\\jolli.cmd")).toBe(false);
+		expect(isShellSafePath("C:\\Users\\100%done\\npm\\jolli.cmd")).toBe(false);
+		expect(isShellSafePath("C:\\Users\\x|y\\npm\\jolli.cmd")).toBe(false);
+		expect(isShellSafePath("C:\\Users\\say \"hi\"\\npm\\jolli.cmd")).toBe(false);
 	});
 });
 
 describe("launchDashboard", () => {
-	it("sends the line immediately, without waiting for the shell", async () => {
-		// The launcher's whole contract: open a terminal, put the command in it,
-		// return. The cosmetic double-echo this leaves is documented at the send
-		// site, along with the two measured fixes that were reverted for costing
-		// seconds per click.
-		const { host, calls } = fakeHost();
-		await launchDashboard(tierOneOptions({ host }));
-		expect(calls.terminals[0]?.shown).toEqual([true]);
-		expect(calls.terminals[0]?.sent).toEqual([`'${RUN_CLI}' dashboard`]);
+	it("spawns the tier-1 executable detached, with stdio ignored and unref'd", async () => {
+		const { host } = fakeHost();
+		const { options, spawn } = tierOneOptions({ host });
+		await launchDashboard(options);
+		expect(spawn.calls).toHaveLength(1);
+		const call = spawn.calls[0];
+		expect(call?.executable).toBe(RUN_CLI);
+		expect(call?.args).toEqual(["dashboard"]);
+		expect(call?.detached).toBe(true);
+		expect(call?.stdio).toBe("ignore");
+		expect(call?.shell).toBe(false);
+		expect(call?.child.unref).toHaveBeenCalledTimes(1);
 	});
 
-	it("refuses a remote window with the hint, touching no terminal", async () => {
+	it("refuses a remote window with the hint, spawning nothing", async () => {
 		const { host, calls } = fakeHost();
-		await launchDashboard(tierOneOptions({ host, remoteName: "ssh-remote" }));
+		const { options, spawn } = tierOneOptions({ host, remoteName: "ssh-remote" });
+		await launchDashboard(options);
 		expect(calls.infos).toEqual([REMOTE_HINT]);
-		expect(calls.created).toEqual([]);
+		expect(spawn.calls).toEqual([]);
 	});
 
-	it("creates the dashboard terminal at the repo root and runs the tier-1 line in it", async () => {
-		const { host, calls } = fakeHost();
-		await launchDashboard(tierOneOptions({ host }));
-		expect(calls.created).toEqual([
-			{ name: TERMINAL_NAME, cwd: REPO, env: { ELECTRON_RUN_AS_NODE: "1" } },
-		]);
-		const terminal = calls.terminals[0];
-		expect(terminal?.sent).toEqual([`'${RUN_CLI}' dashboard`]);
+	it("runs the child at the repo cwd, never as a --cwd argument", async () => {
+		const { host } = fakeHost();
+		const { options, spawn } = tierOneOptions({ host, cwd: "/other/repo" });
+		await launchDashboard(options);
+		expect(spawn.calls[0]?.cwd).toBe("/other/repo");
+		expect(spawn.calls[0]?.args).toEqual(["dashboard"]);
 	});
 
-	it("shows the terminal without stealing focus, before sending", async () => {
-		const { host, calls } = fakeHost();
-		await launchDashboard(tierOneOptions({ host }));
-		const terminal = calls.terminals[0];
-		// `true` is preserveFocus: the click came from the sidebar, not the panel.
-		expect(terminal?.shown).toEqual([true]);
-		expect(terminal?.sent).toHaveLength(1);
+	it("marks tier 1 without ELECTRON_RUN_AS_NODE — it is a real executable", async () => {
+		const { host } = fakeHost();
+		const { options, spawn } = tierOneOptions({ host });
+		await launchDashboard(options);
+		expect(spawn.calls[0]?.env[RUN_AS_NODE_ENV_KEY]).toBeUndefined();
 	});
 
-	it("carries the repo directory ONLY as the terminal's cwd, never in the command", async () => {
-		const { host, calls } = fakeHost();
-		await launchDashboard(tierOneOptions({ host, cwd: "/other/repo" }));
-		// The terminal is created there, and the command says nothing about it — so
-		// `executeDashboard` gets the directory from `process.cwd()`. That is the whole
-		// mechanism, and it is why no `cd` line is sent either.
-		expect(calls.created[0]?.cwd).toBe("/other/repo");
-		expect(calls.terminals[0]?.sent).toEqual([`'${RUN_CLI}' dashboard`]);
+	it("tags every launch with JOLLI_INVOKED_VIA so ps can tell it apart from a manual run", async () => {
+		const { host } = fakeHost();
+		const { options, spawn } = tierOneOptions({ host });
+		await launchDashboard(options);
+		expect(spawn.calls[0]?.env[INVOKED_VIA_ENV_KEY]).toBe(INVOKED_VIA_VALUE);
 	});
 
-	it("opens a NEW terminal on every click, never reusing or revealing an old one", async () => {
-		const { host, calls } = fakeHost();
-		await launchDashboard(tierOneOptions({ host }));
-		await launchDashboard(tierOneOptions({ host }));
-		await launchDashboard(tierOneOptions({ host }));
-		expect(calls.created).toHaveLength(3);
-		// Each terminal carries exactly its own run — no earlier one is written to
-		// again, so no click can land a second command in a terminal already busy.
-		for (const terminal of calls.terminals) {
-			expect(terminal.sent).toEqual([`'${RUN_CLI}' dashboard`]);
-			expect(terminal.shown).toEqual([true]);
+	it("starts a fresh child on every click, never reusing or waiting", async () => {
+		const { host } = fakeHost();
+		const { options, spawn } = tierOneOptions({ host });
+		await launchDashboard(options);
+		await launchDashboard(options);
+		await launchDashboard(options);
+		expect(spawn.calls).toHaveLength(3);
+		for (const call of spawn.calls) {
+			expect(call.executable).toBe(RUN_CLI);
+			expect(call.args).toEqual(["dashboard"]);
 		}
 	});
 
-	it("gives every terminal the same name, cwd and env", async () => {
-		const { host, calls } = fakeHost();
-		await launchDashboard(tierOneOptions({ host }));
-		await launchDashboard(tierOneOptions({ host }));
-		expect(calls.created).toEqual([
-			{ name: TERMINAL_NAME, cwd: REPO, env: { ELECTRON_RUN_AS_NODE: "1" } },
-			{ name: TERMINAL_NAME, cwd: REPO, env: { ELECTRON_RUN_AS_NODE: "1" } },
-		]);
+	it("runs the bundled entry through the host's Node when run-cli is unusable and nothing is registered", async () => {
+		const { host } = fakeHost();
+		const { options, spawn } = tierOneOptions({ host, canExecute: () => false });
+		await launchDashboard(options);
+		expect(spawn.calls[0]?.executable).toBe(EXEC);
+		expect(spawn.calls[0]?.args).toEqual([join("/ext/dist", CLI_ENTRY_FILE), "dashboard"]);
+		expect(spawn.calls[0]?.env[RUN_AS_NODE_ENV_KEY]).toBe("1");
+		expect(spawn.calls[0]?.shell).toBe(false);
 	});
 
-	it("runs the bundled entry through the host's Node when run-cli is unusable", async () => {
-		const { host, calls } = fakeHost();
-		await launchDashboard(tierOneOptions({ host, canExecute: () => false }));
-		expect(calls.terminals[0]?.sent).toEqual([
-			`'${EXEC}' '${join("/ext/dist", CLI_ENTRY_FILE)}' dashboard`,
-		]);
-		// The env is what makes that Electron path behave as node.
-		expect(calls.created[0]?.env).toEqual({ ELECTRON_RUN_AS_NODE: "1" });
+	it("runs the winning registered dist's Cli.js through the host's Node on win32", async () => {
+		const { host } = fakeHost();
+		const { options, spawn } = tierOneOptions({
+			host,
+			platform: "win32",
+			canExecute: () => false,
+			globalCliVersion: null,
+			globalCliPath: null,
+			winningDistCliPath: "/registry/winning/Cli.js",
+		});
+		await launchDashboard(options);
+		expect(spawn.calls[0]?.executable).toBe(EXEC);
+		expect(spawn.calls[0]?.args).toEqual(["/registry/winning/Cli.js", "dashboard"]);
+		expect(spawn.calls[0]?.env[RUN_AS_NODE_ENV_KEY]).toBe("1");
+		expect(spawn.calls[0]?.shell).toBe(false);
+		expect(logCalls.some((c) => c.message.includes("host-node"))).toBe(true);
 	});
 
-	it("reports an incomplete build instead of opening an empty terminal", async () => {
+	it("falls back to the bundled entry when the winning dist's Cli.js is missing", async () => {
+		const { host } = fakeHost();
+		const { options, spawn } = tierOneOptions({
+			host,
+			canExecute: () => false,
+			winningDistCliPath: "/registry/winning/Cli.js",
+			fileExists: (path: string) => path !== "/registry/winning/Cli.js",
+		});
+		await launchDashboard(options);
+		expect(spawn.calls[0]?.executable).toBe(EXEC);
+		expect(spawn.calls[0]?.args).toEqual([join("/ext/dist", CLI_ENTRY_FILE), "dashboard"]);
+		expect(spawn.calls[0]?.env[RUN_AS_NODE_ENV_KEY]).toBe("1");
+	});
+
+	it("reports an incomplete build when neither the winning dist nor the bundled entry exists", async () => {
 		const { host, calls } = fakeHost();
-		await launchDashboard(tierOneOptions({ host, canExecute: () => false, fileExists: () => false }));
+		const { options, spawn } = tierOneOptions({
+			host,
+			canExecute: () => false,
+			winningDistCliPath: "/registry/winning/Cli.js",
+			fileExists: () => false,
+		});
+		await launchDashboard(options);
 		expect(calls.errors).toEqual([UNAVAILABLE_MESSAGE]);
-		expect(calls.created).toEqual([]);
+		expect(spawn.calls).toEqual([]);
+	});
+
+	it("resolves the winning dist from the ambient registry when not injected", async () => {
+		const { host } = fakeHost();
+		const { options, spawn } = tierOneOptions({
+			host,
+			canExecute: () => false,
+			winningDistCliPath: undefined,
+		});
+		await launchDashboard(options);
+		// The path is machine-dependent (a real dist may or may not win), so only
+		// the shape is pinned: tier 2 always runs the host's Node as node.
+		expect(spawn.calls).toHaveLength(1);
+		expect(spawn.calls[0]?.executable).toBe(EXEC);
+		expect(spawn.calls[0]?.env[RUN_AS_NODE_ENV_KEY]).toBe("1");
+		expect(logCalls.some((c) => c.message.includes("host-node"))).toBe(true);
+	});
+
+	it("reports an incomplete build instead of spawning nothing", async () => {
+		const { host, calls } = fakeHost();
+		const { options, spawn } = tierOneOptions({
+			host,
+			canExecute: () => false,
+			fileExists: () => false,
+		});
+		await launchDashboard(options);
+		expect(calls.errors).toEqual([UNAVAILABLE_MESSAGE]);
+		expect(spawn.calls).toEqual([]);
 		expect(logCalls.some((c) => c.level === "error" && c.message.includes(CLI_ENTRY_FILE))).toBe(true);
 	});
 
-	it("runs the readable `jolli dashboard` when a winning global CLI is on PATH", async () => {
+	it("reports a spawn failure with a message box the user can see", async () => {
 		const { host, calls } = fakeHost();
-		await launchDashboard(
-			tierOneOptions({
-				host,
-				globalCliVersion: BUNDLED_CLI_VERSION,
-				minGlobalCliVersion: BUNDLED_CLI_VERSION,
-				pathEnv: "/usr/local/bin",
-				// Stands in for both the PATH probe and the Cli.js check.
-				fileExists: () => true,
-			}),
-		);
-		expect(calls.terminals[0]?.sent).toEqual([`${GLOBAL_BIN_NAME} dashboard`]);
+		const { options, spawn } = tierOneOptions({ host });
+		spawn.throwNextWith = new Error("EACCES");
+		await launchDashboard(options);
+		expect(calls.errors).toEqual([SPAWN_FAILED_MESSAGE]);
+		expect(logCalls.some((c) => c.level === "error" && c.message.includes("EACCES"))).toBe(true);
 	});
 
-	it("skips tier 0 without probing PATH when no global CLI wins", async () => {
-		const probed: Array<string> = [];
+	it("reports an asynchronous spawn error with a message box the user can see", async () => {
 		const { host, calls } = fakeHost();
-		await launchDashboard(
-			tierOneOptions({
-				host,
-				globalCliVersion: null,
-				pathEnv: "/usr/local/bin",
-				fileExists: (path) => {
-					probed.push(path);
-					return true;
-				},
-			}),
-		);
-		// A null version short-circuits the PATH walk entirely, so the only existence
-		// question asked is tier 2's — never `/usr/local/bin/jolli`.
+		const { options, spawn } = tierOneOptions({ host });
+		await launchDashboard(options);
+		expect(spawn.errorListener).toBeDefined();
+		spawn.errorListener?.(new Error("EINVAL"));
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(calls.errors).toEqual([SPAWN_FAILED_MESSAGE]);
+		expect(logCalls.some((c) => c.level === "error" && c.message.includes("EINVAL"))).toBe(true);
+	});
+
+	it("logs a tier-0 exit 127 so a missing shebang interpreter is not silent", async () => {
+		const { host } = fakeHost();
+		const { options, spawn } = tierOneOptions({
+			host,
+			globalCliVersion: BUNDLED_CLI_VERSION,
+			minGlobalCliVersion: BUNDLED_CLI_VERSION,
+			globalCliPath: GLOBAL_JOLLI,
+		});
+		await launchDashboard(options);
+		expect(spawn.exitListener).toBeDefined();
+		spawn.exitListener?.(127, null);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(logCalls.some((c) => c.level === "error" && c.message.includes("exited 127"))).toBe(true);
+	});
+
+	it("runs the readable `jolli dashboard` when a winning global CLI is on PATH", async () => {
+		const { host } = fakeHost();
+		const { options, spawn } = tierOneOptions({
+			host,
+			globalCliVersion: BUNDLED_CLI_VERSION,
+			minGlobalCliVersion: BUNDLED_CLI_VERSION,
+			globalCliPath: GLOBAL_JOLLI,
+		});
+		await launchDashboard(options);
+		expect(spawn.calls[0]?.executable).toBe(GLOBAL_JOLLI);
+		expect(spawn.calls[0]?.args).toEqual(["dashboard"]);
+		expect(spawn.calls[0]?.env[RUN_AS_NODE_ENV_KEY]).toBeUndefined();
+		expect(spawn.calls[0]?.shell).toBe(false);
+	});
+
+	it("passes shell: true to the spawn for a win32 `.cmd` global shim", async () => {
+		const { host } = fakeHost();
+		const { options, spawn } = tierOneOptions({
+			host,
+			platform: "win32",
+			globalCliVersion: BUNDLED_CLI_VERSION,
+			minGlobalCliVersion: BUNDLED_CLI_VERSION,
+			globalCliPath: "C:\\Users\\u\\AppData\\Roaming\\npm\\jolli.cmd",
+			canExecute: () => false,
+		});
+		await launchDashboard(options);
+		expect(spawn.calls[0]?.executable).toBe("C:\\Users\\u\\AppData\\Roaming\\npm\\jolli.cmd");
+		expect(spawn.calls[0]?.args).toEqual(["dashboard"]);
+		expect(spawn.calls[0]?.shell).toBe(true);
+		expect(spawn.calls[0]?.env[RUN_AS_NODE_ENV_KEY]).toBeUndefined();
+	});
+
+	it("skips PATH lookup when no global CLI wins the version competition", async () => {
+		const probed: Array<string> = [];
+		const { host } = fakeHost();
+		const { options, spawn } = tierOneOptions({
+			host,
+			globalCliVersion: null,
+			globalCliPath: undefined,
+			pathEnv: "/usr/local/bin",
+			fileExists: (path) => {
+				probed.push(path);
+				return true;
+			},
+		});
+		await launchDashboard(options);
 		expect(probed.some((path) => path.endsWith(GLOBAL_BIN_NAME))).toBe(false);
-		expect(calls.terminals[0]?.sent[0]).toContain(RUN_CLI);
+		expect(spawn.calls[0]?.executable).toBe(RUN_CLI);
 	});
 
 	it("falls back to run-cli when the winning global CLI is not on PATH", async () => {
-		const { host, calls } = fakeHost();
-		await launchDashboard(
-			tierOneOptions({
-				host,
-				globalCliVersion: BUNDLED_CLI_VERSION,
-				minGlobalCliVersion: BUNDLED_CLI_VERSION,
-				pathEnv: "/usr/local/bin",
-				// Nothing named `jolli` on PATH; run-cli is still executable.
-				fileExists: (path) => !path.endsWith(GLOBAL_BIN_NAME),
-			}),
-		);
-		expect(calls.terminals[0]?.sent[0]).toContain(RUN_CLI);
-	});
-
-	it("searches the ambient PATH when no pathEnv is injected", async () => {
-		const { host, calls } = fakeHost();
-		await launchDashboard(
-			tierOneOptions({
-				host,
-				globalCliVersion: BUNDLED_CLI_VERSION,
-				minGlobalCliVersion: BUNDLED_CLI_VERSION,
-				// pathEnv omitted on purpose: the walk must fall back to process.env.PATH.
-				// Nothing exists there as far as this probe is concerned, so tier 1 wins.
-				fileExists: (path) => !path.endsWith(GLOBAL_BIN_NAME),
-			}),
-		);
-		expect(calls.terminals[0]?.sent[0]).toContain(RUN_CLI);
-	});
-
-	it("reads the real registry and PATH when neither is injected", async () => {
-		const { host, calls } = fakeHost();
-		// `globalCliVersion` omitted, so `readWinningGlobalCliVersion` runs against
-		// the real machine. Only the shape is asserted — whether this machine has a
-		// global CLI decides the tier, and a test must not depend on that.
-		await launchDashboard({
-			cwd: REPO,
-			distDir: "/ext/dist",
-			host,
-			platform: "darwin",
-			shell: "/bin/zsh",
-			execPath: EXEC,
-			runCliPath: RUN_CLI,
-			canExecute: (path) => path === RUN_CLI,
-			fileExists: () => true,
-		});
-		expect(calls.terminals[0]?.sent).toHaveLength(1);
-	});
-
-	it("records the tier and the shell it chose", async () => {
 		const { host } = fakeHost();
-		await launchDashboard(tierOneOptions({ host }));
-		expect(logCalls.some((c) => c.message.includes("run-cli") && c.message.includes("posix shell"))).toBe(
-			true,
-		);
-	});
-
-	it("falls back to the ambient platform and shell when neither is injected", async () => {
-		const { host, calls } = fakeHost();
-		await launchDashboard({
-			cwd: REPO,
-			distDir: "/ext/dist",
+		const { options, spawn } = tierOneOptions({
 			host,
-			remoteName: undefined,
-			execPath: EXEC,
-			runCliPath: RUN_CLI,
-			canExecute: (path) => path === RUN_CLI,
-			fileExists: () => true,
-			// Pinned for the reason `tierOneOptions` states: without it this case
-			// reads the REAL dist-paths registry, so it asserted tier 1 only while
-			// this machine happened to have no available `cli` entry. Building
-			// `cli/dist` locally flipped it to tier 0 and the case went red with
-			// nothing about its subject — the ambient platform/shell — having changed.
-			globalCliVersion: null,
+			globalCliVersion: BUNDLED_CLI_VERSION,
+			minGlobalCliVersion: BUNDLED_CLI_VERSION,
+			globalCliPath: null,
 		});
-		// The mocked `vscode.env.shell` is /bin/zsh, so tier 1 is reachable.
-		expect(calls.terminals[0]?.sent).toEqual([`'${RUN_CLI}' dashboard`]);
+		await launchDashboard(options);
+		expect(spawn.calls[0]?.executable).toBe(RUN_CLI);
 	});
 
-	it("reaches vscode.window when no host is injected", async () => {
-		await launchDashboard({
-			cwd: REPO,
-			distDir: "/ext/dist",
-			platform: "darwin",
-			shell: "/bin/zsh",
-			execPath: EXEC,
-			runCliPath: RUN_CLI,
-			canExecute: (path) => path === RUN_CLI,
-			fileExists: () => true,
+	it("resolves a globalCliPath from the ambient PATH when not injected", async () => {
+		const { host } = fakeHost();
+		const { options, spawn } = tierOneOptions({
+			host,
+			globalCliVersion: BUNDLED_CLI_VERSION,
+			minGlobalCliVersion: BUNDLED_CLI_VERSION,
+			globalCliPath: undefined,
+			pathEnv: "/usr/local/bin",
+			fileExists: (path) => path === join("/usr/local/bin", GLOBAL_BIN_NAME),
 		});
-		expect(createTerminalMock).toHaveBeenCalledWith({
-			name: TERMINAL_NAME,
-			cwd: REPO,
-			env: { ELECTRON_RUN_AS_NODE: "1" },
+		await launchDashboard(options);
+		expect(spawn.calls[0]?.executable).toBe(join("/usr/local/bin", GLOBAL_BIN_NAME));
+	});
+
+	it("records the tier it chose", async () => {
+		const { host } = fakeHost();
+		const { options } = tierOneOptions({ host });
+		await launchDashboard(options);
+		expect(logCalls.some((c) => c.message.includes("run-cli"))).toBe(true);
+	});
+
+	it("quotes argv parts with spaces in the launch log line", async () => {
+		const { host } = fakeHost();
+		const { options } = tierOneOptions({
+			host,
+			globalCliVersion: BUNDLED_CLI_VERSION,
+			minGlobalCliVersion: BUNDLED_CLI_VERSION,
+			globalCliPath: "/Users/me/Library/Application Support/jolli",
 		});
+		await launchDashboard(options);
+		expect(
+			logCalls.some((c) =>
+				c.message.includes('launching dashboard in background via global-jolli: "/Users/me/Library/Application Support/jolli" dashboard'),
+			),
+		).toBe(true);
+	});
+
+	it("falls back to the ambient platform when none is injected", async () => {
+		const { host } = fakeHost();
+		const { options, spawn } = tierOneOptions({
+			host,
+			platform: undefined,
+			globalCliVersion: null,
+			globalCliPath: null,
+		});
+		await launchDashboard(options);
+		expect(spawn.calls).toHaveLength(1);
 	});
 
 	it("uses the real execPath when none is injected", async () => {
-		const { host, calls } = fakeHost();
-		await launchDashboard({
-			cwd: REPO,
-			distDir: "/ext/dist",
+		const { host } = fakeHost();
+		const { options, spawn } = tierOneOptions({
 			host,
-			remoteName: undefined,
-			platform: "darwin",
-			shell: "/bin/zsh",
+			execPath: undefined,
 			canExecute: () => false,
 			fileExists: () => true,
-			// Same machine-independence pin as above: the subject here is tier 2's
-			// execPath default, which tier 0 would short-circuit past entirely.
 			globalCliVersion: null,
+			globalCliPath: null,
 		});
-		expect(calls.terminals[0]?.sent[0]).toContain(process.execPath);
+		await launchDashboard(options);
+		expect(spawn.calls[0]?.executable).toBe(process.execPath);
 	});
 });

--- a/vscode/src/services/DashboardLauncher.ts
+++ b/vscode/src/services/DashboardLauncher.ts
@@ -1,56 +1,51 @@
 /**
- * DashboardLauncher — opens the Jolli dashboard by running `jolli dashboard` in
- * an integrated terminal.
+ * DashboardLauncher — starts `jolli dashboard` as a detached background process.
  *
- * This used to run `executeDashboard` IN the extension host, with three
- * editor-shaped plugs (the output channel, an Electron-as-node server spawner,
- * `vscode.env.openExternal`). Running it in a terminal instead moves all three
- * back to their command-line defaults and hands the user something the in-process
- * version could not: the command's own output, in front of them, as it happens.
- * The launcher's phases are untouched — the browser still opens (the CLI does it),
- * and the history import still runs last, now visibly.
+ * The button used to spawn an integrated terminal and type the command into it.
+ * That mode meant the user carried both the shell window and the CLI's output
+ * on screen, and it left an accumulating strip of dashboard terminals in the
+ * panel. This launcher instead does what the Claude Code plugin's dashboard
+ * skill already does: launch the CLI detached, unref it, and let the CLI itself
+ * open the browser. The command reclaims any existing dashboard on ports 1818 /
+ * 18118, so a second click ends the first server and takes over, with nothing
+ * for this module to poll or clean up.
  *
- * What is left here is one decision: **which command line to send**. Three tiers,
- * in order:
+ * The command selection is unchanged from the terminal-based launcher — same
+ * three tiers, in order:
  *
- *   0. **`jolli`** — the readable spelling, used only when a globally-installed CLI
- *      both WINS the dist-paths version competition and is at least as new as the
- *      core this bundle carries. Presence is not the gate: an ungated bare-`jolli`
- *      tier would bypass that competition, so a stale global CLI would shadow a
- *      newer bundled one and answer `unknown command 'dashboard'`. The competition
- *      is not reimplemented here — see {@link readWinningGlobalCliVersion}, which
- *      calls the same two functions `resolve-dist-path` mirrors. So tier 0 fires
- *      exactly when tier 1 would have chosen the global CLI anyway: same code,
- *      readable spelling.
- *   1. **`~/.jolli/jollimemory/run-cli`** — the machine-global dispatcher, which
- *      resolves the highest-versioned registered dist. This ONE tier covers both
- *      "the user has a global CLI" and "only the VS Code bundle exists", which is
- *      why it, and not tier 0, is the fallback that must always work.
- *   2. **The extension's own `dist/Cli.js`, run by the host's Node** — reached when
- *      tier 1 cannot be used. That is two situations: `run-cli` is absent or not
- *      executable (no repo on this machine has been enabled), or the terminal's
- *      shell cannot execute a `#!/bin/bash` script at all.
+ *   0. **`jolli`** — the readable spelling, used only when a globally-installed
+ *      CLI both WINS the dist-paths version competition and is at least as new
+ *      as the core this bundle carries. Presence is not the gate: a stale
+ *      global CLI would shadow a newer bundled one and answer `unknown command
+ *      'dashboard'`. This tier spawns the absolute global script with the
+ *      extension host's `process.env.PATH` snapshot — not a freshly sourced
+ *      login shell. If the GUI that launched VS Code provided a reduced PATH,
+ *      a POSIX `#!/usr/bin/env node` interpreter can exec and then exit 127
+ *      without ever reaching the `error` event. The `exit` listener below
+ *      records that specific exit code so the failure is not silent.
+ *   1. **`~/.jolli/jollimemory/run-cli`** — the machine-global dispatcher,
+ *      which resolves the highest-versioned registered dist. Covers both "the
+ *      user has a global CLI" and "only the VS Code bundle exists", and is
+ *      POSIX-only because it carries a `#!/bin/bash` shebang.
+ *   2. **The best registered dist's `Cli.js`, run by the host's Node** —
+ *      reached when tiers 0 and 1 are unavailable. The dist-paths registry
+ *      names the highest-available dist — the same competition `run-cli`
+ *      re-reads at runtime — and its `Cli.js` is run by the host's Electron
+ *      under `ELECTRON_RUN_AS_NODE=1` (`engines.vscode` guarantees a Node that
+ *      clears the 22.13 `node:sqlite` floor). If the winner's file is missing
+ *      or nothing is registered, this falls back to the extension's own
+ *      `dist/Cli.js` — the same shape as `resolveMcpCli` — so a stale entry
+ *      pointing at a deleted dist degrades to the bundle instead of failing.
  *
- *      A third situation looks like it belongs beside those and is NOT covered:
- *      tier 1 also needs a `node` on the shell's PATH (its only other source,
- *      `~/.jolli/jollimemory/node-path`, is written by the IntelliJ plugin and
- *      never by this extension), and nothing here probes for one. A machine with
- *      an executable `run-cli` but no PATH node therefore stays on tier 1 and
- *      gets run-cli's own `ERROR: node runtime not found` in the terminal rather
- *      than falling through to tier 2. The integrated terminal is an interactive
- *      shell, so it carries the user's version manager and this is rare — but it
- *      is a known gap, not a handled case.
- *
- * Tier 2 is the one that needs no user Node: `ELECTRON_RUN_AS_NODE` makes the
- * host's own Electron run as node, and `engines.vscode` (^1.101.0) already
- * guarantees that Node clears the 22.13 `node:sqlite` floor. It is the only use
- * of that variable left in the tree — every launcher that spawned a CLI from the
- * extension host used it, and this is the one path that still has to.
- *
- * Nothing checks the Node version on either tier, and nothing should:
- * `executeDashboard` gates on `canUseDashboardDb()` as the second thing it does
- * and names both the required and the running version. In a terminal that message
- * is finally visible — it used to go to an output channel nobody had open.
+ * The spawned child is detached with `stdio: "ignore"` and unref'd, so it
+ * outlives this extension host and the user closing the window. Its stdout
+ * / stderr are dropped: `executeDashboard` inside the CLI opens the browser
+ * itself, and any failure message it prints AFTER a successful spawn — the
+ * runtime-version check, a database error, a port conflict — lands in the
+ * CLI's own `.jolli/jollimemory/debug.log` rather than in a terminal we no
+ * longer open. When the CLI cannot be SPAWNED at all (a synchronous throw or
+ * the async `error` event) we show a VS Code error message the user actually
+ * sees, which is the failure mode that used to reach the terminal.
  */
 
 import { accessSync, constants, existsSync, statSync } from "node:fs";
@@ -59,6 +54,7 @@ import { join, posix as posixPath, win32 as win32Path } from "node:path";
 import * as vscode from "vscode";
 import { pickBestDistPath, traverseDistPaths } from "../../../cli/src/install/DistPathResolver.js";
 import { compareSemver } from "../../../cli/src/install/SemverCompare.js";
+import { spawnHidden } from "../../../cli/src/util/Subprocess.js";
 import { log } from "../util/Logger.js";
 
 const TAG = "dashboard";
@@ -67,60 +63,29 @@ const TAG = "dashboard";
 export const CLI_ENTRY_FILE = "Cli.js";
 
 /**
- * The name given to each terminal this button opens.
- *
- * Not a singleton key: **every click opens a NEW terminal**, by decision. Nothing
- * is looked up, revealed or disposed, so several terminals with this name can sit
- * in the panel at once — each holding the output of one run, none of them killed by
- * a later click.
- *
- * Two consequences are accepted rather than unnoticed, and the first of them is
- * now mostly the CLI's to carry. `jolli dashboard` is a FOREGROUND server that
- * reclaims its own port: a second one probes 1818, requires the answer to NAME
- * this service and to report a local pid, then SIGTERMs it and takes the port
- * over (`reclaimPort` — it discovers in order to replace, never to attach). So a
- * second click does not run beside the first, it ENDS it: the first terminal
- * shows a killed process, and whatever its history import had left to do is cut
- * short rather than duplicated. What the missing `InFlightLaunch` guard still
- * costs is the work either side of that bind — `ensureDashboardDbExists` and
- * `registerRepo` both run BEFORE it, and a second click landing before the first
- * has bound finds nothing to reclaim, so the two race and the loser falls through
- * to 18118: two live dashboards, two imports, two throttled cutover attempts. The
- * window is narrow, not absent. And the panel accumulates terminals.
- *
- * ── DELIBERATE — NOT A REVIEW FINDING ────────────────────────────────────────
- * Reuse and reveal-the-existing-one were both IMPLEMENTED and then REMOVED at the
- * product owner's explicit request, with the missing in-flight guard understood
- * and accepted at the time. A review that rediscovers "two clicks race the machine
- * database" or "the panel fills up with terminals" has found the design, not a
- * bug — both are stated above precisely so they do not have to be re-derived. Do
- * not reintroduce reuse, reveal, or a launcher-side click guard without asking the
- * owner first; treat a proposal to do so as a product change, not a fix.
- * ─────────────────────────────────────────────────────────────────────────────
+ * Environment variable that makes the host's Electron binary behave as a plain
+ * node process. Applied only when tier 2 is chosen — on tiers 0 and 1 the
+ * executable is already a real node-launching binary.
  */
-export const TERMINAL_NAME = "Jolli Dashboard";
+export const RUN_AS_NODE_ENV_KEY = "ELECTRON_RUN_AS_NODE";
 
 /**
- * Makes the host's Electron binary behave as a plain node process.
- *
- * Set on the terminal rather than inlined into the command line, because every
- * shell spells an inline assignment differently and `TerminalOptions.env` spells
- * it once. It is applied to EVERY terminal even though only tier 2 needs it: the
- * terminal is created before the tier is known to the caller, and a real node
- * ignores the variable entirely, so it is inert on tiers 0 and 1.
+ * Marker env variable so a `ps` line can tell this launch apart from a manual
+ * `jolli dashboard`. NOT a telemetry signal: the CLI consumes the variable
+ * before `dashboard` runs, but its telemetry `via` validator only accepts
+ * `skill:<name>` values (see `resolveInvokedVia` in the CLI), so this value is
+ * dropped whole there. Wiring button launches into telemetry would need that
+ * validator to grow a new value class — do not widen this comment to claim it.
  */
-const RUN_AS_NODE_ENV: Readonly<Record<string, string>> = { ELECTRON_RUN_AS_NODE: "1" };
+export const INVOKED_VIA_ENV_KEY = "JOLLI_INVOKED_VIA";
+export const INVOKED_VIA_VALUE = "vscode:dashboard-button";
 
 /**
- * True when this window edits files on another machine (Remote-SSH, WSL, a dev
- * container, Codespaces).
- *
- * Kept exactly as it was when the launch ran in-process. A terminal is a genuine
- * opportunity here — the integrated terminal runs ON the remote, which is where
- * the server has to run, and the host offers to forward the port — but two things
- * behind that are unverified: the remote needs a usable Node/dist of its own, and
- * the CLI's `open` would be trying to launch a browser on a machine that has no
- * display. Both deserve their own change, not a side effect of this one.
+ * True when this window edits files on another machine (Remote-SSH, WSL, dev
+ * container, Codespaces). Kept from the terminal-based launcher: a detached
+ * child of the extension host runs on the host, not the remote, so the server
+ * would bind on the wrong side and the browser call would target a machine
+ * with no display.
  */
 export function isRemoteWorkspace(remoteName: string | undefined = vscode.env.remoteName): boolean {
 	return remoteName !== undefined;
@@ -131,65 +96,12 @@ export const REMOTE_HINT =
 	"The Jolli dashboard runs on the machine that holds your code. " +
 	"Open a terminal on that machine and run `jolli dashboard` — VS Code will offer to forward the port.";
 
-/** Shown when neither tier yielded a runnable command. Details are in the log. */
+/** Shown when no tier yielded a runnable command. Details are in the log. */
 export const UNAVAILABLE_MESSAGE =
 	"Could not find a Jolli CLI to run the dashboard — this build may be incomplete.";
 
-/* ── Command resolution ──────────────────────────────────────────────────────── */
-
-/**
- * How the terminal's shell parses a command line.
- *
- * Only quoting and one prefix depend on this, but both are load-bearing: a
- * quoting style that is wrong for the shell does not fail loudly, it passes a
- * mangled path to the CLI. `powershell` needs the call operator `&` before a
- * quoted executable path, and `&` at the start of a POSIX line is a syntax error
- * — so there is no one string that works everywhere.
- */
-export type ShellFlavor = "posix" | "powershell" | "cmd";
-
-/**
- * Classifies the terminal's default shell.
- *
- * Driven by the shell's own path rather than by `process.platform`, so Git Bash
- * as the default on Windows is recognised as POSIX and gets tier 1 — which is
- * both correct and free. Windows falls back to `powershell` when the shell is
- * unknown because that is the host's default there; `cmd` is only ever chosen
- * when the path actually names it.
- */
-export function detectShellFlavor(shell: string | undefined, platform: NodeJS.Platform): ShellFlavor {
-	if (shell !== undefined) {
-		// Matched against the whole path, anchored to a separator, rather than by
-		// extracting a basename first: `path.basename` is platform-dependent about
-		// backslashes (on POSIX it returns a Windows path whole), and every
-		// hand-rolled alternative carries an unreachable "no last segment" branch.
-		const named = (names: string): RegExp => new RegExp(String.raw`(?:^|[\\/])(?:${names})(?:\.exe)?$`, "i");
-		if (named("pwsh|powershell").test(shell)) return "powershell";
-		if (named("cmd").test(shell)) return "cmd";
-		if (named("bash|sh|zsh|fish|dash|ksh").test(shell)) return "posix";
-	}
-	return platform === "win32" ? "powershell" : "posix";
-}
-
-/**
- * Quotes one argument for `flavor`.
- *
- * POSIX and PowerShell both get single quotes — the only form in either that
- * suppresses interpolation, which matters because a path may legitimately contain
- * `$` (POSIX) or `$`/backtick (PowerShell). They differ only in how a literal
- * quote is escaped. `cmd` has no such form and gets double quotes; a Windows path
- * cannot contain `"` at all, so nothing is lost.
- */
-export function quoteArg(value: string, flavor: ShellFlavor): string {
-	switch (flavor) {
-		case "posix":
-			return `'${value.replaceAll("'", `'\\''`)}'`;
-		case "powershell":
-			return `'${value.replaceAll("'", "''")}'`;
-		case "cmd":
-			return `"${value}"`;
-	}
-}
+/** Shown when the CLI cannot be spawned at all — sync throw or async `error`. */
+export const SPAWN_FAILED_MESSAGE = "Could not start the Jolli dashboard — see Jolli's output channel for details.";
 
 /** Absolute path of the machine-global CLI dispatcher. */
 export function resolveRunCliPath(homeDir: string = homedir()): string {
@@ -198,7 +110,7 @@ export function resolveRunCliPath(homeDir: string = homedir()): string {
 
 /* ── Tier 0: a global `jolli` that is new enough ─────────────────────────────── */
 
-/** The name a global install puts on PATH, and the whole point of tier 0. */
+/** The name a global install puts on PATH. */
 export const GLOBAL_BIN_NAME = "jolli";
 
 /** The dist-paths source tag a global `npm i -g @jolli.ai/cli` writes. */
@@ -206,83 +118,76 @@ export const GLOBAL_CLI_SOURCE = "cli";
 
 /**
  * The core version this bundle carries — the floor a global CLI must clear.
- *
  * `__CLI_PKG_VERSION__`, NOT `__PKG_VERSION__` (the extension's own release
- * number): dist-paths entries record the `@jolli.ai/cli` core version, so that is
- * what the comparison below is against.
+ * number): dist-paths entries record the `@jolli.ai/cli` core version.
  */
 /* v8 ignore next -- compile-time ternary: "0.0.0" under vitest, the real define in bundled builds */
 export const BUNDLED_CLI_VERSION = typeof __CLI_PKG_VERSION__ !== "undefined" ? __CLI_PKG_VERSION__ : "0.0.0";
 
 /**
+ * The single `pickBestDistPath(traverseDistPaths(...))` pass shared by the two
+ * callers that need the winning registry entry. Kept private on purpose: both
+ * public helpers below derive their result from this one traversal, and the
+ * launcher reuses it so a click does not re-read the whole registry twice.
+ */
+function readWinningDistEntry(globalDir?: string): ReturnType<typeof pickBestDistPath> {
+	return pickBestDistPath(traverseDistPaths(globalDir));
+}
+
+/**
  * The version of a globally-installed CLI that outranks every other registered
- * dist, or null when there is no such install.
- *
- * This is the reuse: `traverseDistPaths` + `pickBestDistPath` ARE the "is a CLI
- * installed, and which install wins on version" logic — the same two functions
- * `resolve-dist-path` mirrors and `JolliMemoryBridge` already calls. So tier 0
- * fires exactly when run-cli would have chosen the global CLI anyway, which is
- * what makes it a readable spelling of tier 1 rather than a second opinion. Not
- * reimplemented, and deliberately not probed with `jolli --version` either: a
- * spawn (measured 0.35 s) would answer a question the registry already answers
- * for free, and could disagree with it.
- *
- * The version is still compared against {@link BUNDLED_CLI_VERSION} rather than
- * being taken on trust from `cli` having won. Winning implies "at least as new as
- * this bundle" only while our OWN `dist-paths/vscode` entry is registered — and on
- * a fresh install, or after a failed registration, it is not, so a stale `cli`
- * could win a field of one.
- *
- * KNOWN RESIDUAL RISK, and the price of not spawning: this answers for the install
- * that WROTE `dist-paths/cli`, while the terminal resolves the bare name against
- * its OWN PATH. Those can be different binaries — two node versions under
- * nvm/volta, or a shim earlier on PATH — and then tier 0 clears a gate the CLI
- * that actually runs never faced, so an old one answers `unknown command
- * 'dashboard'` in the terminal. Tier 1 has no such gap, because `run-cli` re-reads
- * the registry itself at run time. Closing it needs the `jolli --version` spawn
- * ruled out above, so the gap is accepted, not overlooked: it costs one visible
- * error line on a misconfigured machine, and the user can still run the printed
- * command by hand.
+ * dist, or null when there is no such install. Same competition `resolve-dist-path`
+ * runs.
  */
 export function readWinningGlobalCliVersion(globalDir?: string): string | null {
-	const winner = pickBestDistPath(traverseDistPaths(globalDir));
+	const winner = readWinningDistEntry(globalDir);
 	return winner?.source === GLOBAL_CLI_SOURCE ? winner.version : null;
 }
 
 /**
- * Finds `binName` on the plain inherited PATH, or null.
+ * Absolute path of the winning registered dist's `Cli.js`, or undefined when no
+ * dist is registered/available. The same competition `run-cli` re-reads at
+ * runtime — this is the Node-side spelling of it, and what `resolveMcpCli`
+ * already does for the MCP launcher. The FILE's existence is checked by the
+ * resolver's `fileExists` seam, not here: `pickBestDistPath` only proves the
+ * dist DIRECTORY exists, and a registered dist may be missing its `Cli.js`.
+ */
+export function resolveWinningDistCliPath(globalDir?: string): string | undefined {
+	const best = readWinningDistEntry(globalDir);
+	return best ? join(best.distDir, CLI_ENTRY_FILE) : undefined;
+}
+
+/**
+ * Whether a path is safe to hand to `cmd.exe` through `shell: true`.
  *
- * Deliberately NOT the local-agent resolver's `discover`: that widens PATH with
- * well-known install dirs because it then spawns the absolute path it found. Tier
- * 0 sends the bare NAME, so the only PATH that matters is the one the TERMINAL
- * resolves it against — widening ours would let us emit a `jolli` the terminal
- * cannot find. A GUI-launched editor's narrow PATH therefore produces false
- * negatives here, which is the right way round: a miss falls through to tier 1,
- * while a false positive is a `command not found` in the user's face.
+ * `shell: true` routes the command through a shell, and the path comes from
+ * the user's own PATH, so it must not be able to change what the shell runs.
+ * cmd metacharacters that survive inside Node's quoting (`%` expands env
+ * vars, `&`/`|`/`<`/`>` separate commands, `"` breaks quoting, `!` enables
+ * delayed expansion, `^` escapes, `*`/`?` glob) refuse the path entirely.
+ * Whitespace is refused for the same reason: Node builds the `cmd.exe` command
+ * by joining the unquoted `file` and `args`, so a directory containing a space
+ * (`C:\Users\John Doe\...\jolli.cmd`) would be split by `cmd.exe` before
+ * execution. Refusal makes tier 0 fall through to tier 1/2 — a graceful
+ * fallback, never a failure.
  *
- * Also why this probes the filesystem and never spawns: the Windows install is a
- * `.cmd` shim that `execFile` refuses outright (EINVAL since the CVE-2024-27980
- * fix), but a bare name is resolved through `PATHEXT` by PowerShell and cmd
- * themselves. We need to know the shim is THERE, not to run it — so Windows needs
- * no shim expansion and tier 0 works there too.
+ * This is NOT the same call as `runNpmCommand`: that helper passes the bare
+ * token `npm` (resolved through `PATHEXT`, so no absolute path can carry a
+ * space) and validates its allow-listed `args`. Here the executable is an
+ * absolute user-controlled path, which is exactly why the path itself is the
+ * guard target.
+ */
+export function isShellSafePath(path: string): boolean {
+	return !/[\s%&|<>^"!*?]/.test(path);
+}
+
+/**
+ * Finds `binName` on PATH, returning its absolute path or null. Used by tier 0
+ * to (a) confirm a global CLI is reachable and (b) hand `spawn` an absolute
+ * path — spawning a bare name on Windows depends on shell resolution.
  *
- * The probe is the EXEC BIT, not mere existence, and the default deliberately
- * shares {@link isExecutableFile} with tier 1's `run-cli` check. A bare
- * `existsSync` answers true for a directory named `jolli`, or for a file whose
- * exec bit was never set — both of which the shell then refuses, which is the
- * `command not found` in the user's face that this whole function exists to
- * avoid, and which tier 1 would have handled fine. `accessSync(X_OK)` is also the
- * right call on Windows for free: that platform has no exec bit, so libuv folds
- * `X_OK` down to an existence check, which is exactly the PATHEXT-membership rule
- * above.
- *
- * Every platform-dependent choice — the PATH separator, the path join, whether
- * `PATHEXT` applies at all — comes from the `platform` ARGUMENT, never from the
- * host. Same rule as the local-agent resolver's `discoveryPath`: a function
- * parameterized by platform must not change shape when the host differs, or its
- * tests assert the host's behaviour instead of the target's. This is not
- * hypothetical here — `"C:\\npm"` split on the host delimiter yields `["C",
- * "\\npm"]` on macOS, so the win32 path was silently unreachable.
+ * Every platform-dependent choice comes from the `platform` argument, not the
+ * host, so a test running on POSIX can assert win32 behaviour.
  */
 export function findExecutableOnPath(
 	binName: string,
@@ -297,8 +202,6 @@ export function findExecutableOnPath(
 	const exists = deps.fileExists ?? isExecutableFile;
 	const paths = deps.platform === "win32" ? win32Path : posixPath;
 	const dirs = (deps.pathEnv ?? "").split(paths.delimiter).filter((dir) => dir.length > 0);
-	// On win32 a bare name is only runnable via one of these extensions; elsewhere
-	// the file itself is the candidate.
 	const suffixes =
 		deps.platform === "win32"
 			? (deps.pathExt ?? ".COM;.EXE;.BAT;.CMD").split(";").filter((ext) => ext.length > 0)
@@ -312,33 +215,48 @@ export function findExecutableOnPath(
 	return null;
 }
 
-/** Which tier produced a command line. Reported in the log, and pinned by tests. */
-export type DashboardCommandTier = "global-jolli" | "run-cli" | "bundled-node";
+/** Which tier produced a command. Reported in the log, and pinned by tests. */
+export type DashboardCommandTier = "global-jolli" | "run-cli" | "host-node";
 
 export interface ResolvedDashboardCommand {
-	/** The exact line to send to the terminal. */
-	readonly commandLine: string;
+	/** Absolute path of the executable to spawn. */
+	readonly executable: string;
+	/** Arguments passed as argv[1..]. */
+	readonly args: ReadonlyArray<string>;
 	readonly tier: DashboardCommandTier;
+	/** True when the child needs `ELECTRON_RUN_AS_NODE=1` in its env (tier 2). */
+	readonly runAsNode: boolean;
+	/**
+	 * True only for win32 `.cmd` / `.bat` shims, which Node refuses to spawn
+	 * directly (EINVAL since the CVE-2024-27980 fix) and which therefore go
+	 * through `cmd.exe` via `shell: true`.
+	 */
+	readonly shell: boolean;
 }
 
-/** The environment probes, injected so tests never touch the real machine. */
 export interface CommandResolutionDeps {
-	/** Repo directory to register and serve from — always passed explicitly, see below. */
+	/** Repo directory to register and serve from — reaches the CLI as its cwd. */
 	readonly cwd: string;
-	/** The extension's `dist/`, holding {@link CLI_ENTRY_FILE}. */
+	/** The extension's `dist/` — the fallback that holds {@link CLI_ENTRY_FILE}. */
 	readonly distDir: string;
-	readonly flavor: ShellFlavor;
-	/** The host's Electron binary; runs as node under {@link RUN_AS_NODE_ENV}. */
+	/** Host platform — decides whether tier 1 (bash script) is reachable. */
+	readonly platform: NodeJS.Platform;
+	/** The host's Electron binary; runs as node under `ELECTRON_RUN_AS_NODE`. */
 	readonly execPath: string;
 	readonly runCliPath?: string | undefined;
 	/**
-	 * Version of the winning globally-installed CLI, or null when none wins.
-	 * Resolved by the caller ({@link readWinningGlobalCliVersion}) so this function
-	 * stays pure — it reads no registry and touches no PATH of its own.
+	 * Absolute path of the winning globally-installed CLI, or null. Resolved by
+	 * the caller so this function stays pure.
 	 */
+	readonly globalCliPath?: string | null | undefined;
+	/** Version of the winning globally-installed CLI, or null. */
 	readonly globalCliVersion?: string | null | undefined;
-	/** Whether {@link GLOBAL_BIN_NAME} is on the PATH the terminal will use. */
-	readonly globalBinOnPath?: boolean | undefined;
+	/**
+	 * Absolute path of the winning registered dist's `Cli.js`, or null.
+	 * Resolved by the caller (via {@link resolveWinningDistCliPath}) so this
+	 * function stays pure — it reads no registry of its own.
+	 */
+	readonly winningDistCliPath?: string | null | undefined;
 	/** The floor a global CLI must clear. Defaults to {@link BUNDLED_CLI_VERSION}. */
 	readonly minGlobalCliVersion?: string | undefined;
 	/** Defaults to {@link isExecutableFile}. */
@@ -347,15 +265,7 @@ export interface CommandResolutionDeps {
 	readonly fileExists?: ((path: string) => boolean) | undefined;
 }
 
-/**
- * A regular file the shell can actually run — what tier 1 needs of `run-cli`, and
- * the default probe tier 0 uses for a PATH candidate.
- *
- * BOTH halves are required, and the directory half is not hypothetical: every
- * directory carries the search bit, so `X_OK` alone says yes to a directory named
- * `jolli` (or `run-cli`) sitting early on PATH. `statSync` follows symlinks, which
- * is what a global npm bin is, so the ordinary install still passes.
- */
+/** A regular file the shell can actually run. */
 function isExecutableFile(path: string): boolean {
 	try {
 		accessSync(path, constants.X_OK);
@@ -366,109 +276,134 @@ function isExecutableFile(path: string): boolean {
 }
 
 /**
- * Picks the tier and builds its command line, or returns null when none is
- * usable.
+ * Picks the tier and returns the argv the spawn will use, or null when no tier
+ * is usable.
  *
- * **The command carries no `--cwd`, by decision.** `executeDashboard` therefore
- * falls back to `process.cwd()` — the working directory of the shell in the
- * terminal — and `createTerminal({ cwd })` is the only thing pointing that at the
- * repo root. That is a weaker guarantee than it looks, and the gap is accepted
- * rather than unknown: a `cd` in the user's `.zshrc` / `.bashrc` overrides the
- * spawn directory outright (measured: spawned in the repo, `pwd` reported `/` once
- * the rc had run). When that happens the button acts on whatever repo the shell is
- * in — `registerRepo` and `maybeAutoCutover` both take that directory, and the
- * second FREEZES the orphan branch of the repo it is given. Nothing on screen
- * distinguishes it, because the dashboard opens either way.
- *
- * (Each click gets a FRESH terminal — see {@link TERMINAL_NAME} — so a `cd` the
- * user typed by hand does not carry into the next launch. The rc-file case is
- * what remains, and it is the one that fires on every launch alike.)
- *
- * ── DELIBERATE — NOT A REVIEW FINDING ────────────────────────────────────────
- * Both fixes were considered and DROPPED at the product owner's explicit request:
- * `--cwd` on the command line, and a `cd` line sent ahead of it. The irreversible
- * consequence above (a fence `jolli enable` cannot clear, on a repo the user did
- * not point at) was on the table when that call was made. A review that
- * rediscovers "the dashboard command should pass --cwd" has found the design, not
- * a bug. Do not add either back without asking the owner first.
- * ─────────────────────────────────────────────────────────────────────────────
+ * The command carries no `--cwd`: the CLI reads `process.cwd()`, and the
+ * spawn's own `cwd` is what points that at the repo root.
  */
 export function resolveDashboardCommand(deps: CommandResolutionDeps): ResolvedDashboardCommand | null {
 	const canExecute = deps.canExecute ?? isExecutableFile;
 	const fileExists = deps.fileExists ?? existsSync;
-	const quote = (value: string): string => quoteArg(value, deps.flavor);
 	const tail = "dashboard";
 
-	// Tier 0 — the readable form, and the only tier that is not platform-gated: a
-	// bare name is resolved through `PATHEXT` by PowerShell and cmd themselves, so
-	// a Windows `jolli.cmd` runs here even though nothing may spawn it directly.
+	// Tier 0 — the readable form. Version-gated so a stale global CLI cannot
+	// shadow a newer bundled one. `globalCliPath` is what turns the "on PATH"
+	// check into an absolute path we can hand `spawn` directly.
 	//
-	// Two conditions, and presence alone is neither of them. A stale global CLI
-	// would shadow a newer bundled one and answer `unknown command 'dashboard'` —
-	// the failure that made an ungated bare-`jolli` tier wrong.
-	// `>=` rather than `>`: an equal version is the same code, so preferring the
-	// readable spelling is free.
+	// win32 wrinkle: the path a global npm install puts on PATH is a `.cmd`
+	// shim, and Node refuses to spawn `.cmd` / `.bat` directly (EINVAL since
+	// the CVE-2024-27980 fix), so those are run through `cmd.exe` via
+	// `shell: true`. That is a different surface from `runNpmCommand`: here the
+	// executable is an absolute user-controlled path, not the bare `npm` token,
+	// and Node joins that path with args without quoting it. The path is
+	// therefore required to be free of cmd metacharacters AND whitespace before
+	// `shell: true` is used; a path that fails that check falls through to
+	// tier 1/2 instead of being quoted into a shell command.
 	const globalVersion = deps.globalCliVersion;
+	const globalPath = deps.globalCliPath;
 	const floor = deps.minGlobalCliVersion ?? BUNDLED_CLI_VERSION;
-	if (globalVersion != null && compareSemver(globalVersion, floor) >= 0 && deps.globalBinOnPath === true) {
-		return { commandLine: `${GLOBAL_BIN_NAME} ${tail}`, tier: "global-jolli" };
+	if (globalVersion != null && globalPath != null && compareSemver(globalVersion, floor) >= 0) {
+		const needsShell = /\.(?:cmd|bat)$/i.test(globalPath);
+		if (!needsShell || isShellSafePath(globalPath)) {
+			return {
+				executable: globalPath,
+				args: [tail],
+				tier: "global-jolli",
+				runAsNode: false,
+				shell: needsShell,
+			};
+		}
 	}
 
-	// Tier 1 is POSIX-only: `run-cli` carries a `#!/bin/bash` shebang and there is
-	// no `.cmd` / `.ps1` sibling, so PowerShell and cmd cannot run it at all.
-	if (deps.flavor === "posix") {
+	// Tier 1 — POSIX-only: `run-cli` carries a `#!/bin/bash` shebang. The
+	// terminal-based launcher also reached this tier under Git Bash on Windows,
+	// because the terminal shell interpreted the shebang; a detached child has
+	// no such shell, and locating/verifying a Git-for-Windows bash is not
+	// attempted here, so win32 skips this tier outright.
+	if (deps.platform !== "win32") {
 		const runCli = deps.runCliPath ?? resolveRunCliPath();
 		if (canExecute(runCli)) {
-			return { commandLine: `${quote(runCli)} ${tail}`, tier: "run-cli" };
+			return { executable: runCli, args: [tail], tier: "run-cli", runAsNode: false, shell: false };
 		}
+	}
+
+	// Tier 2 — the best registered dist's `Cli.js`, run by the host's Node.
+	// Mirrors `resolveMcpCli`: the registry names the highest-available dist,
+	// and when that dist's `Cli.js` is missing — a stale entry pointing at a
+	// deleted or incomplete dist — this falls back to the extension's own
+	// `dist/Cli.js` rather than failing. That fallback is what keeps Windows
+	// (where tiers 0 and 1 are unavailable or bash-only) from freezing the
+	// button on the bundle when a newer plugin dist is registered.
+	const winningEntry = deps.winningDistCliPath;
+	if (winningEntry != null && fileExists(winningEntry)) {
+		return {
+			executable: deps.execPath,
+			args: [winningEntry, tail],
+			tier: "host-node",
+			runAsNode: true,
+			shell: false,
+		};
 	}
 
 	const cliEntry = join(deps.distDir, CLI_ENTRY_FILE);
 	if (!fileExists(cliEntry)) return null;
-	// The call operator is what lets PowerShell treat a quoted string as the
-	// command to run rather than as a value to echo.
-	const prefix = deps.flavor === "powershell" ? "& " : "";
 	return {
-		commandLine: `${prefix}${quote(deps.execPath)} ${quote(cliEntry)} ${tail}`,
-		tier: "bundled-node",
+		executable: deps.execPath,
+		args: [cliEntry, tail],
+		tier: "host-node",
+		runAsNode: true,
+		shell: false,
 	};
 }
 
-/* ── Terminal ────────────────────────────────────────────────────────────────── */
-
-/**
- * The subset of `vscode.Terminal` this module uses.
- *
- * Deliberately narrow: no `exitStatus` and no `dispose`, because nothing here
- * inspects or tears down a terminal. Both were here while the launcher reused one,
- * and they are gone with it rather than left as an invitation.
- */
-export interface TerminalLike {
-	readonly name: string;
-	show(preserveFocus?: boolean): void;
-	sendText(text: string, addNewLine?: boolean): void;
-}
+/* ── Launcher ───────────────────────────────────────────────────────────────── */
 
 /** The window interactions this module performs, as a seam. */
 export interface DashboardLauncherHost {
-	readonly createTerminal: (options: {
-		readonly name: string;
-		readonly cwd: string;
-		readonly env: Readonly<Record<string, string>>;
-	}) => TerminalLike;
 	readonly showInfo: (message: string) => Promise<void>;
 	readonly showError: (message: string) => Promise<void>;
 }
 
-/* v8 ignore start -- thin adapters over vscode.window; every test injects its own */
+/** Options handed to the spawn seam — the minimum this module actually sets. */
+export interface DashboardSpawnOptions {
+	readonly cwd: string;
+	readonly env: NodeJS.ProcessEnv;
+	readonly detached: boolean;
+	readonly stdio: "ignore";
+	/** True only for win32 `.cmd` / `.bat` shims, which need `cmd.exe`. */
+	readonly shell: boolean;
+}
+
+/**
+ * How the spawn happens. Injected so tests never launch a real process. The
+ * return value is minimal on purpose: this module never waits on the child or
+ * reads its output, so there is nothing else to expose.
+ */
+export type DashboardSpawn = (
+	executable: string,
+	args: ReadonlyArray<string>,
+	options: DashboardSpawnOptions,
+) => SpawnedChild;
+
+export interface SpawnedChild {
+	readonly pid: number | undefined;
+	unref(): void;
+	on(event: "error", listener: (err: Error) => void): void;
+	on(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): void;
+}
+
+/* v8 ignore start -- thin adapters over vscode.window and node:child_process */
 function defaultHost(): DashboardLauncherHost {
 	return {
-		createTerminal: (options) => vscode.window.createTerminal(options),
 		showInfo: (message) =>
 			Promise.resolve(vscode.window.showInformationMessage(message)).then(() => undefined),
 		showError: (message) => Promise.resolve(vscode.window.showErrorMessage(message)).then(() => undefined),
 	};
 }
+
+const defaultSpawn: DashboardSpawn = (executable, args, options) =>
+	spawnHidden(executable, [...args], { ...options }) as unknown as SpawnedChild;
 /* v8 ignore stop */
 
 export interface LaunchDashboardOptions {
@@ -480,8 +415,6 @@ export interface LaunchDashboardOptions {
 	readonly host?: DashboardLauncherHost;
 	/** Injected in tests. Defaults to `vscode.env.remoteName`. */
 	readonly remoteName?: string | undefined;
-	/** Injected in tests. Defaults to `vscode.env.shell`. */
-	readonly shell?: string | undefined;
 	/** Injected in tests. Defaults to `process.platform`. */
 	readonly platform?: NodeJS.Platform;
 	/** Injected in tests. Defaults to `process.execPath` (the host's Electron). */
@@ -494,26 +427,30 @@ export interface LaunchDashboardOptions {
 	readonly fileExists?: (path: string) => boolean;
 	/** Injected in tests. Defaults to reading the real dist-paths registry. */
 	readonly globalCliVersion?: string | null | undefined;
+	/** Injected in tests. Defaults to a PATH walk keyed off {@link GLOBAL_BIN_NAME}. */
+	readonly globalCliPath?: string | null | undefined;
+	/** Injected in tests. Defaults to reading the real dist-paths registry. */
+	readonly winningDistCliPath?: string | null | undefined;
 	/** Injected in tests. Defaults to {@link BUNDLED_CLI_VERSION}. */
 	readonly minGlobalCliVersion?: string | undefined;
 	/** Injected in tests. Defaults to `process.env.PATH`. */
 	readonly pathEnv?: string | undefined;
 	/** Injected in tests. Defaults to `process.env.PATHEXT` (win32 only). */
 	readonly pathExt?: string | undefined;
+	/** Injected in tests. Defaults to a real `child_process.spawn`. */
+	readonly spawn?: DashboardSpawn;
 }
 
 /**
- * Opens a new terminal and runs the command in it.
+ * Starts the dashboard as a detached background process.
  *
- * Resolves once the line has been sent — immediately, without waiting for the
- * shell, and certainly without waiting for the command. The command keeps
- * running past that: its output, including the history import that can take
- * minutes, is on screen instead of behind an output channel. Never rejects.
+ * Resolves once the child has been spawned. The child keeps running past that —
+ * `detached: true` + `unref()` means it survives the extension host and the
+ * user closing the window. Its stdio is `"ignore"` so nothing accumulates in
+ * memory here. Never rejects.
  */
 export async function launchDashboard(options: LaunchDashboardOptions): Promise<void> {
 	const host = options.host ?? defaultHost();
-	// Passed straight through: `isRemoteWorkspace` already defaults an absent
-	// argument to `vscode.env.remoteName`.
 	if (isRemoteWorkspace(options.remoteName)) {
 		log.info(TAG, "remote window — not starting a local dashboard server");
 		await host.showInfo(REMOTE_HINT);
@@ -521,75 +458,90 @@ export async function launchDashboard(options: LaunchDashboardOptions): Promise<
 	}
 
 	const platform = options.platform ?? process.platform;
-	const flavor = detectShellFlavor(options.shell ?? vscode.env.shell, platform);
-	// Both reads are cheap and synchronous — two small files from the registry, and
-	// a directory-by-directory existence check. Neither spawns anything, so the
-	// click pays nothing for the extra tier.
+	const ambientWinner =
+		options.globalCliVersion === undefined || options.winningDistCliPath === undefined
+			? readWinningDistEntry()
+			: undefined;
 	const globalCliVersion =
-		options.globalCliVersion !== undefined ? options.globalCliVersion : readWinningGlobalCliVersion();
-	const globalBinOnPath =
-		globalCliVersion !== null &&
-		findExecutableOnPath(GLOBAL_BIN_NAME, {
-			pathEnv: options.pathEnv ?? process.env.PATH,
-			pathExt: options.pathExt ?? process.env.PATHEXT,
-			platform,
-			fileExists: options.fileExists,
-		}) !== null;
+		options.globalCliVersion !== undefined
+			? options.globalCliVersion
+			: ambientWinner?.source === GLOBAL_CLI_SOURCE
+				? ambientWinner.version
+				: null;
+	const globalCliPath =
+		options.globalCliPath !== undefined
+			? options.globalCliPath
+			: globalCliVersion !== null
+				? findExecutableOnPath(GLOBAL_BIN_NAME, {
+						pathEnv: options.pathEnv ?? process.env.PATH,
+						pathExt: options.pathExt ?? process.env.PATHEXT,
+						platform,
+						fileExists: options.fileExists,
+					})
+				: null;
+	const winningDistCliPath =
+		options.winningDistCliPath !== undefined
+			? options.winningDistCliPath
+			: ambientWinner
+				? join(ambientWinner.distDir, CLI_ENTRY_FILE)
+				: undefined;
 	const resolved = resolveDashboardCommand({
 		cwd: options.cwd,
 		distDir: options.distDir,
-		flavor,
+		platform,
 		execPath: options.execPath ?? process.execPath,
 		runCliPath: options.runCliPath,
 		canExecute: options.canExecute,
 		fileExists: options.fileExists,
 		globalCliVersion,
-		globalBinOnPath,
+		globalCliPath,
+		winningDistCliPath,
 		minGlobalCliVersion: options.minGlobalCliVersion,
 	});
 
 	if (resolved === null) {
-		// Every tier unavailable means tier 2's own entry is missing from `dist/`,
-		// since tier 2 has no precondition beyond that. Logged with the path so the
-		// report names the thing that is actually wrong.
-		log.error(TAG, `no CLI entry at ${join(options.distDir, CLI_ENTRY_FILE)} and no usable run-cli`);
+		log.error(
+			TAG,
+			`no usable CLI for the dashboard: no qualifying global jolli, no runnable run-cli, no usable registered dist, and no bundled entry at ${join(options.distDir, CLI_ENTRY_FILE)}`,
+		);
 		await host.showError(UNAVAILABLE_MESSAGE);
 		return;
 	}
 
-	log.info(TAG, `running the dashboard via ${resolved.tier} (${flavor} shell): ${resolved.commandLine}`);
-	// A new terminal every click. Created only now, after resolution succeeded, so a
-	// build that cannot run the dashboard does not leave an empty terminal behind.
-	const terminal = host.createTerminal({ name: TERMINAL_NAME, cwd: options.cwd, env: RUN_AS_NODE_ENV });
-	// Shown before the line is sent so the first output is already visible, and
-	// with focus preserved: the user clicked a button in the sidebar, not in a
-	// terminal, and stealing the cursor to a panel they did not ask for is worse
-	// than making them click once more to type in it.
-	terminal.show(true);
-	// Sent IMMEDIATELY, into a shell that has not started yet. That is deliberate,
-	// and it is the whole of this function's contract: open a terminal, put the
-	// command in it, return. Nothing here waits for the shell, and nothing waits
-	// for `jolli dashboard` — its output arriving later is the point.
-	//
-	// ── DELIBERATE — NOT A REVIEW FINDING ────────────────────────────────────
-	// The known cost is COSMETIC and measured: `createTerminal` only starts a
-	// shell, so these bytes reach a pty still in canonical mode and the line
-	// discipline echoes them — the command appears once, unprefixed, above the
-	// first prompt, and again after it when the shell's line editor redraws the
-	// pending input. One execution, printed twice. (It was effectively invisible
-	// while the launcher reused a terminal, because that shell was already up;
-	// a fresh terminal per click makes it every time.)
-	//
-	// Both fixes for it were IMPLEMENTED, MEASURED and REVERTED, so do not
-	// re-derive them. Waiting for `onDidChangeTerminalShellIntegration` and then
-	// sending does not work at all: that event fires at zsh's `precmd`, BEFORE
-	// the first prompt, which is still inside the echoing window. Waiting and
-	// then sending via `shellIntegration.executeCommand` does fix the echo, but
-	// costs seconds — click-to-CLI-start went from 1.0-3.9 s (13 samples) to
-	// 5.8-8.4 s (3 samples), because `executeCommand` additionally waits for
-	// VS Code's own command detection to confirm a prompt that accepts input.
-	// A double-printed line is worth far less than 4-6 s on every click, and the
-	// product owner made that trade explicitly. Do not reintroduce a wait here.
-	// ─────────────────────────────────────────────────────────────────────────
-	terminal.sendText(resolved.commandLine);
+	const env: NodeJS.ProcessEnv = { ...process.env, [INVOKED_VIA_ENV_KEY]: INVOKED_VIA_VALUE };
+	if (resolved.runAsNode) {
+		env[RUN_AS_NODE_ENV_KEY] = "1";
+	}
+
+	const displayArgv = [resolved.executable, ...resolved.args]
+		.map((part) => (part.includes(" ") ? `"${part}"` : part))
+		.join(" ");
+	log.info(TAG, `launching dashboard in background via ${resolved.tier}: ${displayArgv}`);
+	const spawn = options.spawn ?? defaultSpawn;
+	try {
+		const child = spawn(resolved.executable, resolved.args, {
+			cwd: options.cwd,
+			env,
+			detached: true,
+			stdio: "ignore",
+			shell: resolved.shell,
+		});
+		child.on("error", (err) => {
+			log.error(TAG, `dashboard child spawn error: ${err.message}`);
+			void host.showError(SPAWN_FAILED_MESSAGE);
+		});
+		child.on("exit", (code) => {
+			if (resolved.tier === "global-jolli" && code === 127) {
+				log.error(
+					TAG,
+					"global jolli exited 127 before opening the dashboard — tier 0 inherits this process's PATH snapshot, so a missing `node` on a GUI-launched host is the likely cause",
+				);
+			}
+		});
+		child.unref();
+		log.info(TAG, `dashboard child spawned pid=${child.pid ?? "?"}`);
+	} catch (err) {
+		log.error(TAG, `failed to spawn dashboard child: ${err instanceof Error ? err.message : String(err)}`);
+		await host.showError(SPAWN_FAILED_MESSAGE);
+	}
 }


### PR DESCRIPTION
## Summary

The branch-footer dashboard button used to type `jolli dashboard` into a fresh integrated terminal on every click. It now spawns the CLI as a detached background process (stdio ignored, unref'd) — the same shape the Claude Code plugin's dashboard skill already uses — and lets the CLI open the browser itself. The CLI's existing port reclaim (1818 / 18118) means a second click ends the first server and takes over.

## CLI selection

The three-tier order is unchanged, but tier 2 is now registry-aware, mirroring the shipped MCP launcher (`resolveMcpCli`):

- **Tier 0:** global `jolli` on PATH, version-gated (unchanged)
- **Tier 1:** `~/.jolli/jollimemory/run-cli`, POSIX-only (unchanged)
- **Tier 2:** the highest available registered dist's `Cli.js`, run by the host's Node (`ELECTRON_RUN_AS_NODE=1`), falling back to the bundled `dist/Cli.js` when the winner's file is missing or nothing is registered

On Windows (where run-cli cannot be spawned), this stops the button from freezing on the bundled CLI when a newer dist is registered by another plugin surface — the same result the other surfaces get through run-cli on POSIX.

## Windows fixes found in review

- A global CLI `.cmd`/`.bat` shim is now spawned through cmd.exe (`shell: true`) with a shell-metacharacter guard, instead of being handed to `spawn` directly (EINVAL since the CVE-2024-27980 fix).
- Asynchronous spawn errors now surface a user-visible message box instead of being logged only.
- `JOLLI_INVOKED_VIA=vscode:dashboard-button` is documented as a process marker only: the CLI's telemetry `via` validator accepts `skill:` values, so this value never reaches telemetry.

## Testing

- `npm run all` passes (clean → build → typecheck → lint → test); coverage is above the 97% thresholds (statements 98.89%, branches 97.36%, functions 98.28%, lines 99.06%).
- DashboardLauncher tests grew from 45 to 63, covering the registry-aware tier, win32 shim handling, fallbacks, and async-error UX.
- Caveat: the Windows spawn path cannot be exercised on this machine (macOS); the decision logic is unit-pinned and mirrors the shipped `McpLauncher` / `McpRegistration` precedent.
