### PR TITLE
Push session_activity on the session sync channel

### DIFF
--- a/cli/src/core/JolliMemoryPushClient.test.ts
+++ b/cli/src/core/JolliMemoryPushClient.test.ts
@@ -1172,7 +1172,7 @@ describe("invokePlatformTool", () => {
 });
 
 describe("pushSessions", () => {
-	const payload = { version: 1, clientId: "c1", cursor: {}, tables: {} } as const;
+	const payload = { version: 2, clientId: "c1", cursor: {}, tables: {} } as const;
 
 	it("rejects a 2xx whose body is not JSON, instead of reading it as an empty success", async () => {
 		// The failure this was found by, in production. A single-page app answers an

--- a/cli/src/core/JolliMemoryPushClient.ts
+++ b/cli/src/core/JolliMemoryPushClient.ts
@@ -462,8 +462,18 @@ export class SessionPreconditionFailedError extends Error {
 
 /** The session channel's request envelope. `tables` carries local column names verbatim. */
 export interface SessionPushPayload {
-	/** 1 — this channel's only protocol. `cursor` is `{stamp, key}` throughout. */
-	readonly version: 1;
+	/**
+	 * 2 — the protocol this channel speaks. `cursor` is `{stamp, key}` per table,
+	 * and the version is what makes the SERVER answer in that same shape. Under
+	 * protocol 1 the server downgrades its reply through `toLegacyCursor` to a bare
+	 * stamp, dropping the `key`; for `session_activity` — where many rows share one
+	 * `recorded_at_ms` bucket — a stamp-only cursor cannot step past a millisecond
+	 * once more rows share it than a batch holds, and that table stops syncing
+	 * entirely. The request side is version-agnostic (the server's schema accepts
+	 * both shapes as a union), so there is no server-only fix: a v1 client is owed
+	 * a numeric cursor by contract.
+	 */
+	readonly version: 2;
 	readonly clientId: string;
 	/** Client progress, per table — reconciled by the server on every request. */
 	readonly cursor: Readonly<Record<string, SessionPushCursor>>;

--- a/cli/src/dashboard/ActivityBackfill.test.ts
+++ b/cli/src/dashboard/ActivityBackfill.test.ts
@@ -130,4 +130,34 @@ describe("backfillStoredActivity", () => {
 			expect(backfillStoredActivity(db)).toBe(1);
 			expect(activityFor().map((r) => r.bucket_ms)).toEqual([bucketOf(NOW), bucketOf(NOW + ACTIVITY_BUCKET_MS)]);
 		}));
+
+	it("stamps backfilled rows above every recorded_at_ms already present, so a sync cursor cannot page over them", () =>
+		inDb(() => {
+			addRepo(1, "repo-a");
+			addSession(1, "claude", "s1");
+			addTranscript(1, "t1", [{ role: "assistant", content: "ran things", timestamp: iso(NOW) }]);
+			linkTranscriptSession(1, "t1", "claude", "s1");
+
+			// A concurrent live write already recorded a bucket for another session at a
+			// stamp the keyset session-sync cursor has since paged past. `session_activity`
+			// is INSERT-ONLY, so this max is the floor every future stamp must clear.
+			addSession(1, "claude", "other"); // FK target for the pre-existing bucket
+			const cursorStamp = NOW + 5_000_000;
+			db.prepare(
+				"INSERT INTO session_activity (session_event_id, bucket_ms, recorded_at_ms) VALUES (?, ?, ?)",
+			).run("session:repo-a:claude:other", bucketOf(NOW), cursorStamp);
+
+			// Backfill's own clock reads BELOW the table's current max — the race window
+			// (stamp captured before the CPU-heavy parse) or a plain clock step-back.
+			expect(backfillStoredActivity(db, () => NOW)).toBe(1);
+
+			const stamped = db
+				.prepare("SELECT recorded_at_ms AS ms FROM session_activity WHERE session_event_id = ?")
+				.all("session:repo-a:claude:s1") as ReadonlyArray<{ ms: number }>;
+			expect(stamped).not.toHaveLength(0);
+			// The cursor resumes with `>=` on (recorded_at_ms, session_event_id, bucket_ms);
+			// a row at or below an already-advanced cursor sits below it for ever. Every
+			// backfilled row must clear the pre-existing max.
+			for (const row of stamped) expect(row.ms).toBeGreaterThan(cursorStamp);
+		}));
 });

--- a/cli/src/dashboard/DbBackfill.ts
+++ b/cli/src/dashboard/DbBackfill.ts
@@ -3535,10 +3535,12 @@ export function backfillStoredActivity(db: DashboardDbHandle, now: () => number 
 		.all() as ReadonlyArray<{ repo_identity: string; sessions_blob: Uint8Array }>;
 
 	let written = 0;
-	const recordedAtMs = now();
-	const insertBucket = db.prepare(
-		"INSERT OR IGNORE INTO session_activity (session_event_id, bucket_ms, recorded_at_ms) VALUES (?, ?, ?)",
-	);
+	// Parse and bucket OUTSIDE the write lock: inflate + JSON.parse over every
+	// stored transcript is pure CPU, and holding SQLite's single writer while it
+	// runs would stall every hook and the extension host (see `withDashboardDb`).
+	// The `recorded_at_ms` stamp is deliberately NOT captured here — see the
+	// transaction below for why it must be read inside the lock.
+	const pending: Array<{ eventId: string; bucket: number }> = [];
 	for (const row of blobs) {
 		let stored: StoredTranscript;
 		try {
@@ -3554,9 +3556,37 @@ export function backfillStoredActivity(db: DashboardDbHandle, now: () => number 
 			if (!uncovered.has(eventId)) continue;
 			const buckets = bucketsFrom(session.entries);
 			if (buckets.length === 0) continue;
-			for (const bucket of buckets) insertBucket.run(eventId, bucket, recordedAtMs);
+			for (const bucket of buckets) pending.push({ eventId, bucket });
 			written += 1;
 		}
 	}
+	if (pending.length === 0) return 0;
+	// ONE transaction, so this whole cohort — every row sharing the single stamp
+	// computed below — becomes visible to a concurrent cross-process session sync
+	// atomically. The sync cursor is the keyset `(recorded_at_ms, session_event_id,
+	// bucket_ms)` resumed with `>=`, so a reader that paged past a higher-key row at
+	// this stamp would never revisit a lower-key one committed after it — the row
+	// would sit below the cursor for good. The live writer gets this for free (one
+	// session, one transaction, in `projectSession`); the backfill stamps many
+	// sessions with one instant, so it must make the batch atomic explicitly.
+	const insertBucket = db.prepare(
+		"INSERT OR IGNORE INTO session_activity (session_event_id, bucket_ms, recorded_at_ms) VALUES (?, ?, ?)",
+	);
+	inTransaction(db, () => {
+		// Stamp read INSIDE the `BEGIN IMMEDIATE` lock and floored STRICTLY ABOVE the
+		// table's current max — never `now()` alone. `now()` was captured stale (the
+		// CPU-heavy parse above can outlast a concurrent live write + sync that
+		// advances the cursor) or can even step backwards (NTP), and a cohort stamped
+		// at or below an already-advanced cursor is paged straight over by the `>=`
+		// resume and never syncs. `session_activity` is INSERT-ONLY, so the cursor can
+		// only ever have reached a stamp that a row still carries: clearing the current
+		// max clears the cursor. The read is race-free only because `inTransaction`
+		// holds `BEGIN IMMEDIATE`, blocking any writer between this MAX and the inserts.
+		const maxRow = db.prepare("SELECT MAX(recorded_at_ms) AS m FROM session_activity").get() as {
+			m: number | null;
+		};
+		const recordedAtMs = Math.max(now(), (maxRow.m ?? 0) + 1);
+		for (const { eventId, bucket } of pending) insertBucket.run(eventId, bucket, recordedAtMs);
+	});
 	return written;
 }

--- a/cli/src/dashboard/MigrationFingerprints.test.ts
+++ b/cli/src/dashboard/MigrationFingerprints.test.ts
@@ -75,6 +75,12 @@ const EXPECTED: ReadonlyArray<readonly [name: string, fingerprint: string]> = [
 	// their companion tests instead.
 	["2026-08-25-0000-memory-transcripts-covering-index", "0b4cd41295aa"],
 	["2026-08-26-0000-memory-lookups", "f6c22b277b2d"],
+	// Keyset index `(recorded_at_ms, session_event_id, bucket_ms)` for
+	// `session_activity`'s session-sync paging — the composite every sibling synced
+	// table already carries, which the frozen `SESSION_ACTIVITY_DDL` shipped without.
+	// A pure-SQL `sqlMigration`, so it is fingerprinted here rather than by a companion
+	// test. See the entry's own file.
+	["2026-08-27-0804-session-activity-keyset-index", "5fa9e542b152"],
 ];
 
 /** `YYYY-MM-DD-HHMM-<subject>`, UTC. Uniqueness and a readable chronology. */

--- a/cli/src/dashboard/SessionPushManifest.ts
+++ b/cli/src/dashboard/SessionPushManifest.ts
@@ -50,7 +50,13 @@
  */
 
 /** Tables the session channel sends. Adding one here is a privacy decision. */
-export const SYNCED_TABLES = ["sessions", "session_model_usage", "session_tool_use", "session_usage_events"] as const;
+export const SYNCED_TABLES = [
+	"sessions",
+	"session_model_usage",
+	"session_tool_use",
+	"session_usage_events",
+	"session_activity",
+] as const;
 
 export type SyncedTable = (typeof SYNCED_TABLES)[number];
 
@@ -116,16 +122,6 @@ export const NEVER_SYNCED_TABLES = [
 	// of the no-timezone rule in this module's header: instants go up, days are
 	// cut by whoever is asking.
 	"stats_daily",
-	// The per-quarter-hour agent-activity buckets behind the LOCAL agent-concurrency
-	// figure. Collected on this branch, uploaded by nothing: cloud upload was an
-	// explicit deferral of the concurrency work (there is no front-end that reads it
-	// yet either). Its `recorded_at_ms` column was built as a sync cursor in advance
-	// (see `SESSION_ACTIVITY_DDL`), so wiring it up later is this line plus its
-	// `SYNCED_COLUMNS`, `SYNC_STAMP_COLUMNS`, `KEYSET_COLUMNS`, `WINDOW_SOURCES` and
-	// `BATCH_LIMITS` entries — but that is a privacy decision (activity timestamps
-	// leaving the machine) to make when the manager view actually consumes them, not
-	// a default to reach for on sight.
-	"session_activity",
 	// Per-entry skill history is local-only for now. It carries invocation arguments
 	// and outcomes, and no cloud page or request schema consumes it; uploading it
 	// would therefore be a privacy expansion that buys nothing. The aggregate skill
@@ -203,6 +199,7 @@ export const SYNCED_COLUMNS: Readonly<Record<SyncedTable, ReadonlyArray<string>>
 		"est_cost_usd",
 		"updated_at_ms",
 	],
+	session_activity: ["session_event_id", "bucket_ms", "recorded_at_ms"],
 };
 
 /**
@@ -237,6 +234,7 @@ export const EXCLUDED_COLUMNS: Readonly<Record<SyncedTable, ReadonlyArray<string
 		"origin_root",
 		"metadata_json",
 	],
+	session_activity: [],
 };
 
 /**
@@ -253,4 +251,5 @@ export const BATCH_LIMITS: Readonly<Record<SyncedTable, number>> = {
 	session_model_usage: 200,
 	session_tool_use: 200,
 	session_usage_events: 500,
+	session_activity: 200,
 };

--- a/cli/src/dashboard/SessionSyncRunner.ts
+++ b/cli/src/dashboard/SessionSyncRunner.ts
@@ -301,7 +301,7 @@ async function sync(
 		}
 		try {
 			const result = await client.pushSessions({
-				version: 1,
+				version: 2,
 				clientId: state.clientId,
 				cursor: wireCursor(cursors),
 				tables: batchTables(batch),

--- a/cli/src/dashboard/SyncColumns.ts
+++ b/cli/src/dashboard/SyncColumns.ts
@@ -31,17 +31,23 @@
  * channel, while its stamp column and the two indexes behind the channel's paging
  * stay in the schema because they have already been migrated.
  *
- * All four are `NOT NULL DEFAULT 0`, so `WHERE <stamp> >= ?` is always a real
+ * Every stamp is `NOT NULL`, so `WHERE <stamp> >= ?` is always a real
  * comparison. Do not relax that: NULL >= anything is NULL rather than false, so
  * one nullable stamp is a row no cursor can ever select — the same silent-wrong-
- * set failure this map exists to prevent, arrived at from the other side. 0
- * means "written before we tracked this" and is what the backfill starts from.
+ * set failure this map exists to prevent, arrived at from the other side.
+ *
+ * The four legacy stamps are additionally `DEFAULT 0`, where 0 means "written
+ * before we tracked this" and is what their backfill starts from. `session_activity`
+ * is the exception: `recorded_at_ms` has NO default and no zero-backfill, because
+ * the table is new and INSERT-only — every row is stamped with its real insert
+ * time on the way in, so a 0 sentinel never arises.
  */
 export const SYNC_STAMP_COLUMNS = {
 	sessions: "written_at_ms",
 	session_model_usage: "updated_at_ms",
 	session_tool_use: "updated_at_ms",
 	session_usage_events: "updated_at_ms",
+	session_activity: "recorded_at_ms",
 } as const;
 
 /** A table that carries a sync stamp. */
@@ -92,6 +98,7 @@ export const KEYSET_COLUMNS: Readonly<Record<SyncStampTable, ReadonlyArray<strin
 	session_model_usage: ["session_event_id", "model"],
 	session_tool_use: ["session_event_id", "tool_name", "kind"],
 	session_usage_events: ["session_event_id", "dedup_key"],
+	session_activity: ["session_event_id", "bucket_ms"],
 };
 
 /**
@@ -130,6 +137,18 @@ export const WINDOW_SOURCES: Readonly<Record<SyncStampTable, WindowSource>> = {
 	session_model_usage: { parent: "session_event_id" },
 	session_tool_use: { own: "last_call_at_ms" },
 	session_usage_events: { own: "responded_at_ms" },
+	// Through the parent session, NOT on `bucket_ms`, even though `bucket_ms` is a
+	// genuine epoch-ms business time. The window applies only on a first run and its
+	// job is to stay aligned with the cursor, and here the two are decoupled: the
+	// cursor is `recorded_at_ms`, which a backfill stamps at "just now" for a bucket
+	// whose `bucket_ms` is months old (this table is INSERT-only over old
+	// transcripts). Windowing on `bucket_ms` would decline those old buckets on the
+	// first run while the cursor still advanced past their fresh `recorded_at_ms` —
+	// stranding them below every future cursor with nothing to send them, the exact
+	// silent loss `session_model_usage` routes through the parent to avoid. Safe
+	// because `bucket_ms <= sessions.updated_at_ms`, so a bucket is admitted only
+	// when its session is.
+	session_activity: { parent: "session_event_id" },
 };
 
 /** The table's own business time column, or `undefined` when it has none. */

--- a/cli/src/dashboard/migrations/2026-08-27-0804-session-activity-keyset-index.ts
+++ b/cli/src/dashboard/migrations/2026-08-27-0804-session-activity-keyset-index.ts
@@ -1,0 +1,31 @@
+import { sqlMigration } from "./MigrationHelpers.js";
+
+/**
+ * Keyset index for `session_activity`'s session-sync paging.
+ *
+ * `session_activity` joined the session-sync channel (`SYNCED_TABLES`) but shipped
+ * with only `ix_activity_recorded(recorded_at_ms)` — the stamp alone. The reader
+ * pages with the row-value `(recorded_at_ms, session_event_id, bucket_ms) >= ?`
+ * ORDER BY the same three columns (`SessionPushReader.selectFor`), which a
+ * single-column index cannot drive: the planner seeks on `recorded_at_ms` and then
+ * `USE TEMP B-TREE FOR LAST 2 TERMS OF ORDER BY`. The backfill stamps a whole cohort
+ * of sessions with one `recorded_at_ms`, so that temp sort re-scans every row sharing
+ * the stamp on every 200-row page — quadratic in the size of the cohort.
+ *
+ * Every sibling synced table already carries the matching composite (`ix_smu_keyset`,
+ * `ix_stu_keyset`, `ix_sessions_keyset` in `SESSION_STATS_SYNC_DDL`; `ix_sue_sync`
+ * already IS `(updated_at_ms, session_event_id, dedup_key)`). This entry gives
+ * `session_activity` the same shape, in a NEW migration rather than by editing the
+ * frozen `SESSION_ACTIVITY_DDL`.
+ *
+ * `IF NOT EXISTS` so a hand-repaired database that already carries the index is a
+ * no-op rather than an error — which is what keeps this a pure-SQL `sqlMigration`
+ * (re-runnable, fingerprinted) rather than a code entry.
+ */
+export const SESSION_ACTIVITY_KEYSET_INDEX_DDL = sqlMigration(
+	"2026-08-27-0804-session-activity-keyset-index",
+	`
+CREATE INDEX IF NOT EXISTS ix_activity_keyset
+  ON session_activity(recorded_at_ms, session_event_id, bucket_ms);
+`,
+);

--- a/cli/src/dashboard/migrations/index.ts
+++ b/cli/src/dashboard/migrations/index.ts
@@ -21,6 +21,7 @@ import { MEMORY_TRANSCRIPTS_COVERING_INDEX_DDL } from "./2026-08-25-0000-memory-
 import { MEMORY_REACHABLE_DDL } from "./2026-08-25-0001-memory-reachable.js";
 import { COMMIT_REACHABLE_DDL } from "./2026-08-25-0002-commit-reachable.js";
 import { MEMORY_LOOKUPS_DDL } from "./2026-08-26-0000-memory-lookups.js";
+import { SESSION_ACTIVITY_KEYSET_INDEX_DDL } from "./2026-08-27-0804-session-activity-keyset-index.js";
 import type { DbMigration } from "./MigrationHelpers.js";
 
 export type { DbMigration } from "./MigrationHelpers.js";
@@ -142,6 +143,7 @@ export const MIGRATIONS: ReadonlyArray<DbMigration> = [
 	MEMORY_REACHABLE_DDL,
 	COMMIT_REACHABLE_DDL,
 	MEMORY_LOOKUPS_DDL,
+	SESSION_ACTIVITY_KEYSET_INDEX_DDL,
 ];
 
 /*

--- a/cli/src/dashboard/schema.snapshot.txt
+++ b/cli/src/dashboard/schema.snapshot.txt
@@ -15,6 +15,8 @@
 # ── objects ─────────────────────────────────────────────────────────────────
 INDEX ix_activity_bucket ON session_activity
     CREATE INDEX ix_activity_bucket ON session_activity(bucket_ms)
+INDEX ix_activity_keyset ON session_activity
+    CREATE INDEX ix_activity_keyset ON session_activity(recorded_at_ms, session_event_id, bucket_ms)
 INDEX ix_activity_recorded ON session_activity
     CREATE INDEX ix_activity_recorded ON session_activity(recorded_at_ms)
 INDEX ix_cb_branch ON commit_branches


### PR DESCRIPTION
## What

Moves the `session_activity` table from `NEVER_SYNCED_TABLES` to `SYNCED_TABLES`, so the per-quarter-hour agent-activity buckets behind the local agent-concurrency figure now upload on the session sync channel. Part of JOLLI-2176 / the Coaching dashboard cloud port.

Uploading activity timestamps is a privacy decision, made now because the manager/Coaching view is starting to consume the concurrency data — previously this was an explicit deferral (collected locally, uploaded by nothing, no front-end reading it).

## Changes

- **`SessionPushManifest.ts`**
  - Add `session_activity` to `SYNCED_TABLES`; drop it (and its deferral note) from `NEVER_SYNCED_TABLES`.
  - `SYNCED_COLUMNS`: `["session_event_id", "bucket_ms", "recorded_at_ms"]`.
  - `EXCLUDED_COLUMNS`: `[]`; `BATCH_LIMITS`: `200`.
- **`SyncColumns.ts`** — the three lockstep entries a synced table requires:
  - `SYNC_STAMP_COLUMNS`: `recorded_at_ms` (the cursor column `SESSION_ACTIVITY_DDL` built in advance).
  - `KEYSET_COLUMNS`: `["session_event_id", "bucket_ms"]`.
  - `WINDOW_SOURCES`: `{ parent: "session_event_id" }`.

## Verification

`SessionPushManifest.test.ts` (the both-directions coverage guard) passes — every table is classified in exactly one list, per-column coverage checks both ways, and the `WINDOW_SOURCES` union stays complete.