### PR TITLE
Add session_turns projection + sync + historical backfill

### DIFF
--- a/cli/src/commands/DoctorCommand.test.ts
+++ b/cli/src/commands/DoctorCommand.test.ts
@@ -1447,7 +1447,10 @@ describe("doctor --sync-sessions", () => {
 			held: { rows: 200, tables: ["memory_lookups"] },
 		});
 		expect(out).not.toContain("up to date");
-		expect(out).toContain("Uploaded 0 row(s)");
+		// No "Uploaded 0 row(s)" summary either: nothing was stored, so a "✓ Uploaded"
+		// line would read as a success for a run that uploaded nothing. The held line
+		// carries this case alone.
+		expect(out).not.toContain("Uploaded");
 		// Named, not just counted. Backend-first deployment is the policy, so this
 		// line prints only when that policy broke — and then the table is the one
 		// thing a reader can act on, because it says which deploy is behind.

--- a/cli/src/commands/DoctorCommand.ts
+++ b/cli/src/commands/DoctorCommand.ts
@@ -1165,17 +1165,18 @@ export async function runSessionSyncNow(): Promise<void> {
 	// the user typed this in, if it is one of them.
 	const outcome = await runSessionSync({ force: true });
 	if (outcome.status === "done") {
-		console.log(
-			outcome.rows === 0 && outcome.held.rows === 0
-				? "✓ Session statistics are up to date — nothing new to upload."
-				: `✓ Uploaded ${outcome.rows} row(s) in ${outcome.batches} batch(es).`,
-		);
-		// ⚠ Its own line, and part of the branch above. Held rows were offered and
-		// stored nowhere, so adding them to `rows` would print the one failure the
-		// channel cannot report on its own as an upload — and with `rows` at 0 the
-		// first branch would call a machine that uploaded nothing up to date.
+		if (outcome.rows > 0) {
+			console.log(`✓ Uploaded ${outcome.rows} row(s) in ${outcome.batches} batch(es).`);
+		} else if (outcome.held.rows === 0) {
+			console.log("✓ Session statistics are up to date — nothing new to upload.");
+		}
+		// The remaining case — nothing uploaded but rows held — prints no summary
+		// line above: "Uploaded 0 row(s)" reads as a success for a run that stored
+		// nothing, and "up to date" is false while rows sit queued. Held rows are
+		// offered and stored nowhere, so they are never folded into `rows`; the held
+		// line below carries this case alone.
 		//
-		// It NAMES the tables. Backend-first deployment is the policy here, so this
+		// ⚠ It NAMES the tables. Backend-first deployment is the policy here, so this
 		// line only ever prints when that policy was broken — and then the table is
 		// the one thing a reader can act on, because it says which deploy is behind.
 		if (outcome.held.rows > 0) {

--- a/cli/src/dashboard/DbBackfill.ts
+++ b/cli/src/dashboard/DbBackfill.ts
@@ -78,6 +78,7 @@ import {
 	type RegisteredRepo,
 	readRepoCutoverFence,
 } from "./RepoRegistry.js";
+import { projectSessionTurns, type SessionTurnInput, uncoveredSessionsForSlice } from "./SessionTurnsProjection.js";
 import {
 	countMemoriesAbsentFromListing,
 	EMPTY_IMPORT_RESULT,
@@ -2850,6 +2851,19 @@ export async function dbBackfillRepos(
 	} catch (err) {
 		log.warn("activity backfill failed: %s", errMsg(err));
 	}
+	// Route A': the `session_turns` sibling of the activity backfill above — same
+	// shape (persisted transcripts, whole DB once, after every repo is imported so
+	// the sessions rows these turns hang off already exist), same idempotence, same
+	// warn-not-fail policy. Kept a separate open so one failing backfill cannot mask
+	// the other.
+	try {
+		const rows = await withDashboardDb((db) => backfillStoredSessionTurns(db), {
+			...(rest.dbPath ? { dbPath: rest.dbPath } : {}),
+		});
+		if (rows > 0) log.info("backfilled %d session-turn rows from stored transcripts", rows);
+	} catch (err) {
+		log.warn("session-turns backfill failed: %s", errMsg(err));
+	}
 	// Appended, not prepended: a caller reading the list in order should see the
 	// repos that were worked on first, and these carry no per-repo detail to
 	// interleave with them.
@@ -3589,4 +3603,129 @@ export function backfillStoredActivity(db: DashboardDbHandle, now: () => number 
 		for (const { eventId, bucket } of pending) insertBucket.run(eventId, bucket, recordedAtMs);
 	});
 	return written;
+}
+
+/**
+ * Reprojects `session_turns` for stored transcripts that carry none — the
+ * `session_turns` sibling of {@link backfillStoredActivity}, and needed for the
+ * same reason: the migration only creates the empty table, and the live writer
+ * ({@link projectSessionTurns}, called from `SotWrite`/`SotImport`) fires only
+ * when a transcript is (re)written, so every transcript persisted BEFORE this
+ * table existed has no turns until something happens to rewrite it.
+ *
+ * Reads the SUMMARY PIPELINE's persisted `transcripts.sessions_blob` (never the
+ * live 7-day discovery window) and hands each blob's sessions straight to
+ * {@link projectSessionTurns}, the SOLE writer of this table — no private copy
+ * of the projection rule, so a backfilled row cannot drift from a live one.
+ *
+ * Coverage is per `(session_event_id, slice_id)`, NOT per session: `slice_id` is
+ * the transcript id and one session can span several transcripts, so a
+ * per-session "already has turns" test would wrongly skip a slice it is missing.
+ * A transcript is selected when it has a resolvable session (`transcript_sessions
+ * ⋈ sessions`, the same join {@link backfillStoredActivity} uses) that carries NO
+ * `session_turns` row for this slice. Scoping through `sessions` is what
+ * disambiguates two repos sharing a commit hash: `session_turns` has no
+ * `repo_id`, only `session_event_id`, which encodes the repo identity.
+ *
+ * Idempotent, and inserts only: a blob is SELECTED when any of its sessions is
+ * uncovered, but it can carry already-covered sessions too, so each blob is
+ * narrowed by {@link uncoveredSessionsForSlice} before projection — otherwise
+ * `projectSessionTurns`' delete-then-insert would rewrite covered rows with this
+ * run's fresh, higher `recorded_at_ms` and re-upload them. A transcript whose
+ * session resolves but projects zero rows (no entries and no instants — a shape a
+ * stored session essentially never has) stays selected and is re-parsed each run;
+ * it inserts nothing, so the returned count is still 0 and the pass reads as
+ * converged.
+ *
+ * @returns how many `session_turns` rows this run inserted (0 once converged).
+ */
+export function backfillStoredSessionTurns(db: DashboardDbHandle, now: () => number = Date.now): number {
+	const blobs = db
+		.prepare(
+			// `COALESCE(ts.source, 'claude')`, NOT a bare `s.source = ts.source`: a
+			// legacy session persisted before `source` was recorded is a NULL in
+			// `transcript_sessions` (SotImport writes `session.source ?? null`) but a
+			// `claude` row in `sessions`, and `'claude' = NULL` is never true — so the
+			// bare equality never selected those blobs and their archived turns stayed
+			// unbackfilled. This mirrors `eventIdFor`'s `session.source ?? "claude"`, so
+			// selection and projection agree on the same legacy default. (The
+			// `session_activity` sibling instead skips sourceless sessions outright in
+			// its per-session loop, so it needs no such coalescing.)
+			`SELECT DISTINCT t.repo_id AS repo_id, t.transcript_id AS transcript_id, t.sessions_blob AS sessions_blob
+			   FROM transcripts t
+			   JOIN transcript_sessions ts ON ts.repo_id = t.repo_id AND ts.transcript_id = t.transcript_id
+			   JOIN sessions s ON s.repo_id = ts.repo_id
+			                  AND s.source = COALESCE(ts.source, 'claude')
+			                  AND s.session_id = ts.session_id
+			  WHERE NOT EXISTS (
+			    SELECT 1 FROM session_turns st
+			     WHERE st.session_event_id = s.event_id AND st.slice_id = t.transcript_id
+			  )`,
+		)
+		.all() as ReadonlyArray<{ repo_id: number; transcript_id: string; sessions_blob: Uint8Array }>;
+	if (blobs.length === 0) return 0;
+
+	// Parse OUTSIDE the write lock: inflate + JSON.parse over every stored
+	// transcript is pure CPU, and holding SQLite's single writer while it runs
+	// would stall every hook and the extension host (see backfillStoredActivity).
+	// Holds only what `projectSessionTurns` reads (`SessionTurnInput`), NOT the full
+	// `StoredSession`: every parsed blob lives in `pending` until the one transaction
+	// below commits, so keeping each entry's `content` here would hold the whole
+	// inflated corpus at once — hundreds of MB on a transcript-heavy machine. The
+	// `session_activity` sibling avoids this by pending bare `{eventId, bucket}`
+	// tuples; turns need one row per entry, so the minimum is `{role, timestamp}`.
+	const pending: Array<{
+		repoId: number;
+		transcriptId: string;
+		sessions: ReadonlyArray<SessionTurnInput>;
+	}> = [];
+	for (const row of blobs) {
+		let stored: StoredTranscript;
+		try {
+			stored = JSON.parse(inflateSync(Buffer.from(row.sessions_blob)).toString("utf8")) as StoredTranscript;
+		} catch {
+			// One unreadable blob is one unbackfilled transcript, never a failed run.
+			log.warn("session-turns backfill: unreadable transcript %s", row.transcript_id);
+			continue;
+		}
+		// Project down to `SessionTurnInput` HERE, dropping `content`, so the inflated
+		// JSON string and its parsed object are both eligible for GC before the next blob.
+		const sessions: SessionTurnInput[] = (stored.sessions ?? []).map((s) => ({
+			sessionId: s.sessionId,
+			...(s.source !== undefined ? { source: s.source } : {}),
+			entries: (s.entries ?? []).map((e) => ({
+				role: e.role,
+				...(e.timestamp !== undefined ? { timestamp: e.timestamp } : {}),
+			})),
+			...(s.compactions !== undefined ? { compactions: s.compactions } : {}),
+			...(s.turnAborts !== undefined ? { turnAborts: s.turnAborts } : {}),
+			...(s.testRuns !== undefined ? { testRuns: s.testRuns } : {}),
+		}));
+		pending.push({ repoId: row.repo_id, transcriptId: row.transcript_id, sessions });
+	}
+	if (pending.length === 0) return 0;
+
+	// ONE transaction sharing ONE stamp floored STRICTLY ABOVE the table's current
+	// max — the identical sync-cursor invariant backfillStoredActivity documents:
+	// `recorded_at_ms` is the session-sync keyset cursor, resumed with `>=`, so a
+	// cohort stamped at or below an already-advanced cursor is paged straight over
+	// and never syncs. `projectSessionTurns` stamps every row it writes with the
+	// `nowMs` we pass, so the floored stamp is computed here and threaded in. The
+	// cohort is uncovered by construction (pure inserts), so — like
+	// `session_activity` — clearing the current max clears the reachable cursor.
+	return inTransaction(db, () => {
+		const before = (db.prepare("SELECT count(*) AS c FROM session_turns").get() as { c: number }).c;
+		const maxRow = db.prepare("SELECT MAX(recorded_at_ms) AS m FROM session_turns").get() as { m: number | null };
+		const recordedAtMs = Math.max(now(), (maxRow.m ?? 0) + 1);
+		for (const { repoId, transcriptId, sessions } of pending) {
+			// Only the sessions in this blob that are actually missing turns — a blob
+			// is selected when ANY of its sessions is uncovered, and re-projecting the
+			// already-covered ones would re-stamp their rows with `recordedAtMs` and
+			// re-upload them. Filtering keeps the "inserts only" invariant true.
+			const uncovered = uncoveredSessionsForSlice(db, repoId, transcriptId, sessions);
+			if (uncovered.length > 0) projectSessionTurns(db, repoId, transcriptId, uncovered, recordedAtMs);
+		}
+		const after = (db.prepare("SELECT count(*) AS c FROM session_turns").get() as { c: number }).c;
+		return after - before;
+	});
 }

--- a/cli/src/dashboard/MigrationFingerprints.test.ts
+++ b/cli/src/dashboard/MigrationFingerprints.test.ts
@@ -81,6 +81,17 @@ const EXPECTED: ReadonlyArray<readonly [name: string, fingerprint: string]> = [
 	// A pure-SQL `sqlMigration`, so it is fingerprinted here rather than by a companion
 	// test. See the entry's own file.
 	["2026-08-27-0804-session-activity-keyset-index", "5fa9e542b152"],
+	// Text-free per-turn projection `session_turns` — the web coaching dashboard's
+	// transcript-derived signal source (waits, attribution, compactions, friction,
+	// test-first). A pure-SQL `sqlMigration`, so it is fingerprinted here rather than
+	// by a companion test; the projector `SessionTurnsProjection.ts` has its own test.
+	["2026-08-27-0824-session-turns", "99915a11bc45"],
+	// Keyset index for `session_turns`' session-sync paging — the composite the
+	// reader's `(recorded_at_ms, session_event_id, slice_id, seq)` cursor needs and
+	// the frozen `SESSION_TURNS_DDL`'s primary key cannot drive (it does not lead
+	// with `recorded_at_ms`). The `session_turns` sibling of the `session_activity`
+	// keyset entry above; a pure-SQL `sqlMigration`, so fingerprinted here.
+	["2026-08-28-0516-session-turns-keyset-index", "b86033388ec4"],
 ];
 
 /** `YYYY-MM-DD-HHMM-<subject>`, UTC. Uniqueness and a readable chronology. */

--- a/cli/src/dashboard/SessionPushManifest.ts
+++ b/cli/src/dashboard/SessionPushManifest.ts
@@ -64,6 +64,7 @@ export const SYNCED_TABLES = [
 	// release that started sending it; that disclosure is the consent mechanism and
 	// cannot lag a version behind.
 	"memory_lookups",
+	"session_turns",
 ] as const;
 
 export type SyncedTable = (typeof SYNCED_TABLES)[number];
@@ -212,6 +213,7 @@ export const SYNCED_COLUMNS: Readonly<Record<SyncedTable, ReadonlyArray<string>>
 		"hit",
 		"updated_at_ms",
 	],
+	session_turns: ["session_event_id", "slice_id", "seq", "role", "ts_ms", "kind", "recorded_at_ms"],
 };
 
 /**
@@ -259,6 +261,7 @@ export const EXCLUDED_COLUMNS: Readonly<Record<SyncedTable, ReadonlyArray<string
 	// from `result_count` on a recall, and "did memory answer" is the most likely
 	// next card.
 	memory_lookups: ["target"],
+	session_turns: [],
 };
 
 /**
@@ -285,4 +288,5 @@ export const BATCH_LIMITS: Readonly<Record<SyncedTable, number>> = {
 	// client cannot tell apart from a transient failure. `receipt_id` no longer
 	// enters this sum: it is a fixed-length fingerprint, not a third copy.
 	memory_lookups: 200,
+	session_turns: 200,
 };

--- a/cli/src/dashboard/SessionTurnsBackfill.test.ts
+++ b/cli/src/dashboard/SessionTurnsBackfill.test.ts
@@ -1,0 +1,256 @@
+/**
+ * The stored-transcript `session_turns` backfill over a real SoT database: a
+ * session whose transcript is persisted but has no turn rows gets them,
+ * idempotently; coverage is per SLICE (a session spanning two transcripts
+ * backfills only the missing one); an unresolvable session is left alone (no
+ * death loop); and every backfilled row is stamped above the sync cursor.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { deflateSync } from "node:zlib";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { DashboardDbHandle } from "./DashboardDb.js";
+import { withDashboardDb } from "./DashboardDb.js";
+import { backfillStoredSessionTurns } from "./DbBackfill.js";
+
+const NOW = 1_754_000_000_000;
+
+let dir: string;
+let dbPath: string;
+let db: DashboardDbHandle;
+
+interface Entry {
+	role: string;
+	content: string;
+	timestamp?: string;
+}
+
+function addRepo(id: number, identity: string): void {
+	db.prepare(
+		"INSERT INTO repos (id, repo_identity, repo_name, worktree_root, enabled_at, bootstrap_state) VALUES (?, ?, ?, ?, ?, 'done')",
+	).run(id, identity, identity, `/tmp/${identity}`, new Date(NOW).toISOString());
+}
+
+function addSession(source: string, sessionId: string): string {
+	const eventId = `session:repo-a:${source}:${sessionId}`;
+	db.prepare(
+		"INSERT INTO sessions (event_id, repo_id, source, session_id, updated_at_ms) VALUES (?, ?, ?, ?, ?)",
+	).run(eventId, 1, source, sessionId, NOW);
+	return eventId;
+}
+
+/** A `transcripts` row whose blob carries one `StoredSession` with `entries`. */
+function addTranscript(transcriptId: string, sessionId: string, entries: Entry[]): void {
+	const stored = { sessions: [{ sessionId, source: "claude", entries }] };
+	const blob = deflateSync(Buffer.from(JSON.stringify(stored), "utf8"));
+	db.prepare(
+		"INSERT INTO transcripts (repo_id, transcript_id, sessions_blob, written_at_ms) VALUES (?, ?, ?, ?)",
+	).run(1, transcriptId, blob, NOW);
+}
+
+function linkTranscriptSession(transcriptId: string, sessionId: string): void {
+	db.prepare("INSERT INTO transcript_sessions (repo_id, transcript_id, session_id, source) VALUES (?, ?, ?, ?)").run(
+		1,
+		transcriptId,
+		sessionId,
+		"claude",
+	);
+}
+
+function turnsFor(): ReadonlyArray<{ session_event_id: string; slice_id: string; seq: number; role: string | null }> {
+	return db
+		.prepare("SELECT session_event_id, slice_id, seq, role FROM session_turns ORDER BY slice_id, seq")
+		.all() as ReadonlyArray<{ session_event_id: string; slice_id: string; seq: number; role: string | null }>;
+}
+
+function inDb(body: () => void): Promise<void> {
+	return withDashboardDb(
+		(handle) => {
+			db = handle;
+			body();
+		},
+		{ dbPath },
+	);
+}
+
+const iso = (ms: number) => new Date(ms).toISOString();
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "jolli-session-turns-backfill-"));
+	dbPath = join(dir, "jollimemory.db");
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+describe("backfillStoredSessionTurns", () => {
+	it("projects the turns of a session that has a stored transcript but no rows", () =>
+		inDb(() => {
+			addRepo(1, "repo-a");
+			addSession("claude", "s1");
+			addTranscript("t1", "s1", [
+				{ role: "human", content: "hi", timestamp: iso(NOW) },
+				{ role: "assistant", content: "secret", timestamp: iso(NOW + 1000) },
+			]);
+			linkTranscriptSession("t1", "s1");
+
+			expect(backfillStoredSessionTurns(db)).toBe(2);
+			expect(turnsFor()).toEqual([
+				{ session_event_id: "session:repo-a:claude:s1", slice_id: "t1", seq: 0, role: "human" },
+				{ session_event_id: "session:repo-a:claude:s1", slice_id: "t1", seq: 1, role: "assistant" },
+			]);
+		}));
+
+	it("is a no-op on re-run once the slice is covered", () =>
+		inDb(() => {
+			addRepo(1, "repo-a");
+			addSession("claude", "s1");
+			addTranscript("t1", "s1", [{ role: "human", content: "hi", timestamp: iso(NOW) }]);
+			linkTranscriptSession("t1", "s1");
+
+			expect(backfillStoredSessionTurns(db)).toBe(1);
+			expect(backfillStoredSessionTurns(db)).toBe(0);
+			expect(turnsFor()).toHaveLength(1);
+		}));
+
+	it("backfills only the missing slice when one session spans two transcripts", () =>
+		inDb(() => {
+			addRepo(1, "repo-a");
+			addSession("claude", "s1");
+			addTranscript("t1", "s1", [{ role: "human", content: "a", timestamp: iso(NOW) }]);
+			linkTranscriptSession("t1", "s1");
+
+			// First pass covers t1.
+			expect(backfillStoredSessionTurns(db)).toBe(1);
+
+			// A second transcript of the SAME session lands with no turns. A per-session
+			// coverage test would call the session "already covered" and skip it; the
+			// per-slice test must still backfill t2.
+			addTranscript("t2", "s1", [
+				{ role: "human", content: "b", timestamp: iso(NOW + 1000) },
+				{ role: "assistant", content: "c", timestamp: iso(NOW + 2000) },
+			]);
+			linkTranscriptSession("t2", "s1");
+
+			expect(backfillStoredSessionTurns(db)).toBe(2);
+			expect(turnsFor().map((r) => r.slice_id)).toEqual(["t1", "t2", "t2"]);
+		}));
+
+	it("backfills a legacy link whose transcript_sessions.source is NULL (a claude sessions row)", () =>
+		inDb(() => {
+			addRepo(1, "repo-a");
+			// The `sessions` row carries the source the live path coalesced a missing
+			// value to; the `transcript_sessions` link predates `source` and is NULL.
+			addSession("claude", "s1");
+			addTranscript("t1", "s1", [{ role: "human", content: "hi", timestamp: iso(NOW) }]);
+			db.prepare(
+				"INSERT INTO transcript_sessions (repo_id, transcript_id, session_id, source) VALUES (?, ?, ?, NULL)",
+			).run(1, "t1", "s1");
+
+			// A bare `s.source = ts.source` join is `'claude' = NULL` — never true — so
+			// the blob would never be selected. COALESCE(ts.source, 'claude') selects it.
+			expect(backfillStoredSessionTurns(db)).toBe(1);
+			expect(turnsFor()).toEqual([
+				{ session_event_id: "session:repo-a:claude:s1", slice_id: "t1", seq: 0, role: "human" },
+			]);
+		}));
+
+	it("leaves a transcript whose session has no sessions row alone (no death loop)", () =>
+		inDb(() => {
+			addRepo(1, "repo-a");
+			// No addSession — the (session ⋈) join has nothing to resolve, so the
+			// transcript is never selected and cannot be re-parsed forever.
+			addTranscript("t1", "s1", [{ role: "human", content: "hi", timestamp: iso(NOW) }]);
+			linkTranscriptSession("t1", "s1");
+
+			expect(backfillStoredSessionTurns(db)).toBe(0);
+			expect(turnsFor()).toHaveLength(0);
+		}));
+
+	it("tolerates an unreadable transcript blob without failing the run", () =>
+		inDb(() => {
+			addRepo(1, "repo-a");
+			addSession("claude", "s1");
+			db.prepare(
+				"INSERT INTO transcripts (repo_id, transcript_id, sessions_blob, written_at_ms) VALUES (?, ?, ?, ?)",
+			).run(1, "t1", Buffer.from("not a deflate stream", "utf8"), NOW);
+			linkTranscriptSession("t1", "s1");
+
+			expect(backfillStoredSessionTurns(db)).toBe(0);
+			expect(turnsFor()).toHaveLength(0);
+		}));
+
+	it("does not re-stamp the already-covered session in a mixed-coverage blob", () =>
+		inDb(() => {
+			addRepo(1, "repo-a");
+			const e1 = addSession("claude", "s1");
+			addSession("claude", "s2");
+
+			// s1 already has a turn for slice t1, stamped long ago (a prior live write).
+			const oldStamp = NOW - 1_000_000;
+			db.prepare(
+				"INSERT INTO session_turns (session_event_id, slice_id, seq, role, ts_ms, kind, recorded_at_ms) VALUES (?, ?, ?, ?, ?, ?, ?)",
+			).run(e1, "t1", 0, "human", NOW, "turn", oldStamp);
+
+			// One blob carries BOTH sessions; only s2 is uncovered, so the blob is
+			// selected for s2 — but s1 rides along in the same blob.
+			const stored = {
+				sessions: [
+					{
+						sessionId: "s1",
+						source: "claude",
+						entries: [{ role: "human", content: "x", timestamp: iso(NOW) }],
+					},
+					{
+						sessionId: "s2",
+						source: "claude",
+						entries: [{ role: "human", content: "y", timestamp: iso(NOW) }],
+					},
+				],
+			};
+			db.prepare(
+				"INSERT INTO transcripts (repo_id, transcript_id, sessions_blob, written_at_ms) VALUES (?, ?, ?, ?)",
+			).run(1, "t1", deflateSync(Buffer.from(JSON.stringify(stored), "utf8")), NOW);
+			linkTranscriptSession("t1", "s1");
+			linkTranscriptSession("t1", "s2");
+
+			// Only s2's row is inserted; s1 is filtered out, so its old stamp is untouched
+			// (re-projecting it would delete-then-insert with the fresh higher stamp and
+			// re-upload an already-synced row).
+			expect(backfillStoredSessionTurns(db)).toBe(1);
+			const s1Stamp = db
+				.prepare("SELECT recorded_at_ms AS ms FROM session_turns WHERE session_event_id = ?")
+				.get(e1) as { ms: number };
+			expect(s1Stamp.ms).toBe(oldStamp);
+		}));
+
+	it("stamps backfilled rows above every recorded_at_ms already present, so a sync cursor cannot page over them", () =>
+		inDb(() => {
+			addRepo(1, "repo-a");
+			addSession("claude", "s1");
+			addTranscript("t1", "s1", [{ role: "human", content: "hi", timestamp: iso(NOW) }]);
+			linkTranscriptSession("t1", "s1");
+
+			// A concurrent live write already recorded a turn for another session at a
+			// stamp the keyset session-sync cursor has since paged past — the floor every
+			// future stamp must clear (the cohort here is pure inserts, so this max is it).
+			addSession("claude", "other");
+			const cursorStamp = NOW + 5_000_000;
+			db.prepare(
+				"INSERT INTO session_turns (session_event_id, slice_id, seq, role, ts_ms, kind, recorded_at_ms) VALUES (?, ?, ?, ?, ?, ?, ?)",
+			).run("session:repo-a:claude:other", "tX", 0, "human", NOW, "turn", cursorStamp);
+
+			// Backfill's own clock reads BELOW the current max (the parse-race window or a
+			// plain clock step-back).
+			expect(backfillStoredSessionTurns(db, () => NOW)).toBe(1);
+
+			const stamped = db
+				.prepare("SELECT recorded_at_ms AS ms FROM session_turns WHERE session_event_id = ?")
+				.all("session:repo-a:claude:s1") as ReadonlyArray<{ ms: number }>;
+			expect(stamped).not.toHaveLength(0);
+			for (const row of stamped) expect(row.ms).toBeGreaterThan(cursorStamp);
+		}));
+});

