### PR TITLE
feat: export ALLOWED_JOLLI_HOSTS from the CLI's public API

### DIFF
--- a/cli/src/Api.bundle.test.ts
+++ b/cli/src/Api.bundle.test.ts
@@ -1,13 +1,13 @@
 /// <reference types="node" />
 /**
- * Regression guard for the `parseJolliApiKey` / `parseBaseUrl` re-export
- * pattern in {@link Api.ts}.
+ * Regression guard for the `parseJolliApiKey` / `parseBaseUrl` /
+ * `ALLOWED_JOLLI_HOSTS` re-export pattern in {@link Api.ts}.
  *
  * Vite's lib-mode tree-shaker drops pure `export { … } from "…"` re-exports
  * from the entry bundle when nothing inside the entry consumes them. The
  * current source goes through an `import` binding + a named `export const`
  * to defeat that, but if a future Vite/Rollup upgrade restores the old
- * elision behavior or otherwise drops the names from `dist/Api.js`, the
+ * elision behavior or otherwise drops a name from `dist/Api.js`, the
  * only place that would fail is the downstream plugins that import
  * `@jolli.ai/cli`. This test catches that drift at the host's CI boundary
  * by inspecting the actual built bundle.
@@ -21,6 +21,7 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
+import { ALLOWED_JOLLI_HOSTS } from "./core/JolliApiUtils.js";
 
 // Test file is at cli/src/Api.bundle.test.ts; bundle is at cli/dist/Api.js.
 const distPath = resolve(dirname(fileURLToPath(import.meta.url)), "..", "dist", "Api.js");
@@ -44,7 +45,11 @@ describe("Api.js bundle", () => {
 		expect(distContent).toMatch(/\bparseBaseUrl\b/u);
 	});
 
-	it.skipIf(distContent === null)("declares both helpers in the final `export { … }` block", () => {
+	it.skipIf(distContent === null)("exposes ALLOWED_JOLLI_HOSTS as a named export", () => {
+		expect(distContent).toMatch(/\bALLOWED_JOLLI_HOSTS\b/u);
+	});
+
+	it.skipIf(distContent === null)("declares every re-export in the final `export { … }` block", () => {
 		// Belt-and-suspenders: not only do the names appear somewhere in the
 		// bundle, they're listed in a closing export object. This catches the
 		// case where Vite emits the identifier internally but omits it from
@@ -52,24 +57,34 @@ describe("Api.js bundle", () => {
 		// Api.ts is guarding against.
 		// Match e.g. `export { … parseBaseUrl … parseJolliApiKey … }` (any order,
 		// any internal aliasing like `parseJolliApiKey$1 as parseJolliApiKey`).
-		const exportBlock = /export\s*\{[^}]*\bparseJolliApiKey\b[^}]*\}/u;
-		const exportBlockAlt = /export\s*\{[^}]*\bparseBaseUrl\b[^}]*\}/u;
-		expect(distContent).toMatch(exportBlock);
-		expect(distContent).toMatch(exportBlockAlt);
+		for (const name of ["parseJolliApiKey", "parseBaseUrl", "ALLOWED_JOLLI_HOSTS"]) {
+			expect(distContent).toMatch(new RegExp(`export\\s*\\{[^}]*\\b${name}\\b[^}]*\\}`, "u"));
+		}
 	});
 
 	it.skipIf(distContent === null)(
-		"exposes parseJolliApiKey and parseBaseUrl as callable functions (subprocess import)",
+		"exposes the helpers and the host allowlist as usable values (subprocess import)",
 		() => {
 			// End-to-end check: a clean Node process actually dynamic-imports the
-			// built bundle and confirms both exports resolve to functions at
+			// built bundle and confirms every export resolves to a usable value at
 			// runtime. Source-text greps above catch tree-shaking regressions;
 			// this catches the subtler case where the name is emitted but bound
-			// to `undefined` (or anything non-callable).
+			// to `undefined` (or anything of the wrong shape).
+			//
+			// The expected host list is taken from the source module rather than
+			// restated here, so adding a host is a one-file change and this test
+			// still proves the *bundled* copy carries the same entries.
 			const distUrl = pathToFileURL(distPath).href;
 			const script = `import(${JSON.stringify(distUrl)})
 				.then((m) => {
-					const ok = typeof m.parseJolliApiKey === "function" && typeof m.parseBaseUrl === "function";
+					const expectedHosts = ${JSON.stringify(ALLOWED_JOLLI_HOSTS)};
+					const hosts = m.ALLOWED_JOLLI_HOSTS;
+					const hostsOk =
+						Array.isArray(hosts) &&
+						hosts.length === expectedHosts.length &&
+						expectedHosts.every((h) => hosts.includes(h));
+					const ok =
+						typeof m.parseJolliApiKey === "function" && typeof m.parseBaseUrl === "function" && hostsOk;
 					process.exit(ok ? 0 : 1);
 				})
 				.catch((err) => {

--- a/cli/src/Api.ts
+++ b/cli/src/Api.ts
@@ -43,11 +43,15 @@ import { registerSyncCommand } from "./commands/SyncCommand.js";
 import { registerTelemetryCommand } from "./commands/TelemetryCommand.js";
 import { registerUninstallCommand } from "./commands/UninstallCommand.js";
 import { registerViewCommand } from "./commands/ViewCommand.js";
-// _parseJolliApiKey / _parseBaseUrl: re-exposed at the bottom of this file.
-// See the `parseJolliApiKey` export for the rationale (Vite tree-shaker drops
-// pure re-exports from the entry bundle when nothing inside the entry
-// consumes them).
-import { parseBaseUrl as _parseBaseUrl, parseJolliApiKey as _parseJolliApiKey } from "./core/JolliApiUtils.js";
+// _ALLOWED_JOLLI_HOSTS / _parseJolliApiKey / _parseBaseUrl: re-exposed at the
+// bottom of this file. See the `parseJolliApiKey` export for the rationale
+// (Vite tree-shaker drops pure re-exports from the entry bundle when nothing
+// inside the entry consumes them).
+import {
+	ALLOWED_JOLLI_HOSTS as _ALLOWED_JOLLI_HOSTS,
+	parseBaseUrl as _parseBaseUrl,
+	parseJolliApiKey as _parseJolliApiKey,
+} from "./core/JolliApiUtils.js";
 import { installCommandTelemetryHooks } from "./core/TelemetryCommandHook.js";
 import { CLI_PACKAGE_NAME, REFRESH_COMMAND, refreshUpdateCache } from "./core/UpdateCheck.js";
 import { autoRefreshSkillsIfStale } from "./install/SkillAutoRefresh.js";
@@ -135,6 +139,25 @@ export type PluginRegister = (ctx: PluginContext) => void | Promise<void>;
 export type { JolliApiKeyMeta, ParsedBaseUrl } from "./core/JolliApiUtils.js";
 export const parseJolliApiKey = _parseJolliApiKey;
 export const parseBaseUrl = _parseBaseUrl;
+
+/**
+ * Re-exported allowlist of host suffixes a Jolli API key / OAuth callback may
+ * target (`jolli.ai`, `jolli.dev`, …). Downstream packages import this rather
+ * than restating the list, so a host added in
+ * `core/JolliApiUtils.ts` reaches them without a second edit — the same
+ * anti-drift reason the VS Code Settings webview inlines this exact array.
+ *
+ * Consumers that need the boundary *check* rather than the raw list should
+ * still apply the suffix rule the host uses (`host === h || host.endsWith("." + h)`);
+ * a bare `includes` would accept `evil-jolli.ai`.
+ *
+ * Goes through the same `import` binding + `export const` indirection as
+ * `parseJolliApiKey` above, and for the same reason: a pure
+ * `export { … } from "…"` is elided from the entry bundle by Vite's lib-mode
+ * tree-shaker, which type-checks clean and fails only at the consumer's
+ * runtime.
+ */
+export const ALLOWED_JOLLI_HOSTS = _ALLOWED_JOLLI_HOSTS;
 
 // ── Help-grouping configuration ─────────────────────────────────────────────
 // These shape `jolli --help`: anything in HIDDEN_COMMANDS is filtered out by


