### PR TITLE
chore(plugins): bump claude 1.0.6, codex 1.0.5, cursor 1.0.3

### DIFF
--- a/claude-plugin/plugins/jolli/.claude-plugin/plugin.json
+++ b/claude-plugin/plugins/jolli/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "jolli",
 	"displayName": "Jolli Memory",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"description": "Automatically captures and generates project memory from your development work — team-shareable and synced across devices, so you can recall and search past decisions and context across sessions and agents. Backed by the jolli CLI bundled as an MCP server.",
 	"author": { "name": "jolli.ai", "url": "https://jolli.ai" },
 	"homepage": "https://jolli.ai",

--- a/codex-plugin/plugins/jolli/.codex-plugin/plugin.json
+++ b/codex-plugin/plugins/jolli/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
 	"name": "jolli",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"description": "Automatically captures and generates project memory from your development work — team-shareable and synced across devices, so you can recall and search past decisions and context across sessions and agents. Backed by the jolli CLI bundled with this plugin.",
 	"author": { "name": "jolli.ai", "url": "https://jolli.ai" },
 	"homepage": "https://jolli.ai",

--- a/cursor-plugin/plugins/jolli/.cursor-plugin/plugin.json
+++ b/cursor-plugin/plugins/jolli/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "jolli",
 	"displayName": "Jolli Memory",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "Automatically captures and generates project memory from your development work — team-shareable and synced across devices, so you can recall and search past decisions and context across sessions and agents. Backed by the jolli CLI bundled with this plugin.",
 	"author": { "name": "jolli.ai", "email": "hello@jolli.ai" },
 	"homepage": "https://jolli.ai",


### PR DESCRIPTION
CLI upgrade.

Version-only bump of the three plugin manifests so each bundle ships the
0.99.16 CLI. No behavioural change — the diff is three lines:

| Plugin | Version |
|---|---|
| Claude | 1.0.5 → 1.0.6 |
| Codex  | 1.0.4 → 1.0.5 |
| Cursor | 1.0.2 → 1.0.3 |

All three are already published to their public marketplaces:

- `jolliai/jolli-claude-plugin` @ `841783e`
- `jolliai/jolli-chatgpt-plugin` @ `8eef39b`
- `jolliai/jolli-cursor-plugin` @ `350c886`

Merging this keeps `main` in step with what is published. Without it, the next
release cut from `main` fails the prod version guard, which requires a strictly
higher version than the last published release.

`npm run all` passed before the bump was committed.