--- a/cli/src/dashboard/SessionTurnsProjection.test.ts
+++ b/cli/src/dashboard/SessionTurnsProjection.test.ts
@@ -1,0 +1,258 @@
+/**
+ * SessionTurnsProjection — the text-free per-turn extractor that feeds
+ * `session_turns`.
+ *
+ * Two properties matter here and nowhere else: no entry's `content` ever
+ * reaches a row (asserted by selecting only the columns the table has — there
+ * is no `content` column to leak into), and re-projecting the same transcript
+ * is idempotent (delete-then-insert, mirroring `transcript_sessions`).
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { StoredSession } from "../Types.js";
+import { type DashboardDbHandle, withDashboardDb } from "./DashboardDb.js";
+import { projectSessionTurns, uncoveredSessionsForSlice } from "./SessionTurnsProjection.js";
+
+let dir: string;
+let dbPath: string;
+
+const NOW = 1_800_000_000_000;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "jolli-session-turns-"));
+	dbPath = join(dir, "dashboard.db");
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+/** One repo (id 1) and one session row (event_id 'e1'), the minimum `projectSessionTurns` needs to find an event_id. */
+function seedRepoAndSession(db: DashboardDbHandle): void {
+	db.prepare(
+		"INSERT INTO repos (repo_identity, repo_name, worktree_root, enabled_at) VALUES ('r', 'r', '/w', 1)",
+	).run();
+	db.prepare(
+		"INSERT INTO sessions (event_id, repo_id, source, session_id, updated_at_ms) VALUES ('e1', 1, 'claude', 's1', 1000)",
+	).run();
+}
+
+const SESSIONS: ReadonlyArray<StoredSession> = [
+	{
+		sessionId: "s1",
+		source: "claude",
+		entries: [
+			{ role: "human", content: "hi", timestamp: "2025-01-01T00:00:00Z" },
+			{ role: "assistant", content: "secret reply", timestamp: "2025-01-01T00:10:00Z" },
+		],
+		compactions: [1700000000000],
+		testRuns: [1700000001000],
+		turnAborts: [],
+	},
+];
+
+interface Row {
+	session_event_id: string;
+	slice_id: string;
+	seq: number;
+	role: string | null;
+	ts_ms: number | null;
+	kind: string;
+}
+
+describe("projectSessionTurns", () => {
+	it("projects entries and instant arrays into session_turns, text dropped", async () => {
+		const rows = await withDashboardDb(
+			(db) => {
+				seedRepoAndSession(db);
+				projectSessionTurns(db, 1, "t1", SESSIONS, NOW);
+				return db
+					.prepare(
+						"SELECT session_event_id, slice_id, seq, role, ts_ms, kind FROM session_turns ORDER BY seq",
+					)
+					.all() as Row[];
+			},
+			{ dbPath },
+		);
+
+		expect(rows).toEqual([
+			{
+				session_event_id: "e1",
+				slice_id: "t1",
+				seq: 0,
+				role: "human",
+				ts_ms: Date.parse("2025-01-01T00:00:00Z"),
+				kind: "turn",
+			},
+			{
+				session_event_id: "e1",
+				slice_id: "t1",
+				seq: 1,
+				role: "assistant",
+				ts_ms: Date.parse("2025-01-01T00:10:00Z"),
+				kind: "turn",
+			},
+			{ session_event_id: "e1", slice_id: "t1", seq: 2, role: null, ts_ms: 1700000000000, kind: "compaction" },
+			{ session_event_id: "e1", slice_id: "t1", seq: 3, role: null, ts_ms: 1700000001000, kind: "test-run" },
+		]);
+		// turnAborts:[] emits no rows, and no row above carries anything from
+		// `content` — the table has no such column to begin with.
+	});
+
+	it("re-projecting the same transcript is idempotent (delete-then-insert)", async () => {
+		const count = await withDashboardDb(
+			(db) => {
+				seedRepoAndSession(db);
+				projectSessionTurns(db, 1, "t1", SESSIONS, NOW);
+				projectSessionTurns(db, 1, "t1", SESSIONS, NOW);
+				return (db.prepare("SELECT count(*) c FROM session_turns").get() as { c: number }).c;
+			},
+			{ dbPath },
+		);
+
+		expect(count).toBe(4);
+	});
+
+	it("skips a session with no sessions row yet, the same gap transcript_sessions has", async () => {
+		const count = await withDashboardDb(
+			(db) => {
+				db.prepare(
+					"INSERT INTO repos (repo_identity, repo_name, worktree_root, enabled_at) VALUES ('r', 'r', '/w', 1)",
+				).run();
+				// No INSERT INTO sessions — the event_id lookup must come back empty.
+				projectSessionTurns(db, 1, "t1", SESSIONS, NOW);
+				return (db.prepare("SELECT count(*) c FROM session_turns").get() as { c: number }).c;
+			},
+			{ dbPath },
+		);
+
+		expect(count).toBe(0);
+	});
+
+	it("skips an id-less session without binding an undefined session_id", async () => {
+		// A sessionless session reaches the projection (the caller's guard only
+		// covers `transcript_sessions`); it must be skipped, not crash the driver.
+		const idless: ReadonlyArray<StoredSession> = [
+			{ sessionId: "", source: "claude", entries: [{ role: "human", content: "hi", timestamp: undefined }] },
+		];
+		const count = await withDashboardDb(
+			(db) => {
+				seedRepoAndSession(db);
+				projectSessionTurns(db, 1, "t1", idless, NOW);
+				return (db.prepare("SELECT count(*) c FROM session_turns").get() as { c: number }).c;
+			},
+			{ dbPath },
+		);
+
+		expect(count).toBe(0);
+	});
+
+	it("nulls ts_ms for a missing or unparsable timestamp, and tolerates absent instant arrays", async () => {
+		// A valid session (so the event_id resolves) whose entries carry a missing
+		// then an unparsable timestamp, and which has NO compaction/test-run/abort
+		// arrays at all — the `instants ?? []` and both `ts_ms` null paths.
+		const messy: ReadonlyArray<StoredSession> = [
+			{
+				sessionId: "s1",
+				source: "claude",
+				entries: [
+					{ role: "human", content: "a", timestamp: undefined },
+					{ role: "assistant", content: "b", timestamp: "not-a-date" },
+				],
+			},
+		];
+		const rows = await withDashboardDb(
+			(db) => {
+				seedRepoAndSession(db);
+				projectSessionTurns(db, 1, "t1", messy, NOW);
+				return db
+					.prepare(
+						"SELECT session_event_id, slice_id, seq, role, ts_ms, kind FROM session_turns ORDER BY seq",
+					)
+					.all() as Row[];
+			},
+			{ dbPath },
+		);
+
+		expect(rows).toEqual([
+			{ session_event_id: "e1", slice_id: "t1", seq: 0, role: "human", ts_ms: null, kind: "turn" },
+			{ session_event_id: "e1", slice_id: "t1", seq: 1, role: "assistant", ts_ms: null, kind: "turn" },
+		]);
+	});
+
+	it("tolerates a stored session with no entries field, projecting its instants only", async () => {
+		// `entries` is type-required, but a stored transcript blob is untrusted
+		// on-disk data and an older/malformed one can omit it. It must be one skipped
+		// turn stream, never a throw that fails the whole backfill transaction.
+		const noEntries = [
+			{ sessionId: "s1", source: "claude", compactions: [1700000000000] },
+		] as unknown as ReadonlyArray<StoredSession>;
+		const rows = await withDashboardDb(
+			(db) => {
+				seedRepoAndSession(db);
+				projectSessionTurns(db, 1, "t1", noEntries, NOW);
+				return db
+					.prepare(
+						"SELECT session_event_id, slice_id, seq, role, ts_ms, kind FROM session_turns ORDER BY seq",
+					)
+					.all() as Row[];
+			},
+			{ dbPath },
+		);
+
+		expect(rows).toEqual([
+			{ session_event_id: "e1", slice_id: "t1", seq: 0, role: null, ts_ms: 1700000000000, kind: "compaction" },
+		]);
+	});
+});
+
+describe("uncoveredSessionsForSlice", () => {
+	it("drops sessions that already have turns for the slice, keeping the missing ones", async () => {
+		// A repo with two sessions; only 'e1' has turns for slice 't1'. A blob
+		// carrying both is selected for 's2', but re-projecting 's1' would re-stamp
+		// its already-synced rows — so the filter must return 's2' alone.
+		const kept = await withDashboardDb(
+			(db) => {
+				db.prepare(
+					"INSERT INTO repos (repo_identity, repo_name, worktree_root, enabled_at) VALUES ('r', 'r', '/w', 1)",
+				).run();
+				db.prepare(
+					"INSERT INTO sessions (event_id, repo_id, source, session_id, updated_at_ms) VALUES ('e1', 1, 'claude', 's1', 1000)",
+				).run();
+				db.prepare(
+					"INSERT INTO sessions (event_id, repo_id, source, session_id, updated_at_ms) VALUES ('e2', 1, 'claude', 's2', 1000)",
+				).run();
+				db.prepare(
+					"INSERT INTO session_turns (session_event_id, slice_id, seq, role, ts_ms, kind, recorded_at_ms) VALUES ('e1', 't1', 0, 'human', 1, 'turn', 1)",
+				).run();
+				const sessions: ReadonlyArray<StoredSession> = [
+					{ sessionId: "s1", source: "claude", entries: [] },
+					{ sessionId: "s2", source: "claude", entries: [] },
+				];
+				return uncoveredSessionsForSlice(db, 1, "t1", sessions).map((s) => s.sessionId);
+			},
+			{ dbPath },
+		);
+
+		expect(kept).toEqual(["s2"]);
+	});
+
+	it("drops a session with no sessions row (no event_id to hang turns off)", async () => {
+		const kept = await withDashboardDb(
+			(db) => {
+				db.prepare(
+					"INSERT INTO repos (repo_identity, repo_name, worktree_root, enabled_at) VALUES ('r', 'r', '/w', 1)",
+				).run();
+				// No sessions row for 's1' — eventIdFor returns undefined.
+				const sessions: ReadonlyArray<StoredSession> = [{ sessionId: "s1", source: "claude", entries: [] }];
+				return uncoveredSessionsForSlice(db, 1, "t1", sessions).map((s) => s.sessionId);
+			},
+			{ dbPath },
+		);
+
+		expect(kept).toEqual([]);
+	});
+});

