### PR TITLE
test: stop the discard fixture re-creating a just-removed temp path

### DIFF
--- a/cli/src/core/FileDiscardService.test.ts
+++ b/cli/src/core/FileDiscardService.test.ts
@@ -171,8 +171,21 @@ describe("FileDiscardService", () => {
 	describe("before the first commit (unborn HEAD)", () => {
 		beforeEach(() => {
 			// Re-make the fixture without a commit — the outer beforeEach always lands one.
+			//
+			// Take a FRESH mkdtemp rather than re-creating the outer fixture's path.
+			// Re-creating it was observed failing on CI as
+			// `EEXIST: file already exists, mkdir '/tmp/jolli-discard-fGOhbR'`, while
+			// passing every time this file is run alone. The exact writer that put the
+			// path back was not identified, and the two candidates are far apart in
+			// likelihood — a sibling worker's mkdtemp re-drawing the same six random
+			// characters is ~1-in-62^6, so a straggler (a git subprocess or a logger
+			// flush from an earlier test) recreating the tree between the rm and the
+			// mkdir is the better bet. Rather than guess, drop the requirement: an
+			// unused name cannot be contended. `rmSync` still runs so the committed
+			// fixture is cleaned up rather than leaked; reassigning `cwd` keeps the
+			// outer afterEach correct, and `git` reads `cwd` per invocation.
 			rmSync(cwd, { recursive: true, force: true });
-			mkdirSync(cwd);
+			cwd = mkdtempSync(join(tmpdir(), "jolli-discard-"));
 			git("init", "-q");
 		});
 


### PR DESCRIPTION
## Symptom

`build-vscode` failed on an unrelated PR with:

```
FAIL src/core/FileDiscardService.test.ts > before the first commit (unborn HEAD)
     > unstages and deletes a staged new file
Error: EEXIST: file already exists, mkdir '/tmp/jolli-discard-fGOhbR'
  ❯ src/core/FileDiscardService.test.ts:175:4
```

1 failed, 16349 passed. The file passes 52/52 when run alone. It's in `SLOW_TEST_FILES`, i.e. the real-git fan-out tier.

## Cause

The unborn-HEAD fixture re-made the outer fixture's directory **by name**:

```js
rmSync(cwd, { recursive: true, force: true });
mkdirSync(cwd);
```

`mkdtemp`'s uniqueness guarantee lasts only as long as the directory does. Removing it hands the name back to the OS, and the `mkdirSync` then needs a path that nothing else has taken or recreated in the interim — a requirement this test never needed.

**I could not identify which writer put the path back, and I'd rather say so than guess.** The two candidates are far apart in likelihood: a sibling worker's `mkdtemp` re-drawing the same six random characters is ~1-in-62⁶, so a straggler (a git subprocess, or a logger flush from an earlier test) recreating the tree between the rm and the mkdir is much the better bet. Either way the fix is the same, because it removes the contended name rather than the contender.

## Fix

Take a fresh `mkdtemp` instead of re-creating the old path. An unused name cannot be contended.

- `rmSync` stays, so the committed fixture is cleaned up rather than leaked.
- Reassigning `cwd` keeps the outer `afterEach` correct — it removes whatever `cwd` currently names.
- The `git` helper reads `cwd` per invocation, so the following `git("init", "-q")` runs in the new directory.

## Verification

- `npm run all` green.
- `FileDiscardService.test.ts` passes alone, and 6 concurrent runs of it all pass.
- Honest caveat on that last one: **8 concurrent runs of the *unfixed* file also passed**, so I have no local reproduction of the original failure and cannot claim this is proven to fix that specific CI run. What I can claim is that the pattern it removes is fragile by construction and unnecessary here.

## This PR does not close the root cause

**The root cause is unidentified, and merging this does not establish one.** It fixes fixture hygiene: the old code re-claimed a `mkdtemp`-allocated name in the shared `/tmp` namespace after releasing it, which uses the API against its contract. That is worth fixing on its own merits — it is the only site in the repo doing it, and I would write it this way from scratch with no CI failure in evidence.

What remains open is *why* that path existed when `mkdirSync` ran. `rmSync` had returned without throwing (with `force: true`, Node swallows only `ENOENT` and does not retry `ENOTEMPTY`/`EBUSY` by default), so either something recreated the path in that window, or `rmSync` returned without removing it. I could not distinguish the two:

- A sibling worker's `mkdtemp` re-drawing the same six characters is ~1-in-62⁶, so that is not it.
- The straggler theory (a git subprocess or logger flush writing into a torn-down directory) is the better candidate, but a clean run leaves **zero** leftover `/tmp/jolli-discard-*` directories, which argues against it.
- 8 concurrent runs of the *unfixed* file produced no reproduction.

So this change removes the contended name rather than the contender, and it holds under either branch. If this class of failure recurs — in this file or another — that is a second data point and the signal should be chased properly rather than treated as another flake. In particular, a straggler writing past a test boundary would be a suite-level problem capable of causing unrelated failures, and this PR would not have fixed it.
