### PR TITLE
docs: prep 0.99.17 release notes and version bump

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-<!-- Last synced commit: fb34e0a98 | 2026-08-28 -->
+<!-- Last synced commit: e3287ce7 | 2026-08-31 -->
+
+## 0.99.17
+
+- **Ready for Jolli's new web addresses** — signing in and syncing now work with Jolli's new domains, so keys issued there are accepted.
+- Bug fixes.
 
 ## 0.99.16
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@jolli.ai/cli",
-	"version": "0.99.16",
+	"version": "0.99.17",
 	"description": "Automatic development memory for AI coding agents: turns your Claude Code, Codex, Gemini, Cursor, Copilot, Cline, Devin, OpenCode, Antigravity and Kimi Code sessions into structured commit summaries your agent can recall over MCP",
 	"main": "./dist/Api.js",
 	"types": "./dist/Api.d.ts",

--- a/intellij/CHANGELOG.md
+++ b/intellij/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.99.17
+
+### Changes
+
+- **Ready for Jolli's new web addresses** — signing in now works with Jolli's new domains, so keys issued there are accepted.
+
+### Fixes & Improvements
+
+- Bug fixes.
+
+### Performance
+
+- Performance improvements.
+
 ## 0.99.16
 
 ### Changes

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -17,7 +17,7 @@ plugins {
 }
 
 group = "ai.jolli"
-version = "0.99.16"
+version = "0.99.17"
 
 repositories {
     mavenCentral()

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 		},
 		"cli": {
 			"name": "@jolli.ai/cli",
-			"version": "0.99.16",
+			"version": "0.99.17",
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -7161,7 +7161,7 @@
 		},
 		"vscode": {
 			"name": "jollimemory-vscode",
-			"version": "0.99.16",
+			"version": "0.99.17",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@vscode/codicons": "^0.0.45",

--- a/vscode/CHANGELOG.md
+++ b/vscode/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-<!-- Last synced commit: fb34e0a98 | 2026-08-28 -->
+<!-- Last synced commit: e3287ce7 | 2026-08-31 -->
+
+## 0.99.17
+
+- **Ready for Jolli's new web addresses** — signing in now works with Jolli's new domains, so keys issued there are accepted.
+- Bug fixes.
 
 ## 0.99.16
 

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "jollimemory-vscode",
 	"displayName": "Jolli Memory",
 	"description": "VS Code sidebar for Jolli Memory — AI-powered commit summaries and smart git operations",
-	"version": "0.99.16",
+	"version": "0.99.17",
 	"publisher": "jolli",
 	"license": "Apache-2.0",
 	"icon": "assets/icon.png",


### PR DESCRIPTION
## Summary

Release prep for **0.99.17** — version bumps, changelogs, and a stale-doc fix.

The only functional change since 0.99.16 is the Jolli origin allowlist migration (`jollidev.com` / `jollidev.dev`, PR #558), which is user-invisible, so this release ships as a small maintenance bump.

## Changes

- **Version → 0.99.17** across all three artifacts: `cli/package.json`, `vscode/package.json`, `intellij/build.gradle.kts`. `package-lock.json` carries only the two workspace version fields, edited directly rather than through `npm` (npm's own resolution wants to drop unrelated `peer` markers).
- **Changelogs** — user-facing 0.99.17 entries on `cli/`, `vscode/`, and `intellij/` ("Ready for Jolli's new web addresses" + bug fixes). CLI/VS Code `Last synced commit` markers advanced to `cac3e49a2`.
- **`vscode/DEVELOPMENT.md`** — the shared origin allowlist listing had gone stale (missing `jollidev.com` / `jollidev.dev`); brought back in line with the code and `AGENTS.md`.

## Intentionally unchanged

- **READMEs** — the domain-allowlist change is invisible to their feature descriptions; no README lists the allowlist domains or hardcodes a version, so nothing there needed touching.
- **Root `package.json`** — stays at 0.99.0 (deliberately not tracking artifact versions).

## Notes

- This branch is built on top of the domain-migration commits (PR #558), so the diff overlaps until #558 merges; the 0.99.17 changelog line describes exactly that work.
- `npm run all` was **not** run for this prep (docs/version/lockfile only, no source-logic change; verified no test hardcodes the old version). CI runs the full chain.