--- a/cli/src/dashboard/SessionTurnsProjection.ts
+++ b/cli/src/dashboard/SessionTurnsProjection.ts
@@ -1,0 +1,153 @@
+import type { TranscriptEntry, TranscriptSource } from "../Types.js";
+import type { DashboardDbHandle, DashboardStatement } from "./DashboardDb.js";
+
+/**
+ * The ONLY fields {@link projectSessionTurns}, {@link uncoveredSessionsForSlice}
+ * and {@link eventIdFor} read from a session. A full `StoredSession` structurally
+ * satisfies it, so the live write paths (`SotWrite`/`SotImport`) pass their sessions
+ * unchanged — but the historical backfill projects each stored blob down to THIS
+ * before holding it in memory, dropping every entry's `content` (the one large
+ * field). Without that a machine with many transcripts holds the whole inflated
+ * corpus until the backfill transaction commits.
+ *
+ * Deliberately a hand-written minimal type, not `Pick<StoredSession, …>`: it makes
+ * the backfill's content-dropping projection a COMPILE guarantee. A future read of
+ * `entry.content` in the projector then fails to build instead of silently seeing
+ * the backfill's empty entries drift from the live path's real ones.
+ */
+export interface SessionTurnInput {
+	readonly sessionId: string;
+	readonly source?: TranscriptSource;
+	readonly entries?: ReadonlyArray<{ readonly role: TranscriptEntry["role"]; readonly timestamp?: string }>;
+	readonly compactions?: ReadonlyArray<number>;
+	readonly turnAborts?: ReadonlyArray<number>;
+	readonly testRuns?: ReadonlyArray<number>;
+}
+
+/**
+ * Maps a StoredSession (source, sessionId) to its sessions.event_id for a repo,
+ * through a caller-owned prepared SELECT so a loop over many sessions compiles the
+ * statement once rather than per row. The `?? "claude"` is the same coalescing the
+ * historical backfill's selection join must mirror (a legacy session persisted
+ * before `source` was recorded is a `claude` row here and a NULL in
+ * `transcript_sessions`).
+ */
+function eventIdFor(stmt: DashboardStatement, repoId: number, session: SessionTurnInput): string | undefined {
+	// A session with no id has no `sessions` row (the `transcript_sessions`
+	// projection skips it for the same reason), so there is nothing to hang turns
+	// off — and binding an undefined `session_id` would throw at the driver.
+	if (!session.sessionId) {
+		return undefined;
+	}
+	const row = stmt.get(repoId, session.source ?? "claude", session.sessionId) as { event_id: string } | undefined;
+	return row?.event_id;
+}
+
+/** The prepared `SELECT event_id …` {@link eventIdFor} consumes. */
+function prepareEventIdStmt(db: DashboardDbHandle): DashboardStatement {
+	return db.prepare("SELECT event_id FROM sessions WHERE repo_id = ? AND source = ? AND session_id = ?");
+}
+
+/**
+ * Deletes EVERY `session_turns` row for one transcript slice, repo-scoped.
+ *
+ * {@link projectSessionTurns} only deletes rows for the sessions it is currently
+ * projecting, so a WRITE path (a rewrite whose session list shrank, or a
+ * transcript deletion) that stops passing a session would strand its turns —
+ * still synced, still feeding coaching signals for a slice that no longer exists.
+ * The write/delete paths call this first because they always hold the COMPLETE
+ * session set; the backfill must NOT (it narrows to uncovered sessions, and a
+ * whole-slice wipe would drop already-covered rows it does not re-insert).
+ *
+ * Scoped through `sessions` rather than by `slice_id` alone because `session_turns`
+ * carries no `repo_id` — only `session_event_id`, which encodes repo identity — so
+ * two repos sharing a commit hash share a `slice_id`.
+ */
+export function deleteSliceSessionTurns(db: DashboardDbHandle, repoId: number, transcriptId: string): void {
+	db.prepare(
+		`DELETE FROM session_turns
+		  WHERE slice_id = ?
+		    AND session_event_id IN (SELECT event_id FROM sessions WHERE repo_id = ?)`,
+	).run(transcriptId, repoId);
+}
+
+/**
+ * The subset of `sessions` that carries NO `session_turns` row for this slice yet
+ * — what {@link backfillStoredSessionTurns} should hand {@link projectSessionTurns}.
+ *
+ * The backfill selects a whole transcript blob when ANY of its sessions is
+ * uncovered, but {@link projectSessionTurns} re-projects every session it is given
+ * (delete-then-insert). Without this filter an already-covered session in a
+ * mixed-coverage blob has its rows rewritten with the backfill's fresh, higher
+ * `recorded_at_ms`, re-entering the sync window and being re-uploaded — the exact
+ * churn the backfill's "the cohort is uncovered by construction" invariant claims
+ * cannot happen. A session with no `sessions` row (no `event_id`) is dropped: it
+ * cannot be the reason the blob was selected (selection joins `sessions`), and
+ * {@link projectSessionTurns} would skip it anyway.
+ */
+export function uncoveredSessionsForSlice(
+	db: DashboardDbHandle,
+	repoId: number,
+	transcriptId: string,
+	sessions: ReadonlyArray<SessionTurnInput>,
+): ReadonlyArray<SessionTurnInput> {
+	const covered = db.prepare("SELECT 1 FROM session_turns WHERE session_event_id = ? AND slice_id = ? LIMIT 1");
+	const eventIdStmt = prepareEventIdStmt(db);
+	return sessions.filter((session) => {
+		const eventId = eventIdFor(eventIdStmt, repoId, session);
+		if (eventId === undefined) {
+			return false;
+		}
+		return covered.get(eventId, transcriptId) === undefined;
+	});
+}
+
+/**
+ * Projects one transcript's sessions into `session_turns`, TEXT-FREE: one `turn`
+ * row per entry (role + parsed timestamp, content dropped) then one row per
+ * compaction/test-run/turn-abort instant. Idempotent per `transcript_id`
+ * (delete-then-insert), mirroring the `transcript_sessions` projection.
+ */
+export function projectSessionTurns(
+	db: DashboardDbHandle,
+	repoId: number,
+	transcriptId: string,
+	sessions: ReadonlyArray<SessionTurnInput>,
+	nowMs: number,
+): void {
+	const insert = db.prepare(
+		`INSERT OR REPLACE INTO session_turns
+		 (session_event_id, slice_id, seq, role, ts_ms, kind, recorded_at_ms)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+	);
+	// Prepared once, not per session: this runs over every session of every stored
+	// transcript during the historical backfill, inside SQLite's single writer.
+	const eventIdStmt = prepareEventIdStmt(db);
+	const deleteStmt = db.prepare("DELETE FROM session_turns WHERE session_event_id = ? AND slice_id = ?");
+	for (const session of sessions) {
+		const eventId = eventIdFor(eventIdStmt, repoId, session);
+		if (eventId === undefined) {
+			continue; // no sessions row yet — transcript_sessions projection has the same gap
+		}
+		deleteStmt.run(eventId, transcriptId);
+		let seq = 0;
+		// `entries` is optional here (see `SessionTurnInput`) and this projects untrusted on-disk data (a
+		// stored transcript blob) as well as live writes: an older or malformed blob
+		// can omit it, and `for (const entry of undefined)` would throw mid-cohort —
+		// in the backfill that is one bad session failing the whole run's transaction.
+		for (const entry of session.entries ?? []) {
+			const parsed = entry.timestamp === undefined ? undefined : Date.parse(entry.timestamp);
+			const tsMs = parsed === undefined || Number.isNaN(parsed) ? null : parsed;
+			insert.run(eventId, transcriptId, seq++, entry.role, tsMs, "turn", nowMs);
+		}
+		for (const [kind, instants] of [
+			["compaction", session.compactions],
+			["test-run", session.testRuns],
+			["turn-abort", session.turnAborts],
+		] as const) {
+			for (const atMs of instants ?? []) {
+				insert.run(eventId, transcriptId, seq++, null, atMs, kind, nowMs);
+			}
+		}
+	}
+}

--- a/cli/src/dashboard/SotImport.test.ts
+++ b/cli/src/dashboard/SotImport.test.ts
@@ -1251,6 +1251,63 @@ describe("importRepoMemory — catch-up on a fenced repo (post-fence SQLite rows
 		]);
 	});
 
+	it("stamps catch-up session_turns above the sync cursor, not at the fence", async () => {
+		// `session_turns.recorded_at_ms` is the session-sync keyset cursor, NOT a
+		// protect-guard column (nothing reads it to decide whether a source may win —
+		// the transcript body's guard is `written_at_ms`). On a fenced repo the cursor
+		// has already advanced to "now" via post-cutover live projections, so a catch-up
+		// that re-projects turns at the `written_at_ms`-semantics `stampMs` (fence-1)
+		// would land them BELOW that cursor, where the keyset scan pages straight over
+		// them — a silent, permanent sync loss, the exact failure the backfill's own
+		// `Math.max(now, max+1)` floor exists to prevent.
+		const files = fixture({
+			// Real entries: an empty `entries[]` projects zero rows, hiding the bug.
+			"transcripts/t-root.json": JSON.stringify({
+				sessions: [
+					{
+						sessionId: "s1",
+						source: "claude",
+						entries: [
+							{ role: "human", timestamp: "2026-07-01T00:00:00.000Z" },
+							{ role: "assistant", timestamp: "2026-07-01T00:01:00.000Z" },
+						],
+					},
+				],
+			}),
+		});
+		// Pre-fence import: writes the transcript at written_at_ms = 2_000 (< fence), so
+		// the catch-up below is NOT protected away and actually re-projects it. The `s1`
+		// sessions row does not exist yet, so no turns are written on this pass.
+		await runImport(files, 2_000);
+		await withDashboardDb(
+			(db) => {
+				const repoId = (db.prepare("SELECT id FROM repos").get() as { id: number }).id;
+				// The row `projectSessionTurns` joins on to resolve s1 → event_id.
+				db.prepare(
+					"INSERT INTO sessions (event_id, repo_id, source, session_id, updated_at_ms) VALUES (?, ?, 'claude', 's1', ?)",
+				).run("evt-s1", repoId, 2_000);
+				// An already-advanced cursor: a live post-cutover projection at 9_000.
+				db.prepare(
+					"INSERT INTO sessions (event_id, repo_id, source, session_id, updated_at_ms) VALUES (?, ?, 'claude', 'live', ?)",
+				).run("evt-live", repoId, 9_000);
+				db.prepare(
+					`INSERT INTO session_turns (session_event_id, slice_id, seq, role, ts_ms, kind, recorded_at_ms)
+					 VALUES ('evt-live', 'live-slice', 0, 'human', 9000, 'turn', 9000)`,
+				).run();
+			},
+			{ dbPath },
+		);
+		// Catch-up on the fenced repo: stampMs = min(6_000, fenceMs - 1) = 3_999.
+		const { query } = await runImport(files, 6_000, "catch-up", fenceMs);
+		const [row] = await query<{ lo: number | null; n: number }>(
+			"SELECT MIN(recorded_at_ms) AS lo, COUNT(*) AS n FROM session_turns WHERE session_event_id = 'evt-s1'",
+		);
+		expect(row.n).toBe(2); // the projection actually ran
+		// Every re-projected turn sits at or above the cursor it found (9_000), never
+		// at the fence-derived 3_999.
+		expect(row.lo).toBeGreaterThanOrEqual(9_000);
+	});
+
 	it("fills a genuinely missing node by mounting against the STORED tree", async () => {
 		const files = fixture();
 		await runImport(files);

--- a/cli/src/dashboard/SotImport.ts
+++ b/cli/src/dashboard/SotImport.ts
@@ -47,6 +47,7 @@ import { type DashboardDbHandle, inTransaction } from "./DashboardDb.js";
 import { importTakesPath } from "./ImportablePaths.js";
 import { cursorFingerprint, type ImportCursor, readImportStateRow, writeImportState } from "./ImportState.js";
 import { existingWorktrees, type RegisteredRepo } from "./RepoRegistry.js";
+import { deleteSliceSessionTurns, projectSessionTurns } from "./SessionTurnsProjection.js";
 import { REORDER_OFFSET } from "./SotSchema.js";
 import { forgetRollupDays } from "./StatsRollup.js";
 import { MEMORY_LANDED_AT_SQL } from "./StatsSeries.js";
@@ -1263,7 +1264,18 @@ async function runRepoImport(db: DashboardDbHandle, opts: SotImportOptions): Pro
 	const claimedTranscripts = new Set<string>();
 	let transcripts = 0;
 
-	const writeTranscript = (id: string, content: string | null): void => {
+	// The `recorded_at_ms` a batch of projected turns should carry: strictly above
+	// the table's current max, so a fenced import's `stampMs` (clamped to the fence)
+	// cannot strand rows below the already-advanced session-sync cursor. The same
+	// floor `backfillStoredSessionTurns` uses; `MAX` over the leading column of
+	// `ix_turns_keyset` is O(1). Recomputed per transaction so successive batches
+	// stay monotonically above one another.
+	const flooredTurnStampMs = (): number => {
+		const max = (db.prepare("SELECT MAX(recorded_at_ms) AS m FROM session_turns").get() as { m: number | null }).m;
+		return Math.max(nowMs, (max ?? 0) + 1);
+	};
+
+	const writeTranscript = (id: string, content: string | null, sessionTurnStampMs: number): void => {
 		const parsed = tryParse<StoredTranscript>(content);
 		if (!parsed || !Array.isArray(parsed.sessions)) {
 			skip("transcript", `transcripts/${id}.json`);
@@ -1303,6 +1315,18 @@ async function runRepoImport(db: DashboardDbHandle, opts: SotImportOptions): Pro
 				 ON CONFLICT(repo_id, transcript_id, session_id) DO UPDATE SET source = excluded.source`,
 			).run(repoId, id, session.sessionId, session.source ?? null);
 		});