### PR DESCRIPTION
## What

Exports `ALLOWED_JOLLI_HOSTS` from `cli/src/Api.ts`, so downstream packages can `import { ALLOWED_JOLLI_HOSTS } from "@jolli.ai/cli/api"` instead of restating the list. Adding a host stays a single edit in `core/JolliApiUtils.ts`.

## Why the indirection

Not `export { ALLOWED_JOLLI_HOSTS } from "./core/JolliApiUtils.js"`. Vite's lib-mode tree-shaker elides a pure re-export from the entry bundle when nothing inside the entry consumes it — the function body still lands in the shared chunk, only the entry's export statement goes. The `.d.ts` stays correct, so it type-checks clean and fails **only at runtime in the consumer**.

So this follows the existing import-binding + `export const` pattern that `parseJolliApiKey` / `parseBaseUrl` already use, documented in the comment block above them.

The doc comment on the new export carries one consumer warning: the exported value is the raw list, so a consumer needs the same suffix rule the host applies (`host === h || host.endsWith("." + h)`). A bare `includes` would accept `evil-jolli.ai`.

## Test

`Api.bundle.test.ts` is the only thing that inspects the emitted `dist/Api.js`, and all four of its assertions named the two existing helpers literally. All four now cover the new name:

- new name-presence test for `ALLOWED_JOLLI_HOSTS`;
- the export-block test became a loop over all three names (was two hand-written regexes);
- the subprocess import now also asserts `Array.isArray` + same length + same entries — it takes the expected list by importing from the source module rather than restating it, so adding a host is still a one-file change while the test proves the *bundled* copy matches.

## Verification

- `npm run all` green.
- `dist/Api.js` really carries the name — the closing export block reads `SE as ALLOWED_JOLLI_HOSTS` (aliased from the minified internal, which is the expected shape).
- Guard confirmed to have teeth: deleting the alias from a scratch `dist/Api.js` fails 3 of the 5 tests.

## Scope

Export half only. The host-widening is deliberately left out — it's blocked on domain-ownership confirmation.