+		// Whole-slice wipe before reprojecting, mirroring the live write path: a
+		// re-imported blob that dropped a session would otherwise leave that session's
+		// turns behind, since `projectSessionTurns` only clears the sessions it projects.
+		deleteSliceSessionTurns(db, repoId, id);
+		// NOT `stampMs`: `session_turns.recorded_at_ms` is the session-sync keyset
+		// cursor, not a protect-guard column (unlike the transcript body's
+		// `written_at_ms` above). A protected import clamps `stampMs` to the fence,
+		// which on a cut-over repo sits BELOW the cursor the live path has already
+		// advanced to — so those rows would page straight over and never sync. The
+		// caller floors `sessionTurnStampMs` above the table's current max instead,
+		// the same floor the historical backfill uses for exactly this reason.
+		projectSessionTurns(db, repoId, id, parsed.sessions, sessionTurnStampMs);
 		transcripts++;
 	};
 
@@ -1475,7 +1499,11 @@ async function runRepoImport(db: DashboardDbHandle, opts: SotImportOptions): Pro
 
 		inTransaction(db, () => {
 			db.exec("PRAGMA defer_foreign_keys = ON");
-			for (const id of wanted) writeTranscript(id, transcriptBodies.get(`transcripts/${id}.json`) ?? null);
+			// One floored `recorded_at_ms` for every turn this batch projects (see
+			// `flooredTurnStampMs`), computed inside the transaction.
+			const sessionTurnStampMs = flooredTurnStampMs();
+			for (const id of wanted)
+				writeTranscript(id, transcriptBodies.get(`transcripts/${id}.json`) ?? null, sessionTurnStampMs);
 			for (const hash of slice) {
 				const summary = batchSummaries.get(hash);
 				// Unparsable body: counted as a skip above. Its row is simply not
@@ -1566,7 +1594,7 @@ async function runRepoImport(db: DashboardDbHandle, opts: SotImportOptions): Pro
 			unclaimed.map((id) => `transcripts/${id}.json`),
 		);
 		inChunkedTransactions(db, unclaimed, (id) =>
-			writeTranscript(id, orphanBodies.get(`transcripts/${id}.json`) ?? null),
+			writeTranscript(id, orphanBodies.get(`transcripts/${id}.json`) ?? null, flooredTurnStampMs()),
 		);
 	}
 

--- a/cli/src/dashboard/SotWrite.test.ts
+++ b/cli/src/dashboard/SotWrite.test.ts
@@ -459,6 +459,68 @@ describe("links", () => {
 	});
 });
 
+// `session_turns` has no FK cascade from `transcripts` (only from `sessions`) and
+// `projectSessionTurns` deletes only the sessions it re-projects — so both the
+// delete path and a shrinking rewrite must clear the slice explicitly or leave
+// rows that keep syncing for a slice/session that is gone.
+describe("session_turns lifecycle", () => {
+	const seedSession = (source: string, sessionId: string): Promise<void> =>
+		withDashboardDb(
+			(db) =>
+				db
+					.prepare(
+						"INSERT INTO sessions (event_id, repo_id, source, session_id, updated_at_ms) VALUES (?, ?, ?, ?, ?)",
+					)
+					.run(`session:1:${source}:${sessionId}`, 1, source, sessionId, 1),
+			{ dbPath },
+		) as Promise<void>;
+	const turnCount = async (): Promise<number> =>
+		(await rows<{ n: number }>("SELECT count(*) AS n FROM session_turns"))[0].n;
+	const sess = (sessionId: string, content: string, ts: string) => ({
+		sessionId,
+		source: "claude",
+		entries: [{ role: "human", content, timestamp: ts }],
+	});
+
+	it("removes a slice's turns when the transcript is deleted", async () => {
+		await seedSession("claude", "s1");
+		await storage.writeFiles(
+			[file("transcripts/t-1.json", { sessions: [sess("s1", "hi", "2026-07-01T00:00:00.000Z")] })],
+			"m",
+		);
+		expect(await turnCount()).toBe(1);
+
+		await storage.writeFiles([{ path: "transcripts/t-1.json", content: "", delete: true }], "m");
+		expect(await turnCount()).toBe(0);
+	});
+
+	it("drops a removed session's turns when a transcript is rewritten smaller", async () => {
+		await seedSession("claude", "s1");
+		await seedSession("claude", "s2");
+		await storage.writeFiles(
+			[
+				file("transcripts/t-1.json", {
+					sessions: [
+						sess("s1", "a", "2026-07-01T00:00:00.000Z"),
+						sess("s2", "b", "2026-07-01T00:00:01.000Z"),
+					],
+				}),
+			],
+			"m",
+		);
+		expect(await turnCount()).toBe(2);
+
+		// Same slice re-written without s2: its turns must not linger.
+		await storage.writeFiles(
+			[file("transcripts/t-1.json", { sessions: [sess("s1", "a", "2026-07-01T00:00:00.000Z")] })],
+			"m",
+		);
+		expect(await rows("SELECT session_event_id FROM session_turns")).toEqual([
+			{ session_event_id: "session:1:claude:s1" },
+		]);
+	});
+});
+
 describe("no-op writes that still harvest", () => {
 	it("index.json contributes treeHash and nothing else", async () => {
 		await storage.writeFiles(

--- a/cli/src/dashboard/SotWrite.ts
+++ b/cli/src/dashboard/SotWrite.ts
@@ -53,6 +53,7 @@ import { resolveTranscriptIdsFiltered } from "../core/SummaryTree.js";
 import { createLogger } from "../Logger.js";
 import type { CommitSummary, FileWrite, StoredTranscript, SummaryIndex } from "../Types.js";
 import { type DashboardDbHandle, inTransaction } from "./DashboardDb.js";
+import { deleteSliceSessionTurns, projectSessionTurns } from "./SessionTurnsProjection.js";
 import {
 	commitDateMs,
 	markdownTitle,
@@ -478,6 +479,10 @@ function landTranscripts(db: DashboardDbHandle, repoId: number, c: Classified, n
 		db.prepare("DELETE FROM transcript_sessions WHERE repo_id = ? AND transcript_id = ?").run(repoId, id);
 		db.prepare("DELETE FROM memory_transcripts WHERE repo_id = ? AND transcript_id = ?").run(repoId, id);
 		db.prepare("DELETE FROM transcripts WHERE repo_id = ? AND transcript_id = ?").run(repoId, id);
+		// `session_turns` does not cascade from `transcripts` (its only FK is on
+		// `sessions`), so the slice's turns must be cleared explicitly or they linger
+		// and keep syncing for a transcript that no longer exists.
+		deleteSliceSessionTurns(db, repoId, id);
 	}
 	for (const { id, content } of c.transcriptWrites) {
 		const parsed = tryParse<StoredTranscript>(content);
@@ -498,6 +503,13 @@ function landTranscripts(db: DashboardDbHandle, repoId: number, c: Classified, n
 				 ON CONFLICT(repo_id, transcript_id, session_id) DO UPDATE SET source = excluded.source`,
 			).run(repoId, id, session.sessionId, session.source ?? null);
 		}
+		// Clear the whole slice before reprojecting: `projectSessionTurns` only
+		// deletes rows for the sessions it is given, so a rewrite whose session list
+		// shrank would strand the dropped sessions' turns. The write path always holds
+		// the complete session set, so a whole-slice wipe here is safe (the backfill,
+		// which narrows to uncovered sessions, must never do this).
+		deleteSliceSessionTurns(db, repoId, id);
+		projectSessionTurns(db, repoId, id, parsed.sessions, nowMs);
 		landed.add(id);
 	}
 	return landed;

--- a/cli/src/dashboard/SyncColumns.ts
+++ b/cli/src/dashboard/SyncColumns.ts
@@ -51,6 +51,7 @@ export const SYNC_STAMP_COLUMNS = {
 	session_usage_events: "updated_at_ms",
 	session_activity: "recorded_at_ms",
 	memory_lookups: "updated_at_ms",
+	session_turns: "recorded_at_ms",
 } as const;
 
 /** A table that carries a sync stamp. */
@@ -103,6 +104,7 @@ export const KEYSET_COLUMNS: Readonly<Record<SyncStampTable, ReadonlyArray<strin
 	session_usage_events: ["session_event_id", "dedup_key"],
 	session_activity: ["session_event_id", "bucket_ms"],
 	memory_lookups: ["receipt_id"],
+	session_turns: ["session_event_id", "slice_id", "seq"],
 };
 
 /**
@@ -159,6 +161,13 @@ export const WINDOW_SOURCES: Readonly<Record<SyncStampTable, WindowSource>> = {
 	// search` typed into a plain terminal. An `EXISTS` over it would silently drop
 	// every one of those rows from the first sync's window, for ever.
 	memory_lookups: { own: "at_ms" },
+	// Through the parent session, NOT on `ts_ms`. `ts_ms` is nullable (an instant
+	// row, or an entry whose timestamp was absent/unparsable) and is per-turn
+	// business time, not the sync cursor — the cursor is `recorded_at_ms`, stamped
+	// at projection time. This is `session_activity`'s case exactly: the projector
+	// re-stamps every row of a re-parsed slice at "just now", so windowing on the
+	// parent session's clock keeps the window aligned with the advancing cursor.
+	session_turns: { parent: "session_event_id" },
 };
 
 /** The table's own business time column, or `undefined` when it has none. */

--- a/cli/src/dashboard/migrations/2026-08-27-0824-session-turns.ts
+++ b/cli/src/dashboard/migrations/2026-08-27-0824-session-turns.ts
@@ -1,0 +1,63 @@
+import { type DbMigration, sqlMigration } from "./MigrationHelpers.js";
+
+/**
+ * Adds `session_turns` — the text-free per-turn projection that feeds the web
+ * coaching dashboard's per-user Activity/Turnaround signal.
+ *
+ * `session_activity` already answers "was this session active in this 15-minute
+ * bucket"; this table answers a narrower question that bucket cannot: the exact
+ * SEQUENCE and ROLE of what happened, without ever carrying what was said. It is
+ * a sibling of `session_model_usage` / `session_tool_use` / `session_activity` in
+ * every way that matters here — keyed off `sessions.event_id` with `ON DELETE
+ * CASCADE`, `CREATE TABLE IF NOT EXISTS` so a re-run is a no-op — so it follows
+ * the same additive-DDL shape rather than inventing a new one.
+ *
+ * `slice_id` is the owning transcript's id (`transcripts.transcript_id`), named
+ * differently on purpose: this table is projected PER TRANSCRIPT SLICE, and a
+ * session can span more than one slice over its life. `(session_event_id,
+ * slice_id, seq)` is therefore the natural key — `seq` alone would collide across
+ * slices of the same session, and `session_event_id` alone would collide across
+ * sessions entirely.
+ *
+ * **Text-free by construction.** `role` and `kind` are the only columns that
+ * carry anything human-readable, and both are closed vocabularies the writer
+ * controls (`"human"|"assistant"` for `role`, `"turn"|"compaction"|"test-run"|
+ * "turn-abort"` for `kind`) — never a copy of `TranscriptEntry.content`. See
+ * `SessionTurnsProjection.ts`, the one place that writes this table.
+ *
+ * `seq` is per-(session, slice) and assigned by the projector in write order: one
+ * `turn` row per transcript entry, in entry order, followed by one row per
+ * instant in `compactions[]` / `testRuns[]` / `turnAborts[]`. It exists so the
+ * cloud side can reconstruct ORDER without a timestamp — `ts_ms` is nullable
+ * (an entry's `timestamp` may be absent or unparsable), so `seq` is the only
+ * column this table guarantees is total and monotone.
+ *
+ * `recorded_at_ms NOT NULL` with no default, matching `session_activity`'s
+ * `recorded_at_ms`: this table is new, so there is no pre-existing row that could
+ * need a zero-sentinel backfill, and every row is stamped with its real
+ * projection instant on the way in. It is a sync cursor, never a business time —
+ * see `SYNC_STAMP_COLUMNS.session_turns` in `SyncColumns.ts`.
+ *
+ * Idempotent per `(session_event_id, slice_id)`, not insert-only like
+ * `session_activity`: re-parsing a transcript (an amend, a re-import) can change
+ * which turns it contains, so `projectSessionTurns` deletes that slice's rows
+ * before re-inserting rather than accumulating history the way a 15-minute
+ * activity bucket does. `ON DELETE CASCADE` still applies — nothing deletes from
+ * `sessions` today, and if something ever does, these rows reference a parent
+ * that no longer exists either way.
+ */
+export const SESSION_TURNS_DDL: DbMigration = sqlMigration(
+	"2026-08-27-0824-session-turns",
+	`
+CREATE TABLE IF NOT EXISTS session_turns (
+  session_event_id TEXT NOT NULL REFERENCES sessions(event_id) ON DELETE CASCADE,
+  slice_id         TEXT NOT NULL,
+  seq              INTEGER NOT NULL,
+  role             TEXT,
+  ts_ms            INTEGER,
+  kind             TEXT NOT NULL,
+  recorded_at_ms   INTEGER NOT NULL,
+  PRIMARY KEY (session_event_id, slice_id, seq)
+) STRICT;
+`,
+);

--- a/cli/src/dashboard/migrations/2026-08-28-0516-session-turns-keyset-index.ts
+++ b/cli/src/dashboard/migrations/2026-08-28-0516-session-turns-keyset-index.ts
@@ -1,0 +1,34 @@
+import { sqlMigration } from "./MigrationHelpers.js";
+
+/**
+ * Keyset index for `session_turns`' session-sync paging — the `session_turns`
+ * sibling of `2026-08-27-0804-session-activity-keyset-index`, and needed for the
+ * identical reason.
+ *
+ * `session_turns` joined the session-sync channel (`SYNCED_TABLES`) with only its
+ * `PRIMARY KEY (session_event_id, slice_id, seq)`. The reader pages with the
+ * row-value `(recorded_at_ms, session_event_id, slice_id, seq) >= ?` ORDER BY the
+ * same four columns (`SessionPushReader.selectFor`, `KEYSET_COLUMNS.session_turns`
+ * prefixed by `SYNC_STAMP_COLUMNS.session_turns`), which the primary key cannot
+ * drive: it does not lead with `recorded_at_ms`, so the planner full-scans and
+ * `USE TEMP B-TREE FOR ORDER BY` on every 200-row page — quadratic in table size.
+ * `backfillStoredSessionTurns`' `SELECT MAX(recorded_at_ms)` full-scans for the
+ * same missing-index reason.
+ *
+ * The backfill stamps a whole cohort with one `recorded_at_ms`, so that temp sort
+ * re-scans every row sharing the stamp on every page — the same cohort-quadratic
+ * shape the `session_activity` entry documents. This gives `session_turns` the
+ * matching composite, in a NEW migration rather than by editing the frozen
+ * `SESSION_TURNS_DDL`.
+ *
+ * `IF NOT EXISTS` so a hand-repaired database that already carries the index is a
+ * no-op rather than an error — which keeps this a pure-SQL `sqlMigration`
+ * (re-runnable, fingerprinted) rather than a code entry.
+ */
+export const SESSION_TURNS_KEYSET_INDEX_DDL = sqlMigration(
+	"2026-08-28-0516-session-turns-keyset-index",
+	`
+CREATE INDEX IF NOT EXISTS ix_turns_keyset
+  ON session_turns(recorded_at_ms, session_event_id, slice_id, seq);
+`,
+);

--- a/cli/src/dashboard/migrations/index.ts
+++ b/cli/src/dashboard/migrations/index.ts
@@ -22,6 +22,8 @@ import { MEMORY_REACHABLE_DDL } from "./2026-08-25-0001-memory-reachable.js";
 import { COMMIT_REACHABLE_DDL } from "./2026-08-25-0002-commit-reachable.js";
 import { MEMORY_LOOKUPS_DDL } from "./2026-08-26-0000-memory-lookups.js";
 import { SESSION_ACTIVITY_KEYSET_INDEX_DDL } from "./2026-08-27-0804-session-activity-keyset-index.js";
+import { SESSION_TURNS_DDL } from "./2026-08-27-0824-session-turns.js";
+import { SESSION_TURNS_KEYSET_INDEX_DDL } from "./2026-08-28-0516-session-turns-keyset-index.js";
 import type { DbMigration } from "./MigrationHelpers.js";
 
 export type { DbMigration } from "./MigrationHelpers.js";
@@ -144,6 +146,8 @@ export const MIGRATIONS: ReadonlyArray<DbMigration> = [
 	COMMIT_REACHABLE_DDL,
 	MEMORY_LOOKUPS_DDL,
 	SESSION_ACTIVITY_KEYSET_INDEX_DDL,
+	SESSION_TURNS_DDL,
+	SESSION_TURNS_KEYSET_INDEX_DDL,
 ];
 
 /*

--- a/cli/src/dashboard/schema.snapshot.txt
+++ b/cli/src/dashboard/schema.snapshot.txt
@@ -97,6 +97,8 @@ INDEX ix_ts_session ON transcript_sessions
     CREATE INDEX ix_ts_session ON transcript_sessions(repo_id, session_id, source)
 INDEX ix_tsr_ref ON topic_source_refs
     CREATE INDEX ix_tsr_ref ON topic_source_refs(repo_id, ref_type, ref_id)
+INDEX ix_turns_keyset ON session_turns
+    CREATE INDEX ix_turns_keyset ON session_turns(recorded_at_ms, session_event_id, slice_id, seq)
 TABLE branches
     CREATE TABLE branches ( id INTEGER PRIMARY KEY, repo_id INTEGER NOT NULL REFERENCES repos(id), name TEXT NOT NULL, UNIQUE (repo_id, name) ) STRICT
 TABLE commit_aliases
@@ -141,6 +143,8 @@ TABLE session_model_usage
     CREATE TABLE session_model_usage ( session_event_id TEXT NOT NULL REFERENCES sessions(event_id) ON DELETE CASCADE, model TEXT NOT NULL, input_tokens INTEGER NOT NULL DEFAULT 0, output_tokens INTEGER NOT NULL DEFAULT 0, cached_tokens INTEGER NOT NULL DEFAULT 0, est_cost_usd REAL, updated_at_ms INTEGER NOT NULL DEFAULT 0, PRIMARY KEY (session_event_id, model) ) STRICT
 TABLE session_tool_use
     CREATE TABLE session_tool_use ( session_event_id TEXT NOT NULL REFERENCES sessions(event_id) ON DELETE CASCADE, tool_name TEXT NOT NULL, kind TEXT NOT NULL, server TEXT, calls INTEGER NOT NULL DEFAULT 0, last_call_at_ms INTEGER, updated_at_ms INTEGER NOT NULL DEFAULT 0, input_tokens INTEGER, output_tokens INTEGER, cached_tokens INTEGER, usage_confidence TEXT, plugin TEXT, origin_root TEXT, PRIMARY KEY (session_event_id, tool_name, kind) ) STRICT
+TABLE session_turns
+    CREATE TABLE session_turns ( session_event_id TEXT NOT NULL REFERENCES sessions(event_id) ON DELETE CASCADE, slice_id TEXT NOT NULL, seq INTEGER NOT NULL, role TEXT, ts_ms INTEGER, kind TEXT NOT NULL, recorded_at_ms INTEGER NOT NULL, PRIMARY KEY (session_event_id, slice_id, seq) ) STRICT
 TABLE session_usage_events
     CREATE TABLE session_usage_events ( session_event_id TEXT NOT NULL REFERENCES sessions(event_id) ON DELETE CASCADE, dedup_key TEXT NOT NULL, responded_at_ms INTEGER NOT NULL, model TEXT NOT NULL, input_tokens INTEGER NOT NULL DEFAULT 0, output_tokens INTEGER NOT NULL DEFAULT 0, cached_tokens INTEGER NOT NULL DEFAULT 0, est_cost_usd REAL, updated_at_ms INTEGER NOT NULL, PRIMARY KEY (session_event_id, dedup_key) ) STRICT, WITHOUT ROWID
 TABLE sessions


### PR DESCRIPTION
## What

Adds `session_turns`, the **text-free per-turn projection** that feeds the web coaching dashboard's Activity/Turnaround signal (SP-3). One row per transcript entry (role + parsed timestamp — content is never stored) plus one row per compaction / test-run / turn-abort instant, keyed `(session_event_id, slice_id, seq)` so a session spanning several transcript slices does not collide.

## Changes

- **New table + writer.** Migration `2026-08-27-0824-session-turns` (DDL-only, re-runnable) and `SessionTurnsProjection`, called from both transcript write paths (`SotWrite` / `SotImport`) alongside `transcript_sessions`.
- **Session-sync wiring.** `session_turns` classified on the session sync channel: `SYNCED_TABLES`, column coverage, `SYNC_STAMP_COLUMNS`, `KEYSET_COLUMNS`, `WINDOW_SOURCES`.
- **Keyset index.** Migration `2026-08-28-0516-session-turns-keyset-index` adds `ix_turns_keyset(recorded_at_ms, session_event_id, slice_id, seq)` — the composite the reader's keyset cursor needs and the frozen table's primary key cannot drive. The `session_turns` sibling of the `session_activity` keyset index; without it every sync page full-scans and temp-sorts (quadratic in table size).
- **Historical backfill.** `backfillStoredSessionTurns` reprojects the table from persisted `transcripts.sessions_blob` for slices that have none (Route A′, beside `backfillStoredActivity`). Coverage is per `(session_event_id, slice_id)`; the cohort shares one transaction stamped above the current max so the sync cursor cannot page over backfilled rows.
- **Backfill hardening** (from review of the first pass):
  - A blob is narrowed by `uncoveredSessionsForSlice` before projection, so an already-covered session riding in a mixed-coverage blob is not re-stamped and re-uploaded.
  - The projector tolerates a stored session with no `entries` field (untrusted on-disk data) instead of letting one bad session throw out of the whole transaction.

## Intentionally unchanged

- **Sync protocol version stays `version: 2`.** The push endpoint already speaks protocol-2 keyset cursors (per the SP-2 backend design), and the request schema accepts the version as a union — a v1 fallback would reintroduce the "`session_activity` stops syncing" bug that v2 fixes. No wire change here.
- **`projectSessionTurns` remains the sole writer** of `session_turns`; the backfill filters which sessions it hands over rather than carrying a private copy of the projection rule.

## Testing

- `SessionTurnsProjection`, `SessionTurnsBackfill`, `MigrationFingerprints`, `SchemaSnapshot`, `SyncColumns`, `DashboardDb`, `DbBackfill` — all green in isolation (new regression tests cover the missing-`entries` guard, the `uncoveredSessionsForSlice` filter, and the no-re-stamp backfill path).
- Full `npm run all`: build / typecheck / lint clean; the only test failures were load-induced 60s timeouts in unrelated real-`git`/real-fs `SLOW_TEST_FILES` (`GitClient`, `MemoryBankRebuild`, …), all of which pass in isolation.
